### PR TITLE
[Initial Port][Epic 2] Port @takazudo/zudo-design-token-panel package

### DIFF
--- a/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
+++ b/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
@@ -1,0 +1,982 @@
+# Design Token Panel — Portable Contract
+
+This document codifies the public contract that the
+`@takazudo/zudo-design-token-panel` package exposes to its host applications.
+It is the source of truth for the package's portable API surface. Reviewers
+should be able to check off any change to the package against the section
+that pins the surface it touches.
+
+The package extracts every project-specific identifier behind a single
+configure-once init (`configurePanel({...})`) so the same package can ship
+into any Preact-supporting Astro / Vite / Next.js / Rust-SSG consumer. Storage
+keys, console namespace, modal class prefixes, schema id, palette CSS-var
+pattern, the token manifest, and the color cluster are all host-supplied.
+
+---
+
+## 1. `configurePanel({...})` — configure-once init
+
+The package exposes a single, idempotent setup function. Hosts call it exactly
+once per page lifecycle, before the panel adapter is dynamically imported
+(typically from a small Astro host script that gates the adapter behind a
+visibility / persistence probe — see §5).
+
+```ts
+export interface PanelConfig {
+  /** Base for every derived storage key. See §2. */
+  storagePrefix: string;
+  /** Console API namespace — installed as `window[consoleNamespace].showDesignPanel`, etc. */
+  consoleNamespace: string;
+  /** BEM-style prefix used by every modal in the panel (export / import / apply). */
+  modalClassPrefix: string;
+  /** `$schema` value emitted into export JSON and required on import. */
+  schemaId: string;
+  /** Default filename base — exports save as `${exportFilenameBase}.json`. */
+  exportFilenameBase: string;
+  /** Editable design tokens grouped per-tab. See §3. */
+  tokens: TokenManifest;
+  /** Palette + base roles + semantic table. See §4. */
+  colorCluster: ColorClusterConfig;
+  /**
+   * Optional secondary color cluster. Host-driven:
+   *  - `undefined` (field omitted) — secondary section hidden.
+   *  - `null` — explicit opt-out: secondary section hidden + apply/clear skipped.
+   *  - `ColorClusterConfig` — host-supplied secondary cluster.
+   * See §4.3 for the resolution contract.
+   */
+  secondaryColorCluster?: ColorClusterConfig | null;
+  /**
+   * Optional host-supplied color-scheme presets. Surfaces additional named
+   * `ColorScheme` entries in the Color tab "Scheme..." dropdown alongside
+   * `colorCluster.colorSchemes`. The package itself ships zero presets —
+   * this is the host's escape hatch for shipping a larger preset library
+   * without bloating the panel bundle for every consumer. Defaults to `{}`.
+   * See §4.5 for the merge contract.
+   */
+  colorPresets?: Record<string, ColorScheme>;
+  /**
+   * Optional dev-API endpoint URL. When the host wires the panel into a
+   * project that ships its own design-tokens-apply route, supply the URL
+   * here; the Apply button POSTs its diff payload to it. When `undefined`,
+   * the Apply button stays disabled with a tooltip — hosts that ship
+   * export/import only can omit this field.
+   */
+  applyEndpoint?: string;
+  /**
+   * Optional CSS-var prefix → repo-relative source-file routing map.
+   * Drives `routeTokensToFiles` so a host whose tokens use any prefix
+   * family can opt into the apply pipeline without forking the package.
+   * Apply is gated on `applyEndpoint` AND a non-empty routing map. Omit
+   * to disable apply entirely.
+   *
+   * Example:
+   *
+   * ```ts
+   * applyRouting: {
+   *   myapp: 'src/styles/tokens.css',
+   *   'myapp-extra': 'src/styles/extra-tokens.css',
+   * }
+   * ```
+   */
+  applyRouting?: Record<string, string>;
+}
+
+export function configurePanel(config: PanelConfig): void;
+
+/**
+ * Lazy preset attachment. Hosts that don't want to ship the preset library
+ * inline in the SSR config blob can call this AFTER the panel has been
+ * configured to attach the preset map from a deferred dynamic import. Same
+ * precedence rules as `PanelConfig.colorPresets` — see §4.4.
+ */
+export function setPanelColorPresets(presets: Record<string, ColorScheme>): void;
+
+/**
+ * Runtime validator at the host-adapter trust boundary. Throws with a
+ * message naming the offending field when a parsed inline config is
+ * malformed. The Astro adapter calls this automatically on every page
+ * load; hosts that wire the panel without the Astro entry point should
+ * call it too.
+ */
+export function assertValidPanelConfig(value: unknown): asserts value is PanelConfig;
+```
+
+Required behaviours:
+
+- **One-shot.** Calling `configurePanel` more than once with different values
+  is an error. The panel may either throw or warn-and-ignore, but it MUST
+  NOT silently overwrite a previously-configured cluster mid-session.
+- **Synchronous.** No I/O, no awaits. The call must be cheap enough to run
+  inline at module-init from the Astro frontmatter side.
+- **Pure data only.** Every field on `PanelConfig` (and every nested field
+  inside `tokens` / `colorCluster`) MUST be JSON-serializable. This is the
+  hard precondition for the Astro frontmatter → island prop handoff (§5):
+  Astro stringifies props, so functions / class instances do not survive.
+- **No default `PanelConfig` baked into the package.** Hosts MUST configure
+  the panel explicitly via `<DesignTokenPanelHost config={...} />` or a
+  direct `configurePanel({...})` call. The package ships zero baked-in
+  identifiers — every storage prefix, namespace, palette template, and
+  manifest entry comes from the host.
+
+---
+
+## 2. Storage-key derivation
+
+`storagePrefix` is the only knob that controls every persisted key. The panel
+derives the keys at runtime from this single base.
+
+| Logical key | Derivation                  | Owner                | Purpose                                                                                                                                                      |
+| ----------- | --------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `state-v2`  | `${storagePrefix}-state-v2` | tweak-state          | Unified envelope: color + spacing + typography + size + panelPosition + optional secondary cluster slice.                                                    |
+| `state-v1`  | `${storagePrefix}-state`    | tweak-state (legacy) | Pre-v2 flat-state format (Color-only). Migrated into `state-v2` on first load, then deleted.                                                                 |
+| `open`      | `${storagePrefix}-open`     | panel                | Mirror of the panel's `open` boolean state (so the next mount opens directly into the user's last state without a post-render toggle dispatch).              |
+| `position`  | `${storagePrefix}-position` | panel                | Drag position (`{ top, right }`) so the panel reappears where the user left it.                                                                              |
+| `visible`   | `${storagePrefix}:visible`  | adapter              | Adapter-level visibility-intent flag, owned by the lazy-load gate (§5).                                                                                      |
+
+**Constraint — colon, not dash, for `visible`.** The `visible` key uses a
+`:` separator, every other derived key uses `-`. This is a historical artifact
+preserved for storage-key continuity: a key rename would silently lose users'
+visibility intent on first load. The derivation MUST emit the colon literally;
+do not "fix" it during refactors.
+
+**Storage-key derivation is literal.** With `storagePrefix: "myapp-design-token-panel"`,
+the derivation produces:
+
+```
+myapp-design-token-panel-state-v2
+myapp-design-token-panel-state
+myapp-design-token-panel-open
+myapp-design-token-panel-position
+myapp-design-token-panel:visible
+```
+
+Unit tests in the package verify these derivations with literal-equality
+checks, and the v1 → v2 migration path at first-load is part of the test
+matrix.
+
+---
+
+## 3. Token manifest contract
+
+The panel does not know which tokens a host site exposes. The host supplies
+its own token manifest, and the panel iterates it to render rows + apply
+overrides to `:root`.
+
+### 3.1 Public interfaces
+
+These shapes already exist in `src/tokens/manifest.ts`. The portable contract
+freezes them as the public surface:
+
+```ts
+export type TokenGroup = string;
+
+export type TokenControl = 'slider' | 'select' | 'text';
+
+export interface TokenDef {
+  /** Stable id used as the Record key in persisted state (e.g. `hsp-2xs`). */
+  id: string;
+  /** CSS custom property written to `:root` (e.g. `--myapp-spacing-hgap-2xs`). */
+  cssVar: string;
+  /** Display label shown in the panel row. */
+  label: string;
+  /** Manifest group — tab components use this for section headers. */
+  group: TokenGroup;
+  /** Default value as a CSS string (`0.125rem`, `12px`, etc.). */
+  default: string;
+  /** Slider min, in `unit`. Unused when `readonly` or non-slider. */
+  min: number;
+  /** Slider max, in `unit`. */
+  max: number;
+  /** Slider step, in `unit`. */
+  step: number;
+  /** Unit suffix (`rem`, `px`, …). May be empty for unitless / read-only tokens. */
+  unit: string;
+  /** Read-only tokens are displayed but not editable. */
+  readonly?: true;
+  /** Which control renders this token. Defaults to `"slider"` when absent. */
+  control?: TokenControl;
+  /** Select options — only used when `control === "select"`. */
+  options?: readonly string[];
+  /** Hide behind the per-tab Advanced `<details>` disclosure. */
+  advanced?: true;
+  /** Opt-in pill toggle (e.g. for `--radius-full` 9999px sentinel). */
+  pill?: { value: string; customDefault: string };
+}
+
+export interface TokenManifest {
+  spacing: readonly TokenDef[];
+  typography: readonly TokenDef[];
+  size: readonly TokenDef[];
+  color: readonly TokenDef[];
+  /** Optional spacing-tab group order. Falls back to the package-bundled `GROUP_ORDER`. */
+  spacingGroupOrder?: readonly string[];
+  /** Optional font-tab primary group order. Falls back to `FONT_GROUP_ORDER`. */
+  fontGroupOrder?: readonly string[];
+  /** Optional size-tab group order. Falls back to `SIZE_GROUP_ORDER`. */
+  sizeGroupOrder?: readonly string[];
+  /** Optional human-readable section titles keyed by group id. Falls back to `GROUP_TITLES`. */
+  groupTitles?: Readonly<Record<string, string>>;
+}
+```
+
+**Note on `TokenGroup`.** `TokenGroup` is `string` (not a closed union) so
+consumers can coin their own group ids without forking the package types.
+The four optional fields above (`spacingGroupOrder`, `fontGroupOrder`,
+`sizeGroupOrder`, `groupTitles`) let a host customise how groups within a
+tab are ordered and titled. Manifests that omit a field inherit the
+package-bundled default ordering for that tab. Consumers coining unknown
+group ids SHOULD populate `groupTitles` so the section headers carry
+human-readable labels — the tabs fall back to printing the raw group id
+otherwise.
+
+### 3.2 Helpers (re-exported from the package root)
+
+These shipped helpers are part of the contract — consumers MAY call them when
+authoring their manifest:
+
+| Helper              | Signature                                                                   | Purpose                                                                                                                                    |
+| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `parseNumericValue` | `(value: string) => number \| null`                                         | Strip the leading numeric portion from a CSS length string (`"1.5rem"` → `1.5`). Returns `null` for unparseable input (e.g. `clamp(...)`). |
+| `formatValue`       | `(n: number, unit: string) => string`                                       | Re-format a numeric slider value back into the stored string form (`(1.5, "rem")` → `"1.5rem"`).                                           |
+| `buildTokenIndex`   | `(...groups: readonly (readonly TokenDef[])[]) => Record<string, TokenDef>` | Convenience: build a flat lookup keyed by `TokenDef.id`.                                                                                   |
+
+### 3.3 Consumer responsibility
+
+The host project provides the four manifest arrays:
+
+- `SPACING_TOKENS` — passed as `tokens.spacing`.
+- `FONT_TOKENS` — passed as `tokens.typography`. (Note the slice / array name
+  divergence: the persist envelope's slice is `typography`; the array constant
+  uses the upstream `FONT_TOKENS` name. The panel reads them through
+  `panelConfig.tokens.typography`, so consumers can use either name in their
+  source — the field on `PanelConfig` is what the contract pins.)
+- `SIZE_TOKENS` — passed as `tokens.size`.
+- `COLOR_TOKENS` — passed as `tokens.color`. Cluster-driven hosts ship an
+  empty array (color is driven by the cluster, not by per-token rows); the
+  field is required by the manifest shape so a cluster-less host can
+  provide rows here.
+
+The panel package itself ships ZERO baked-in manifest data — the host is
+the source of truth. The package's role is consuming whatever the host
+hands in.
+
+### 3.4 Apply behaviour
+
+The panel's `applyTokenOverrides(tokens, overrides)` (already present in
+`state/tweak-state.ts`) walks each `TokenDef`:
+
+- If `readonly`, skip both directions (display-only).
+- If the override map has a non-empty string for `id`, write
+  `document.documentElement.style.setProperty(t.cssVar, value)`.
+- Otherwise, remove the inline property (so the stylesheet default wins).
+
+The contract requires this read/write target to be `:root`. No shadow DOM, no
+scoped overrides — this is intentional, the panel ships a global tweak.
+
+---
+
+## 4. Color cluster contract
+
+The color tab — palette + base roles + semantic table + scheme list — is
+parameterised through a `ColorClusterConfig` so a portable host can ship a
+different palette size, a different CSS-var family, or a different semantic
+vocabulary without touching the panel internals.
+
+### 4.1 `ColorClusterConfig` interface
+
+```ts
+export type BaseRoleKey = 'background' | 'foreground' | 'cursor' | 'selectionBg' | 'selectionFg';
+
+export interface ColorClusterConfig {
+  /** Stable id — used for debugging / logging only. */
+  id: string;
+  /**
+   * Optional human-visible label rendered in the Color tab section
+   * headings. When absent, the tab falls back to `id.toUpperCase()`.
+   */
+  label?: string;
+  /** Expected palette length. Drives init + persisted-state validation. */
+  paletteSize: number;
+  /**
+   * Palette-slot CSS var template. The panel substitutes `{n}` with the
+   * palette index at apply time.
+   *
+   *   paletteCssVarTemplate: '--myapp-p{n}'    →  --myapp-p0, --myapp-p1, ...
+   *   paletteCssVarTemplate: '--brand-pa{n}'   →  --brand-pa0, --brand-pa1, ...
+   *
+   * String form is mandatory because the cluster config must round-trip
+   * through Astro frontmatter as a JSON-serialised prop (§5).
+   */
+  paletteCssVarTemplate: string;
+  /**
+   * Map of base-role name → CSS custom-property name. A cluster MAY declare
+   * a subset (an empty map is legal); only declared roles are written on apply.
+   */
+  baseRoles: Partial<Record<BaseRoleKey, string>>;
+  /** Semantic token name → default palette index. */
+  semanticDefaults: Record<string, number>;
+  /** Semantic token name → CSS custom-property name. */
+  semanticCssNames: Record<string, string>;
+  /**
+   * Fallback palette indices when a scheme omits a base role. Same partial
+   * shape as `baseRoles`. `ColorTweakState` always carries all 5 numeric
+   * fields for envelope round-trip, but inert roles emit zero CSS writes.
+   */
+  baseDefaults: Partial<Record<BaseRoleKey, number>>;
+  /** Fallback `shikiTheme` when a scheme lacks one. (Inert when no shiki integration.) */
+  defaultShikiTheme: string;
+  /**
+   * Color-scheme registry. Keyed by display name (`"Default Dark"`, etc.).
+   * Each entry mirrors the existing `ColorScheme` shape from
+   * `config/color-schemes.ts` (palette: 16-tuple, optional semantic overrides,
+   * etc.). The portable contract requires this to be a plain object — no
+   * dynamic loaders. Pass `{}` for clusters that don't use schemes.
+   */
+  colorSchemes: Record<string, ColorScheme>;
+  /**
+   * Panel-level scheme settings. Carried inside the cluster (rather than as a
+   * separate import) so `getActiveSchemeName` / `initColorFromScheme` can
+   * read everything from the cluster argument.
+   */
+  panelSettings: {
+    /** Scheme name to seed state from when `colorMode` is `false`. */
+    colorScheme: string;
+    /**
+     * Optional light/dark pairing. When set to an object, the panel honours
+     * `document.documentElement[data-theme]` and switches schemes accordingly
+     * on init. Set to `false` to disable the light/dark UI.
+     */
+    colorMode: false | { defaultMode: 'light' | 'dark'; lightScheme: string; darkScheme: string };
+  };
+}
+```
+
+> **Public alias** — the runtime type that ships in the package source is
+> `ColorClusterDataConfig` (in `src/config/`). `ColorClusterConfig` is
+> re-exported from the package root as the public-facing alias for this
+> same shape:
+> `import type { ColorClusterConfig } from '@takazudo/zudo-design-token-panel'`.
+> The two names are interchangeable.
+
+`ColorScheme` itself stays the same shape used today (`config/color-schemes.ts`):
+
+```ts
+export type ColorRef = number | string;
+
+export interface ColorScheme {
+  background: ColorRef;
+  foreground: ColorRef;
+  cursor: ColorRef;
+  selectionBg: ColorRef;
+  selectionFg: ColorRef;
+  palette: readonly string[]; // length must match cluster.paletteSize
+  shikiTheme: string;
+  semantic?: Record<string, ColorRef>; // keys must be a subset of cluster.semanticDefaults
+}
+```
+
+### 4.2 JSON-serializable constraint
+
+**Every field on `ColorClusterConfig` (and on each `ColorScheme` it nests)
+MUST be JSON-serializable.** No function fields, no class instances, no
+`Symbol` keys, no `undefined` where `null` is meant. This is enforced by Astro
+frontmatter → component prop handoff: the host adapter (§5) stringifies the
+config into the rendered island and parses it back at runtime. Function
+fields silently disappear under that round-trip and would surface as cryptic
+runtime errors.
+
+The palette CSS-var name is therefore expressed as a string template, not a
+function:
+
+```ts
+// wrong (function — silently dropped by JSON.stringify)
+// paletteCssVar: (i) => `--myapp-p${i}`,
+
+// right (string template, JSON-serializable)
+paletteCssVarTemplate: '--myapp-p{n}',
+```
+
+The panel resolves `{n}` to the palette index at every call site that
+previously called `paletteCssVar(i)` (palette apply, clear-applied, scheme
+diff). The substitution is plain string replacement — no template-engine
+features. `{n}` is the only placeholder; literal `{n}` text in an output var
+name is not a use case the contract supports.
+
+### 4.3 Multi-cluster support
+
+The package supports a primary cluster and an optional secondary cluster.
+`PanelConfig.colorCluster` is the primary cluster (always required).
+`PanelConfig.secondaryColorCluster` is the secondary cluster slot —
+host-driven, three states:
+
+| `secondaryColorCluster` value | Meaning | Effect |
+|---|---|---|
+| `undefined` (field omitted) | Secondary section hidden | The Color tab does not render a secondary palette / semantic section. |
+| `null` | Explicit opt-out | Same render-side effect as `undefined`; in addition, apply / clear / load skip every secondary code path. The persist envelope's secondary-cluster slice is NOT hydrated. |
+| `ColorClusterDataConfig` object | Host-supplied secondary cluster | Same render / apply / clear contract as the primary cluster, scoped to the supplied palette + semantic vocabulary. |
+
+The resolution is performed through the `resolveSecondaryColorCluster()`
+helper exported from `config/panel-config.ts`. Call sites (color-tab render,
+apply-modal flatten, tweak-state apply / clear / load) MUST read through that
+helper rather than the raw field so every code path treats the three states
+consistently.
+
+The persist envelope's secondary-cluster slice (the slot name is historical
+and remains stable for storage continuity) is the on-disk shape for the
+secondary cluster.
+
+### 4.4 Host-supplied scheme presets — `colorPresets`
+
+`PanelConfig.colorPresets` is the optional, host-supplied preset map
+surfaced by the Color tab "Scheme..." dropdown. It defaults to `{}` and
+the package itself ships zero presets — hosts that want a curated preset
+library (Dracula / Solarized / Tokyo Night / etc.) ship it themselves so
+consumers do not pay for it by default.
+
+| `colorPresets` value | Meaning | Effect |
+|---|---|---|
+| `undefined` (field omitted) | Default | Equivalent to `{}` — only `colorCluster.colorSchemes` populates the dropdown. |
+| `{}` | Explicit empty | Same as `undefined`. |
+| `Record<string, ColorScheme>` | Host-supplied | Each key surfaces as a `<option>` below the cluster's bundled schemes. Sorted alphabetically. |
+
+**Merge order in the dropdown:**
+
+```
+<option disabled>Scheme...</option>
+... cluster.colorSchemes (insertion order) ...
+<hr />
+... colorPresets (alphabetical) ...
+```
+
+**Key collision** — if a `colorPresets` entry shares a name with one in
+`colorCluster.colorSchemes`, the cluster's bundled scheme wins for the
+`handleLoadPreset` lookup. The bundled cluster scheme is the cluster
+owner's documented default (typically `"Default"` / `"Default Light"` /
+`"Default Dark"`) and overrides the optional host preset list. The
+dropdown still renders both `<option>` entries — visually deduplicated
+display is out of scope for the Color tab and would require a bespoke
+`<select>` widget; a duplicate name is the host's signal to rename one of
+its own preset keys.
+
+**JSON-serializable** — every `ColorScheme` MUST satisfy the same
+JSON-serializable constraint as the cluster (§4.2). The map is read at
+render time through `getPanelConfig().colorPresets`, so the standard
+Astro frontmatter → island handoff applies.
+
+**Lazy attachment via `setPanelColorPresets()`** — hosts that ship a
+large preset library can omit `colorPresets` from the SSR config blob and
+call `setPanelColorPresets(presets)` from a client-side dynamic import.
+This keeps the preset payload out of the inline
+`<script type="application/json">` and lets the bundler emit it as a
+separate JS chunk. The trailing call wins on conflict (no throw, unlike
+`configurePanel`); a host that pre-calls `setPanelColorPresets` before
+`configurePanel` is serviced via a holding slot inside `panel-config.ts`.
+
+### 4.5 Apply behaviour
+
+The contract follows `applyColorState(state, cluster)` from
+`state/tweak-state.ts`:
+
+- For each palette slot `i` in `0..cluster.paletteSize`, write
+  `cluster.paletteCssVarTemplate.replace('{n}', String(i))` ← `palette[i]`.
+- For each `(roleKey, cssName)` in `cluster.baseRoles`, write
+  `cssName` ← `palette[state[roleKey]]`. Roles absent from `baseRoles` are
+  not written.
+- For each `(semanticKey, cssName)` in `cluster.semanticCssNames`, resolve
+  `state.semanticMappings[semanticKey] ?? cluster.semanticDefaults[semanticKey]`
+  through `resolveMapping` (handles `"bg"` / `"fg"` shorthands) and write
+  `cssName` ← resolved hex.
+- `clearAppliedStyles(clusters)` removes every property the cluster could
+  have set (palette + base roles + semantic). Default wipes both primary and
+  any optional secondary cluster.
+
+### 4.6 `applyEndpoint` and `applyRouting` — panel config fields
+
+The Apply modal's button is gated on two `PanelConfig` fields:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `applyEndpoint` | `string` | URL the Apply button POSTs the flat cssVar diff to. The host's dev-API handler routes the diff to the bin. |
+| `applyRouting` | `Record<string, string>` | Map of CSS-var prefix family (without leading `--` and trailing `-`) → repo-relative source-file path. Passed to the bin via `--routing <json>` flag. |
+
+When both are set (and the routing map is non-empty), the Apply button is enabled. When either is missing, the modal still mounts so the user can preview the diff, but the action stays disabled with a tooltip.
+
+**Note:** Routing configuration is documented under §5 Apply pipeline (see §5.4) as the canonical location. The bin and the panel UI both read the same JSON file to eliminate drift hazards.
+
+---
+
+## 5. Apply pipeline
+
+The **bin server** is the reference implementation for the apply contract. When a user clicks "Apply" in the panel UI, it POSTs a flat CSS-var diff to the host's endpoint, which routes the diff to the bin, which atomically rewrites source files.
+
+### 5.1 Request & response envelopes
+
+The Apply button POSTs to `PanelConfig.applyEndpoint` with a flat JSON diff.
+
+**Request**
+
+```
+POST <applyEndpoint>
+Content-Type: application/json
+
+{
+  "tokens": {
+    "--myapp-spacing-md": "2rem",
+    "--myapp-extra-slider-length": "200px"
+  }
+}
+```
+
+The `tokens` field is mandatory and must be a JSON object with string keys (CSS custom property names, prefixed with `--`) and string values (CSS strings, no validation at the panel level).
+
+**Response 200 (success)**
+
+```json
+{
+  "ok": true,
+  "updated": [
+    {
+      "file": "src/styles/tokens.css",
+      "changed": ["--myapp-spacing-md"],
+      "unchanged": ["--myapp-spacing-lg"],
+      "unknown": []
+    }
+  ],
+  "unknownCssVars": [],
+  "unchangedCssVars": ["--myapp-spacing-lg"]
+}
+```
+
+- `ok: true` marks success.
+- `updated[]` per-file results: `file` is repo-relative, `changed[]` lists tokens that were rewritten, `unchanged[]` lists tokens found in the file but not in the diff, `unknown[]` lists tokens in the diff that don't exist in the file's `:root` block.
+- `unknownCssVars` and `unchangedCssVars` are flattened across all files for UI feedback.
+
+**Response 400 (bad request)**
+
+```json
+{
+  "ok": false,
+  "error": "<message>",
+  "rejected"?: ["--invalid-token"]
+}
+```
+
+Returned for:
+- Malformed JSON: `"Invalid JSON in request body"`
+- Body not an object: `"Request body must be a JSON object"`
+- Missing `tokens` field or not an object: `"tokens must be a JSON object"`
+- Empty tokens map: `"tokens must contain at least one entry"`
+- Invalid token names (no `--` prefix, spaces, slashes, etc.): `"..."` with optional `rejected[]` array
+- Unsupported CSS-var prefix (no route configured): `"Unsupported cssVar prefix"` with `rejected[]` listing the offending prefixes
+- Path escape attempt (`../../etc/passwd`): `"Path not allowed: <relativePath>"`
+
+**Response 403 (Forbidden)**
+
+```json
+{
+  "ok": false,
+  "error": "Origin not allowed"
+}
+```
+
+No `Access-Control-Allow-Origin` header. The bin rejects cross-origin requests.
+
+**Response 405 (Method not allowed)**
+
+Empty body, `Allow: POST, OPTIONS` header. The endpoint accepts only POST and OPTIONS.
+
+**Response 409 (Conflict)**
+
+```json
+{
+  "ok": false,
+  "error": "No top-level :root { ... } block in <file>"
+}
+```
+
+The target CSS file has no `:root` block. The bin cannot apply token overrides without one.
+
+**Response 500 (Internal server error)**
+
+```json
+{
+  "ok": false,
+  "error": "<message>",
+  "failedFile"?: "<relativePath>",
+  "restoreFailures"?: ["<file1>", "<file2>"]
+}
+```
+
+Returned for:
+- File read/parse failure: `"Failed to read or parse source file"`
+- Write failure with rollback: `"Failed to write file <file>; previously-written files were restored."` + `failedFile`
+- Rollback failure: `"Failed to write file <file>; rollback also failed for N file(s) — disk state is inconsistent. Inspect the listed files manually."` + `failedFile` + `restoreFailures[]`
+
+### 5.2 Reference implementation
+
+The bin server (`src/bin/server.ts`) inside this package is the reference for this contract. It reads `--routing <json>` at startup and exposes a Fetch API handler (`createApplyHandler` from `src/server/create-apply-handler.ts`).
+
+The handler validates every token name, routes by prefix, resolves absolute paths with sandbox checks, computes rewrites in memory, writes atomically, and responds with the exact shapes pinned above. Read the handler source as the spec.
+
+### 5.3 Implementing the contract natively (advanced)
+
+Hosts physically unable to spawn Node.js can implement the apply contract natively. The implementation must:
+
+1. **Validate token names** — reject names without `--` prefix, with spaces, slashes, or special characters.
+2. **Sanitize and route** — split each CSS-var prefix, look up the target file in the routing map, reject prefixes not in the map.
+3. **Path safety** — resolve each target path to an absolute path, verify it sits within `writeRoot`, reject path-escape attempts.
+4. **Read & parse** — load each CSS file, find the `:root { ... }` block (fail 409 if missing), parse the existing variable values.
+5. **Compute rewrite** — for each token in the diff, decide which are already present (`unchanged`), which are new (`unknown`), which are being changed (`changed`). Build the updated `:root` block.
+6. **Atomic write** — keep the original file content in memory. Write the updated content to a temp file. Atomically rename temp to target. If any write fails, restore every file written so far from the in-memory original.
+7. **Respond** — return the exact JSON envelope shapes pinned in §5.1.
+
+The panel package's source code (`src/apply/apply-token-overrides.ts`, `src/server/create-apply-handler.ts`, `src/server/path-safety.ts`) documents the exact algorithm. Native implementations should mirror it.
+
+### 5.4 Routing config — single source of truth
+
+Both the **panel UI** (`PanelConfig.applyRouting`) and the **bin** (`--routing` flag) read the same JSON file. The map is keyed by the CSS-var prefix family (without leading `--` and trailing `-`); the value is a repo-relative path to the source file the bin rewrites. See README §3.2 for invocation patterns.
+
+---
+
+## 6. Astro export contract
+
+The package exposes a second entry point, `./astro`, for Astro projects. It
+ships a single component:
+
+```astro
+---
+// astro frontmatter
+import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+import { panelConfig } from '~/lib/design-token-panel-config';
+---
+
+<DesignTokenPanelHost config={panelConfig} />
+```
+
+### 6.1 Component prop
+
+The component accepts the full `PanelConfig` from §1 as its `config` prop.
+Astro frontmatter passes the value at SSR time; the adapter serialises it into
+the rendered island (typically as a `JSON.stringify(config)` payload on a
+`data-*` attribute or inline `<script type="application/json">`) and reads it
+back at runtime to call `configurePanel(config)` before importing the panel
+module.
+
+This is the reason the JSON-serializable constraint in §4.2 is non-negotiable:
+Astro frontmatter cannot send a function across the SSR boundary.
+
+### 6.2 Lazy-load gate
+
+The host script's eager-import gate is the package's mechanism for
+keeping the panel out of the initial bundle while still re-applying
+persisted overrides on hard reload:
+
+```ts
+if (wasVisible() || hasPersistedOverrides()) {
+  void loadPanelModule();
+}
+```
+
+- `wasVisible()` reads `${storagePrefix}:visible` (the colon-form key from
+  §2). Returns `true` when the user had the panel open at last unload.
+- `hasPersistedOverrides()` probes `${storagePrefix}-state-v2`. Returns
+  `true` when the user has any saved tweaks — overrides MUST be re-applied
+  to `:root` even when the panel itself stays hidden, otherwise hard-nav
+  produces a FOUT.
+
+The gate's contract:
+
+- When neither probe is true, the adapter stays out of the initial bundle.
+- When either probe is true, the adapter is dynamically imported. Its
+  module-init side-effects re-apply persisted overrides synchronously and,
+  if `wasVisible()` was true, re-mount the Preact shell.
+- The console API (`window[consoleNamespace].showDesignPanel`,
+  `hideDesignPanel`, `toggleDesignPanel`) is installed eagerly — calling
+  them is what triggers `loadPanelModule()` for cold-start users.
+
+The gate's two probes use the storage keys derived from `panelConfig.storagePrefix`,
+not hardcoded literals. The host script (which ships from the package's
+`./astro` sub-export) reads `panelConfig.storagePrefix` and derives both
+probe keys from it.
+
+### 6.3 Astro view-transition lifecycle
+
+The adapter's existing `astro:before-swap` and `astro:page-load` listeners
+stay. They are Astro-specific and only register when `document` is available.
+The adapter MUST continue to:
+
+- `astro:before-swap` → unmount the Preact tree (`render(null, root)`),
+  remove the host node, and snapshot/restore visibility intent so the
+  remount decision survives the body swap.
+- `astro:page-load` → re-apply persisted overrides + re-materialise the
+  shell when either gate probe is true.
+
+A non-Astro host (Vite-only) gets a degraded but functional adapter: the
+soft-nav lifecycle hooks are no-ops, but the storage / mount / apply paths
+all work. The `./astro` sub-export is the only place that imports anything
+Astro-flavoured.
+
+### 6.4 Console API
+
+`configurePanel.consoleNamespace` controls the global object the package
+installs. Today's installation:
+
+```ts
+window[consoleNamespace].showDesignPanel = () => Promise<void>;
+window[consoleNamespace].hideDesignPanel = () => Promise<void>;
+window[consoleNamespace].toggleDesignPanel = () => Promise<void>;
+```
+
+Each helper lazy-imports the adapter module and forwards to its
+corresponding non-async public function (`showDesignTokenPanel`,
+`hideDesignTokenPanel`, `toggleDesignPanel`). The host script preserves
+co-existing namespace fields (e.g. `window.myapp.someOtherDevTool` from a
+sibling package); installation MUST merge into the existing namespace,
+not overwrite it.
+
+---
+
+## 7. CSS contract
+
+### 7.1 Panel-private namespace
+
+The panel ships its own bundled CSS (no Tailwind dependency in the
+consumer). The bundled stylesheets MUST declare every panel-chrome
+variable under a panel-private namespace, scoped to the panel shell +
+modal class prefix:
+
+```css
+:where(.tokenpanel-shell, [data-design-token-panel-modal]) {
+  --tokentweak-pad-md: …;
+  --tokentweak-gap-sm: …;
+  --tokentweak-text-body: …;
+  --radius-tokentweak: …;
+  /* …every panel-chrome value lives here */
+}
+```
+
+- **Naming:** `--tokentweak-*` is the only allowed prefix for panel-private
+  vars. No consumer-namespaced identifiers may appear in the panel chrome.
+  `panel.css` MUST read only `--tokentweak-*` — it MUST NOT read host
+  vars like `--color-*` or `--font-mono` directly. `panel-tokens.css` is
+  the single indirection point where host vars are consumed (see §7.4).
+- **Files:** `panel.css` (chrome layout / typography / controls) +
+  `panel-tokens.css` (the `--tokentweak-*` declarations). Both ship from
+  the package, combined into a single `dist/design-token-panel.css` by the
+  Vite library build. Vite library mode strips the source `import './styles/panel.css'`
+  from the emitted JS, so the consumer MUST import the combined stylesheet
+  exactly once on their static module graph (typically next to where they
+  mount `<DesignTokenPanelHost>`):
+
+  ```ts
+  import '@takazudo/zudo-design-token-panel/styles';
+  ```
+
+  The `./styles` sub-export (alias `./styles.css`) resolves to
+  `dist/design-token-panel.css`. Skipping the import leaves the panel JS
+  fully functional but every chrome rule missing — `.tokenpanel-shell`
+  renders with the host page's transparent background and default font, so
+  the panel appears invisible. See README §3.4 / §11 for the full rationale.
+- **No Tailwind dependency.** The package MUST build and run without
+  Tailwind in the consumer. The panel JSX uses hand-authored CSS classes
+  backed by `--tokentweak-*` vars exclusively.
+
+### 7.2 Consumer's editable tokens
+
+The tokens the panel writes to (the `cssVar` field on each `TokenDef`,
+plus the cluster's `paletteCssVarTemplate`, base-role names, and
+semantic-CSS names) are entirely consumer-controlled. Hosts pick names
+like `--myapp-spacing-hgap-md`, `--myapp-p0`, `--myapp-semantic-bg`
+themselves; the panel just writes them through `setProperty` on `:root`.
+
+The package contract is therefore:
+
+- **Read:** the panel never reads consumer CSS variables (it carries its
+  own defaults via `TokenDef.default`).
+- **Write:** the panel only writes the consumer-supplied `cssVar` strings,
+  one per overridden token, plus the cluster's palette / base / semantic
+  vars on apply.
+
+### 7.3 Modal class prefix + `data-design-token-panel-modal`
+
+`configurePanel.modalClassPrefix` controls the BEM root for every modal
+the panel owns (export, import, apply). The host picks any string and
+the panel emits classes like `${modalClassPrefix}__overlay`,
+`${modalClassPrefix}__panel`, `${modalClassPrefix}__header`, etc.
+
+**The bundled CSS keys on the data attribute, NOT on the class prefix.**
+Every modal `<dialog>` element emits `data-design-token-panel-modal=""`
+(with `data-design-token-panel-modal-variant` set to `"apply"` /
+`"export"` / `"import"`). `panel.css` anchors all modal chrome rules on
+`[data-design-token-panel-modal]` and matches sub-elements via
+`[class*='__title']`-style attribute selectors. This means a host that
+customises `modalClassPrefix` still inherits the bundled chrome —
+selecting on the literal class prefix would leave any non-default host
+with unstyled modals.
+
+The class prefix remains useful as a higher-specificity hook for hosts
+that want to layer custom rules on top of the bundled chrome.
+
+### 7.4 Host-CSS-var indirection ladder for chrome colors
+
+The panel-chrome color tokens are declared in `panel-tokens.css` as a
+`var(--host, fallback)` ladder so a host that does not define
+`--color-*` / `--font-mono` still gets a sane paint:
+
+```css
+:where(.tokenpanel-shell, [data-design-token-panel-modal]) {
+  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
+  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
+  --tokentweak-color-muted: var(--color-muted, oklch(70% 0.01 60));
+  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
+  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
+  --tokentweak-color-accent-hover: var(--color-accent-hover, oklch(55% 0.18 45));
+  --tokentweak-color-code-bg: var(--color-code-bg, oklch(17% 0.005 50));
+  --tokentweak-color-code-fg: var(--color-code-fg, oklch(87% 0.01 60));
+  --tokentweak-color-success: var(--color-success, oklch(65% 0.19 145));
+  --tokentweak-color-danger: var(--color-danger, oklch(60% 0.2 10));
+  --tokentweak-color-warning: var(--color-warning, oklch(75% 0.17 75));
+  --tokentweak-font-mono: var(--font-mono, Menlo, Monaco, Consolas, …);
+}
+```
+
+- **Public surface:** `--tokentweak-color-fg`, `--tokentweak-color-bg`,
+  `--tokentweak-color-muted`, `--tokentweak-color-surface`,
+  `--tokentweak-color-accent`, `--tokentweak-color-accent-hover`,
+  `--tokentweak-color-code-bg`, `--tokentweak-color-code-fg`,
+  `--tokentweak-color-success`, `--tokentweak-color-danger`,
+  `--tokentweak-color-warning`, `--tokentweak-font-mono`. These are
+  panel-private variables that hosts MAY override on the same scope to
+  retheme the panel chrome without touching their own `--color-*` theme.
+- **Override layers:** a host can override at the `--color-*` level
+  (cascades into the panel via the fallback ladder) or at the
+  `--tokentweak-color-*` level (panel-only, bypasses the host theme).
+- **Fallback values** are picked to be a sensible neutral dark theme so
+  the panel paints readably without any host theme declared.
+- **Invariant:** `panel.css` MUST NOT read `--color-*` or `--font-mono`
+  directly. The only legal site for those reads is the indirection
+  ladder in `panel-tokens.css`. Acceptance check:
+
+  ```bash
+  grep -n 'var(--color-' src/styles/panel.css   # → 0
+  grep -n 'var(--font-mono' src/styles/panel.css # → 0
+  ```
+
+### 7.5 Host-adapter side-effect import (paired-unit obligation)
+
+Alongside the `./styles` import (§6.1), the consumer MUST also own a side-effect import for the host-adapter, paired with `<DesignTokenPanelHost>`. The `<DesignTokenPanelHost>` component AND a sibling `<script>` block loading `@takazudo/zudo-design-token-panel/astro/host-adapter` are a single unit — both lines are required, always together.
+
+Required wiring shape (mirrors README §3.2):
+
+```astro
+<DesignTokenPanelHost config={myPanelConfig} />
+
+<script>
+  void import('@takazudo/zudo-design-token-panel/astro/host-adapter');
+</script>
+```
+
+- **Why a dynamic `void import('...')` rather than a top-level `import '...';`?** Both forms work — the package's `package.json` lists `dist/astro/host-adapter.js` in `sideEffects` so Rollup preserves consumer-side imports of the host-adapter regardless of whether the result is used. The dynamic form is the recommended canonical wiring because it loads the host-adapter chunk off the critical page-load path (mirrors the existing color-presets lazy-loader pattern) and is robust to future packaging changes that could miss-configure `sideEffects`.
+- **Why not the `./styles`-style "single import per page" pattern?** Browser caching makes the duplicated `import()` cheap (one network fetch per session), and the wrapper component is the single authoritative mount point so duplicating the import there is a non-issue.
+- **Skipping this import** leaves the JSON config payload from `<DesignTokenPanelHost>` on the page with no JS to read it, so calling `window.<consoleNamespace>.showDesignPanel()` throws `ReferenceError`. Symptom in deployed builds: silent failure, no panel chrome ever paints.
+
+The `./astro/host-adapter` sub-export points at the built `dist/astro/host-adapter.js` file plus its `.d.ts` types. Acceptance check (vitest):
+
+```bash
+pnpm --filter @takazudo/zudo-design-token-panel test -- package-exports
+```
+
+This test pins the exports-map shape against accidental edits — see `src/__tests__/package-exports.test.ts`.
+
+---
+
+## 8. Storage-key continuity & migration paths
+
+### 8.1 No default `PanelConfig`
+
+The package ships **zero** baked-in identifiers — no default storage prefix,
+no default console namespace, no default palette template, no default token
+manifest. The host MUST configure the panel explicitly via
+`<DesignTokenPanelHost config={...} />` or a direct `configurePanel({...})`
+call. A package import without an explicit configure-call surfaces a clear
+runtime error that names the missing field.
+
+### 8.2 Storage-key derivation is literal
+
+For any host's chosen `storagePrefix`, the derivation produces
+deterministic, literal-equal storage keys (see §2). Unit tests pin the
+five derived keys to literal strings so a future refactor cannot silently
+break the v1 → v2 migration path.
+
+For example, with `storagePrefix: 'myapp-design-token-panel'`:
+
+```
+myapp-design-token-panel-state-v2
+myapp-design-token-panel-state
+myapp-design-token-panel-open
+myapp-design-token-panel-position
+myapp-design-token-panel:visible
+```
+
+### 8.3 v1 → v2 in-place migration
+
+The v1 → v2 migration in `loadPersistedState` (drop the legacy flat-state
+key, re-write the unified envelope) is performed in-place per
+`storagePrefix`. A user who last opened the panel before v2 landed gets
+their old color tweaks lifted into the new envelope on first load:
+
+- v1 read key: `${storagePrefix}-state`
+- v2 write key: `${storagePrefix}-state-v2`
+
+After the rewrite, the v1 key is deleted.
+
+### 8.4 Typography-id rename map
+
+A hard-coded typography-id rename map (`text-caption` → `text-xs`, etc.,
+plus a small set of dropped legacy ids) lives inside `loadPersistedState`.
+It applies regardless of `storagePrefix`. Hosts whose token manifest does
+not use those legacy ids see no behaviour change — the map only triggers
+when matching keys appear in the persisted payload.
+
+---
+
+## 9. Out-of-scope (deferred)
+
+Items this contract deliberately does NOT pin down:
+
+- **Persist envelope shape** (`TweakState`'s `color` / `spacing` /
+  `typography` / `size` / `panelPosition` / secondary-cluster slices) —
+  frozen at the current shape so existing user state round-trips
+  without migration.
+- **Schema id versioning.** `schemaId` is a configure-time string; bumping
+  it is the host's responsibility and is out of scope for this contract.
+- **Shadow-DOM scoping.** The panel writes to `:root` only. Per-component
+  scoping is a future feature, not part of this contract.
+- **Theme-API surface.** The panel does not expose a programmatic API for
+  reading the current overrides outside the persist envelope. Hosts that
+  need that today should `JSON.parse(localStorage.getItem(state-v2-key))`.
+
+---
+
+## Appendix A — section index
+
+Cross-reference table — what each section pins down.
+
+| Topic                                                                              | Section     |
+| ---------------------------------------------------------------------------------- | ----------- |
+| `configurePanel({...})` signature and lifecycle                                    | §1          |
+| Storage-key derivation                                                             | §2, §8      |
+| `TokenManifest` / `TokenDef` / `TokenGroup` / `TokenControl` and helpers           | §3          |
+| `ColorClusterConfig` shape and `paletteCssVarTemplate` constraint                  | §4.1, §4.2  |
+| Multi-cluster (primary + secondary) resolution                                     | §4.3        |
+| `colorPresets` and `setPanelColorPresets()` lazy attachment                        | §4.4        |
+| Apply pipeline request / response envelopes                                        | §5.1        |
+| Reference-implementation algorithm + native-implementation guidance                | §5.2, §5.3  |
+| Routing config single-source                                                       | §5.4        |
+| Astro `<DesignTokenPanelHost>` prop, lazy-load gate, console API                   | §6          |
+| `--tokentweak-*` namespace and Tailwind-free CSS contract                          | §7.1        |
+| Modal class prefix and `data-design-token-panel-modal` selector contract           | §7.3        |
+| Host-CSS-var indirection ladder for chrome colors                                  | §7.4        |
+| Host-adapter side-effect import (paired-unit obligation)                           | §7.5        |
+| v1 → v2 storage migration and typography-id rename map                             | §8.3, §8.4  |
+| Out-of-scope / deferred concerns                                                   | §9          |

--- a/packages/zudo-design-token-panel/README.md
+++ b/packages/zudo-design-token-panel/README.md
@@ -1,0 +1,1026 @@
+# @takazudo/zudo-design-token-panel
+
+A live-tweak design-token panel for Astro sites. Drop a single `<DesignTokenPanelHost>` component into your layout, hand it a `PanelConfig`, and your users get an in-page UI for adjusting CSS custom properties (spacing, typography, sizing, color palette + semantic roles). Changes apply to `:root` instantly, persist to `localStorage`, and survive view transitions and hard reloads.
+
+The package is portable: every project-specific identifier is driven by the host's `PanelConfig`. Storage keys, console namespace, modal class prefix, schema id, the editable token list, and the entire color cluster (palette + semantics + scheme registry) are all configured by the consumer. Every config field is JSON-serializable so the configuration crosses the Astro frontmatter → client island boundary without losing fidelity.
+
+The authoritative API spec is [`PORTABLE-CONTRACT.md`](./PORTABLE-CONTRACT.md). This README is the consumer-oriented translation. When the two disagree, the contract wins — please file an issue against this README.
+
+---
+
+## 0. Architecture at a glance
+
+The design-token panel is a browser-based UI that writes token overrides to `:root`, with an optional **apply pipeline** for persisting those overrides back to disk source files.
+
+```
+┌─ Your dev server (Astro / Vite / any host) ──────┐
+│                                                  │
+│  Panel UI (browser)  ←─────────────────────────> │  Host adapter (side-effect import)
+│  ↓ (user tweaks)                                  │
+│  POST /apply (JSON diff)                         │  Apply endpoint (routes tokens to files)
+│  ↓                                                │
+└──────────────────────────────────────────────────┘
+         │
+         │ (HTTP)
+         ↓
+┌─ design-token-panel bin server ───────────────┐
+│ Receives POST /apply with token diff          │
+│ Validates tokens & paths                      │
+│ Rewrites source CSS files atomically          │
+│ (respects --write-root sandbox)               │
+└──────────────────────────────────────────────┘
+```
+
+The **host adapter** import (`@takazudo/zudo-design-token-panel/astro/host-adapter`) is a separate concern: it reads the inline config, installs `window.<namespace>.*`, and gates lazy-load of the panel module. The **apply pipeline** (bin server + endpoint) is optional — hosts that only want export/import omit `applyEndpoint` and `applyRouting` from `PanelConfig`.
+
+---
+
+## 1. What it is
+
+A Preact-rendered side panel that:
+
+- Reads a host-supplied **token manifest** (spacing, typography, size, color groups) and renders one row per editable token. Sliders, selects, text inputs, and pill toggles are all supported.
+- Reads a host-supplied **color cluster** (palette, base roles like `background`/`foreground`, semantic tokens like `primary`/`accent`, and a registry of named color schemes) and renders a color tab for picking schemes and tweaking palette slots / semantics.
+- Writes every override to `document.documentElement.style.setProperty(...)` against the consumer-supplied CSS-var names — so your stylesheet can be plain CSS, CSS Modules, Tailwind, or anything else.
+- Persists state to `localStorage` under a host-chosen prefix and re-applies overrides synchronously on next page load (no FOUT — this is a hard requirement of the contract).
+- Exposes a small console API (`window.<namespace>.showDesignPanel()` etc.) so a developer can pop the panel without it being mounted on every page.
+- Plugs into Astro's view-transition lifecycle (`astro:before-swap` / `astro:page-load`) so soft navigation does not double-mount the panel.
+
+The package builds against Preact (declared as a `peerDependency`) and ships its own bundled CSS scoped under the `--tokentweak-*` namespace. **It does not require Tailwind** in the consumer; see §11.
+
+> Visual: a screenshot or short capture would go here. Skipped in the v1 README — a placeholder is worse than nothing. Run any of the example apps ((§15)15) to see the panel live.
+
+---
+
+## 2. Install
+
+Install from npm. Preact is a peer dependency — bring your own copy so the panel shares one runtime with any other Preact islands you mount.
+
+```sh
+pnpm add @takazudo/zudo-design-token-panel preact
+```
+
+```jsonc
+// consumer/package.json
+{
+  "dependencies": {
+    "@takazudo/zudo-design-token-panel": "^0.1.0",
+  },
+  "peerDependencies": {
+    "preact": "^10.29.1",
+  },
+}
+```
+
+### Peer dependencies
+
+| Peer     | Range      | Why                                                                                                                                     |
+| -------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `preact` | `^10.29.1` | The panel UI is rendered with Preact. The consumer must bring its own copy so the panel and any other Preact islands share one runtime. |
+
+The package's CSS is self-contained — it ships its own bundled stylesheet under the panel-private `--tokentweak-*` namespace and does not depend on any host design-system package.
+
+---
+
+## 3. Apply pipeline (the bin)
+
+The **bin server** is the recommended — and only supported — way to apply panel tweaks back to disk. When a user clicks "Apply" in the panel UI, the token diff POSTs to your dev-API endpoint, which the bin processes atomically (all-or-nothing write, never a half-rewritten state).
+
+### 3.1 CLI usage
+
+The bin ships as an executable in the `design-token-panel` package. Start it with:
+
+```bash
+# After pnpm install, the bin is available via:
+node dist/bin/server.js \
+  --routing <routing-file.json> \
+  --write-root <dir> \
+  --allow-origin <origin> \
+  [--root <dir>] [--host <addr>] [--port <number>] [--quiet]
+
+# Or use the npm bin field:
+design-token-panel-server \
+  --routing <routing-file.json> \
+  --write-root <dir> \
+  --allow-origin <origin>
+```
+
+**Flags** (authoritative source: [`src/bin/parse-args.ts`](./src/bin/parse-args.ts)):
+
+| Flag | Required | Purpose | Example |
+|---|---|---|---|
+| `--routing` | yes | Path to JSON file mapping CSS-var prefixes → source files. See §3.2. | `./apply.routing.json` |
+| `--write-root` | yes | The single directory the bin is allowed to write into. All resolved routing paths must sit inside this tree. Absolute, or relative to `--root`. | `sub-packages/design-system` |
+| `--allow-origin` | yes (≥ 1) | Origin allowed to POST to `/apply`. Repeatable — pass once per dev origin (scheme + host + port, no trailing slash). At least one is required for any browser to apply. | `--allow-origin http://localhost:34434` |
+| `--root` | no | Repo root used as the CWD reference for routing/write-root paths. Default: the bin's current working directory. | `--root /path/to/repo` |
+| `--host` | no | Bind address. Default: `127.0.0.1` (loopback). Use `0.0.0.0` to expose on the LAN (off by default). | `--host 0.0.0.0` |
+| `--port` | no | TCP port to bind. Default: `24681`. The example apps in this repo use `24682`/`24683`/`24684` to avoid collision when running multiple bins side by side. | `--port 9876` |
+| `--quiet` | no | Suppress per-request logs. | `--quiet` |
+| `--help` / `-h` | no | Print usage and exit 0. | `--help` |
+
+The bin reads the routing JSON once at startup and does not hot-reload it. Restart the bin if you edit the routing file.
+
+### 3.2 Routing configuration
+
+Both the **panel UI** (for preview and button state) and the **bin** (for actual write) must agree on which CSS-var prefixes write to which files. The canonical way to enforce this is a shared JSON file:
+
+```json
+{
+  "myapp": "src/styles/tokens.css",
+  "myapp-extra": "src/styles/extra-tokens.css"
+}
+```
+
+The host imports this file as a static JSON module; the bin reads it via `--routing`:
+
+```ts
+// host/src/lib/panel-config.ts
+import routing from './apply.routing.json' assert { type: 'json' };
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+
+export const panelConfig: PanelConfig = {
+  // ... other fields ...
+  applyRouting: routing,  // UI uses this for routing validation + button state
+  applyEndpoint: '/api/dev/design-tokens-apply',
+};
+```
+
+```bash
+# bin invocation uses the same file
+design-token-panel-server \
+  --routing /absolute/path/to/apply.routing.json \
+  --write-root src/styles \
+  --allow-origin http://localhost:34434
+```
+
+Note: `applyEndpoint` above is the **panel UI config** — the URL the browser POSTs to (typically a dev-only API route on your host server that forwards to the bin). It is unrelated to the bin's CLI flags. The bin itself binds its own loopback HTTP listener at `--host`/`--port` and accepts POSTs from origins listed via `--allow-origin`.
+
+See [`PORTABLE-CONTRACT.md` §5.4](./PORTABLE-CONTRACT.md#54-routing-config--single-source-of-truth) for the authoritative routing schema.
+
+### 3.3 Security model
+
+The bin is **dev-only** and intended for use only on `localhost` (loopback by default):
+
+- **Loopback default:** binds to `127.0.0.1:24681` so only local requests are accepted. Token diffs are never exposed over the network by default. Override with `--host`/`--port` if needed.
+- **Sandbox (`--write-root`):** the bin enforces a strict write sandbox via the explicit `--write-root` flag. Every resolved routing path must sit inside that directory tree. Attempts to escape (`../../etc/passwd`) are rejected with a 400 and a descriptive error.
+- **Path sanitization:** every token name is validated (`--` prefix, no spaces, no slashes). Invalid names are rejected before any file I/O.
+- **Atomic writes:** computed changes are kept in memory. Only after every file is validated and computed is any file written. If a write fails partway, previously-written files are restored from the in-memory snapshot — disk cannot land in a half-rewritten state.
+
+**CORS:** the bin requires explicit `--allow-origin <origin>` (repeatable) for any browser POST to `/apply`. Each request's `Origin` header is matched **verbatim** against the configured allow-list — `http://localhost:8080` and `http://127.0.0.1:8080` are different origins, and trailing slashes matter, so pass each dev origin you actually serve from. Requests without a matching `--allow-origin` value receive a 403 with no `Access-Control-Allow-Origin` header. Same-origin requests (e.g. when host and bin share a port behind a reverse proxy) still need the origin listed; no special-case bypass exists.
+
+### 3.4 Lifecycle & signal handling
+
+The **host owns the supervisor.** The bin is a subprocess of the dev server (typically started via `concurrently` in the host's build script). When the host dev server shuts down, the bin should exit cleanly.
+
+- **SIGTERM / SIGINT:** when the host sends `SIGTERM` or `SIGINT`, the bin exits gracefully (existing connections allowed to finish, no new requests accepted).
+- **EADDRINUSE:** if the port is already bound, the bin logs a clear error and exits with code 1. The host's supervisor (e.g. `concurrently`) can then retry or escalate as configured.
+
+Example setup with `concurrently` (mirrors the canonical example-app form — see the example apps under `examples/` in this repo):
+
+```json
+{
+  "scripts": {
+    "dev": "concurrently -k -n astro,tokens-bin -c blue,green \"astro dev --port 44324\" \"design-token-panel-server --write-root . --routing ./apply.routing.json --port 24682 --allow-origin http://localhost:44324\""
+  }
+}
+```
+
+`concurrently -k` ensures that when one process exits the others are killed too, so SIGTERM propagates from the host runner to the bin.
+
+The example apps under `examples/` (Astro, Vite + React, Next.js) demonstrate this wiring live.
+
+---
+
+## 4. Consumer recipes
+
+The panel package is portable — every config field is host-supplied. Below are worked integration paths for different contexts.
+
+### 4.1 Consumer recipes — Astro
+
+Minimal end-to-end wiring — five steps, drop-in for a new Astro project.
+
+### 4.1.1 Define your panel config
+
+```ts
+// src/lib/my-panel-config.ts
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+import { myTokens } from './my-tokens';
+import { myColorCluster } from './my-color-cluster';
+
+export const myPanelConfig: PanelConfig = {
+  storagePrefix: 'myapp-design-token-panel',
+  consoleNamespace: 'myapp',
+  modalClassPrefix: 'myapp-design-token-panel-modal',
+  schemaId: 'myapp-design-tokens/v1',
+  exportFilenameBase: 'myapp-design-tokens',
+  tokens: myTokens,
+  colorCluster: myColorCluster,
+};
+```
+
+### 4.1.2 Drop the host into your layout
+
+The `<DesignTokenPanelHost>` component AND a paired `<script>` block that loads the host adapter are a **single unit** — both lines are required, always together. Do not omit the script tag.
+
+```astro
+---
+// src/layouts/Layout.astro
+import { ClientRouter } from 'astro:transitions';
+import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+import { myPanelConfig } from '../lib/my-panel-config';
+import '@takazudo/zudo-design-token-panel/styles';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <ClientRouter />
+  </head>
+  <body>
+    <slot />
+    <DesignTokenPanelHost config={myPanelConfig} />
+  </body>
+</html>
+
+<script>
+  // Required side-effect load — see §3.5 for the rationale. Use a dynamic
+  // `void import(...)` here, NOT a top-level `import '...';` statement.
+  void import('@takazudo/zudo-design-token-panel/astro/host-adapter');
+</script>
+```
+
+That is the entire integration. `<DesignTokenPanelHost>` emits a JSON `<script>` with the serialized config; the paired `<script>` block above loads the host adapter — which reads that JSON, calls `configurePanel(...)` synchronously, installs `window.myapp.{showDesignPanel, hideDesignPanel, toggleDesignPanel}`, and lazy-loads the panel module only when the user has saved overrides or opens it via the console API.
+
+### 4.1.3 Open the panel
+
+```js
+// In the browser devtools console
+window.myapp.toggleDesignPanel();
+```
+
+Or wire a hidden keyboard shortcut / dev-only button to call the same helper.
+
+### 4.1.4 Bundled CSS
+
+The package builds in Vite library mode, which extracts every CSS side-effect import from the source into a single emitted stylesheet at `dist/design-token-panel.css` and **strips the `import './styles/panel.css'` line from the emitted JS**. That means the consumer's bundler has no static reference to follow and the CSS will not arrive on its own — you MUST import the bundled stylesheet exactly once from somewhere on the consumer's static module graph (typically next to where you mount `<DesignTokenPanelHost>`):
+
+```ts
+// Astro frontmatter, Vite entry, anywhere on the static import chain
+import '@takazudo/zudo-design-token-panel/styles';
+```
+
+The `./styles` (alias `./styles.css`) sub-export resolves to `./dist/design-token-panel.css` — the single combined chrome + tokens file Vite emits at build time. `package.json` still declares `sideEffects: ["**/*.css"]` so production bundlers don't tree-shake the import away.
+
+If you skip this line, the panel's JS will still run, `window.<ns>.showDesignPanel()` will mount `#…-design-token-panel-root`, and the shell DOM will render — but with no chrome rules applied (transparent background, default page font), so it appears invisible. See §13 for further notes on bundler behaviour.
+
+### 4.1.5 Why the host-adapter import lives in your wrapper
+
+The host-adapter `<script>` block in §4.1.2 is the second half of the paired-unit contract. It must live in YOUR layout, not inside the package's `<DesignTokenPanelHost>` component.
+
+The package's distributed Astro surface ships built `dist/astro/*` files, and the package-side hoisted `<script>` from those built files does not reliably reach production page bundles — Vite/Rollup processes the import, recognizes it as resolving to a file outside the consumer's source tree, emits an empty chunk, and never links it from any page entry. Owning the host-adapter import in the consumer wrapper sidesteps that pipeline issue.
+
+The recommended form is a dynamic `void import('...')` — it loads the host-adapter chunk off the critical path (mirroring the existing color-presets lazy-loader pattern) and is robust to future packaging changes. A top-level `import '...';` also works because the package's `sideEffects` list explicitly includes `dist/astro/host-adapter.js` so Rollup preserves the import.
+
+For the regression-guard tests that pin this contract, see `package-exports.test.ts` under the package's test suite.
+
+### 4.2 Consumer recipes — any framework / Rust SSG
+
+The Astro recipe above shows the case where a host owns the config import and the host-adapter side-effect import. For non-Astro hosts (Vite SPA, Rust SSG, custom framework) the pattern is the same, just without Astro-specific syntax.
+
+**Worked example:** the example apps under [`examples/astro/`](../../examples/astro/), [`examples/vite-react/`](../../examples/vite-react/), and [`examples/next/`](../../examples/next/) prove the contract end-to-end. Each ships:
+
+- A host-side config file with deliberately different names (e.g. `--astroexample-palette-{n}`, `astroExample` namespace).
+- A routing JSON file at the example's root.
+- A bin invocation via `concurrently` in the dev script, pointing at that routing file.
+
+Copy the example's structure when porting the panel into a new host.
+
+If you are building a **Rust SSG** or other non-Node host, the bin still runs as a sidecar Node.js subprocess (started by your host's build orchestration). The same routing JSON and host-adapter setup applies — the only difference is your host ships its own config format (not TypeScript) and you invoke the bin via your build system's subprocess spawner rather than npm scripts.
+
+### 4.3 Recipe — Rust SSG (zfb)
+
+Worked example for the case where the host is a Rust dev server (e.g. [zfb / zudo-front-builder](https://github.com/Takazudo/zudo-front-builder)) rather than a Node-based runner. The bin itself is unchanged — it remains a Node.js subprocess invoked as `node path/to/dist/bin/server.js ...`. The Rust host's only job is to spawn that Node process, forward shutdown signals to it, and configure `--allow-origin` so the browser POST from the panel UI is accepted.
+
+The actual flag surface is `--routing`, `--write-root`, and `--allow-origin` (required), plus optional `--root`, `--host`, `--port`, `--quiet`. See `src/bin/parse-args.ts` for the authoritative list. **`--allow-origin` is repeatable and is required for any browser to issue the apply POST**, so pass your dev server's exact origin (scheme + host + port, no trailing slash).
+
+#### Async (preferred): `tokio::process::Command`
+
+```rust
+use std::process::Stdio;
+use tokio::process::{Child, Command};
+use tokio::signal::unix::{signal, SignalKind};
+
+async fn spawn_design_token_panel_bin() -> std::io::Result<Child> {
+    // Resolve the bin path however your host prefers — e.g. `node_modules/.bin`
+    // discovery, a config-supplied absolute path, or a fixed workspace layout.
+    let bin = "node_modules/@takazudo/zudo-design-token-panel/dist/bin/server.js";
+
+    // (Path is shown explicitly; in practice your host's npm script runner
+    // resolves the bin via the package's `bin` field and `node_modules/.bin`.)
+
+    let mut child = Command::new("node")
+        .arg(bin)
+        .arg("--routing").arg("./design-tokens.routing.json")
+        .arg("--write-root").arg("./src/styles")
+        // Repeat --allow-origin for each origin your dev UI runs on.
+        .arg("--allow-origin").arg("http://localhost:8080")
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        // Important: do NOT set `kill_on_drop(true)` here — we forward signals
+        // explicitly below so the bin can finish in-flight writes cleanly.
+        .spawn()?;
+
+    // Forward Ctrl-C / SIGTERM so the bin shuts down gracefully when the
+    // Rust dev server exits.
+    let pid = child.id().map(|p| p as i32);
+    tokio::spawn(async move {
+        let mut sigint = signal(SignalKind::interrupt()).expect("sigint handler");
+        let mut sigterm = signal(SignalKind::terminate()).expect("sigterm handler");
+        tokio::select! {
+            _ = sigint.recv() => {}
+            _ = sigterm.recv() => {}
+        }
+        if let Some(pid) = pid {
+            // SAFETY: we only signal a child we just spawned, and `kill(2)` with
+            // SIGTERM is the documented graceful-shutdown path for the bin.
+            unsafe { libc::kill(pid, libc::SIGTERM); }
+        }
+    });
+
+    Ok(child)
+}
+```
+
+#### Sync fallback: `std::process::Command`
+
+If your host is sync (no Tokio runtime), `std::process::Command` works the same way — spawn the Node process with identical args, then handle SIGINT / SIGTERM on whatever signal-handling primitive your host already uses (e.g. `ctrlc::set_handler` or a hand-rolled `signal_hook` listener), and call `libc::kill(child.id() as i32, libc::SIGTERM)` from the handler. The flag surface and lifecycle contract are identical to the async case.
+
+#### Note on origin matching
+
+`--allow-origin` is matched verbatim against the `Origin` request header — `http://localhost:8080` and `http://127.0.0.1:8080` are different origins. Pass each dev origin you actually serve from. Cross-origin POSTs without a matching `--allow-origin` value receive a 403 with no `Access-Control-Allow-Origin` header.
+
+#### Upstream tracking
+
+The zfb (zudo-front-builder) integration is documented in that project's own repository; this README is docs-only and does not require any zfb repo changes.
+
+---
+
+## 5. `configurePanel()` and the `PanelConfig` shape
+
+`configurePanel(config)` is the configure-once init. The Astro host adapter calls it for you (it reads the inline JSON config emitted by `<DesignTokenPanelHost>` and forwards it). For a non-Astro host, you would call `configurePanel(myPanelConfig)` yourself before the panel adapter is dynamically imported.
+
+```ts
+import { configurePanel, type PanelConfig } from '@takazudo/zudo-design-token-panel';
+
+configurePanel(myPanelConfig);
+```
+
+### 5.1 Behaviour
+
+- **One-shot per page lifecycle.** Calling `configurePanel` twice with identical values is a no-op. Calling it twice with different values throws — silently overwriting a previously-configured cluster mid-session is the failure mode the contract explicitly rules out.
+- **Synchronous, no I/O.** The call must be cheap enough to run inline at module init.
+- **JSON-serializable input.** Every nested field MUST round-trip through `JSON.stringify` / `JSON.parse` without loss. No function fields, no class instances, no `Symbol` keys, no `undefined`-where-`null`-is-meant. This is the hard precondition for the Astro frontmatter → client island handoff (§8).
+
+### 5.2 Field summary
+
+| Field                | Type                 | Purpose                                                                                                                                                                |
+| -------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `storagePrefix`      | `string`             | Base for every derived `localStorage` key. See §11.                                                                                                                     |
+| `consoleNamespace`   | `string`             | Global object the package installs `showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel` on (e.g. `consoleNamespace: 'myapp'` → `window.myapp.showDesignPanel`). |
+| `modalClassPrefix`   | `string`             | BEM root class for every modal the panel owns (export, import, apply). Emits `${prefix}__overlay`, `${prefix}__panel`, etc.                                            |
+| `schemaId`           | `string`             | `$schema` value emitted into export JSON and required on import.                                                                                                       |
+| `exportFilenameBase` | `string`             | Default download filename base — exports save as `${exportFilenameBase}.json`.                                                                                         |
+| `tokens`             | `TokenManifest`      | Editable design tokens grouped per-tab. See §6.                                                                                                                        |
+| `colorCluster`       | `ColorClusterConfig` | Palette + base roles + semantic table + scheme registry. See §6.                                                                                                       |
+| `colorPresets`       | `Record<string, ColorScheme>` (optional) | Optional named scheme presets surfaced in the Color tab "Scheme..." dropdown. Defaults to `{}`. See §6.5.                                              |
+
+### 5.3 Mount strategy & auto-mount
+
+The Astro entry point (`<DesignTokenPanelHost>`) handles mounting for you. Internally:
+
+- The console API (`showDesignPanel` etc.) is **always installed eagerly**, even when the panel module has not loaded — calling them is what triggers the lazy import for cold-start users.
+- The panel module is **dynamically imported on first need**: either when the user calls a console helper, OR when first-paint detects either a `${storagePrefix}:visible` flag set to `1` or any `${storagePrefix}-state-v2` payload in `localStorage`.
+- This gating keeps the panel out of the initial JS bundle for first-time visitors while still re-applying overrides on hard reload for users who have tweaked things.
+
+For a Vite-only / non-Astro host, mount it yourself by importing the adapter module after `configurePanel(...)`. See §11.5.
+
+---
+
+## 6. Token manifest schema
+
+The token manifest is the host-supplied list of editable design tokens. The panel iterates it to render rows in the spacing / typography / size / color tabs.
+
+### 6.1 `TokenDef`
+
+```ts
+export type TokenGroup = string;
+export type TokenControl = 'slider' | 'select' | 'text';
+
+export interface TokenDef {
+  /** Stable id used as the key in persisted state (e.g. `hsp-2xs`). */
+  id: string;
+  /** CSS custom property written to `:root` (e.g. `--myapp-spacing-md`). */
+  cssVar: string;
+  /** Display label shown in the panel row. */
+  label: string;
+  /** Manifest group — tab components use this for section headers. */
+  group: TokenGroup;
+  /** Default value as a CSS string (`0.125rem`, `12px`, etc.). */
+  default: string;
+  /** Slider min, in `unit`. Unused for non-slider controls. */
+  min: number;
+  /** Slider max, in `unit`. */
+  max: number;
+  /** Slider step, in `unit`. */
+  step: number;
+  /** Unit suffix (`rem`, `px`, `%`, …). May be empty for unitless tokens. */
+  unit: string;
+  /** Read-only tokens are displayed but not editable. */
+  readonly?: true;
+  /** Which control renders this token. Defaults to `'slider'` when absent. */
+  control?: TokenControl;
+  /** Select options — only used when `control === 'select'`. */
+  options?: readonly string[];
+  /** Hide behind the per-tab Advanced `<details>` disclosure. */
+  advanced?: true;
+  /** Opt-in pill toggle (e.g. for `--radius-full` 9999px sentinel). */
+  pill?: { value: string; customDefault: string };
+}
+```
+
+### 6.2 `TokenManifest`
+
+```ts
+export interface TokenManifest {
+  spacing: readonly TokenDef[];
+  typography: readonly TokenDef[];
+  size: readonly TokenDef[];
+  color: readonly TokenDef[];
+  /** Optional — group ordering & titles. Panels render in declaration order if absent. */
+  groupOrder?: {
+    spacing?: readonly TokenGroup[];
+    typography?: readonly TokenGroup[];
+    size?: readonly TokenGroup[];
+    color?: readonly TokenGroup[];
+  };
+  groupTitles?: Readonly<Record<TokenGroup, string>>;
+}
+```
+
+The four arrays are required even if some are empty. Hosts whose color tab is driven entirely by the cluster (the common case) ship `color: []` and let the cluster do the work.
+
+### 6.3 Worked example
+
+```ts
+// src/lib/my-tokens.ts
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+
+type TokenManifest = PanelConfig['tokens'];
+
+export const myTokens: TokenManifest = {
+  spacing: [
+    {
+      id: 'spacing-md',
+      cssVar: '--myapp-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'text-base',
+      cssVar: '--myapp-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [],
+  color: [],
+};
+```
+
+### 6.4 Helpers (re-exported)
+
+Three utility functions are part of the public surface — call them when authoring a manifest:
+
+| Helper              | Signature                                                                   | Purpose                                                                                                                                    |
+| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `parseNumericValue` | `(value: string) => number \| null`                                         | Strip the leading numeric portion from a CSS length string (`'1.5rem'` → `1.5`). Returns `null` for unparseable input (e.g. `clamp(...)`). |
+| `formatValue`       | `(n: number, unit: string) => string`                                       | Re-format a numeric slider value back into the stored string form (`(1.5, 'rem')` → `'1.5rem'`).                                           |
+| `buildTokenIndex`   | `(...groups: readonly (readonly TokenDef[])[]) => Record<string, TokenDef>` | Build a flat lookup keyed by `TokenDef.id`.                                                                                                |
+
+### 6.5 Empty manifest — the empty-state UI
+
+When a tab's category in `tokens` is an empty array, the panel surfaces a friendly empty-state inside that tab body instead of a blank pane:
+
+> No tokens are registered for this tab. Pass a `TokenManifest` to `configurePanel({ tokens })` — see the package README §3.
+
+This is intentionally scoped to the **spacing**, **typography**, and **size** tabs — the categories whose tab body is driven by `tokens.<category>` directly. The **color** tab is NOT covered by the empty-state branch because it is driven by `colorCluster`, not by `tokens.color`. Cluster-driven hosts deliberately ship `color: []` for that reason; surfacing the empty-state under the color tab on the strength of an empty `tokens.color` would fire on every cluster-driven host.
+
+If you want the empty-state to disappear on first integration, supply at least one `TokenDef` in the relevant category — the `<EmptyState>` only fires when the array is literally empty.
+
+### 6.6 Apply behaviour
+
+The panel walks each `TokenDef` on apply:
+
+- If `readonly`, the row is display-only — no writes.
+- If the override map has a non-empty string for `id`, the panel calls `document.documentElement.style.setProperty(t.cssVar, value)`.
+- Otherwise, the panel removes the inline property so the consumer's stylesheet default wins.
+
+The write target is always `:root`. No shadow DOM, no scoped overrides — the panel ships a global tweak intentionally.
+
+---
+
+## 7. Color cluster schema
+
+The color tab — palette + base roles + semantic table + scheme registry — is parameterized through a `ColorClusterConfig` so any host can ship a different palette size, CSS-var family, or semantic vocabulary without touching the panel internals.
+
+### 7.1 `ColorClusterConfig`
+
+```ts
+export type BaseRoleKey = 'background' | 'foreground' | 'cursor' | 'selectionBg' | 'selectionFg';
+
+export interface ColorClusterConfig {
+  /** Stable id — used for debugging / logging only. */
+  id: string;
+  /** Expected palette length. Drives init + persisted-state validation. */
+  paletteSize: number;
+  /**
+   * Palette-slot CSS var template. The panel substitutes `{n}` with the
+   * palette index at apply time.
+   *
+   *   '--myapp-palette-{n}'  →  --myapp-palette-0, --myapp-palette-1, ...
+   */
+  paletteCssVarTemplate: string;
+  /** base-role name → CSS custom-property name. A cluster MAY declare a subset. */
+  baseRoles: Partial<Record<BaseRoleKey, string>>;
+  /** Semantic token name → default palette index. */
+  semanticDefaults: Record<string, number>;
+  /** Semantic token name → CSS custom-property name. */
+  semanticCssNames: Record<string, string>;
+  /** Fallback palette indices when a scheme omits a base role. */
+  baseDefaults: Partial<Record<BaseRoleKey, number>>;
+  /** Fallback `shikiTheme` when a scheme lacks one. */
+  defaultShikiTheme: string;
+  /**
+   * Bundled scheme registry — keyed by display name. The Scheme… dropdown in
+   * the color tab lists these. Pass `{}` for clusters that don't use schemes.
+   */
+  colorSchemes: Record<string, ColorScheme>;
+  /**
+   * Panel-level scheme settings. Drives `getActiveSchemeName` and the seed
+   * scheme used by `initColorFromScheme`.
+   */
+  panelSettings: {
+    /** Scheme name to seed state from when `colorMode` is `false`. */
+    colorScheme: string;
+    /**
+     * Optional light/dark pairing. When set to an object, the panel honours
+     * `<html data-theme>` and switches schemes accordingly on init. Set to
+     * `false` to disable the light/dark UI.
+     */
+    colorMode: false | { defaultMode: 'light' | 'dark'; lightScheme: string; darkScheme: string };
+  };
+}
+
+export interface ColorScheme {
+  background: number | string;
+  foreground: number | string;
+  cursor: number | string;
+  selectionBg: number | string;
+  selectionFg: number | string;
+  palette: readonly string[]; // length must match paletteSize
+  shikiTheme: string;
+  semantic?: Record<string, number | string>;
+}
+```
+
+> **Note** — the runtime type that ships in the package source is
+> `ColorClusterDataConfig` (in `src/config/`). `ColorClusterConfig` is
+> the public-facing alias re-exported from the package root:
+> `import type { ColorClusterConfig } from '@takazudo/zudo-design-token-panel'`.
+> The two names are interchangeable.
+
+### 7.2 JSON-serializable constraint (important)
+
+**Every field on `ColorClusterConfig` MUST be JSON-serializable.** No function fields, no class instances. The Astro adapter stringifies the whole config into a `<script type="application/json">` element on the server side and `JSON.parse`s it back at runtime. Functions silently disappear under that round-trip and would surface as cryptic runtime errors.
+
+This is why the palette CSS-var name is a string template (`'--myapp-palette-{n}'`) and not a function `(i) => ...`. The panel substitutes `{n}` for the palette index by plain string replacement.
+
+### 7.3 Worked example
+
+```ts
+// src/lib/my-color-cluster.ts
+import type { ColorClusterConfig } from '@takazudo/zudo-design-token-panel';
+
+export const myColorCluster: ColorClusterConfig = {
+  id: 'myapp-cluster',
+  paletteSize: 16,
+  paletteCssVarTemplate: '--myapp-palette-{n}',
+  baseRoles: {
+    background: '--myapp-bg',
+    foreground: '--myapp-fg',
+  },
+  semanticDefaults: { primary: 1, accent: 3, surface: 0, muted: 8, danger: 5 },
+  semanticCssNames: {
+    primary: '--myapp-color-primary',
+    accent: '--myapp-color-accent',
+    surface: '--myapp-color-surface',
+    muted: '--myapp-color-muted',
+    danger: '--myapp-color-danger',
+  },
+  baseDefaults: { background: 0, foreground: 15 },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};
+```
+
+### 7.4 Apply behaviour
+
+For each palette slot `i` in `0..paletteSize`, the panel writes `paletteCssVarTemplate.replace('{n}', String(i))` ← `palette[i]`. For each declared base role, it writes the role's CSS-var ← `palette[state[roleKey]]`. For each declared semantic, it resolves the mapping (handles `'bg'`/`'fg'` shorthand) and writes the semantic CSS-var ← resolved hex.
+
+Roles absent from `baseRoles` are not written, so a minimalist cluster (just `background` + `foreground`) is fine.
+
+### 7.5 Host-supplied scheme presets — `colorPresets`
+
+The Color tab's "Scheme..." dropdown surfaces named `ColorScheme` entries. Two sources feed it:
+
+1. **`colorCluster.colorSchemes`** — the cluster's bundled scheme registry. Always present, typically holds your default scheme(s) (`"Default"`, `"Default Light"` / `"Default Dark"`).
+2. **`PanelConfig.colorPresets`** — an optional, host-supplied preset map for an additional, larger preset library. Defaults to `{}` — the package itself ships zero presets.
+
+This split exists so a host that just wants the panel for a single scheme (zero or one cluster scheme) does not pay for a long preset blob, while a host that wants to ship a "playground" of curated schemes (Dracula / Solarized / Tokyo Night / etc.) drops them into a single config field.
+
+```ts
+// src/lib/my-panel-config.ts
+import type {
+  PanelConfig,
+  ColorScheme,
+} from '@takazudo/zudo-design-token-panel/astro';
+
+const myPresets: Record<string, ColorScheme> = {
+  Dracula: {
+    background: '#282a36',
+    foreground: 7,
+    cursor: 7,
+    selectionBg: '#44475a',
+    selectionFg: '#ffffff',
+    palette: [
+      // 16 hex strings — length must match colorCluster.paletteSize
+      '#21222c',
+      '#ff5555',
+      '#50fa7b',
+      '#f1fa8c',
+      '#bd93f9',
+      '#ff79c6',
+      '#8be9fd',
+      '#f8f8f2',
+      '#6272a4',
+      '#ff6e6e',
+      '#69ff94',
+      '#ffffa5',
+      '#d6acff',
+      '#ff92df',
+      '#a4ffff',
+      '#ffffff',
+    ],
+    shikiTheme: 'dracula',
+    semantic: { primary: 4, accent: 5 },
+  },
+  // ... more presets
+};
+
+export const myPanelConfig: PanelConfig = {
+  // ... storagePrefix, tokens, colorCluster, etc.
+  colorPresets: myPresets,
+};
+```
+
+**Dropdown layout** — `<option>`s render in this order:
+
+1. The disabled `Scheme...` placeholder.
+2. Each `colorCluster.colorSchemes` entry, in insertion order.
+3. An `<hr />` separator.
+4. Each `colorPresets` entry, sorted alphabetically.
+
+**Key collision** — if a `colorPresets` key matches a `colorCluster.colorSchemes` key, the cluster scheme wins for `handleLoadPreset`. The bundled cluster scheme is the cluster owner's documented default and overrides the optional host preset list. Rename one of the keys if you want both to be selectable.
+
+**JSON-serializable** — every `ColorScheme` is plain JSON, same as the cluster (§6.2). The host-supplied preset map crosses the Astro frontmatter → island boundary as part of the serialised `PanelConfig`.
+
+> **Note on preset libraries.** The package ships zero baked-in scheme presets — the long preset blob (Dracula / Solarized / Tokyo Night / etc.) historically baked into earlier internal versions has been moved out of the package so consumers do not pay for a preset library they do not use. Hosts that want a curated preset list ship it themselves through `panelConfig.colorPresets`.
+
+---
+
+## 8. Astro wiring
+
+```astro
+---
+import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+import { myPanelConfig } from '../lib/my-panel-config';
+---
+
+<DesignTokenPanelHost config={myPanelConfig} />
+```
+
+### 8.1 The `config` prop
+
+`<DesignTokenPanelHost>` accepts the full `PanelConfig` from §6. The component renders two sibling `<script>` blocks:
+
+1. An inline `<script type="application/json" id="tokenpanel-config">` carrying `JSON.stringify(config)` (with `<` defensively escaped to `<` for HTML-parsing safety).
+2. An Astro `<script>` that imports the host adapter side-effect-style. The consumer's Astro toolchain bundles this into the page's client JS.
+
+The adapter reads the JSON, calls `configurePanel(...)`, installs the console API, and gates the lazy import.
+
+### 8.2 JSON-serializability constraint
+
+Astro stringifies props at render time. **Functions, class instances, and `undefined` values silently disappear** when the config crosses the SSR → client boundary. Always design your `PanelConfig` with `JSON.parse(JSON.stringify(config))` round-trip in mind. The biggest gotcha is the palette CSS-var template — keep it a string template (`'--myapp-palette-{n}'`), never a `(i) => ...` function.
+
+### 8.3 View-transition lifecycle
+
+When the consumer site renders Astro's `<ClientRouter />`, the panel's host adapter automatically wires:
+
+- `astro:before-swap` → unmount the Preact tree (`render(null, root)`), remove the host node, snapshot visibility intent so the remount decision survives the body swap.
+- `astro:page-load` → re-apply persisted overrides + re-materialise the shell when either the visibility flag or the persisted-overrides flag is set.
+
+No additional wiring needed in your layout beyond importing `<ClientRouter />` from `astro:transitions`.
+
+### 8.4 Where to mount
+
+The conventional placement is **at the end of `<body>`** in your shared layout. Mounting it earlier still works but the render order looks better when the panel is the last child of `<body>`.
+
+### 8.5 Non-Astro hosts (Vite-only)
+
+The `./astro` sub-export is the only place that imports anything Astro-flavoured. The package's main entry (`@takazudo/zudo-design-token-panel`) is framework-agnostic: call `configurePanel(...)` yourself, then `import('@takazudo/zudo-design-token-panel')` to materialise the panel. The `astro:before-swap` / `astro:page-load` listeners no-op outside an Astro context but the storage / mount / apply paths work identically.
+
+---
+
+## 9. Storage-key derivation
+
+`storagePrefix` is the single knob that controls every persisted key. The panel derives keys from this base at runtime.
+
+| Logical key | Derivation                  | Purpose                                                                                                                 |
+| ----------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `state-v2`  | `${storagePrefix}-state-v2` | Unified envelope (color + spacing + typography + size + panelPosition + optional secondary cluster).                    |
+| `state-v1`  | `${storagePrefix}-state`    | Legacy pre-v2 flat-state format. Migrated into `state-v2` on first load, then deleted.                                  |
+| `open`      | `${storagePrefix}-open`     | Mirror of the panel's `open` boolean (synchronous mount-time read — preserves user intent across reloads, fixes #1549). |
+| `position`  | `${storagePrefix}-position` | Drag position `{ top, right }` so the panel reappears where the user left it.                                           |
+| `visible`   | `${storagePrefix}:visible`  | Adapter-level visibility-intent flag, owned by the lazy-load gate.                                                      |
+
+For example, with `storagePrefix: 'myapp-design-token-panel'`:
+
+```
+myapp-design-token-panel-state-v2
+myapp-design-token-panel-state
+myapp-design-token-panel-open
+myapp-design-token-panel-position
+myapp-design-token-panel:visible
+```
+
+### Note: colon vs dash on the `visible` key
+
+The `visible` key uses a literal `:` separator, not `-`. Every other derived key uses `-`. This is intentional — see [`PORTABLE-CONTRACT.md`](./PORTABLE-CONTRACT.md) §2 for the historical reason. Don't try to "normalize" it; the unit tests assert this specific shape.
+
+---
+
+## 10. Console API contract
+
+Once `configurePanel` has run, the package installs three async helpers on the global `window[consoleNamespace]` object:
+
+```ts
+window.myapp.showDesignPanel(); // open the panel
+window.myapp.hideDesignPanel(); // close the panel
+window.myapp.toggleDesignPanel(); // toggle
+```
+
+All three are **async** — the first call lazy-imports the panel module. Subsequent calls share the memoised module promise and resolve synchronously after the first import completes.
+
+### Co-existing helpers on the same namespace
+
+The adapter **merges** its three helpers into any existing object at `window[namespace]` rather than overwriting the namespace wholesale. This means a host can share a namespace between multiple dev tools (e.g. `window.myapp.ogpDebug.show()` from a separate package, alongside `window.myapp.showDesignPanel()` from this one) without collisions.
+
+### Default
+
+There is no default `consoleNamespace` exposed to consumers — the field is required on `PanelConfig`. Pick a short, unambiguous string (typically your app's slug).
+
+---
+
+## 11. Tailwind not required
+
+The panel ships its own bundled CSS scoped under a panel-private namespace:
+
+```css
+:where(.tokenpanel-shell, [data-design-token-panel-modal]) {
+  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
+  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
+  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
+  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
+  --tokentweak-font-mono: var(--font-mono, Menlo, Monaco, Consolas, …);
+  --tokentweak-pad-md: …;
+  --tokentweak-gap-sm: …;
+  --tokentweak-text-body: …;
+  --radius-tokentweak: …;
+  /* …one custom property per panel-chrome value */
+}
+```
+
+- **Naming:** every panel-private CSS variable uses the `--tokentweak-*` prefix. Consumer-namespaced identifiers do not appear in the panel chrome — `panel.css` reads only `--tokentweak-*`.
+- **Files:** `panel.css` (chrome layout / typography / controls) + `panel-tokens.css` (the `--tokentweak-*` declarations). Both ship from the package and the consumer pulls them in via `sideEffects`.
+- **No Tailwind dependency in the consumer.** The panel chrome uses hand-authored CSS classes backed by `--tokentweak-*` variables. You can integrate the panel into a Tailwind site, a CSS Modules site, a vanilla CSS site, or anything in between.
+
+### 11.1 Two-layer override model for chrome colors
+
+The panel-chrome color tokens (`--tokentweak-color-fg`, `--tokentweak-color-bg`, `--tokentweak-color-muted`, `--tokentweak-color-surface`, `--tokentweak-color-accent`, `--tokentweak-color-accent-hover`, `--tokentweak-color-code-bg`, `--tokentweak-color-code-fg`, `--tokentweak-color-success`, `--tokentweak-color-danger`, `--tokentweak-color-warning`, `--tokentweak-font-mono`) are declared as a `var(--host, fallback)` ladder. This gives hosts two override layers and works out-of-the-box when neither is supplied:
+
+| Host declares | Outcome |
+|---|---|
+| Nothing | Built-in fallback paints the panel (a sensible neutral dark theme). |
+| `--color-fg` (and friends) at `:root` | Host theme cascades into the panel — no panel-side change needed. |
+| `--tokentweak-color-fg` directly | Panel-only override that bypasses the host's `--color-*` theme. Useful when you want the panel to look different from your site shell (e.g., a brand-neutral inspector overlay). |
+
+Because the fallback ladder is host-CSS-var-driven, a brand-new consumer can mount the panel without declaring any `--color-*` tokens and still get readable chrome.
+
+The CSS variables the panel **writes to** (the `cssVar` field on each `TokenDef`, the cluster's `paletteCssVarTemplate`, base-role names, and semantic CSS names) are entirely consumer-controlled. The package never reads those consumer CSS variables; it only writes through `setProperty` on `:root`.
+
+---
+
+## 12. Bundler notes
+
+The package builds in **Vite library mode**, which has a quirk that's important to understand: it extracts every `import './something.css'` from the source and emits a single combined stylesheet (`dist/design-token-panel.css`), but **removes the import statements from the emitted JS files**. The `dist/index.js` and `dist/astro/host-adapter.js` therefore have no static reference back to the CSS — `sideEffects: ["**/*.css"]` in `package.json` only protects existing imports from tree-shaking; it cannot resurrect an import the build step has already deleted.
+
+Net effect: the consumer MUST add a one-line side-effect import to their static module graph, as described in §3.4. The `./styles` sub-export is the canonical entry:
+
+```ts
+import '@takazudo/zudo-design-token-panel/styles';
+```
+
+`./styles.css` is provided as an alias for clarity in tooling that prefers explicit extensions:
+
+```ts
+import '@takazudo/zudo-design-token-panel/styles.css';
+```
+
+If you forget the import, the JS layer still works — `window.<ns>.showDesignPanel()` mounts the shell DOM correctly — but every chrome rule is missing, so the panel appears invisible against the host page background. The fix is the import, not bundler reconfiguration.
+
+(Historical note: an earlier draft of this section claimed `sideEffects` alone was sufficient and consumers did not need to import CSS. That was incorrect — Vite library mode's CSS-extraction behaviour means `sideEffects` is necessary but not sufficient. The §3.4 + this section now reflect the actual contract.)
+
+### 12.1 Host-adapter side-effect import (paired-unit contract)
+
+The package's distributed Astro surface ships built `dist/astro/*` files. The host-adapter (`dist/astro/host-adapter.js`) is the runtime that reads the inline JSON config emitted by `<DesignTokenPanelHost>` and installs `window.<consoleNamespace>.*`. Earlier package versions emitted a hoisted `<script>import './host-adapter';</script>` block from inside `DesignTokenPanelHost.astro` to load it; that block did not reliably reach production page bundles — Vite/Rollup processed the import, recognized it as resolving to a sibling JS file outside the consumer's source tree, emitted an empty chunk, and never linked it from any page entry.
+
+For consumer-side imports, the package's `package.json` lists `dist/astro/host-adapter.js` in the `sideEffects` array so Rollup preserves the import even when its result is discarded (the host adapter has top-level execution that registers the console API — Rollup's tree-shaker has no way to know that without the metadata hint).
+
+Net effect: the consumer MUST own the host-adapter import in their wrapper layout. Use the dynamic `void import('...')` form below — it loads the host-adapter chunk off the critical path (mirrors the existing color-presets lazy-loader) and is robust to future packaging changes that could miss-configure `sideEffects`. A top-level `import '...';` works too with the current `sideEffects` list, but the dynamic form is the recommended canonical wiring.
+
+```astro
+<script>
+  void import('@takazudo/zudo-design-token-panel/astro/host-adapter');
+</script>
+```
+
+This is the second half of the paired-unit contract from §3.2 (`<DesignTokenPanelHost>` AND the host-adapter `<script>` block — always together). If you forget it, the `<DesignTokenPanelHost>` JSON config payload still ships, but no JS reads it, so calling `window.<consoleNamespace>.showDesignPanel()` throws `ReferenceError`.
+
+For the regression-guard tests that pin this contract, see `package-exports.test.ts` under the package's test suite.
+
+---
+
+## 13. Troubleshooting
+
+### 13.1 FOUT (flash of unstyled tokens) on hard navigation
+
+**Symptom:** on first paint after a hard reload, the page renders with the consumer's default token values for a beat before snapping to the user's saved overrides.
+
+**Resolution:** the host adapter eagerly re-applies persisted overrides during the lazy-load gate (probes `${storagePrefix}-state-v2` and `${storagePrefix}:visible` synchronously from `localStorage`). If you still see a flash, your `<DesignTokenPanelHost>` is being rendered too late in the document (e.g. inside a deferred island) — move it to the layout's `<body>` and verify the inline `<script type="application/json" id="tokenpanel-config">` is in the initial HTML.
+
+### 13.2 Auto-mount race on first reload
+
+**Symptom:** the panel does not re-open on the first reload after the user closed it, even though `${storagePrefix}-open` is set in `localStorage`.
+
+**Resolution:** the open boolean is mirrored to `localStorage` synchronously and read at mount time so the next mount opens directly into the user's last state without a post-render toggle dispatch. If the symptom persists, confirm the storage key matches what the contract derives (§8) and that nothing else in the page is clearing the key on load.
+
+### 13.3 Live-apply regression test approach
+
+**Symptom:** after a panel-package change, you want to confirm the live-apply pipeline (storage → adapter → `:root`) is unbroken end-to-end.
+
+**Resolution:** the canonical regression test is each example app's `apply-roundtrip.spec.ts` Playwright spec under `examples/<framework>/tests/e2e/`. It boots the example's preview build, seeds a v2 state under the example's storage prefix, hard-reloads, and asserts the adapter rehydrated and applied the override against the example's palette and semantic CSS variable names. The contract: storage prefix, palette template, semantic CSS names — change one of those and this spec fails first.
+
+---
+
+## 14. Migration recipe — adopting the panel into an existing consumer
+
+This recipe walks through wiring the panel into a project that does not currently use it. If you previously consumed an internal pre-OSS snapshot of the panel where storage keys, console namespace, modal class prefix, and cluster identifiers were hardcoded literals, the same steps apply — your job is to lift those literals into a `PanelConfig` value.
+
+1. **Install the package.**
+
+   ```sh
+   pnpm add @takazudo/zudo-design-token-panel preact
+   ```
+
+2. **Define your `PanelConfig` literals.**
+
+   Pick identifiers for `storagePrefix`, `consoleNamespace`, `modalClassPrefix`, `schemaId`, `exportFilenameBase`, and your palette CSS-var family (`paletteCssVarTemplate`). Pull these into a host-side config file (e.g. `src/lib/panel-config.ts`). If you are migrating from an internal snapshot fork and want to preserve users' saved state across the migration, keep the legacy values verbatim; otherwise pick fresh, neutral identifiers (e.g. `myapp-design-token-panel`).
+
+3. **Author your token manifest in the host project.**
+
+   The package itself ships zero baked-in manifest data. Define `SPACING_TOKENS`, `FONT_TOKENS`, `SIZE_TOKENS`, `COLOR_TOKENS` (or whatever names you prefer) in your project and wire them up as `tokens.spacing`, `tokens.typography`, `tokens.size`, `tokens.color`. The host is the source of truth.
+
+4. **Author your color cluster in the host project.**
+
+   Build a `ColorClusterConfig` value with your palette, base roles, semantic table, and scheme registry. **The palette CSS-var name MUST be a string template, not a function:**
+
+   ```ts
+   // wrong (function — does not survive Astro frontmatter → island handoff)
+   // paletteCssVar: (i) => `--myapp-p${i}`,
+
+   // right (string template, JSON-serializable)
+   paletteCssVarTemplate: '--myapp-p{n}',
+   ```
+
+   Every other field on the cluster is a plain value already.
+
+5. **Drop `<DesignTokenPanelHost>` into your layout.**
+
+   ```astro
+   ---
+   import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+   import { myPanelConfig } from '../lib/panel-config';
+   ---
+
+   <DesignTokenPanelHost config={myPanelConfig} />
+   ```
+
+   The host adapter does the rest (calls `configurePanel`, installs the console API, gates lazy-load). Don't forget the paired host-adapter `<script>` block — see §4.1.2.
+
+6. **Verify storage keys derive to the expected literals.**
+
+   Open devtools → Application → Local Storage. Confirm you see keys derived under your `storagePrefix` and that any pre-existing user state (under the legacy prefix, if you preserved it) is migrated forward through the v1 → v2 path on first load.
+
+7. **Run the live-apply e2e spec.**
+
+   Use any of the example apps' Playwright spec under `examples/<framework>/tests/e2e/apply-roundtrip.spec.ts` as a template: seed a `${storagePrefix}-state-v2` payload, hard-reload, assert your palette and semantic CSS variables on `:root` reflect the seeded values.
+
+For edge cases hit during the migration, see CONTRIBUTING and the doc-site reference pages for each `PanelConfig` field.
+
+---
+
+## 15. Worked examples
+
+The canonical worked examples live under [`examples/`](../../examples/) at the repo root. Three independent consumer apps demonstrate the panel across different host frameworks:
+
+- [`examples/astro/`](../../examples/astro/) — Astro + Preact island consumer. Uses `storagePrefix: 'astro-example-tokens'`, `consoleNamespace: 'astroExample'`, `paletteCssVarTemplate: '--astroexample-palette-{n}'`.
+- [`examples/vite-react/`](../../examples/vite-react/) — Vite + React consumer (panel mounted as a Preact island, React tree untouched). Uses the `viteReactExample` namespace.
+- [`examples/next/`](../../examples/next/) — Next.js (App Router) + React consumer, panel as a `'use client'` boundary. Uses the `nextExample` namespace.
+
+Each example renders a tiny page with cards, buttons, and palette swatches whose styles reference its own demo CSS variables, so panel tweaks update the page in real time. Each ships a Playwright spec at `tests/e2e/apply-roundtrip.spec.ts` that asserts the live-apply pipeline.
+
+To run any example locally:
+
+```sh
+pnpm install
+pnpm --filter @takazudo/zudo-design-token-panel build
+pnpm --filter astro-example dev
+# open http://localhost:44324
+# in devtools console: window.astroExample.toggleDesignPanel()
+```
+
+Use the closest example as a copy-paste template when wiring the panel into your own project — they are the smallest end-to-end consumers that exercise every contract surface.

--- a/packages/zudo-design-token-panel/package.json
+++ b/packages/zudo-design-token-panel/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@takazudo/zudo-design-token-panel",
+  "version": "0.0.0",
+  "description": "Dynamic design-token tweak panel — host-config-driven, framework-agnostic Preact UI.",
+  "private": false,
+  "license": "MIT",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Takazudo/zudo-design-token-panel.git"
+  },
+  "homepage": "https://github.com/Takazudo/zudo-design-token-panel",
+  "bugs": {
+    "url": "https://github.com/Takazudo/zudo-design-token-panel/issues"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": [
+    "**/*.css",
+    "./dist/astro/host-adapter.js",
+    "**/host-adapter.js"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./astro": {
+      "types": "./dist/astro/index.d.ts",
+      "import": "./dist/astro/index.js"
+    },
+    "./astro/host-adapter": {
+      "types": "./dist/astro/host-adapter.d.ts",
+      "import": "./dist/astro/host-adapter.js"
+    },
+    "./astro/DesignTokenPanelHost.astro": "./dist/astro/DesignTokenPanelHost.astro",
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./styles": "./dist/design-token-panel.css",
+    "./styles.css": "./dist/design-token-panel.css"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build && tsc -p tsconfig.build.json && node scripts/copy-astro-assets.mjs",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "preact": "^10.29.1"
+  },
+  "devDependencies": {
+    "preact": "^10.29.1",
+    "typescript": "^5.6.0",
+    "vite": "^7.3.2",
+    "vitest": "^4.1.4"
+  }
+}

--- a/packages/zudo-design-token-panel/package.json
+++ b/packages/zudo-design-token-panel/package.json
@@ -37,12 +37,8 @@
       "import": "./dist/astro/host-adapter.js"
     },
     "./astro/DesignTokenPanelHost.astro": "./dist/astro/DesignTokenPanelHost.astro",
-    "./server": {
-      "types": "./dist/server/index.d.ts",
-      "import": "./dist/server/index.js"
-    },
-    "./styles": "./dist/design-token-panel.css",
-    "./styles.css": "./dist/design-token-panel.css"
+    "./styles": "./dist/zudo-design-token-panel.css",
+    "./styles.css": "./dist/zudo-design-token-panel.css"
   },
   "files": [
     "dist"
@@ -57,6 +53,8 @@
     "preact": "^10.29.1"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "jsdom": "^25.0.0",
     "preact": "^10.29.1",
     "typescript": "^5.6.0",
     "vite": "^7.3.2",

--- a/packages/zudo-design-token-panel/scripts/copy-astro-assets.mjs
+++ b/packages/zudo-design-token-panel/scripts/copy-astro-assets.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Postbuild step.
+ *
+ * Vite lib mode does not compile .astro files. The package's exports map
+ * points `./astro` at `dist/astro/index.js`, whose re-export
+ * (`export { default as DesignTokenPanelHost } from './DesignTokenPanelHost.astro'`)
+ * is left as a literal because `vite.config.ts` marks `*.astro` external.
+ *
+ * This script copies the raw `.astro` source alongside the emitted JS so
+ * the consumer's Astro toolchain can resolve the relative import at build
+ * time.
+ *
+ * The sibling `dist/astro/host-adapter.js` file emitted by the Vite library
+ * build is part of the package's public surface — exposed via the
+ * `./astro/host-adapter` entry in the exports map and consumed via a
+ * `<script>import` line in the consumer's wrapper layout.
+ *
+ * Kept dependency-free on purpose — no `shx`, `cpy`, or
+ * `vite-plugin-static-copy`. Build dependency surface stays small.
+ */
+
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+
+const assets = [
+  {
+    src: join(root, 'src/astro/DesignTokenPanelHost.astro'),
+    dest: join(root, 'dist/astro/DesignTokenPanelHost.astro'),
+  },
+];
+
+for (const { src, dest } of assets) {
+  if (!existsSync(src)) {
+    console.error(`[zudo-design-token-panel] copy-astro-assets: missing source ${src}`);
+    process.exit(1);
+  }
+  mkdirSync(dirname(dest), { recursive: true });
+  copyFileSync(src, dest);
+  console.log(`[zudo-design-token-panel] Copied ${src} -> ${dest}`);
+}

--- a/packages/zudo-design-token-panel/src/__tests__/_test-helpers.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/_test-helpers.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared test helpers for the design-token panel package.
+ *
+ * The package itself ships an empty stub cluster + manifest as the
+ * fallback `DEFAULT_PANEL_CONFIG`, so tests that exercise color-state /
+ * persistence / serde paths need to configure a non-empty cluster before
+ * the helpers under test will accept their fixtures.
+ *
+ * `installFixturePanelConfig()` wires a 16-slot palette cluster + a small
+ * spacing / typography / size manifest that mirrors what most tests in this
+ * suite expect. Call it from `beforeEach` AFTER `__resetPanelConfigForTests()`.
+ */
+
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  type PanelConfig,
+} from '../config/panel-config';
+import type { ColorClusterDataConfig } from '../config/cluster-config';
+import type { TokenManifest, TokenDef } from '../tokens/manifest';
+
+/**
+ * 16-slot test cluster with the historical zd-style palette template. The
+ * specific CSS-var template / id are arbitrary — what matters for state
+ * validation is `paletteSize: 16`.
+ */
+export const FIXTURE_CLUSTER: ColorClusterDataConfig = {
+  id: 'fixture',
+  label: 'Fixture',
+  paletteSize: 16,
+  baseRoles: {},
+  paletteCssVarTemplate: '--fixture-p{n}',
+  semanticDefaults: { accent: 6, muted: 8, active: 14 },
+  semanticCssNames: {
+    accent: '--fixture-semantic-accent',
+    muted: '--fixture-semantic-muted',
+    active: '--fixture-semantic-active',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+    cursor: 6,
+    selectionBg: 0,
+    selectionFg: 15,
+  },
+  defaultShikiTheme: 'dracula',
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false },
+};
+
+const SPACING_TOKENS: readonly TokenDef[] = [
+  {
+    id: 'hsp-md',
+    cssVar: '--zd-spacing-hgap-md',
+    label: 'hsp-md',
+    group: 'hsp',
+    default: '40px',
+    min: 0,
+    max: 64,
+    step: 1,
+    unit: 'px',
+  },
+  {
+    id: 'vsp-sm',
+    cssVar: '--zd-spacing-vgap-sm',
+    label: 'vsp-sm',
+    group: 'vsp',
+    default: '16px',
+    min: 0,
+    max: 64,
+    step: 1,
+    unit: 'px',
+  },
+];
+
+const TYPOGRAPHY_TOKENS: readonly TokenDef[] = [
+  {
+    id: 'text-base',
+    cssVar: '--zd-font-base-size',
+    label: 'text-base',
+    group: 'main',
+    default: '1.4rem',
+    min: 0.5,
+    max: 4,
+    step: 0.05,
+    unit: 'rem',
+  },
+];
+
+const SIZE_TOKENS: readonly TokenDef[] = [
+  {
+    id: 'radius-lg',
+    cssVar: '--radius-lg',
+    label: 'radius-lg',
+    group: 'radius',
+    default: '8px',
+    min: 0,
+    max: 32,
+    step: 1,
+    unit: 'px',
+  },
+];
+
+export const FIXTURE_MANIFEST: TokenManifest = {
+  spacing: SPACING_TOKENS,
+  typography: TYPOGRAPHY_TOKENS,
+  size: SIZE_TOKENS,
+  color: [],
+};
+
+export const FIXTURE_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'zudo-design-token-panel',
+  consoleNamespace: 'zudo',
+  modalClassPrefix: 'zudo-design-token-panel-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'zudo-design-tokens',
+  tokens: FIXTURE_MANIFEST,
+  colorCluster: FIXTURE_CLUSTER,
+  secondaryColorCluster: null,
+  colorPresets: {},
+};
+
+/**
+ * Reset and re-configure the panel-config singleton for a test. Call from
+ * `beforeEach` so each test starts from a known state.
+ */
+export function installFixturePanelConfig(overrides: Partial<PanelConfig> = {}): void {
+  __resetPanelConfigForTests();
+  configurePanel({ ...FIXTURE_PANEL_CONFIG, ...overrides });
+}

--- a/packages/zudo-design-token-panel/src/__tests__/auto-mount-on-visibility.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/auto-mount-on-visibility.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression test for the auto-mount-with-visibility-flag pre-mount-seed
+ * pattern.
+ *
+ * Repro recipe:
+ *
+ *   1. localStorage.setItem('<storagePrefix>:visible', '1');
+ *   2. (Do NOT touch the OPEN_KEY — leave it absent.)
+ *   3. Hard reload.
+ *   4. Expected: panel auto-mounts visibly.
+ *      Actual (pre-fix): panel does not auto-mount; user has to call
+ *      `window.<consoleNamespace>.showDesignPanel()` manually each time.
+ *
+ * Root cause: `ensureMounted()` renders the Preact shell, then
+ * `showDesignTokenPanel` used to call `dispatchToggleAfterMount()`, which
+ * queued the toggle event on the microtask queue. But `panel.tsx` registers
+ * its toggle listener inside a `useEffect`, and Preact flushes effects via
+ * `requestAnimationFrame`. The microtask drained long before the next
+ * animation frame, so the dispatched event landed before the listener
+ * attached, and the panel stayed closed.
+ *
+ * When the user had previously opened-then-closed the panel, OPEN_KEY=='1'
+ * had been written by panel.tsx; the mount-effect would then read that key
+ * and set `open=true` directly, masking the dispatch race. The bug only
+ * surfaced when visibility was set without OPEN_KEY.
+ *
+ * Fix (`seedOpenStateBeforeMount` in index.tsx): on a fresh mount, write
+ * OPEN_KEY synchronously *before* calling `render`. `panel.tsx`'s
+ * mount-effect then reads the seeded value and sets `open` correctly —
+ * no event dispatch, no rAF dependency.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getOpenKey } from '../state/tweak-state';
+import {
+  __resetPanelConfigForTests,
+  getPanelConfig,
+  panelRootId,
+  storageKey_visible,
+} from '../config/panel-config';
+
+// Derived under the default config — under the package's documented
+// neutral defaults these MUST match the literals below (see
+// panel-config.test.ts for the explicit literal assertions).
+const STORAGE_KEY_VISIBLE = storageKey_visible(getPanelConfig());
+const PANEL_ROOT_ID = panelRootId(getPanelConfig());
+
+// Sanity-check the literal contract directly here too, so a future config
+// drift surfaces in this test file before the e2e behavioural assertions
+// even run.
+if (STORAGE_KEY_VISIBLE !== 'zudo-design-token-panel:visible') {
+  throw new Error(`STORAGE_KEY_VISIBLE drifted: ${STORAGE_KEY_VISIBLE}`);
+}
+if (PANEL_ROOT_ID !== 'zudo-design-token-panel-root') {
+  throw new Error(`PANEL_ROOT_ID drifted: ${PANEL_ROOT_ID}`);
+}
+
+/** Tag used in the panel header — see panel.tsx. */
+const OPEN_PANEL_HEADER_TEXT = 'Design Tokens';
+
+/**
+ * Wait until Preact has flushed pending effects. Preact uses
+ * `requestAnimationFrame` to flush effects (with a `setTimeout(35)` fallback
+ * inside `w`), so we wait long enough for either path to fire and then yield
+ * to any further microtasks.
+ */
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  // One macrotask tick after the rAFs to let any setTimeout(0) fallbacks run.
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+describe('design-token-panel adapter — auto-mount with visibility flag', () => {
+  beforeEach(() => {
+    // Fresh DOM + storage between tests. Vitest's jsdom env shares one window
+    // per test file by default, so we need to reset state explicitly.
+    __resetPanelConfigForTests();
+    localStorage.clear();
+    document.body.innerHTML = '';
+    // Drop adapter and module caches so the top-level bootstrap re-runs in
+    // each test. Both window slots are cleared because `host-adapter.ts`
+    // owns `__zudoDesignTokenPanelAdapter` (per-storagePrefix map) and
+    // `index.tsx` owns `__zudoDesignTokenPanelLifecycle` (panel module bind
+    // flag). Either could leak into the next test if not reset.
+    const adapterWin = window as unknown as Record<string, unknown>;
+    delete adapterWin.__zudoDesignTokenPanelAdapter;
+    delete adapterWin.__zudoDesignTokenPanelLifecycle;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('renders open panel content when STORAGE_KEY is set without OPEN_KEY', async () => {
+    // Set up the canonical bug repro: visibility=1, OPEN_KEY absent.
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+    expect(localStorage.getItem(getOpenKey())).toBeNull();
+
+    // Use vi.resetModules + dynamic import so the adapter's top-level
+    // bootstrap runs cleanly. We also import inside the test to avoid the
+    // module-init side effects firing at file evaluation time (which would
+    // happen before our beforeEach storage setup).
+    const { showDesignTokenPanel } = await import('../index');
+
+    // The adapter's module-init bootstrap calls `reapplyFromStorage`, which
+    // calls `showDesignTokenPanel` internally when wasVisible() is true. But
+    // since the import is async and runs once per test process (vitest
+    // re-imports between tests via cache reset only when configured), we
+    // call `showDesignTokenPanel` explicitly to make the test independent of
+    // import timing. The fix path is the same either way.
+    showDesignTokenPanel();
+
+    // The panel root must be appended.
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root).not.toBeNull();
+
+    // Primary user-observable assertion: after Preact flushes the
+    // mount-effect, `panel.tsx` must render its open content (the "Design
+    // Tokens" header is the easiest unique sentinel). Without the fix,
+    // `panel.tsx` reads OPEN_KEY at mount-time, sees it absent, and stays at
+    // `open=false` — which renders `null`, leaving the root empty.
+    await waitForEffectFlush();
+    expect(root!.textContent ?? '').toContain(OPEN_PANEL_HEADER_TEXT);
+
+    // Implementation contract: the fix path seeds OPEN_KEY before mount.
+    // Asserted separately so a future change that drives the panel open via
+    // a different mechanism would still pass the user-observable check above
+    // but flag this assertion as needing the comment above to be revisited.
+    expect(localStorage.getItem(getOpenKey())).toBe('1');
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/clamp-position.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/clamp-position.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for PR #1440 review item B2 — `clampPosition` `panelHeight`
+ * tautology bug, plus the codex-review follow-up that caught a symmetric-fix
+ * UX regression.
+ *
+ * The pre-fix code had:
+ *
+ *   const minTop = -(VISIBLE_MIN / 2);
+ *   const maxTop = Math.max(window.innerHeight - VISIBLE_MIN, panelHeight > 0 ? 0 : 0);
+ *
+ * `panelHeight > 0 ? 0 : 0` was a tautology — both branches yielded 0 — so
+ * `panelHeight` was effectively dead code on the upper bound. The original
+ * lower-bound `-(VISIBLE_MIN / 2)` was correct in spirit (kept the header
+ * visible) but the code looked broken because of the tautology and the
+ * unused parameter.
+ *
+ * The first fix attempt mirrored the horizontal axis symmetrically:
+ *
+ *   const minTop = -(panelHeight - VISIBLE_MIN);
+ *   const maxTop = window.innerHeight - VISIBLE_MIN;
+ *
+ * That looked right in isolation but introduced a UX regression — the drag
+ * handle is the panel header (`panel.tsx` attaches `onMouseDown` to
+ * `.tokenpanel-header`), which sits at the top of the panel. With the
+ * symmetric lower bound, an upward drag could push the entire header above
+ * the viewport, leaving only the footer visible and the panel ungrippable.
+ *
+ * The shipped fix preserves the original lower-bound policy (header stays
+ * visible) but removes the tautology and uses the simpler `maxTop`:
+ *
+ *   const minTop = -(VISIBLE_MIN / 2);
+ *   const maxTop = window.innerHeight - VISIBLE_MIN;
+ *
+ * `panelHeight` stays on the signature so callers don't churn, but is
+ * currently unused on the vertical axis (the panel is CSS-clamped to the
+ * viewport via `maxHeight: calc(100vh - 32px)` so a "tall panel" carve-out
+ * isn't needed today).
+ *
+ * These tests pin the asymmetric vertical clamp + the symmetric horizontal
+ * clamp.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { clampPosition, VISIBLE_MIN } from '../state/tweak-state';
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+const ORIGINAL_INNER_HEIGHT = window.innerHeight;
+
+function setViewport(w: number, h: number): void {
+  // jsdom allows direct assignment to window.innerWidth / innerHeight, but
+  // some environments require a configurable property descriptor. Wrap in
+  // Object.defineProperty so this works under both.
+  Object.defineProperty(window, 'innerWidth', { value: w, configurable: true });
+  Object.defineProperty(window, 'innerHeight', { value: h, configurable: true });
+}
+
+describe('clampPosition', () => {
+  beforeEach(() => {
+    setViewport(1024, 768);
+  });
+
+  afterEach(() => {
+    setViewport(ORIGINAL_INNER_WIDTH, ORIGINAL_INNER_HEIGHT);
+  });
+
+  it('returns positions inside the legal range unchanged', () => {
+    const result = clampPosition(100, 50, 600, 500);
+    expect(result).toEqual({ top: 100, right: 50 });
+  });
+
+  it('clamps top to maxTop = innerHeight - VISIBLE_MIN', () => {
+    // Try to push the panel below the bottom edge — clamp to the maximum
+    // (so 60px of the panel-top, including the header, stays visible).
+    const result = clampPosition(99999, 0, 600, 500);
+    expect(result.top).toBe(window.innerHeight - VISIBLE_MIN);
+  });
+
+  it('clamps top to minTop = -(VISIBLE_MIN / 2) — keeps the header reachable', () => {
+    // Try to push the panel above the top edge — clamp to a small upward
+    // overshoot so the header (the only drag handle) stays visible.
+    // Symmetric mirroring of the horizontal axis would let the header
+    // leave the viewport entirely; that's the regression codex flagged in
+    // the review of the first B2 fix attempt.
+    const result = clampPosition(-99999, 0, 600, 500);
+    expect(result.top).toBe(-(VISIBLE_MIN / 2));
+  });
+
+  it('clamps right symmetrically on the horizontal axis (panelWidth scales the lower bound)', () => {
+    // Maximum: panel can be pushed past the left edge but VISIBLE_MIN must
+    // remain visible.
+    const farLeft = clampPosition(0, 99999, 600, 500);
+    expect(farLeft.right).toBe(window.innerWidth - VISIBLE_MIN);
+    // Minimum: panel can be pushed past the right edge by panelWidth -
+    // VISIBLE_MIN. The horizontal axis IS symmetric because the header
+    // spans the full panel width — any leftover horizontal slice contains
+    // a draggable strip of the header.
+    const farRight = clampPosition(0, -99999, 600, 500);
+    expect(farRight.right).toBe(-(600 - VISIBLE_MIN));
+  });
+
+  it('vertical lower bound does NOT depend on panelHeight (regression for B2 + codex review follow-up)', () => {
+    // Both a tall and a short panel land at the same minTop = -(VISIBLE_MIN/2).
+    // The asymmetry with the horizontal axis is intentional: header-as-drag-
+    // handle means we can't mirror the horizontal lower bound vertically.
+    const small = clampPosition(-99999, 0, 600, 200);
+    const large = clampPosition(-99999, 0, 600, 800);
+    expect(small.top).toBe(-(VISIBLE_MIN / 2));
+    expect(large.top).toBe(-(VISIBLE_MIN / 2));
+  });
+
+  it('produces a deterministic result on degenerate (sub-VISIBLE_MIN) viewports — PR #1440 M-13', () => {
+    // PR #1440 review item M-13 — when the viewport is narrower / shorter
+    // than VISIBLE_MIN, the raw maxTop / maxRight could fall below their
+    // respective minimums and Math.min/Math.max would emit Math.max's
+    // first argument. Pin the actual return so a future regression in
+    // bound-collapse logic is caught.
+    setViewport(20, 20);
+    const result = clampPosition(0, 0, 600, 500);
+    // Vertical: minTopRaw = -30, maxTopRaw = -40 (innerHeight - VISIBLE_MIN).
+    // Collapse maxTop to minTopRaw — both bounds become -30.
+    expect(result.top).toBe(-(VISIBLE_MIN / 2));
+    // Horizontal: minRight = -540 (-(panelWidth - VISIBLE_MIN)),
+    // maxRightRaw = -40. minRight < maxRightRaw so no collapse needed.
+    expect(result.right).toBeGreaterThanOrEqual(-540);
+    expect(result.right).toBeLessThanOrEqual(-40);
+  });
+
+  it('handles a viewport narrower than panelWidth without inverting horizontal bounds', () => {
+    // When innerWidth < VISIBLE_MIN, maxRightRaw goes negative below
+    // minRight; the collapse keeps both at minRight so the result stays
+    // deterministic.
+    setViewport(20, 800);
+    const result = clampPosition(100, 0, 600, 500);
+    expect(Number.isFinite(result.right)).toBe(true);
+    expect(Number.isFinite(result.top)).toBe(true);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/clamp-position.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/clamp-position.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 /**
- * Regression tests for PR #1440 review item B2 — `clampPosition` `panelHeight`
+ * Regression tests for `clampPosition` `panelHeight`
  * tautology bug, plus the codex-review follow-up that caught a symmetric-fix
  * UX regression.
  *
@@ -110,8 +110,8 @@ describe('clampPosition', () => {
     expect(large.top).toBe(-(VISIBLE_MIN / 2));
   });
 
-  it('produces a deterministic result on degenerate (sub-VISIBLE_MIN) viewports — PR #1440 M-13', () => {
-    // PR #1440 review item M-13 — when the viewport is narrower / shorter
+  it('produces a deterministic result on degenerate (smaller-than-VISIBLE_MIN) viewports', () => {
+    // when the viewport is narrower / shorter
     // than VISIBLE_MIN, the raw maxTop / maxRight could fall below their
     // respective minimums and Math.min/Math.max would emit Math.max's
     // first argument. Pin the actual return so a future regression in

--- a/packages/zudo-design-token-panel/src/__tests__/configure-panel-reinit.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/configure-panel-reinit.test.ts
@@ -12,17 +12,17 @@ import type { TokenManifest } from '../tokens/manifest';
 import type { ColorClusterDataConfig } from '../config/cluster-config';
 
 /**
- * Regression tests for PR #1440 review items:
+ * Regression tests covering:
  *
- *  - [P0-4] re-init guard uses structural deep-equality so Astro
+ *  - The re-init guard uses structural deep-equality so Astro
  *    view-transition reruns of the host-adapter (which `JSON.parse` the
  *    inline config every page load) no longer throw on byte-identical
  *    fresh objects.
- *  - [P0-3] applyEndpoint defaults / opt-out behaviour.
- *  - [P0-2] applyRouting defaults / opt-out behaviour.
- *  - [M-12] setPanelColorPresets attaches presets after configurePanel,
- *    or pre-configurePanel via the holding slot.
- *  - [P1-11] assertValidPanelConfig() trust-boundary validator messages.
+ *  - `applyEndpoint` defaults / opt-out behaviour.
+ *  - `applyRouting` defaults / opt-out behaviour.
+ *  - `setPanelColorPresets` attaches presets after `configurePanel`, or
+ *    pre-`configurePanel` via the holding slot.
+ *  - `assertValidPanelConfig()` trust-boundary validator messages.
  */
 
 const EMPTY_MANIFEST: TokenManifest = {

--- a/packages/zudo-design-token-panel/src/__tests__/configure-panel-reinit.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/configure-panel-reinit.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  assertValidPanelConfig,
+  configurePanel,
+  getPanelConfig,
+  resolveApplyRouting,
+  setPanelColorPresets,
+  type PanelConfig,
+} from '../config/panel-config';
+import type { TokenManifest } from '../tokens/manifest';
+import type { ColorClusterDataConfig } from '../config/cluster-config';
+
+/**
+ * Regression tests for PR #1440 review items:
+ *
+ *  - [P0-4] re-init guard uses structural deep-equality so Astro
+ *    view-transition reruns of the host-adapter (which `JSON.parse` the
+ *    inline config every page load) no longer throw on byte-identical
+ *    fresh objects.
+ *  - [P0-3] applyEndpoint defaults / opt-out behaviour.
+ *  - [P0-2] applyRouting defaults / opt-out behaviour.
+ *  - [M-12] setPanelColorPresets attaches presets after configurePanel,
+ *    or pre-configurePanel via the holding slot.
+ *  - [P1-11] assertValidPanelConfig() trust-boundary validator messages.
+ */
+
+const EMPTY_MANIFEST: TokenManifest = {
+  spacing: [],
+  typography: [],
+  size: [],
+  color: [],
+};
+
+const EMPTY_CLUSTER: ColorClusterDataConfig = {
+  id: 'empty',
+  paletteSize: 4,
+  baseRoles: {},
+  paletteCssVarTemplate: '--empty-{n}',
+  semanticDefaults: {},
+  semanticCssNames: {},
+  baseDefaults: {},
+  defaultShikiTheme: 'dracula',
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false },
+};
+
+const BASE: PanelConfig = {
+  storagePrefix: 'demo',
+  consoleNamespace: 'demo',
+  modalClassPrefix: 'demo-modal',
+  schemaId: 'demo/v1',
+  exportFilenameBase: 'demo',
+  tokens: EMPTY_MANIFEST,
+  colorCluster: EMPTY_CLUSTER,
+};
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+});
+afterEach(() => {
+  __resetPanelConfigForTests();
+});
+
+describe('configurePanel — structural re-init guard (P0-4)', () => {
+  it('accepts a byte-identical-but-fresh-reference second call without throwing', () => {
+    configurePanel(BASE);
+    // Simulate a JSON-parse round-trip — the second call's object is
+    // structurally identical but referentially distinct.
+    const reparsed = JSON.parse(JSON.stringify(BASE)) as PanelConfig;
+    expect(() => configurePanel(reparsed)).not.toThrow();
+  });
+
+  it('still throws on a structurally different second call', () => {
+    configurePanel(BASE);
+    expect(() => configurePanel({ ...BASE, storagePrefix: 'other' })).toThrow(
+      /already called with different values/,
+    );
+  });
+});
+
+describe('apply pipeline opt-in (P0-2 / P0-3)', () => {
+  it('defaults applyRouting/applyEndpoint to empty for hosts that omit them', () => {
+    configurePanel(BASE);
+    const cfg = getPanelConfig();
+    expect(cfg.applyEndpoint).toBeUndefined();
+    expect(resolveApplyRouting(cfg)).toEqual({});
+  });
+
+  it('honours host-supplied applyRouting + applyEndpoint', () => {
+    configurePanel({
+      ...BASE,
+      applyEndpoint: '/api/dev/foo-tokens-apply',
+      applyRouting: { foo: 'src/foo.css' },
+    });
+    const cfg = getPanelConfig();
+    expect(cfg.applyEndpoint).toBe('/api/dev/foo-tokens-apply');
+    expect(resolveApplyRouting(cfg)).toEqual({ foo: 'src/foo.css' });
+  });
+});
+
+describe('setPanelColorPresets — lazy attach (M-12)', () => {
+  it('attaches presets after configurePanel without throwing', () => {
+    configurePanel(BASE);
+    setPanelColorPresets({ neon: { ...BASELINE_SCHEME() } });
+    const cfg = getPanelConfig();
+    expect(cfg.colorPresets).toEqual({ neon: BASELINE_SCHEME() });
+  });
+
+  it('parks presets in a holding slot when called before configurePanel, then merges on configure', () => {
+    setPanelColorPresets({ neon: BASELINE_SCHEME() });
+    configurePanel(BASE);
+    const cfg = getPanelConfig();
+    expect(cfg.colorPresets).toEqual({ neon: BASELINE_SCHEME() });
+  });
+});
+
+describe('assertValidPanelConfig — trust-boundary validator (P1-11)', () => {
+  it('rejects null / non-object inputs', () => {
+    expect(() => assertValidPanelConfig(null)).toThrow(/non-null object/);
+    expect(() => assertValidPanelConfig(42)).toThrow(/non-null object/);
+    expect(() => assertValidPanelConfig([])).toThrow(/non-null object/);
+  });
+
+  it('names the missing primitive field in its error message', () => {
+    expect(() => assertValidPanelConfig({ ...BASE, storagePrefix: '' } as unknown)).toThrow(
+      /storagePrefix/,
+    );
+  });
+
+  it('rejects malformed tokens / colorCluster shapes', () => {
+    expect(() =>
+      assertValidPanelConfig({
+        ...BASE,
+        tokens: { spacing: 'not-an-array', typography: [], size: [], color: [] },
+      } as unknown),
+    ).toThrow(/tokens\.spacing/);
+    expect(() =>
+      assertValidPanelConfig({
+        ...BASE,
+        colorCluster: { ...EMPTY_CLUSTER, id: '' },
+      } as unknown),
+    ).toThrow(/colorCluster\.id/);
+  });
+
+  it('passes a valid PanelConfig silently', () => {
+    expect(() => assertValidPanelConfig(BASE)).not.toThrow();
+  });
+});
+
+function BASELINE_SCHEME() {
+  // ColorScheme.palette is typed as a 16-tuple; build it explicitly.
+  const palette: [
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+  ] = Array.from({ length: 16 }, (_, i) => `#${i.toString(16).padStart(2, '0')}0000`) as [
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  return {
+    background: 0,
+    foreground: 1,
+    cursor: 2,
+    selectionBg: 0,
+    selectionFg: 1,
+    palette,
+    shikiTheme: 'dracula',
+  };
+}

--- a/packages/zudo-design-token-panel/src/__tests__/custom-manifest.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/custom-manifest.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  DEFAULT_PANEL_CONFIG,
+  getPanelConfig,
+} from '../config/panel-config';
+import type { TokenDef } from '../tokens/manifest';
+
+/**
+ * Consumer-supplied manifest works end-to-end at the config level.
+ *
+ * The portable contract lets a host pass an arbitrary `TokenManifest` into
+ * `configurePanel`. The package itself ships an empty stub manifest;
+ * different consumers can ship distinct manifests of any shape. Passing 3
+ * spacing tokens and zero typography tokens MUST produce a panel that
+ * surfaces 3 spacing rows and zero typography rows.
+ *
+ * This test exercises the plumbing — `configurePanel` accepts a smaller
+ * manifest, `getPanelConfig().tokens` reflects it.
+ */
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+});
+
+const FAKE_SPACING_TOKENS: readonly TokenDef[] = [
+  {
+    id: 'demo-sm',
+    cssVar: '--demo-sm',
+    label: 'demo-sm',
+    group: 'hsp',
+    default: '4px',
+    min: 0,
+    max: 32,
+    step: 1,
+    unit: 'px',
+  },
+  {
+    id: 'demo-md',
+    cssVar: '--demo-md',
+    label: 'demo-md',
+    group: 'hsp',
+    default: '8px',
+    min: 0,
+    max: 32,
+    step: 1,
+    unit: 'px',
+  },
+  {
+    id: 'demo-lg',
+    cssVar: '--demo-lg',
+    label: 'demo-lg',
+    group: 'hsp',
+    default: '16px',
+    min: 0,
+    max: 64,
+    step: 1,
+    unit: 'px',
+  },
+] as const;
+
+describe('configurePanel — consumer-supplied smaller manifest', () => {
+  it('exposes a 3-token spacing manifest with no typography tokens', () => {
+    configurePanel({
+      ...DEFAULT_PANEL_CONFIG,
+      tokens: {
+        spacing: FAKE_SPACING_TOKENS,
+        typography: [],
+        size: [],
+        color: [],
+      },
+    });
+
+    const tokens = getPanelConfig().tokens;
+    expect(tokens.spacing.length).toBe(3);
+    expect(tokens.typography.length).toBe(0);
+    expect(tokens.size.length).toBe(0);
+    expect(tokens.color.length).toBe(0);
+    expect(tokens.spacing.map((t) => t.id)).toEqual(['demo-sm', 'demo-md', 'demo-lg']);
+  });
+
+  it('default config exposes the empty stub manifest when configurePanel is not called', () => {
+    // No configurePanel call — the singleton stays null, getPanelConfig
+    // returns DEFAULT_PANEL_CONFIG, which ships an empty stub manifest.
+    // Hosts MUST call configurePanel to drive useful behaviour.
+    const tokens = getPanelConfig().tokens;
+    expect(tokens.spacing).toEqual([]);
+    expect(tokens.typography).toEqual([]);
+    expect(tokens.size).toEqual([]);
+    expect(tokens.color).toEqual([]);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/empty-state.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/empty-state.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+/**
+ * Empty-state UI for tabs with zero registered tokens.
+ *
+ * Acceptance criteria:
+ *
+ *  - Active tab with zero tokens shows the empty-state copy.
+ *  - Active tab with non-empty tokens shows the existing UI (no regression).
+ *
+ * The empty-state lives inside `panel.tsx` and only fires for the spacing,
+ * font, and size tabs — color is driven by `colorCluster`, not
+ * `tokens.color`, so the empty-state would trigger spuriously on every
+ * cluster-driven host that ships `color: []` (which is the default).
+ *
+ * The two scenarios below exercise both branches via the actual mount path
+ * (the visibility-flag bootstrap that `auto-mount-on-visibility.test.tsx`
+ * already proves end-to-end). Both tabpanels render concurrently — only the
+ * `hidden` attribute differs — so we can read all four tab bodies straight
+ * out of the panel root without simulating tab clicks.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  DEFAULT_PANEL_CONFIG,
+  panelRootId,
+  storageKey_visible,
+} from '../config/panel-config';
+import type { TokenDef } from '../tokens/manifest';
+
+const STORAGE_KEY_VISIBLE = storageKey_visible(DEFAULT_PANEL_CONFIG);
+const PANEL_ROOT_ID = panelRootId(DEFAULT_PANEL_CONFIG);
+
+const EMPTY_STATE_COPY = 'No tokens are registered for this tab';
+
+/**
+ * Wait for Preact to flush effects. Preact uses `requestAnimationFrame`
+ * (with a `setTimeout(35)` polyfill in `w`) so we burn two rAFs and a
+ * macrotask to be safe.
+ */
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+const DEMO_SPACING_TOKEN: TokenDef = {
+  id: 'demo-sm',
+  cssVar: '--demo-sm',
+  label: 'demo-sm',
+  group: 'hsp',
+  default: '4px',
+  min: 0,
+  max: 32,
+  step: 1,
+  unit: 'px',
+};
+
+describe('design-token-panel empty-state', () => {
+  beforeEach(() => {
+    __resetPanelConfigForTests();
+    localStorage.clear();
+    document.body.innerHTML = '';
+    // Drop adapter / lifecycle slots so the dynamic import re-bootstraps for
+    // each test.
+    const adapterWin = window as unknown as Record<string, unknown>;
+    delete adapterWin.__zudoDesignTokenPanelAdapter;
+    delete adapterWin.__zudoDesignTokenPanelLifecycle;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    __resetPanelConfigForTests();
+  });
+
+  it('renders empty-state copy when spacing/font/size manifests are empty', async () => {
+    // Configure with a fully-empty token manifest. The empty-state should
+    // surface for spacing / font / size; the color tab is driven by the
+    // cluster, not `tokens.color`.
+    configurePanel({
+      ...DEFAULT_PANEL_CONFIG,
+      tokens: { spacing: [], typography: [], size: [], color: [] },
+    });
+
+    // Bootstrap path mirrors auto-mount-on-visibility — set the visibility
+    // flag, then call `showDesignTokenPanel` to mount the panel synchronously.
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+    const { showDesignTokenPanel } = await import('../index');
+    showDesignTokenPanel();
+    await waitForEffectFlush();
+
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root).not.toBeNull();
+
+    // The empty-state copy MUST appear in the rendered DOM. Three tabpanels
+    // (spacing / font / size) render it concurrently — `hidden` only controls
+    // visibility, not whether the subtree exists — so a single substring
+    // check suffices to prove at least one fired.
+    expect(root!.textContent ?? '').toContain(EMPTY_STATE_COPY);
+
+    // The empty-state ships an anchor pointing at the README — guarding the
+    // anchor presence keeps the actionable affordance from regressing into
+    // a plain text-only message in a future refactor.
+    const anchor = root!.querySelector('a.tokenpanel-empty-state-link');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href') ?? '').toContain('README.md');
+  });
+
+  it('renders the populated tab UI (no empty-state) when the host configures a non-empty manifest', async () => {
+    // Configure with a non-empty spacing manifest so the empty-state must
+    // NOT fire on the spacing tab. Other tabs may still show the
+    // empty-state, so we assert specifically against the spacing tabpanel.
+    configurePanel({
+      ...DEFAULT_PANEL_CONFIG,
+      tokens: {
+        spacing: [DEMO_SPACING_TOKEN],
+        typography: [],
+        size: [],
+        color: [],
+      },
+    });
+
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+    const { showDesignTokenPanel } = await import('../index');
+    showDesignTokenPanel();
+    await waitForEffectFlush();
+
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root).not.toBeNull();
+
+    // The spacing tabpanel must NOT contain the empty-state copy when the
+    // spacing manifest is non-empty — this is the regression guard.
+    const spacingPanel = root!.querySelector('#dtp-panel-spacing');
+    expect(spacingPanel).not.toBeNull();
+    expect(spacingPanel!.textContent ?? '').not.toContain(EMPTY_STATE_COPY);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/empty-state.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/empty-state.test.tsx
@@ -102,12 +102,15 @@ describe('design-token-panel empty-state', () => {
     // check suffices to prove at least one fired.
     expect(root!.textContent ?? '').toContain(EMPTY_STATE_COPY);
 
-    // The empty-state ships an anchor pointing at the README — guarding the
-    // anchor presence keeps the actionable affordance from regressing into
-    // a plain text-only message in a future refactor.
+    // The empty-state ships an anchor pointing at the package's GitHub
+    // README — guarding the anchor presence keeps the actionable
+    // affordance from regressing into a plain text-only message in a
+    // future refactor.
     const anchor = root!.querySelector('a.tokenpanel-empty-state-link');
     expect(anchor).not.toBeNull();
-    expect(anchor?.getAttribute('href') ?? '').toContain('README.md');
+    expect(anchor?.getAttribute('href') ?? '').toContain(
+      'github.com/Takazudo/zudo-design-token-panel',
+    );
   });
 
   it('renders the populated tab UI (no empty-state) when the host configures a non-empty manifest', async () => {

--- a/packages/zudo-design-token-panel/src/__tests__/package-exports.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/package-exports.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Package-exports pin test.
+ *
+ * Mechanical pin so an accidental edit to the exports map (or a build
+ * refactor that renames a dist artifact) fails fast in unit-test land.
+ *
+ * The `dist/`-existence assertions only fire when the dist directory
+ * actually exists — i.e. after a `pnpm build` run. CI runs build before
+ * tests; local quick `pnpm test` runs without a fresh build skip the
+ * existence check rather than fail.
+ */
+
+const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
+const packageJsonPath = `${packageRoot}/package.json`;
+
+interface ExportConditional {
+  types?: string;
+  import?: string;
+}
+
+interface PackageJsonShape {
+  name?: string;
+  exports?: Record<string, string | ExportConditional>;
+}
+
+function readPackageJson(): PackageJsonShape {
+  const raw = readFileSync(packageJsonPath, 'utf8');
+  return JSON.parse(raw) as PackageJsonShape;
+}
+
+describe('package.json — name and exports map shape', () => {
+  it('package name is @takazudo/zudo-design-token-panel', () => {
+    const pkg = readPackageJson();
+    expect(pkg.name).toBe('@takazudo/zudo-design-token-panel');
+  });
+
+  it('exports map declares the documented entry points', () => {
+    const pkg = readPackageJson();
+    expect(pkg.exports).toBeDefined();
+    const exportsMap = pkg.exports!;
+    expect(exportsMap['.']).toBeDefined();
+    expect(exportsMap['./astro']).toBeDefined();
+    expect(exportsMap['./astro/host-adapter']).toBeDefined();
+    expect(exportsMap['./astro/DesignTokenPanelHost.astro']).toBeDefined();
+    expect(exportsMap['./styles']).toBeDefined();
+    expect(exportsMap['./styles.css']).toBeDefined();
+  });
+});
+
+describe('package.json exports — ./astro/host-adapter sub-export', () => {
+  it('declares the ./astro/host-adapter entry in the exports map', () => {
+    const pkg = readPackageJson();
+    expect(
+      pkg.exports?.['./astro/host-adapter'],
+      'exports["./astro/host-adapter"] must be present so consumers can import the host-adapter side-effect chunk',
+    ).toBeDefined();
+  });
+
+  it('points the import target at ./dist/astro/host-adapter.js', () => {
+    const pkg = readPackageJson();
+    const entry = pkg.exports?.['./astro/host-adapter'];
+    expect(entry, 'exports["./astro/host-adapter"] must be a conditional object').toBeTypeOf(
+      'object',
+    );
+    if (typeof entry === 'object' && entry !== null) {
+      expect(entry.import).toBe('./dist/astro/host-adapter.js');
+      // Skip existence assertion when dist/ has not been built yet.
+      const resolvedJs = `${packageRoot}/dist/astro/host-adapter.js`;
+      const distExists = existsSync(`${packageRoot}/dist`);
+      if (distExists) {
+        expect(
+          existsSync(resolvedJs),
+          `${resolvedJs} must exist on disk — run pnpm --filter @takazudo/zudo-design-token-panel build first`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('points the types target at ./dist/astro/host-adapter.d.ts', () => {
+    const pkg = readPackageJson();
+    const entry = pkg.exports?.['./astro/host-adapter'];
+    if (typeof entry === 'object' && entry !== null) {
+      expect(entry.types).toBe('./dist/astro/host-adapter.d.ts');
+      const resolvedDts = `${packageRoot}/dist/astro/host-adapter.d.ts`;
+      const distExists = existsSync(`${packageRoot}/dist`);
+      if (distExists) {
+        expect(
+          existsSync(resolvedDts),
+          `${resolvedDts} must exist on disk — run the package build to refresh tsc output`,
+        ).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PANEL_CONFIG,
+  __resetPanelConfigForTests,
+  configurePanel,
+  exportFilename,
+  getPanelConfig,
+  modalClass,
+  panelRootId,
+  storageKey_open,
+  storageKey_position,
+  storageKey_stateV1,
+  storageKey_stateV2,
+  storageKey_visible,
+  type PanelConfig,
+} from '../config/panel-config';
+import type { TokenManifest } from '../tokens/manifest';
+import type { ColorClusterDataConfig } from '../config/cluster-config';
+
+/**
+ * Empty manifest used by tests that don't care about token data — they're
+ * exercising the storage / namespace / branding plumbing only. `tokens` is
+ * a required field on `PanelConfig`; this stub keeps the fixtures focused
+ * on what each test is actually asserting.
+ */
+const EMPTY_MANIFEST: TokenManifest = {
+  spacing: [],
+  typography: [],
+  size: [],
+  color: [],
+};
+
+/**
+ * Minimal cluster fixture used by tests that don't care about cluster data —
+ * `colorCluster` is a required field on `PanelConfig`; this stub keeps the
+ * storage / namespace / branding fixtures focused on what they assert.
+ */
+const EMPTY_CLUSTER: ColorClusterDataConfig = {
+  id: 'empty',
+  paletteSize: 0,
+  baseRoles: {},
+  paletteCssVarTemplate: '--empty-{n}',
+  semanticDefaults: {},
+  semanticCssNames: {},
+  baseDefaults: {},
+  defaultShikiTheme: 'dracula',
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false },
+};
+
+/**
+ * `panel-config.ts` contract:
+ *
+ * The whole point of this module is that swapping the config in one place
+ * re-targets every storage key, schema id, modal class, and filename the
+ * panel emits. These tests pin both ends of that contract:
+ *
+ *  1. With the default config we land on the documented zudo-flavoured
+ *     neutral defaults.
+ *
+ *  2. With a different config the same derivation helpers produce
+ *     different literals — proof the panel is decoupled from any single
+ *     consumer.
+ *
+ *  3. `configurePanel` is one-shot: same-value re-calls are no-ops, but
+ *     different-value re-calls throw so config conflicts surface early
+ *     rather than silently corrupting one of the two callers' assumptions.
+ */
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+});
+
+describe('panel-config — default config literal-equality', () => {
+  it('default config exposes neutral zudo-flavoured stub values', () => {
+    // The package ships intentionally minimal defaults so the panel imports
+    // cleanly even when no host has called configurePanel. Hosts MUST
+    // override via configurePanel(...) for useful behaviour. The literals
+    // below are the documented neutral defaults.
+    expect(DEFAULT_PANEL_CONFIG.storagePrefix).toBe('zudo-design-token-panel');
+    expect(DEFAULT_PANEL_CONFIG.consoleNamespace).toBe('zudo');
+    expect(DEFAULT_PANEL_CONFIG.modalClassPrefix).toBe('zudo-design-token-panel-modal');
+    expect(DEFAULT_PANEL_CONFIG.schemaId).toBe('zudo-design-tokens/v1');
+    expect(DEFAULT_PANEL_CONFIG.exportFilenameBase).toBe('zudo-design-tokens');
+    // tokens is the empty stub manifest — every slice is an empty array.
+    expect(DEFAULT_PANEL_CONFIG.tokens).toBeDefined();
+    expect(DEFAULT_PANEL_CONFIG.tokens.spacing).toEqual([]);
+    expect(DEFAULT_PANEL_CONFIG.tokens.typography).toEqual([]);
+    expect(DEFAULT_PANEL_CONFIG.tokens.size).toEqual([]);
+    expect(DEFAULT_PANEL_CONFIG.tokens.color).toEqual([]);
+  });
+
+  it('storage-key derivations produce the documented literal strings', () => {
+    const cfg = DEFAULT_PANEL_CONFIG;
+    expect(storageKey_stateV1(cfg)).toBe('zudo-design-token-panel-state');
+    expect(storageKey_stateV2(cfg)).toBe('zudo-design-token-panel-state-v2');
+    expect(storageKey_open(cfg)).toBe('zudo-design-token-panel-open');
+    expect(storageKey_position(cfg)).toBe('zudo-design-token-panel-position');
+    // NOTE: colon, not dash — historical artifact preserved.
+    expect(storageKey_visible(cfg)).toBe('zudo-design-token-panel:visible');
+  });
+
+  it('default `colorPresets` is the empty object', () => {
+    // The package itself ships zero presets. Consumers opt in by passing
+    // `colorPresets` to `configurePanel`.
+    expect(DEFAULT_PANEL_CONFIG.colorPresets).toEqual({});
+  });
+
+  it('panelRootId / modalClass / exportFilename produce the documented literals', () => {
+    const cfg = DEFAULT_PANEL_CONFIG;
+    expect(panelRootId(cfg)).toBe('zudo-design-token-panel-root');
+    expect(modalClass(cfg, '')).toBe('zudo-design-token-panel-modal');
+    expect(modalClass(cfg, '--export')).toBe('zudo-design-token-panel-modal--export');
+    expect(modalClass(cfg, '__title')).toBe('zudo-design-token-panel-modal__title');
+    expect(exportFilename(cfg)).toBe('zudo-design-tokens.json');
+  });
+
+  it('getPanelConfig returns DEFAULT_PANEL_CONFIG when configurePanel was never called', () => {
+    expect(getPanelConfig()).toEqual(DEFAULT_PANEL_CONFIG);
+  });
+});
+
+describe('panel-config — derivation flips with a non-default config', () => {
+  const ALT_CONFIG: PanelConfig = {
+    storagePrefix: 'foo-bar',
+    consoleNamespace: 'foo',
+    modalClassPrefix: 'foo-bar-modal',
+    schemaId: 'foo-bar-tokens/v1',
+    exportFilenameBase: 'foo-bar-tokens',
+    tokens: EMPTY_MANIFEST,
+    colorCluster: EMPTY_CLUSTER,
+  };
+
+  it('every derivation flips with the new prefix', () => {
+    expect(storageKey_stateV1(ALT_CONFIG)).toBe('foo-bar-state');
+    expect(storageKey_stateV2(ALT_CONFIG)).toBe('foo-bar-state-v2');
+    expect(storageKey_open(ALT_CONFIG)).toBe('foo-bar-open');
+    expect(storageKey_position(ALT_CONFIG)).toBe('foo-bar-position');
+    expect(storageKey_visible(ALT_CONFIG)).toBe('foo-bar:visible');
+    expect(panelRootId(ALT_CONFIG)).toBe('foo-bar-root');
+    expect(modalClass(ALT_CONFIG, '')).toBe('foo-bar-modal');
+    expect(modalClass(ALT_CONFIG, '--export')).toBe('foo-bar-modal--export');
+    expect(exportFilename(ALT_CONFIG)).toBe('foo-bar-tokens.json');
+  });
+
+  it('configurePanel installs the alt config so getPanelConfig() returns it', () => {
+    configurePanel(ALT_CONFIG);
+    expect(getPanelConfig()).toEqual(ALT_CONFIG);
+    // And the live derivations now route through the alt config.
+    expect(storageKey_stateV2(getPanelConfig())).toBe('foo-bar-state-v2');
+    expect(modalClass(getPanelConfig(), '__title')).toBe('foo-bar-modal__title');
+  });
+});
+
+describe('panel-config — configurePanel idempotency', () => {
+  const CONFIG_A: PanelConfig = {
+    storagePrefix: 'aaa',
+    consoleNamespace: 'aaa',
+    modalClassPrefix: 'aaa-modal',
+    schemaId: 'aaa/v1',
+    exportFilenameBase: 'aaa',
+    tokens: EMPTY_MANIFEST,
+    colorCluster: EMPTY_CLUSTER,
+  };
+
+  const CONFIG_B: PanelConfig = {
+    storagePrefix: 'bbb',
+    consoleNamespace: 'bbb',
+    modalClassPrefix: 'bbb-modal',
+    schemaId: 'bbb/v1',
+    exportFilenameBase: 'bbb',
+    tokens: EMPTY_MANIFEST,
+    colorCluster: EMPTY_CLUSTER,
+  };
+
+  it('calling configurePanel twice with identical values is a no-op (does not throw)', () => {
+    configurePanel(CONFIG_A);
+    expect(() => configurePanel({ ...CONFIG_A })).not.toThrow();
+    expect(getPanelConfig()).toEqual(CONFIG_A);
+  });
+
+  it('calling configurePanel twice with different values throws', () => {
+    configurePanel(CONFIG_A);
+    expect(() => configurePanel(CONFIG_B)).toThrow(/already called with different values/);
+    // The first config is preserved — the second call did not silently overwrite.
+    expect(getPanelConfig()).toEqual(CONFIG_A);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/react-alias-smoke.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/react-alias-smoke.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Smoke test: verify the `react` → `preact/compat` alias resolves.
+ *
+ * zudo-doc's ported control components import `from "react"` verbatim. This
+ * file mimics that shape so TypeScript + Vite both have to resolve "react"
+ * through the alias configured in `tsconfig.json` paths + `vite.config.ts`
+ * `resolve.alias`. If either layer forgets the alias, this file fails to
+ * type-check (paths lookup) or to bundle (vite alias).
+ *
+ * The test asserts the imported hooks are the functions exported by
+ * preact/compat (identity check against preact/hooks), and nothing more —
+ * rendering is left to jsdom-based tests if/when this sub-package gains
+ * a DOM test environment.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType } from 'react';
+import * as preactHooks from 'preact/hooks';
+
+function ZudoDocStyleControl({ label }: { label: string }): preact.JSX.Element {
+  const [value, setValue] = useState<string>(label);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const id = useMemo(() => `smoke-${label}`, [label]);
+
+  useEffect(() => {
+    return () => undefined;
+  }, [id]);
+
+  const onReset = useCallback(() => setValue(label), [label]);
+
+  return (
+    <div ref={ref} data-id={id} onClick={onReset}>
+      {value}
+    </div>
+  );
+}
+
+describe('react → preact/compat alias', () => {
+  it('resolves `from "react"` hook imports against preact', () => {
+    // When the alias is active, `react`'s `useState` is preact/compat's
+    // wrapper, which ultimately reuses preact/hooks. Verifying function
+    // identity via `.name` keeps the assertion resilient across preact
+    // versions while still proving the alias fired.
+    expect(typeof useState).toBe('function');
+    expect(typeof useEffect).toBe('function');
+    expect(typeof useMemo).toBe('function');
+    expect(typeof useCallback).toBe('function');
+    expect(typeof useRef).toBe('function');
+    expect(typeof preactHooks.useState).toBe('function');
+  });
+
+  it('type-checks a zudo-doc-shaped component using react hooks', () => {
+    const C: ComponentType<{ label: string }> = ZudoDocStyleControl;
+    expect(typeof C).toBe('function');
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/sanitize-css-value.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/sanitize-css-value.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeCssValue } from '../controls/sanitize-css-value';
+
+/**
+ * Guards the character-class stripping that keeps free-form font-family values
+ * from breaking out of a CSS property-value context (and keeps the exported
+ * CSS snippet tidy).
+ *
+ * Ported verbatim from zudo-doc's upstream test — the sanitizer's character
+ * class (`[\r\n\\;]`) is identical across the two projects, so the same
+ * fixtures lock the same behaviour.
+ */
+describe('sanitizeCssValue', () => {
+  it('passes through common font-family strings untouched', () => {
+    expect(sanitizeCssValue('"Inter", system-ui, sans-serif')).toBe(
+      '"Inter", system-ui, sans-serif',
+    );
+    expect(sanitizeCssValue('ui-monospace, monospace')).toBe('ui-monospace, monospace');
+    expect(sanitizeCssValue("'Noto Sans JP', sans-serif")).toBe("'Noto Sans JP', sans-serif");
+  });
+
+  it('strips newlines', () => {
+    expect(sanitizeCssValue('Inter,\nsystem-ui')).toBe('Inter,system-ui');
+    expect(sanitizeCssValue('Inter\r\nFallback')).toBe('InterFallback');
+  });
+
+  it('strips backslashes', () => {
+    expect(sanitizeCssValue('"Esc\\aped", sans-serif')).toBe('"Escaped", sans-serif');
+  });
+
+  it('strips semicolons so exported CSS snippets stay well-formed', () => {
+    expect(sanitizeCssValue('Inter; color: red')).toBe('Inter color: red');
+  });
+
+  it('leaves the empty string empty', () => {
+    expect(sanitizeCssValue('')).toBe('');
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/settings-alias.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/settings-alias.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * The panel is enabled when either `designTokenPanel` OR the deprecated
+ * `colorTweakPanel` alias is truthy. This test documents and locks that gate
+ * expression so a future refactor can't accidentally drop the alias.
+ *
+ * Both the Astro layout and the header use this same boolean check, so we
+ * model both call sites with tiny stand-in objects.
+ */
+type LikeSettings = {
+  designTokenPanel?: boolean;
+  colorTweakPanel?: boolean | undefined;
+};
+
+function isPanelEnabled(s: LikeSettings): boolean {
+  return Boolean(s.designTokenPanel || s.colorTweakPanel);
+}
+
+describe('design-token-panel enablement gate', () => {
+  it('is enabled when only designTokenPanel is true', () => {
+    expect(isPanelEnabled({ designTokenPanel: true })).toBe(true);
+  });
+
+  it('is enabled when only the deprecated colorTweakPanel alias is true', () => {
+    expect(isPanelEnabled({ colorTweakPanel: true })).toBe(true);
+  });
+
+  it('is enabled when both are true', () => {
+    expect(isPanelEnabled({ designTokenPanel: true, colorTweakPanel: true })).toBe(true);
+  });
+
+  it('is disabled when both are false/undefined', () => {
+    expect(isPanelEnabled({})).toBe(false);
+    expect(isPanelEnabled({ designTokenPanel: false })).toBe(false);
+    expect(isPanelEnabled({ designTokenPanel: false, colorTweakPanel: false })).toBe(false);
+  });
+
+  it('the deprecated alias still enables the panel even when designTokenPanel is explicitly false', () => {
+    // Deliberate permissive behaviour: the alias lets legacy projects keep
+    // their setting without noticing breakage for one release.
+    expect(isPanelEnabled({ designTokenPanel: false, colorTweakPanel: true })).toBe(true);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getStorageKeyV1,
+  getStorageKeyV2,
+  type ColorTweakState,
+  type StorageLike,
+  loadPersistedState,
+} from '../state/tweak-state';
+import { __resetPanelConfigForTests } from '../config/panel-config';
+import { installFixturePanelConfig } from './_test-helpers';
+
+/**
+ * Spacing / typography / size sections:
+ *   - v1 migration initialises them to empty maps (v1 only knew about color).
+ *   - v2 payloads missing the sections hydrate to `{}` without warnings.
+ *   - v2 payloads containing overrides pass them through unchanged.
+ *   - Non-string values inside `spacing` are silently dropped (defensive
+ *     hydration — we don't want a broken entry to crash the panel).
+ *
+ * Adapted from zudo-doc's upstream suite. The only rename is `font` →
+ * `typography` to match the zmod2 state envelope introduced in Sub 1.
+ */
+
+function makeStorage(initial: Record<string, string> = {}): StorageLike & {
+  entries: Record<string, string>;
+} {
+  const entries: Record<string, string> = { ...initial };
+  return {
+    entries,
+    getItem: (k) => (k in entries ? entries[k] : null),
+    setItem: (k, v) => {
+      entries[k] = v;
+    },
+    removeItem: (k) => {
+      delete entries[k];
+    },
+  };
+}
+
+const palette16 = Array.from(
+  { length: 16 },
+  (_, i) => `#${i.toString(16).padStart(2, '0').repeat(3)}`,
+);
+
+const defaults: ColorTweakState = {
+  palette: palette16,
+  background: 0,
+  foreground: 15,
+  cursor: 6,
+  selectionBg: 0,
+  selectionFg: 15,
+  semanticMappings: { accent: 6, muted: 8 },
+  shikiTheme: 'dracula',
+};
+
+function makeColor(): ColorTweakState {
+  return {
+    palette: palette16.map((c) => c),
+    background: 1,
+    foreground: 14,
+    cursor: 5,
+    selectionBg: 2,
+    selectionFg: 13,
+    semanticMappings: { accent: 6, muted: 8 },
+    shikiTheme: 'tokyo-night',
+  };
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let STORAGE_KEY_V1 = '';
+let STORAGE_KEY_V2 = '';
+beforeEach(() => {
+  installFixturePanelConfig();
+  STORAGE_KEY_V1 = getStorageKeyV1();
+  STORAGE_KEY_V2 = getStorageKeyV2();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  __resetPanelConfigForTests();
+  warnSpy.mockRestore();
+});
+
+describe('loadPersistedState — spacing / typography / size sections', () => {
+  it('fills spacing / typography / size with empty maps when migrating from v1', () => {
+    const v1 = makeColor();
+    const storage = makeStorage({ [STORAGE_KEY_V1]: JSON.stringify(v1) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.spacing).toEqual({});
+    expect(result!.typography).toEqual({});
+    expect(result!.size).toEqual({});
+
+    // Persisted v2 carries the empty sections so future loads stay stable.
+    const persisted = JSON.parse(storage.entries[STORAGE_KEY_V2]);
+    expect(persisted.spacing).toEqual({});
+    expect(persisted.typography).toEqual({});
+    expect(persisted.size).toEqual({});
+  });
+
+  it('hydrates v2 missing the new sections to empty maps (no warn)', () => {
+    const v2 = { color: makeColor() }; // no spacing/typography/size keys
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(v2) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.spacing).toEqual({});
+    expect(result!.typography).toEqual({});
+    expect(result!.size).toEqual({});
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('round-trips spacing overrides from v2', () => {
+    const v2 = {
+      color: makeColor(),
+      spacing: { 'hsp-sm': '0.75rem', 'vsp-md': '2rem' },
+      typography: {},
+      size: {},
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(v2) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result!.spacing).toEqual({ 'hsp-sm': '0.75rem', 'vsp-md': '2rem' });
+  });
+
+  it('drops non-string entries inside spacing (defensive hydration)', () => {
+    const v2 = {
+      color: makeColor(),
+      spacing: { 'hsp-sm': '0.75rem', 'hsp-md': 42, bogus: null },
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(v2) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result!.spacing).toEqual({ 'hsp-sm': '0.75rem' });
+  });
+
+  it('migrates legacy typography ids to the Sub 6 main-site tiers', () => {
+    // Payload written under the old id scheme (text-caption / text-body /
+    // text-heading / text-display) should land on the new ids (text-xs /
+    // text-base / text-3xl / text-5xl). text-micro has no main-site
+    // equivalent and should be dropped silently.
+    const v2 = {
+      color: makeColor(),
+      typography: {
+        'text-micro': '0.8rem', // dropped
+        'text-caption': '1rem',
+        'text-small': '1.15rem',
+        'text-body': '1.5rem',
+        'text-subheading': '1.7rem',
+        'text-heading': '3.4rem',
+        'text-display': '5rem',
+      },
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(v2) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result!.typography).toEqual({
+      'text-xs': '1rem',
+      'text-sm': '1.15rem',
+      'text-base': '1.5rem',
+      'text-lg': '1.7rem',
+      'text-3xl': '3.4rem',
+      'text-5xl': '5rem',
+    });
+  });
+
+  it('prefers the post-migration id when both legacy and current keys exist', () => {
+    // If the user already tweaked text-base after migration and we still
+    // see an ancient text-body value lingering in storage, the fresh one
+    // wins — we must not clobber the user's post-rename edit.
+    const v2 = {
+      color: makeColor(),
+      typography: {
+        'text-body': '1.5rem', // legacy
+        'text-base': '1.6rem', // current — wins
+      },
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(v2) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result!.typography).toEqual({ 'text-base': '1.6rem' });
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
@@ -18,7 +18,7 @@ import { installFixturePanelConfig } from './_test-helpers';
  *     hydration — we don't want a broken entry to crash the panel).
  *
  * Adapted from zudo-doc's upstream suite. The only rename is `font` →
- * `typography` to match the zmod2 state envelope introduced in Sub 1.
+ * `typography` to match the state envelope.
  */
 
 function makeStorage(initial: Record<string, string> = {}): StorageLike & {
@@ -138,7 +138,7 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     expect(result!.spacing).toEqual({ 'hsp-sm': '0.75rem' });
   });
 
-  it('migrates legacy typography ids to the Sub 6 main-site tiers', () => {
+  it('migrates legacy typography ids to the current main-site tiers', () => {
     // Payload written under the old id scheme (text-caption / text-body /
     // text-heading / text-display) should land on the new ids (text-xs /
     // text-base / text-3xl / text-5xl). text-micro has no main-site

--- a/packages/zudo-design-token-panel/src/__tests__/structural-equal.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/structural-equal.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from 'vitest';
 import { structuralEqual } from '../utils/structural-equal';
 
 /**
- * Unit tests for the structural-equal utility introduced in PR #1440 review
- * item P0-4. The pre-fix `configurePanel` re-init guard used referential
- * shallow-equality, which broke Astro view-transition reruns of the
- * host-adapter (every `JSON.parse` produced a new object that was
- * byte-identical but referentially distinct). The replacement compares by
- * deep structure so the second `configurePanel(parsedConfig)` call passes
- * silently when the payload hasn't changed.
+ * Unit tests for the structural-equal utility. The pre-fix `configurePanel`
+ * re-init guard used referential shallow-equality, which broke Astro
+ * view-transition reruns of the host-adapter (every `JSON.parse` produced
+ * a new object that was byte-identical but referentially distinct). The
+ * replacement compares by deep structure so the second
+ * `configurePanel(parsedConfig)` call passes silently when the payload
+ * hasn't changed.
  */
 
 describe('structuralEqual', () => {
@@ -64,7 +64,7 @@ describe('structuralEqual', () => {
   });
 
   it('handles property order independently', () => {
-    // PR #1440 review item M-14 — the import-modal "nothing applied"
+    // the import-modal "nothing applied"
     // detector relied on JSON.stringify equality, which is V8 property-order
     // sensitive. structuralEqual is order-independent.
     const a = { foreground: 1, background: 0, palette: ['#000'] };

--- a/packages/zudo-design-token-panel/src/__tests__/structural-equal.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/structural-equal.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { structuralEqual } from '../utils/structural-equal';
+
+/**
+ * Unit tests for the structural-equal utility introduced in PR #1440 review
+ * item P0-4. The pre-fix `configurePanel` re-init guard used referential
+ * shallow-equality, which broke Astro view-transition reruns of the
+ * host-adapter (every `JSON.parse` produced a new object that was
+ * byte-identical but referentially distinct). The replacement compares by
+ * deep structure so the second `configurePanel(parsedConfig)` call passes
+ * silently when the payload hasn't changed.
+ */
+
+describe('structuralEqual', () => {
+  it('returns true for identical primitives', () => {
+    expect(structuralEqual('a', 'a')).toBe(true);
+    expect(structuralEqual(42, 42)).toBe(true);
+    expect(structuralEqual(true, true)).toBe(true);
+    expect(structuralEqual(null, null)).toBe(true);
+    expect(structuralEqual(undefined, undefined)).toBe(true);
+  });
+
+  it('returns false for primitives of different types or values', () => {
+    expect(structuralEqual('1', 1)).toBe(false);
+    expect(structuralEqual(true, 1)).toBe(false);
+    expect(structuralEqual(null, undefined)).toBe(false);
+    expect(structuralEqual(0, false)).toBe(false);
+  });
+
+  it('treats NaN as equal to itself (Object.is semantics)', () => {
+    expect(structuralEqual(Number.NaN, Number.NaN)).toBe(true);
+  });
+
+  it('compares plain objects by value, not by reference', () => {
+    const a = { storagePrefix: 'foo', tokens: { spacing: [1, 2, 3] } };
+    const b = { storagePrefix: 'foo', tokens: { spacing: [1, 2, 3] } };
+    expect(a).not.toBe(b);
+    expect(structuralEqual(a, b)).toBe(true);
+  });
+
+  it('returns false on key-set mismatch', () => {
+    expect(structuralEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(structuralEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+  });
+
+  it('returns false on value mismatch', () => {
+    expect(structuralEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('compares arrays element-wise (length-first short-circuit)', () => {
+    expect(structuralEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(structuralEqual([1, 2], [1, 2, 3])).toBe(false);
+    expect(structuralEqual([1, 2, 3], [1, 3, 2])).toBe(false);
+  });
+
+  it('descends into nested arrays / objects', () => {
+    const a = { palette: ['#000', '#fff'], baseRoles: { background: 'bg' } };
+    const b = { palette: ['#000', '#fff'], baseRoles: { background: 'bg' } };
+    expect(structuralEqual(a, b)).toBe(true);
+  });
+
+  it('does not confuse arrays with objects of numeric keys', () => {
+    expect(structuralEqual([1, 2, 3], { 0: 1, 1: 2, 2: 3 })).toBe(false);
+  });
+
+  it('handles property order independently', () => {
+    // PR #1440 review item M-14 — the import-modal "nothing applied"
+    // detector relied on JSON.stringify equality, which is V8 property-order
+    // sensitive. structuralEqual is order-independent.
+    const a = { foreground: 1, background: 0, palette: ['#000'] };
+    const b = { background: 0, palette: ['#000'], foreground: 1 };
+    expect(structuralEqual(a, b)).toBe(true);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getStorageKeyV1,
+  getStorageKeyV2,
+  type ColorTweakState,
+  type StorageLike,
+  loadPersistedState,
+} from '../state/tweak-state';
+import { __resetPanelConfigForTests } from '../config/panel-config';
+import { installFixturePanelConfig } from './_test-helpers';
+
+/**
+ * v1→v2 migration tests.
+ *
+ * We use an in-memory storage double so the tests run in node without a DOM.
+ * The color defaults are injected explicitly so the migration does not need to
+ * resolve the active scheme (which depends on `document`).
+ *
+ * Adapted from zudo-doc's upstream suite. Palette size and shape are identical
+ * (16-slot `ColorTweakState`); semantic-mapping key names are free-form so the
+ * fixtures keep the upstream `accent` / `muted` names for readability.
+ */
+
+function makeStorage(initial: Record<string, string> = {}): StorageLike & {
+  entries: Record<string, string>;
+} {
+  const entries: Record<string, string> = { ...initial };
+  return {
+    entries,
+    getItem: (k) => (k in entries ? entries[k] : null),
+    setItem: (k, v) => {
+      entries[k] = v;
+    },
+    removeItem: (k) => {
+      delete entries[k];
+    },
+  };
+}
+
+const palette16 = Array.from(
+  { length: 16 },
+  (_, i) => `#${i.toString(16).padStart(2, '0').repeat(3)}`,
+);
+
+const defaults: ColorTweakState = {
+  palette: palette16,
+  background: 0,
+  foreground: 15,
+  cursor: 6,
+  selectionBg: 0,
+  selectionFg: 15,
+  semanticMappings: { accent: 6, muted: 8, active: 14 },
+  shikiTheme: 'dracula',
+};
+
+function makeV1(overrides?: Partial<ColorTweakState>): ColorTweakState {
+  return {
+    palette: palette16.map((c) => c),
+    background: 1,
+    foreground: 14,
+    cursor: 5,
+    selectionBg: 2,
+    selectionFg: 13,
+    semanticMappings: { accent: 6, muted: 8, active: 14 },
+    shikiTheme: 'tokyo-night',
+    ...overrides,
+  };
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+// Storage keys are derived from the active panel config and re-resolved per
+// test (the fixture cluster has paletteSize=16 so the migration / hydration
+// helpers accept the 16-slot fixtures below).
+let STORAGE_KEY_V1 = '';
+let STORAGE_KEY_V2 = '';
+
+beforeEach(() => {
+  installFixturePanelConfig();
+  STORAGE_KEY_V1 = getStorageKeyV1();
+  STORAGE_KEY_V2 = getStorageKeyV2();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+  warnSpy.mockRestore();
+});
+
+describe('loadPersistedState — v1→v2 migration', () => {
+  it('returns null when nothing is stored (fresh defaults)', () => {
+    const storage = makeStorage();
+    const result = loadPersistedState(storage, defaults);
+    expect(result).toBeNull();
+  });
+
+  it('loads a valid v1 state and writes it to v2, deleting v1', () => {
+    const v1 = makeV1();
+    const storage = makeStorage({ [STORAGE_KEY_V1]: JSON.stringify(v1) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.color.background).toBe(1);
+    expect(result!.color.foreground).toBe(14);
+    expect(result!.color.shikiTheme).toBe('tokyo-night');
+    expect(result!.color.palette).toEqual(v1.palette);
+
+    // v2 was written, v1 was removed.
+    expect(storage.entries[STORAGE_KEY_V2]).toBeDefined();
+    expect(storage.entries[STORAGE_KEY_V1]).toBeUndefined();
+
+    const persisted = JSON.parse(storage.entries[STORAGE_KEY_V2]);
+    expect(persisted.color.background).toBe(1);
+    expect(persisted.color.shikiTheme).toBe('tokyo-night');
+  });
+
+  it('fills in missing fields from defaults on a partial v1 state', () => {
+    // v1 missing shikiTheme + semanticMappings — still has the required 16-item palette & numeric indices
+    const partial = {
+      palette: palette16,
+      background: 2,
+      foreground: 13,
+      cursor: 4,
+      selectionBg: 0,
+      selectionFg: 15,
+      semanticMappings: {}, // empty object — still valid shape
+    } as ColorTweakState;
+    const storage = makeStorage({ [STORAGE_KEY_V1]: JSON.stringify(partial) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.color.background).toBe(2);
+    // missing shikiTheme filled from defaults
+    expect(result!.color.shikiTheme).toBe(defaults.shikiTheme);
+    // missing semantic keys filled from defaults
+    expect(result!.color.semanticMappings.accent).toBe(defaults.semanticMappings.accent);
+    // v2 written
+    expect(storage.entries[STORAGE_KEY_V2]).toBeDefined();
+    // v1 removed
+    expect(storage.entries[STORAGE_KEY_V1]).toBeUndefined();
+  });
+
+  it('returns null and removes v1 when v1 JSON is corrupt', () => {
+    const storage = makeStorage({ [STORAGE_KEY_V1]: '{not valid json' });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+    expect(storage.entries[STORAGE_KEY_V1]).toBeUndefined();
+  });
+
+  it('prefers v2 when both v1 and v2 are present', () => {
+    const v1 = makeV1({ shikiTheme: 'v1-theme' });
+    const v2 = { color: { ...makeV1({ shikiTheme: 'v2-theme' }) } };
+    const storage = makeStorage({
+      [STORAGE_KEY_V1]: JSON.stringify(v1),
+      [STORAGE_KEY_V2]: JSON.stringify(v2),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.color.shikiTheme).toBe('v2-theme');
+    // v1 was NOT touched (v2 wins means we don't run migration)
+    expect(storage.entries[STORAGE_KEY_V1]).toBeDefined();
+  });
+
+  it('fills in missing semantic keys from defaults when v2 state predates them', () => {
+    // Simulate a v2 state written by an older build that did not yet know
+    // about `price` / `sold` / `active`. The persisted semanticMappings has
+    // the old keys only; loading it should backfill the new keys from the
+    // caller-supplied defaults rather than leaving them undefined (which
+    // would blow up `applyColorState`).
+    const legacyV2 = {
+      color: {
+        palette: palette16,
+        background: 1,
+        foreground: 14,
+        cursor: 5,
+        selectionBg: 2,
+        selectionFg: 13,
+        // Missing `price` / `sold` / `active` on purpose.
+        semanticMappings: { accent: 6, muted: 8 },
+        shikiTheme: 'tokyo-night',
+      },
+    };
+    const freshDefaults: ColorTweakState = {
+      ...defaults,
+      semanticMappings: {
+        ...defaults.semanticMappings,
+        price: 12,
+        sold: 13,
+        active: 14,
+      },
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(legacyV2) });
+
+    const result = loadPersistedState(storage, freshDefaults);
+
+    expect(result).not.toBeNull();
+    // User-persisted values preserved.
+    expect(result!.color.background).toBe(1);
+    expect(result!.color.semanticMappings.accent).toBe(6);
+    // New keys hydrated from defaults — this is what protects users who
+    // upgrade into a build that added new semantic tokens.
+    expect(result!.color.semanticMappings.price).toBe(12);
+    expect(result!.color.semanticMappings.sold).toBe(13);
+    expect(result!.color.semanticMappings.active).toBe(14);
+  });
+
+  it('preserves a user-remapped active mapping through v1 → v2 migration', () => {
+    // User remapped `active` away from the default p14 before upgrading. The
+    // migration must preserve their choice, not overwrite with defaults.
+    const v1 = makeV1({ semanticMappings: { accent: 6, muted: 8, active: 5 } });
+    const storage = makeStorage({ [STORAGE_KEY_V1]: JSON.stringify(v1) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.color.semanticMappings.active).toBe(5);
+    // v2 written, v1 removed.
+    expect(storage.entries[STORAGE_KEY_V2]).toBeDefined();
+    expect(storage.entries[STORAGE_KEY_V1]).toBeUndefined();
+  });
+
+  it('falls back to v1 when v2 is malformed (with console.warn)', () => {
+    const v1 = makeV1();
+    const storage = makeStorage({
+      [STORAGE_KEY_V1]: JSON.stringify(v1),
+      [STORAGE_KEY_V2]: '{broken',
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.color.shikiTheme).toBe(v1.shikiTheme);
+    expect(warnSpy).toHaveBeenCalled();
+    // migration ran successfully → v1 deleted, v2 overwritten
+    expect(storage.entries[STORAGE_KEY_V1]).toBeUndefined();
+    expect(storage.entries[STORAGE_KEY_V2]).toBeDefined();
+  });
+});

--- a/packages/zudo-design-token-panel/src/apply-modal.tsx
+++ b/packages/zudo-design-token-panel/src/apply-modal.tsx
@@ -1,0 +1,741 @@
+/**
+ * Apply modal — previews the diff between the current `TweakState` and the
+ * scheme defaults, then POSTs the diff to the dev-only
+ * `/api/dev/design-tokens-apply` endpoint so the tweaks are written back into
+ * `tokens.css` / `zaudio-tokens.css` on disk.
+ *
+ * Wiring summary (Sub 14)
+ * -----------------------
+ * - Diff building is delegated to `./apply/build-apply-overrides`, which
+ *   consumes the new `ColorTweakState` shape (palette + semanticMappings) and
+ *   emits the flat `{ cssVar: value }` map using Sub 2's `SEMANTIC_CSS_NAMES`.
+ * - Per-file grouping (for the preview and for the success view) uses
+ *   `./apply/route-tokens-to-files` — the exact same routing the dev-API
+ *   handler runs server-side, so the preview matches the server's view of the
+ *   world byte-for-byte.
+ * - Styling uses bundled BEM classes derived from `panelConfig.modalClassPrefix`
+ *   via `modalClass(...)` (Sub 5b, #1556). The matching CSS lives in
+ *   `styles/panel.css` keyed on the default prefix `zmod-design-token-panel-modal*`;
+ *   consumers that override the prefix opt out of bundled CSS and ship their
+ *   own. No Tailwind classes remain.
+ *
+ * Dialog lifecycle (unchanged)
+ * ----------------------------
+ * Uses the native `<dialog>` element. Every dismissal path (× / backdrop /
+ * Escape / programmatic close) routes through `dialog.close()`, which fires
+ * the native `close` event exactly once; `onClose` then fires exactly once
+ * per dismissal regardless of the path taken.
+ */
+
+import { useEffect, useMemo, useRef, useState } from 'preact/compat';
+import { buildApplyOverrides } from './apply/build-apply-overrides';
+import { routeTokensToFiles, type RouteGroup } from './apply/route-tokens-to-files';
+import {
+  getPanelConfig,
+  modalClass,
+  resolveApplyRouting,
+  resolveSecondaryColorCluster,
+} from './config/panel-config';
+import { type ColorTweakState, type TweakState } from './state/tweak-state';
+import { serialize } from './utils/design-token-serde';
+
+const COPY_REVERT_MS = 2000;
+
+export interface ApplyModalProps {
+  state: TweakState;
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Scheme baseline used to diff the current `state.color` against when
+   * computing the flat cssVar overrides. When absent, the entire color block
+   * is treated as changed — useful for tests, but real callers (the panel
+   * itself) always pass the active scheme's initial `ColorTweakState`.
+   */
+  colorDefaults?: ColorTweakState;
+  /**
+   * Fired exactly once after the user confirms a successful apply by clicking
+   * "Done". The parent is expected to clear the persisted state envelope,
+   * clear any inline-applied styles, and reset in-memory state to empty.
+   */
+  onApplied: () => void;
+}
+
+/**
+ * Shape of a per-file result block in the API response.
+ *
+ * The handler ships `{ ok, updated: [...], unknownCssVars, unchangedCssVars }`;
+ * each `updated` entry matches this shape. We keep every field optional so a
+ * response that predates the latest handler still renders cleanly.
+ */
+interface ApplyFileResult {
+  file?: string;
+  changed?: string[];
+  unknown?: string[];
+  unchanged?: string[];
+}
+
+interface ApplyResponse {
+  ok?: boolean;
+  updated?: ApplyFileResult[];
+  unknownCssVars?: string[];
+  unchangedCssVars?: string[];
+  error?: string;
+  /** Legacy / fallback shape: results keyed by file name. */
+  [file: string]: unknown;
+}
+
+type Phase =
+  | { kind: 'preview' }
+  | { kind: 'applying' }
+  | { kind: 'success'; response: ApplyResponse; previewJson: string }
+  | { kind: 'error'; message: string };
+
+const INITIAL_PHASE: Phase = { kind: 'preview' };
+
+type CopyLabel = 'Copy pre-apply state to clipboard' | 'Copied!';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pretty-print the pre-apply diff JSON so the success view can offer it as a
+ * revert blob. The user pastes this back into Import → Apply to roll the
+ * change back.
+ */
+function buildPreviewJson(state: TweakState, colorDefaults: ColorTweakState | undefined): string {
+  return JSON.stringify(serialize(state, { colorDefaults }), null, 2);
+}
+
+/**
+ * Normalize whatever shape the dev-API returned into a uniform list. Accepts
+ * all three historical shapes:
+ *
+ *   - `{ updated: [...] }`   — current handler (post Sub 1454)
+ *   - `{ results: [...] }`   — intermediate shape
+ *   - `{ "tokens.css": {...} }` — very early shape
+ */
+function normalizeResults(response: ApplyResponse): ApplyFileResult[] {
+  if (Array.isArray(response.updated)) return response.updated;
+  const legacyResults = (response as { results?: unknown }).results;
+  if (Array.isArray(legacyResults)) return legacyResults as ApplyFileResult[];
+
+  const out: ApplyFileResult[] = [];
+  for (const [key, value] of Object.entries(response)) {
+    if (
+      key === 'updated' ||
+      key === 'results' ||
+      key === 'ok' ||
+      key === 'unknownCssVars' ||
+      key === 'unchangedCssVars' ||
+      key === 'error' ||
+      value === null ||
+      typeof value !== 'object'
+    ) {
+      continue;
+    }
+    const entry = value as Record<string, unknown>;
+    const changed = Array.isArray(entry.changed) ? (entry.changed as string[]) : undefined;
+    const unknown = Array.isArray(entry.unknown) ? (entry.unknown as string[]) : undefined;
+    const unchanged = Array.isArray(entry.unchanged) ? (entry.unchanged as string[]) : undefined;
+    if (changed || unknown || unchanged) {
+      out.push({ file: key, changed, unknown, unchanged });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// BEM modal classes — derived at render time from `panelConfig.modalClassPrefix`
+// ---------------------------------------------------------------------------
+//
+// CSS rules backing these classes live in `styles/panel.css` under the
+// default prefix `zmod-design-token-panel-modal*`. Consumers that override
+// `modalClassPrefix` opt out of bundled CSS and ship their own — see the
+// "Modal layer" header in panel.css for the full rationale.
+//
+// `buildClasses(cfg)` is pure, so we memo it per-cfg-object inside the
+// component and pass the result down to body subviews as a single bag.
+
+interface ModalClasses {
+  dialog: string;
+  header: string;
+  title: string;
+  closeButton: string;
+  hint: string;
+  sectionHeading: string;
+  list: string;
+  listItem: string;
+  actions: string;
+  primaryButton: string;
+  neutralButton: string;
+  statusWarning: string;
+  statusSuccess: string;
+  statusError: string;
+  applying: string;
+  spinner: string;
+  revertHint: string;
+  jsonBlock: string;
+}
+
+function buildClasses(cfg: ReturnType<typeof getPanelConfig>): ModalClasses {
+  return {
+    dialog: `${modalClass(cfg, '')} ${modalClass(cfg, '--apply')}`,
+    header: modalClass(cfg, '__header'),
+    title: modalClass(cfg, '__title'),
+    closeButton: modalClass(cfg, '__close-button'),
+    hint: modalClass(cfg, '__hint'),
+    sectionHeading: modalClass(cfg, '__section-heading'),
+    list: modalClass(cfg, '__list'),
+    listItem: modalClass(cfg, '__list-item'),
+    actions: modalClass(cfg, '__actions'),
+    primaryButton: `${modalClass(cfg, '__button')} ${modalClass(cfg, '__button--primary')}`,
+    neutralButton: modalClass(cfg, '__button'),
+    statusWarning: `${modalClass(cfg, '__status')} ${modalClass(cfg, '__status--warning')}`,
+    statusSuccess: `${modalClass(cfg, '__status')} ${modalClass(cfg, '__status--success')}`,
+    statusError: `${modalClass(cfg, '__status')} ${modalClass(cfg, '__status--error')}`,
+    applying: modalClass(cfg, '__applying'),
+    spinner: modalClass(cfg, '__spinner'),
+    revertHint: modalClass(cfg, '__revert-hint'),
+    jsonBlock: modalClass(cfg, '__json'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ApplyModal(props: ApplyModalProps) {
+  const { state, open, onClose, colorDefaults, onApplied } = props;
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement | null>(null);
+  const cfg = getPanelConfig();
+  const cls = useMemo(() => buildClasses(cfg), [cfg]);
+
+  // Stable id for aria-labelledby (PR #1440 review item Q1). Native
+  // <dialog>.showModal() implies aria-modal=true, so only the title pointer
+  // is needed.
+  const titleId = `${cfg.modalClassPrefix}-apply-title`;
+
+  const [phase, setPhase] = useState<Phase>(INITIAL_PHASE);
+  const [copyLabel, setCopyLabel] = useState<CopyLabel>('Copy pre-apply state to clipboard');
+
+  // Drive the native dialog from the `open` prop.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const isOpen = dialog.open;
+    if (open && !isOpen) {
+      if (typeof dialog.showModal === 'function') {
+        dialog.showModal();
+      } else {
+        dialog.setAttribute('open', '');
+      }
+      // Focus the primary action on open. Native <dialog>.close() restores
+      // focus to the trigger automatically (PR #1440 review item Q2).
+      window.requestAnimationFrame(() => {
+        primaryButtonRef.current?.focus();
+      });
+    } else if (!open && isOpen) {
+      if (typeof dialog.close === 'function') {
+        dialog.close();
+      } else {
+        dialog.removeAttribute('open');
+      }
+    }
+  }, [open]);
+
+  // Reset transient UI every time the modal re-opens.
+  useEffect(() => {
+    if (!open) return;
+    setPhase(INITIAL_PHASE);
+    setCopyLabel('Copy pre-apply state to clipboard');
+  }, [open]);
+
+  // Revert the copy label after COPY_REVERT_MS.
+  useEffect(() => {
+    if (copyLabel !== 'Copied!') return;
+    const id = window.setTimeout(
+      () => setCopyLabel('Copy pre-apply state to clipboard'),
+      COPY_REVERT_MS,
+    );
+    return () => window.clearTimeout(id);
+  }, [copyLabel]);
+
+  const flattenedOverrides = useMemo(() => {
+    // Primary zd cluster — diffed against the scheme baseline.
+    const zdOverrides = buildApplyOverrides(state, colorDefaults);
+    // Optional secondary cluster (Sub S5b, #1589). Three short-circuits:
+    //
+    //   1. Host opted out (`secondaryColorCluster: null`) — `secondaryCluster`
+    //      is null → emit no secondary keys.
+    //   2. Host kept the default but the persist envelope has no zaudio
+    //      slice yet — `state.zaudio` undefined → skip.
+    //   3. Otherwise — diff against `undefined` (no scheme baseline yet)
+    //      and merge into the flat overrides. The shallow
+    //      `{ ...state, color: state.zaudio }` swap lets `buildApplyOverrides`
+    //      reuse its existing logic without signature changes.
+    const secondaryCluster = resolveSecondaryColorCluster(cfg);
+    const secondaryOverrides =
+      secondaryCluster && state.zaudio
+        ? buildApplyOverrides({ ...state, color: state.zaudio }, undefined, secondaryCluster)
+        : {};
+    return { ...zdOverrides, ...secondaryOverrides };
+  }, [state, colorDefaults, cfg]);
+  const applyRouting = useMemo(() => resolveApplyRouting(cfg), [cfg]);
+  const { groups, rejected, rejectedReasons } = useMemo(
+    () => routeTokensToFiles(flattenedOverrides, applyRouting),
+    [flattenedOverrides, applyRouting],
+  );
+  const totalCount = useMemo(() => Object.keys(flattenedOverrides).length, [flattenedOverrides]);
+  const isEmpty = totalCount === 0;
+  const hasRoutableEntries = groups.length > 0;
+  // PR #1440 review item P0-3 — Apply button is gated on the host having
+  // configured both an endpoint AND a non-empty routing map. Either one
+  // missing means the modal still renders (so the user can preview the
+  // diff), but the primary action is disabled with a tooltip explaining
+  // why. Non-zmod hosts that only want export/import opt out of apply by
+  // omitting these fields entirely.
+  const applyEndpoint = cfg.applyEndpoint;
+  const applyConfigured = Boolean(applyEndpoint) && Object.keys(applyRouting).length > 0;
+
+  async function runApply() {
+    if (!applyEndpoint) {
+      // Defensive — runApply should never be reachable when applyEndpoint is
+      // missing (the primary button is disabled). Surface a clear error
+      // instead of POSTing to undefined.
+      setPhase({
+        kind: 'error',
+        message: 'Apply is not configured: PanelConfig.applyEndpoint is missing.',
+      });
+      return;
+    }
+    // Snapshot the pre-apply JSON now so the success view can still show it
+    // after the parent clears persisted state in `onApplied`.
+    const previewJson = buildPreviewJson(state, colorDefaults);
+    setPhase({ kind: 'applying' });
+
+    try {
+      const response = await fetch(applyEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tokens: flattenedOverrides }),
+      });
+
+      if (!response.ok) {
+        let serverMessage = '';
+        try {
+          const text = await response.text();
+          if (text) {
+            try {
+              const parsed = JSON.parse(text) as { error?: string; message?: string };
+              serverMessage = parsed.error ?? parsed.message ?? text;
+            } catch {
+              serverMessage = text;
+            }
+          }
+        } catch {
+          // Response.text() is unlikely to throw, but keep the failure path
+          // robust either way.
+        }
+        const message = serverMessage
+          ? `Apply failed (${response.status}): ${serverMessage}`
+          : `Apply failed (${response.status} ${response.statusText || 'error'}).`;
+        setPhase({ kind: 'error', message });
+        return;
+      }
+
+      let data: ApplyResponse = {};
+      try {
+        data = (await response.json()) as ApplyResponse;
+      } catch {
+        // Non-JSON success — treat as an empty success envelope.
+        data = {};
+      }
+
+      setPhase({ kind: 'success', response: data, previewJson });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setPhase({ kind: 'error', message: `Network error: ${message}` });
+    }
+  }
+
+  function handleCopyPreApplyState(json: string) {
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+    if (!clipboard?.writeText) return;
+    clipboard.writeText(json).then(
+      () => setCopyLabel('Copied!'),
+      () => {
+        // Browser denied clipboard access — swallow silently so we don't
+        // clobber the "Copied!" affordance.
+      },
+    );
+  }
+
+  function handleDone() {
+    onApplied();
+    requestClose();
+  }
+
+  function handleRetry() {
+    setPhase(INITIAL_PHASE);
+  }
+
+  function handleClose() {
+    onClose();
+  }
+
+  function requestClose() {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      onClose();
+      return;
+    }
+    if (typeof dialog.close === 'function') {
+      dialog.close();
+    } else {
+      dialog.removeAttribute('open');
+      onClose();
+    }
+  }
+
+  function handleBackdropClick(event: React.MouseEvent<HTMLDialogElement>) {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom
+    ) {
+      requestClose();
+    }
+  }
+
+  // Primary-button label changes to reflect what files the apply will edit
+  // (when host-configured) or that apply is unavailable. Falling back to the
+  // legacy zmod-flavoured label only when the routing matches zmod's path.
+  const routingFiles = useMemo(
+    () =>
+      Object.values(applyRouting)
+        .map((p) => {
+          const slash = p.lastIndexOf('/');
+          return slash >= 0 ? p.slice(slash + 1) : p;
+        })
+        .join(' / '),
+    [applyRouting],
+  );
+  const primaryLabel =
+    phase.kind === 'applying'
+      ? 'Applying…'
+      : applyConfigured
+        ? `Apply to ${routingFiles}`
+        : 'Apply (host not configured)';
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={cls.dialog}
+      data-design-token-panel-modal=""
+      data-design-token-panel-modal-variant="apply"
+      aria-labelledby={titleId}
+      onClose={handleClose}
+      onClick={handleBackdropClick}
+    >
+      <header className={cls.header}>
+        <h2 id={titleId} className={cls.title}>
+          Apply design tokens to codebase
+        </h2>
+        <button
+          className={cls.closeButton}
+          type="button"
+          aria-label="Close apply modal"
+          onClick={requestClose}
+        >
+          ×
+        </button>
+      </header>
+
+      <div>
+        {phase.kind === 'preview' && (
+          <PreviewBody
+            cls={cls}
+            groups={groups}
+            rejected={rejected}
+            rejectedReasons={rejectedReasons}
+            totalCount={totalCount}
+            isEmpty={isEmpty}
+            applyConfigured={applyConfigured}
+          />
+        )}
+        {phase.kind === 'applying' && <ApplyingBody cls={cls} />}
+        {phase.kind === 'success' && (
+          <SuccessBody
+            cls={cls}
+            results={normalizeResults(phase.response)}
+            unknownCssVars={
+              Array.isArray(phase.response.unknownCssVars)
+                ? (phase.response.unknownCssVars as string[])
+                : []
+            }
+            previewJson={phase.previewJson}
+            copyLabel={copyLabel}
+            onCopy={() => handleCopyPreApplyState(phase.previewJson)}
+          />
+        )}
+        {phase.kind === 'error' && <ErrorBody cls={cls} message={phase.message} />}
+      </div>
+
+      <div className={cls.actions}>
+        {phase.kind === 'preview' && (
+          <>
+            <button
+              ref={primaryButtonRef}
+              className={cls.primaryButton}
+              type="button"
+              disabled={isEmpty || !hasRoutableEntries || !applyConfigured}
+              onClick={runApply}
+              title={
+                !applyConfigured
+                  ? 'Host has not configured an apply endpoint or routing map. The Apply modal can preview the diff but cannot rewrite source files.'
+                  : undefined
+              }
+            >
+              {primaryLabel}
+            </button>
+            <button className={cls.neutralButton} type="button" onClick={requestClose}>
+              Close
+            </button>
+          </>
+        )}
+
+        {phase.kind === 'applying' && (
+          <button className={cls.primaryButton} type="button" disabled>
+            {primaryLabel}
+          </button>
+        )}
+
+        {phase.kind === 'success' && (
+          <button className={cls.primaryButton} type="button" onClick={handleDone}>
+            Done
+          </button>
+        )}
+
+        {phase.kind === 'error' && (
+          <>
+            <button className={cls.primaryButton} type="button" onClick={handleRetry}>
+              Retry
+            </button>
+            <button className={cls.neutralButton} type="button" onClick={requestClose}>
+              Close
+            </button>
+          </>
+        )}
+      </div>
+    </dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Body subviews
+// ---------------------------------------------------------------------------
+
+interface PreviewBodyProps {
+  cls: ModalClasses;
+  groups: RouteGroup[];
+  rejected: string[];
+  rejectedReasons: string[];
+  totalCount: number;
+  isEmpty: boolean;
+  applyConfigured: boolean;
+}
+
+function PreviewBody({
+  cls,
+  groups,
+  rejected,
+  rejectedReasons,
+  totalCount,
+  isEmpty,
+  applyConfigured,
+}: PreviewBodyProps) {
+  if (isEmpty) {
+    return (
+      <p className={cls.statusWarning}>
+        No overrides to apply — make a change first, then come back.
+      </p>
+    );
+  }
+
+  const routableCount = groups.reduce((sum, g) => sum + Object.keys(g.tokens).length, 0);
+
+  return (
+    <>
+      {!applyConfigured && (
+        <p className={cls.statusWarning}>
+          The host has not configured an apply endpoint or routing map. The diff below is read-only
+          — the Apply button will stay disabled.
+        </p>
+      )}
+      <p className={cls.hint}>
+        {routableCount} override{routableCount === 1 ? '' : 's'} will be written to disk.
+        {routableCount !== totalCount && (
+          <>
+            {' '}
+            {totalCount - routableCount} entr
+            {totalCount - routableCount === 1 ? 'y' : 'ies'} were skipped (no route configured).
+          </>
+        )}
+      </p>
+      {groups.map((group) => (
+        <div key={group.prefix}>
+          <h3 className={cls.sectionHeading}>
+            {fileLabelForPath(group.relativePath)} ({Object.keys(group.tokens).length})
+          </h3>
+          <ul className={cls.list}>
+            {Object.entries(group.tokens).map(([cssVar, value]) => (
+              <li className={cls.listItem} key={cssVar}>
+                <code>{cssVar}</code>: <code>{value}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      {rejected.length > 0 && (
+        <div>
+          <h3 className={cls.sectionHeading}>Skipped — no route configured ({rejected.length})</h3>
+          <ul className={cls.list}>
+            {rejected.map((cssVar, i) => (
+              <li className={cls.listItem} key={cssVar}>
+                <code>{cssVar}</code>
+                {rejectedReasons[i] ? (
+                  <>
+                    {' '}
+                    — <span>{rejectedReasons[i]}</span>
+                  </>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+}
+
+function ApplyingBody({ cls }: { cls: ModalClasses }) {
+  return (
+    <div className={cls.applying} role="status" aria-live="polite">
+      <span className={cls.spinner} aria-hidden="true" />
+      <span>Applying changes…</span>
+    </div>
+  );
+}
+
+interface SuccessBodyProps {
+  cls: ModalClasses;
+  results: ApplyFileResult[];
+  unknownCssVars: string[];
+  previewJson: string;
+  copyLabel: CopyLabel;
+  onCopy: () => void;
+}
+
+function SuccessBody({
+  cls,
+  results,
+  unknownCssVars,
+  previewJson,
+  copyLabel,
+  onCopy,
+}: SuccessBodyProps) {
+  return (
+    <div>
+      <p className={cls.statusSuccess} role="status">
+        Applied successfully.
+      </p>
+
+      {results.length === 0 ? (
+        <p className={cls.hint}>The server returned no per-file details.</p>
+      ) : (
+        results.map((result) => (
+          <div key={result.file ?? 'unknown-file'}>
+            <h3 className={cls.sectionHeading}>{result.file ?? '(unknown file)'}</h3>
+            <FileResultList cls={cls} label="changed" values={result.changed} />
+            <FileResultList cls={cls} label="unknown" values={result.unknown} />
+            <FileResultList cls={cls} label="unchanged" values={result.unchanged} />
+          </div>
+        ))
+      )}
+
+      {unknownCssVars.length > 0 && (
+        <p className={cls.statusWarning}>
+          {unknownCssVars.length} cssVar{unknownCssVars.length === 1 ? '' : 's'} did not match any
+          entry in the target file(s). Check the list above.
+        </p>
+      )}
+
+      <button className={cls.neutralButton} type="button" onClick={onCopy} aria-live="polite">
+        {copyLabel}
+      </button>
+      <p className={cls.revertHint}>
+        To revert, paste this JSON into Load from JSON… and re-apply.
+      </p>
+      <pre className={cls.jsonBlock}>{previewJson}</pre>
+    </div>
+  );
+}
+
+interface FileResultListProps {
+  cls: ModalClasses;
+  label: string;
+  values: string[] | undefined;
+}
+
+function FileResultList({ cls, label, values }: FileResultListProps) {
+  if (!values || values.length === 0) return null;
+  return (
+    <div>
+      <p className={cls.hint}>
+        {label} ({values.length})
+      </p>
+      <ul className={cls.list}>
+        {values.map((cssVar) => (
+          <li className={cls.listItem} key={cssVar}>
+            <code>{cssVar}</code>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface ErrorBodyProps {
+  cls: ModalClasses;
+  message: string;
+}
+
+function ErrorBody({ cls, message }: ErrorBodyProps) {
+  return (
+    <div>
+      <p className={cls.statusError} role="alert">
+        {message}
+      </p>
+      <p className={cls.hint}>
+        Your edits are still intact — click Retry to send the same diff again, or Close to keep
+        editing.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Render a routing path as a basename — the panel cares about the file name,
+ * not the full repo-relative path.
+ */
+function fileLabelForPath(full: string): string {
+  if (!full) return '(unknown file)';
+  const slash = full.lastIndexOf('/');
+  return slash >= 0 ? full.slice(slash + 1) : full;
+}

--- a/packages/zudo-design-token-panel/src/apply-modal.tsx
+++ b/packages/zudo-design-token-panel/src/apply-modal.tsx
@@ -1,23 +1,23 @@
 /**
  * Apply modal — previews the diff between the current `TweakState` and the
  * scheme defaults, then POSTs the diff to the dev-only
- * `/api/dev/design-tokens-apply` endpoint so the tweaks are written back into
- * `tokens.css` / `zaudio-tokens.css` on disk.
+ * `/api/dev/design-tokens-apply` endpoint so the tweaks are written back
+ * into the host's design-system CSS files on disk.
  *
- * Wiring summary (Sub 14)
- * -----------------------
+ * Wiring summary
+ * --------------
  * - Diff building is delegated to `./apply/build-apply-overrides`, which
  *   consumes the new `ColorTweakState` shape (palette + semanticMappings) and
- *   emits the flat `{ cssVar: value }` map using Sub 2's `SEMANTIC_CSS_NAMES`.
+ *   emits the flat `{ cssVar: value }` map using `SEMANTIC_CSS_NAMES`.
  * - Per-file grouping (for the preview and for the success view) uses
  *   `./apply/route-tokens-to-files` — the exact same routing the dev-API
- *   handler runs server-side, so the preview matches the server's view of the
- *   world byte-for-byte.
- * - Styling uses bundled BEM classes derived from `panelConfig.modalClassPrefix`
- *   via `modalClass(...)` (Sub 5b, #1556). The matching CSS lives in
- *   `styles/panel.css` keyed on the default prefix `zmod-design-token-panel-modal*`;
- *   consumers that override the prefix opt out of bundled CSS and ship their
- *   own. No Tailwind classes remain.
+ *   handler runs server-side, so the preview matches the server's view of
+ *   the world byte-for-byte.
+ * - Styling uses bundled BEM classes derived from
+ *   `panelConfig.modalClassPrefix` via `modalClass(...)`. The matching CSS
+ *   lives in `styles/panel.css` keyed on the default modal class prefix;
+ *   consumers that override the prefix opt out of bundled CSS and ship
+ *   their own. No Tailwind classes remain.
  *
  * Dialog lifecycle (unchanged)
  * ----------------------------
@@ -111,7 +111,7 @@ function buildPreviewJson(state: TweakState, colorDefaults: ColorTweakState | un
  * Normalize whatever shape the dev-API returned into a uniform list. Accepts
  * all three historical shapes:
  *
- *   - `{ updated: [...] }`   — current handler (post Sub 1454)
+ *   - `{ updated: [...] }`   — current handler
  *   - `{ results: [...] }`   — intermediate shape
  *   - `{ "tokens.css": {...} }` — very early shape
  */
@@ -150,9 +150,9 @@ function normalizeResults(response: ApplyResponse): ApplyFileResult[] {
 // ---------------------------------------------------------------------------
 //
 // CSS rules backing these classes live in `styles/panel.css` under the
-// default prefix `zmod-design-token-panel-modal*`. Consumers that override
-// `modalClassPrefix` opt out of bundled CSS and ship their own — see the
-// "Modal layer" header in panel.css for the full rationale.
+// default modal class prefix. Consumers that override `modalClassPrefix`
+// opt out of bundled CSS and ship their own — see the "Modal layer"
+// header in panel.css for the full rationale.
 //
 // `buildClasses(cfg)` is pure, so we memo it per-cfg-object inside the
 // component and pass the result down to body subviews as a single bag.
@@ -212,7 +212,7 @@ export function ApplyModal(props: ApplyModalProps) {
   const cfg = getPanelConfig();
   const cls = useMemo(() => buildClasses(cfg), [cfg]);
 
-  // Stable id for aria-labelledby (PR #1440 review item Q1). Native
+  // Stable id for aria-labelledby. Native
   // <dialog>.showModal() implies aria-modal=true, so only the title pointer
   // is needed.
   const titleId = `${cfg.modalClassPrefix}-apply-title`;
@@ -232,7 +232,7 @@ export function ApplyModal(props: ApplyModalProps) {
         dialog.setAttribute('open', '');
       }
       // Focus the primary action on open. Native <dialog>.close() restores
-      // focus to the trigger automatically (PR #1440 review item Q2).
+      // focus to the trigger automatically.
       window.requestAnimationFrame(() => {
         primaryButtonRef.current?.focus();
       });
@@ -265,7 +265,7 @@ export function ApplyModal(props: ApplyModalProps) {
   const flattenedOverrides = useMemo(() => {
     // Primary zd cluster — diffed against the scheme baseline.
     const zdOverrides = buildApplyOverrides(state, colorDefaults);
-    // Optional secondary cluster (Sub S5b, #1589). Three short-circuits:
+    // Optional secondary cluster. Three short-circuits:
     //
     //   1. Host opted out (`secondaryColorCluster: null`) — `secondaryCluster`
     //      is null → emit no secondary keys.
@@ -291,12 +291,11 @@ export function ApplyModal(props: ApplyModalProps) {
   const totalCount = useMemo(() => Object.keys(flattenedOverrides).length, [flattenedOverrides]);
   const isEmpty = totalCount === 0;
   const hasRoutableEntries = groups.length > 0;
-  // PR #1440 review item P0-3 — Apply button is gated on the host having
-  // configured both an endpoint AND a non-empty routing map. Either one
-  // missing means the modal still renders (so the user can preview the
-  // diff), but the primary action is disabled with a tooltip explaining
-  // why. Non-zmod hosts that only want export/import opt out of apply by
-  // omitting these fields entirely.
+  // Apply button is gated on the host having configured both an endpoint
+  // AND a non-empty routing map. Either one missing means the modal still
+  // renders (so the user can preview the diff), but the primary action is
+  // disabled with a tooltip explaining why. Hosts that only want
+  // export/import opt out of apply by omitting these fields entirely.
   const applyEndpoint = cfg.applyEndpoint;
   const applyConfigured = Boolean(applyEndpoint) && Object.keys(applyRouting).length > 0;
 
@@ -415,8 +414,7 @@ export function ApplyModal(props: ApplyModalProps) {
   }
 
   // Primary-button label changes to reflect what files the apply will edit
-  // (when host-configured) or that apply is unavailable. Falling back to the
-  // legacy zmod-flavoured label only when the routing matches zmod's path.
+  // (when host-configured) or that apply is unavailable.
   const routingFiles = useMemo(
     () =>
       Object.values(applyRouting)

--- a/packages/zudo-design-token-panel/src/apply-modal.tsx
+++ b/packages/zudo-design-token-panel/src/apply-modal.tsx
@@ -269,16 +269,17 @@ export function ApplyModal(props: ApplyModalProps) {
     //
     //   1. Host opted out (`secondaryColorCluster: null`) — `secondaryCluster`
     //      is null → emit no secondary keys.
-    //   2. Host kept the default but the persist envelope has no zaudio
-    //      slice yet — `state.zaudio` undefined → skip.
+    //   2. Host kept the default but the persist envelope has no secondary
+    //      slice yet — `state.secondary` undefined → skip.
     //   3. Otherwise — diff against `undefined` (no scheme baseline yet)
     //      and merge into the flat overrides. The shallow
-    //      `{ ...state, color: state.zaudio }` swap lets `buildApplyOverrides`
-    //      reuse its existing logic without signature changes.
+    //      `{ ...state, color: state.secondary }` swap lets
+    //      `buildApplyOverrides` reuse its existing logic without
+    //      signature changes.
     const secondaryCluster = resolveSecondaryColorCluster(cfg);
     const secondaryOverrides =
-      secondaryCluster && state.zaudio
-        ? buildApplyOverrides({ ...state, color: state.zaudio }, undefined, secondaryCluster)
+      secondaryCluster && state.secondary
+        ? buildApplyOverrides({ ...state, color: state.secondary }, undefined, secondaryCluster)
         : {};
     return { ...zdOverrides, ...secondaryOverrides };
   }, [state, colorDefaults, cfg]);

--- a/packages/zudo-design-token-panel/src/apply/__tests__/route-tokens-to-files.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/route-tokens-to-files.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import { TOKEN_SOURCE_FILES, routeTokensToFiles, type RouteResult } from '../route-tokens-to-files';
+
+describe('TOKEN_SOURCE_FILES', () => {
+  it('ships an empty default routing map (host MUST configure routing)', () => {
+    expect(TOKEN_SOURCE_FILES).toEqual({});
+  });
+});
+
+const DEMO_ROUTING = {
+  brand: 'src/styles/brand.css',
+  audio: 'src/styles/audio.css',
+};
+
+describe('routeTokensToFiles — single-prefix grouping', () => {
+  it('groups all matching cssVars under their configured prefix', () => {
+    const result: RouteResult = routeTokensToFiles(
+      {
+        '--brand-p5': 'oklch(99% 0 0)',
+        '--brand-spacing-hgap-sm': '24px',
+      },
+      DEMO_ROUTING,
+    );
+    expect(result.rejected).toEqual([]);
+    expect(result.groups).toHaveLength(1);
+    const [group] = result.groups;
+    expect(group.prefix).toBe('brand');
+    expect(group.relativePath).toBe(DEMO_ROUTING.brand);
+    expect(group.tokens).toEqual({
+      '--brand-p5': 'oklch(99% 0 0)',
+      '--brand-spacing-hgap-sm': '24px',
+    });
+  });
+
+  it('preserves insertion order of tokens within a group', () => {
+    const result = routeTokensToFiles(
+      {
+        '--brand-z9': 'z',
+        '--brand-a1': 'a',
+        '--brand-m5': 'm',
+      },
+      DEMO_ROUTING,
+    );
+    expect(Object.keys(result.groups[0].tokens)).toEqual([
+      '--brand-z9',
+      '--brand-a1',
+      '--brand-m5',
+    ]);
+  });
+});
+
+describe('routeTokensToFiles — multi-prefix grouping', () => {
+  it('produces one group per prefix, each with its own path', () => {
+    const result = routeTokensToFiles(
+      {
+        '--brand-p5': 'red',
+        '--audio-font-md': '15px',
+        '--brand-p1': 'blue',
+        '--audio-touch-target': '48px',
+      },
+      DEMO_ROUTING,
+    );
+    expect(result.rejected).toEqual([]);
+    expect(result.groups).toHaveLength(2);
+
+    const brand = result.groups.find((g) => g.prefix === 'brand');
+    const audio = result.groups.find((g) => g.prefix === 'audio');
+    expect(brand).toBeDefined();
+    expect(audio).toBeDefined();
+    expect(brand!.relativePath).toBe(DEMO_ROUTING.brand);
+    expect(audio!.relativePath).toBe(DEMO_ROUTING.audio);
+    expect(brand!.tokens).toEqual({ '--brand-p5': 'red', '--brand-p1': 'blue' });
+    expect(audio!.tokens).toEqual({
+      '--audio-font-md': '15px',
+      '--audio-touch-target': '48px',
+    });
+  });
+
+  it('preserves insertion order within each group (not across groups)', () => {
+    const result = routeTokensToFiles(
+      {
+        '--brand-z9': 'z',
+        '--audio-b2': 'b',
+        '--brand-a1': 'a',
+        '--audio-a1': 'a',
+      },
+      DEMO_ROUTING,
+    );
+    const brand = result.groups.find((g) => g.prefix === 'brand')!;
+    const audio = result.groups.find((g) => g.prefix === 'audio')!;
+    expect(Object.keys(brand.tokens)).toEqual(['--brand-z9', '--brand-a1']);
+    expect(Object.keys(audio.tokens)).toEqual(['--audio-b2', '--audio-a1']);
+  });
+});
+
+describe('routeTokensToFiles — rejected inputs', () => {
+  it('routes unknown double-dash prefixes to rejected', () => {
+    const result = routeTokensToFiles(
+      {
+        '--color-bg': 'pink',
+        '--something-not-known': 'value',
+      },
+      DEMO_ROUTING,
+    );
+    expect(result.groups).toEqual([]);
+    expect(result.rejected).toEqual(['--color-bg', '--something-not-known']);
+  });
+
+  it('rejects keys that do not start with --', () => {
+    const result = routeTokensToFiles(
+      {
+        'brand-p5': 'red',
+        'not-a-css-var': 'value',
+      },
+      DEMO_ROUTING,
+    );
+    expect(result.groups).toEqual([]);
+    expect(result.rejected).toEqual(['brand-p5', 'not-a-css-var']);
+  });
+
+  it('rejects the bare prefix without a trailing segment', () => {
+    const result = routeTokensToFiles(
+      {
+        '--brand': 'x',
+        '--brand-': 'x',
+        '--audio': 'y',
+        '--audio-': 'y',
+      },
+      DEMO_ROUTING,
+    );
+    expect(result.groups).toEqual([]);
+    expect(result.rejected).toEqual(['--brand', '--brand-', '--audio', '--audio-']);
+  });
+
+  it('splits accepted and rejected entries in a mixed input', () => {
+    const result = routeTokensToFiles(
+      {
+        '--brand-p5': 'red',
+        '--unknown-foo': 'x',
+        '--audio-font-md': '15px',
+        'bare-key': 'nope',
+      },
+      DEMO_ROUTING,
+    );
+    expect(result.rejected).toEqual(['--unknown-foo', 'bare-key']);
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups.find((g) => g.prefix === 'brand')!.tokens).toEqual({ '--brand-p5': 'red' });
+    expect(result.groups.find((g) => g.prefix === 'audio')!.tokens).toEqual({
+      '--audio-font-md': '15px',
+    });
+  });
+});
+
+describe('routeTokensToFiles — empty input', () => {
+  it('returns empty groups and empty rejected list', () => {
+    const result = routeTokensToFiles({}, DEMO_ROUTING);
+    expect(result.groups).toEqual([]);
+    expect(result.rejected).toEqual([]);
+  });
+});
+
+describe('routeTokensToFiles — host-supplied routing', () => {
+  it('uses the supplied routing map when provided', () => {
+    const result = routeTokensToFiles(
+      { '--demo-pa1': '#ff0000', '--brand-p5': '#00ff00' },
+      { demo: 'src/demo.css' },
+    );
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toEqual({
+      prefix: 'demo',
+      relativePath: 'src/demo.css',
+      tokens: { '--demo-pa1': '#ff0000' },
+    });
+    // --brand-p5 is rejected because the host's routing has no `brand` entry.
+    expect(result.rejected).toEqual(['--brand-p5']);
+  });
+
+  it('emits a non-empty rejectedReasons list with prefix-aware diagnostics', () => {
+    const result = routeTokensToFiles(
+      { '--unknown-x': '1', 'bare-key': '2' },
+      { brand: 'tokens.css' },
+    );
+    expect(result.rejectedReasons).toHaveLength(2);
+    expect(result.rejectedReasons[0]).toMatch(/no route configured.*"brand"/);
+    expect(result.rejectedReasons[1]).toMatch(/not a CSS custom property/);
+  });
+
+  it('rejects everything when the routing map is empty (apply disabled)', () => {
+    const result = routeTokensToFiles({ '--brand-p5': 'red' }, {});
+    expect(result.groups).toEqual([]);
+    expect(result.rejected).toEqual(['--brand-p5']);
+    expect(result.rejectedReasons[0]).toMatch(/no applyRouting configured/);
+  });
+});

--- a/packages/zudo-design-token-panel/src/apply/apply-token-overrides.ts
+++ b/packages/zudo-design-token-panel/src/apply/apply-token-overrides.ts
@@ -4,7 +4,7 @@
  * `applyTokenOverrides(source, overrides)` rewrites the values of one or more
  * CSS custom properties inside the FIRST top-level `:root { ... }` block of a
  * CSS file, preserving surrounding whitespace and trailing inline comments.
- * The module is the regex foundation that the dev-API endpoint (Sub 1454)
+ * The module is the regex foundation that the dev-API endpoint
  * wraps; it performs no IO, no DOM access, and is safe to import in any
  * environment.
  *
@@ -238,7 +238,7 @@ interface SingleReplaceResult {
  *
  * would have its commented-out value rewritten by the regex (it matches the
  * FIRST occurrence), leaving the live declaration untouched and silently
- * corrupting the user-authored comment. See PR #1440 review item B4.
+ * corrupting the user-authored comment.
  */
 function maskComments(input: string): string {
   return input.replace(/\/\*[\s\S]*?\*\//g, (m) => ' '.repeat(m.length));

--- a/packages/zudo-design-token-panel/src/apply/apply-token-overrides.ts
+++ b/packages/zudo-design-token-panel/src/apply/apply-token-overrides.ts
@@ -1,0 +1,362 @@
+/**
+ * Pure, IO-free CSS custom-property value replacement.
+ *
+ * `applyTokenOverrides(source, overrides)` rewrites the values of one or more
+ * CSS custom properties inside the FIRST top-level `:root { ... }` block of a
+ * CSS file, preserving surrounding whitespace and trailing inline comments.
+ * The module is the regex foundation that the dev-API endpoint (Sub 1454)
+ * wraps; it performs no IO, no DOM access, and is safe to import in any
+ * environment.
+ *
+ * Behavior summary
+ * ----------------
+ * - Only the FIRST top-level `:root { ... }` block is modified. Tokens inside
+ *   `@media`, `@layer`, `@supports`, or nested `:root` blocks are IGNORED.
+ * - Per-cssVar regex: `(--name:)\s*([\s\S]+?);` with the name regex-escaped.
+ *   The non-greedy value capture stops at the first `;`, which preserves any
+ *   trailing `/​* ... *​/` inline comment on the same logical line.
+ * - A whitespace-trimmed comparison between the old value and the override
+ *   decides whether the cssVar lands in `changed` or `unchanged`.
+ * - Idempotent: applying the same overrides twice in a row reports every key
+ *   as `unchanged` on the second call and produces byte-identical output.
+ *
+ * Known limitations (if a richer transform is ever needed, swap this module
+ * for a real CSS parser such as postcss):
+ * - Only `:root` as a bare selector is recognized. Grouped selectors such as
+ *   `:root, html { ... }` are NOT treated as a `:root` block.
+ * - Nested `:root` under `@media` / `@layer` / `@supports` is intentionally
+ *   skipped; see the test matrix in the companion `__tests__` file.
+ * - Values containing a literal `;` inside a string or comment would confuse
+ *   the non-greedy regex. Not supported.
+ * - If the same cssVar is declared multiple times in the top-level `:root`
+ *   block, only the FIRST occurrence is rewritten.
+ */
+
+export interface ApplyResult {
+  /** The new CSS file contents (byte-identical to `source` when nothing
+   *  changed, including the "no :root block" case). */
+  updated: string;
+  /** cssVar names actually rewritten (trimmed new value differs from old). */
+  changed: string[];
+  /** cssVar names present in the file whose trimmed value already matched
+   *  the override. */
+  unchanged: string[];
+  /** cssVar names in `overrides` that were not found in the first top-level
+   *  `:root` block (either because the name is absent, or because no
+   *  top-level `:root` block exists). */
+  unknown: string[];
+}
+
+/**
+ * Thrown by {@link applyTokenOverridesOrThrow} when the source has no
+ * top-level `:root { ... }` block. Lets the dev-API handler surface a
+ * diagnostic message without having to probe the result shape.
+ */
+export class NoRootBlockError extends Error {
+  constructor(message = 'No top-level ":root { ... }" block found in source.') {
+    super(message);
+    this.name = 'NoRootBlockError';
+    Object.setPrototypeOf(this, NoRootBlockError.prototype);
+  }
+}
+
+interface RootBlockBounds {
+  /** Index of the first character INSIDE the `:root { ... }` block (just
+   *  after the opening `{`). */
+  contentStart: number;
+  /** Index of the matching `}` (exclusive end of block content). */
+  contentEnd: number;
+}
+
+/**
+ * Scan `source` with a small state machine that tracks brace depth while
+ * skipping CSS block comments and string literals. Returns the bounds of the
+ * first top-level `:root { ... }` block, or `null` if none exists.
+ *
+ * "Top-level" means brace depth is zero at the point `:root` appears, so
+ * `:root` blocks nested under `@media`, `@layer`, `@supports`, etc. are
+ * deliberately skipped.
+ */
+function findFirstTopLevelRootBlock(source: string): RootBlockBounds | null {
+  const len = source.length;
+  let i = 0;
+  let depth = 0;
+
+  while (i < len) {
+    const ch = source[i];
+
+    // Block comment — /* ... */
+    if (ch === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2);
+      if (end === -1) return null;
+      i = end + 2;
+      continue;
+    }
+
+    // String literals — preserve `{`, `}`, `;` inside
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i++;
+      while (i < len && source[i] !== quote) {
+        if (source[i] === '\\' && i + 1 < len) i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth++;
+      i++;
+      continue;
+    }
+    if (ch === '}') {
+      if (depth > 0) depth--;
+      i++;
+      continue;
+    }
+
+    if (depth === 0 && ch === ':' && source.startsWith(':root', i)) {
+      const after = i + 5;
+      const nextCh = source[after] ?? '';
+      if (!isIdentChar(nextCh)) {
+        const braceIdx = skipTriviaToBrace(source, after);
+        if (braceIdx !== -1) {
+          const contentStart = braceIdx + 1;
+          const contentEnd = findMatchingClose(source, contentStart);
+          if (contentEnd !== -1) {
+            return { contentStart, contentEnd };
+          }
+          return null;
+        }
+      }
+    }
+
+    i++;
+  }
+
+  return null;
+}
+
+function isIdentChar(ch: string): boolean {
+  return /[A-Za-z0-9_-]/.test(ch);
+}
+
+/**
+ * Skip whitespace and block comments starting at `from`, returning the index
+ * of the next `{` character, or -1 if anything else intervenes (indicating
+ * the `:root` token was not the start of a simple block, e.g. a grouped
+ * selector like `:root, html { ... }`).
+ */
+function skipTriviaToBrace(source: string, from: number): number {
+  const len = source.length;
+  let j = from;
+  while (j < len) {
+    const c = source[j];
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f') {
+      j++;
+      continue;
+    }
+    if (c === '/' && source[j + 1] === '*') {
+      const end = source.indexOf('*/', j + 2);
+      if (end === -1) return -1;
+      j = end + 2;
+      continue;
+    }
+    return c === '{' ? j : -1;
+  }
+  return -1;
+}
+
+/**
+ * Given an index pointing at the character AFTER an opening `{`, return the
+ * index of the matching closing `}`, or -1 on malformed input. Comments and
+ * string literals are skipped so their `{`/`}` characters do not affect
+ * balance.
+ */
+function findMatchingClose(source: string, from: number): number {
+  const len = source.length;
+  let k = from;
+  let sub = 1;
+  while (k < len) {
+    const c = source[k];
+    if (c === '/' && source[k + 1] === '*') {
+      const end = source.indexOf('*/', k + 2);
+      if (end === -1) return -1;
+      k = end + 2;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      const quote = c;
+      k++;
+      while (k < len && source[k] !== quote) {
+        if (source[k] === '\\' && k + 1 < len) k++;
+        k++;
+      }
+      k++;
+      continue;
+    }
+    if (c === '{') {
+      sub++;
+      k++;
+      continue;
+    }
+    if (c === '}') {
+      sub--;
+      if (sub === 0) return k;
+      k++;
+      continue;
+    }
+    k++;
+  }
+  return -1;
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
+type SingleReplaceStatus = 'changed' | 'unchanged' | 'unknown';
+
+interface SingleReplaceResult {
+  content: string;
+  status: SingleReplaceStatus;
+}
+
+/**
+ * Replace every CSS block comment (`/​* ... *​/`) with same-length whitespace
+ * so the per-declaration regex below cannot match a fake declaration that
+ * lives INSIDE a comment. Same-length is critical: the masked string is used
+ * only as a search space, but the resulting `match.index` is then sliced
+ * straight back into the original (un-masked) `content`, so masked and
+ * original must agree byte-for-byte on offsets.
+ *
+ * Pre-fix behaviour: a `:root` containing
+ *
+ *   /* --zd-foo: red; *​/
+ *   --zd-foo: blue;
+ *
+ * would have its commented-out value rewritten by the regex (it matches the
+ * FIRST occurrence), leaving the live declaration untouched and silently
+ * corrupting the user-authored comment. See PR #1440 review item B4.
+ */
+function maskComments(input: string): string {
+  return input.replace(/\/\*[\s\S]*?\*\//g, (m) => ' '.repeat(m.length));
+}
+
+/**
+ * Replace the value of a single custom property inside `content`. The name
+ * may be supplied with or without the leading `--`. Returns the updated
+ * content along with a status flag used to populate `changed` / `unchanged`
+ * / `unknown` in the top-level {@link ApplyResult}.
+ *
+ * The match is run against a comment-masked copy of `content` so a
+ * commented-out declaration cannot shadow a live one (B4 fix). Edits are
+ * still spliced back into the original `content` so trailing inline comments
+ * survive byte-for-byte.
+ */
+function replaceOne(content: string, cssVarName: string, newValue: string): SingleReplaceResult {
+  const bareName = cssVarName.startsWith('--') ? cssVarName.slice(2) : cssVarName;
+  const escaped = escapeRegExp(bareName);
+  // Three capture groups so we can re-emit the original whitespace byte-for-byte:
+  //   1: the `--name:` prefix
+  //   2: whitespace between `:` and the value
+  //   3: the value, non-greedy so it stops at the first `;`
+  const re = new RegExp('(--' + escaped + ':)(\\s*)([\\s\\S]+?);');
+  const masked = maskComments(content);
+  const match = re.exec(masked);
+  if (!match) return { content, status: 'unknown' };
+
+  const [fullMaskedMatch, prefix, whitespace] = match;
+  const start = match.index;
+  const end = start + fullMaskedMatch.length;
+
+  // Slice the value from the ORIGINAL content. The masked string only
+  // changes characters inside `/​* ... *​/` to spaces, and a live declaration
+  // (the only thing the regex can now match) sits outside any comment, so
+  // the value substring is identical in masked and original — but we still
+  // read from `content` so any future mask change can't introduce drift.
+  const valueStart = start + prefix.length + whitespace.length;
+  const valueEnd = end - 1; // before the trailing ';'
+  const oldValue = content.slice(valueStart, valueEnd);
+
+  const trimmedOld = oldValue.trim();
+  const trimmedNew = newValue.trim();
+  if (trimmedOld === trimmedNew) {
+    return { content, status: 'unchanged' };
+  }
+
+  const updated =
+    content.slice(0, start) + prefix + whitespace + newValue + ';' + content.slice(end);
+  return { content: updated, status: 'changed' };
+}
+
+/**
+ * Rewrite `overrides` into the first top-level `:root { ... }` block of
+ * `source` and return an {@link ApplyResult} describing the outcome.
+ *
+ * If `source` has no top-level `:root` block, the function returns
+ * `source` unchanged with every key routed to `unknown` — the companion
+ * {@link applyTokenOverridesOrThrow} raises {@link NoRootBlockError} in
+ * that case so callers that need a hard failure can distinguish it from a
+ * block where merely none of the overrides matched.
+ */
+export function applyTokenOverrides(
+  source: string,
+  overrides: Record<string, string>,
+): ApplyResult {
+  const keys = Object.keys(overrides);
+  const bounds = findFirstTopLevelRootBlock(source);
+  if (!bounds) {
+    return {
+      updated: source,
+      changed: [],
+      unchanged: [],
+      unknown: [...keys],
+    };
+  }
+
+  let content = source.slice(bounds.contentStart, bounds.contentEnd);
+  const changed: string[] = [];
+  const unchanged: string[] = [];
+  const unknown: string[] = [];
+
+  for (const key of keys) {
+    const result = replaceOne(content, key, overrides[key]);
+    content = result.content;
+    if (result.status === 'changed') changed.push(key);
+    else if (result.status === 'unchanged') unchanged.push(key);
+    else unknown.push(key);
+  }
+
+  const updated = source.slice(0, bounds.contentStart) + content + source.slice(bounds.contentEnd);
+
+  return { updated, changed, unchanged, unknown };
+}
+
+/**
+ * Throwing variant. Same shape as {@link applyTokenOverrides} except it
+ * raises {@link NoRootBlockError} when no top-level `:root { ... }` block
+ * exists, instead of returning every override under `unknown`. Use this from
+ * server-side handlers where "no :root block" is a fatal configuration
+ * problem rather than an expected state.
+ */
+export function applyTokenOverridesOrThrow(
+  source: string,
+  overrides: Record<string, string>,
+): ApplyResult {
+  const bounds = findFirstTopLevelRootBlock(source);
+  if (!bounds) {
+    throw new NoRootBlockError();
+  }
+  return applyTokenOverrides(source, overrides);
+}
+
+/**
+ * Low-level predicate exposed primarily for callers that want to report a
+ * precise diagnostic without running a full rewrite. Returns `true` iff the
+ * source contains at least one top-level `:root { ... }` block.
+ */
+export function hasTopLevelRootBlock(source: string): boolean {
+  return findFirstTopLevelRootBlock(source) !== null;
+}

--- a/packages/zudo-design-token-panel/src/apply/build-apply-overrides.ts
+++ b/packages/zudo-design-token-panel/src/apply/build-apply-overrides.ts
@@ -1,0 +1,120 @@
+/**
+ * Build the flat `{ cssVarName: cssValue }` diff consumed by the host's
+ * Apply endpoint (e.g. a dev-API route that POSTs the diff to the panel
+ * server).
+ *
+ * Consumes the `TweakState` shape directly:
+ *
+ *   - `state.color.palette: string[]` — palette hex values
+ *   - `state.color.semanticMappings: Record<string, number | 'bg' | 'fg'>` —
+ *     semantic-token → palette-index map
+ *   - `state.color.background` / `foreground` — palette indices used when a
+ *     semantic mapping is `"bg"` / `"fg"` respectively
+ *
+ * The routing layer (`route-tokens-to-files.ts`) then splits the map into
+ * per-file groups. The host (or the deferred bin) applies each group to
+ * its target `.css` file.
+ *
+ * Scope
+ * -----
+ * Only cssVars that the cluster's CSS files actually declare are emitted.
+ * Specifically:
+ *
+ *   - Palette slots (resolved via `resolvePaletteCssVar(cluster, i)`) —
+ *     EMITTED as hex values.
+ *   - Semantic tokens (`cluster.semanticCssNames` entries) — EMITTED as
+ *     `var(--<paletteSlotName>)` so the rewrite preserves the indirection
+ *     that the hand-authored CSS relies on.
+ *   - Base roles (`cluster.baseRoles` entries) — NOT emitted. They do not
+ *     belong to the apply pipeline's rewrite scope.
+ *   - Spacing / typography / size — NOT emitted here. They live in a
+ *     separate token file the Apply endpoint may or may not rewrite;
+ *     routing them would surface as rejected prefixes.
+ *
+ * Diff-only output
+ * ----------------
+ * A cssVar is emitted ONLY when the current state differs from the provided
+ * baseline. Callers without a baseline (tests, degraded-init paths) can pass
+ * `colorDefaults: undefined`; in that case the whole color block is treated
+ * as changed so the payload still goes out rather than silently noop'ing.
+ *
+ * Pure / no IO — safe to import anywhere (browser, Node, tests).
+ */
+
+import type { ColorTweakState, TweakState, ColorClusterConfig } from '../state/tweak-state';
+import { resolvePaletteCssVar, safeIndex } from '../state/tweak-state';
+import { getPanelConfig } from '../config/panel-config';
+
+/**
+ * Produce the flat cssVar → value map for the dev-API handler.
+ *
+ * `colorDefaults` should be the scheme baseline the UI diffs against (the
+ * same baseline the panel passes to the Export / Import modals). Pass
+ * `undefined` to force the whole color block into the output.
+ *
+ * `cluster` defaults to `getPanelConfig().colorCluster` so primary-cluster
+ * callers do not have to thread the active cluster through every layer.
+ * Secondary-cluster callers MUST pass an explicit cluster argument.
+ */
+export function buildApplyOverrides(
+  state: TweakState,
+  colorDefaults: ColorTweakState | undefined,
+  cluster: ColorClusterConfig = getPanelConfig().colorCluster,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const color = state.color;
+
+  // ---------- Palette slots ----------
+  const paletteLen = color.palette.length;
+  for (let i = 0; i < paletteLen; i++) {
+    const current = color.palette[i];
+    if (typeof current !== 'string' || current.length === 0) continue;
+    const baseline = colorDefaults?.palette[i];
+    if (colorDefaults === undefined || current !== baseline) {
+      out[resolvePaletteCssVar(cluster, i)] = current;
+    }
+  }
+
+  // ---------- Semantic mappings ----------
+  // Walk the cluster's semantic registry (SEMANTIC_CSS_NAMES under the hood)
+  // so we emit exactly the tokens the design system declares — any stray keys
+  // in `semanticMappings` with no matching cssVar are silently dropped.
+  for (const [key, cssVar] of Object.entries(cluster.semanticCssNames)) {
+    const currentMapping = color.semanticMappings[key];
+    if (currentMapping === undefined) continue;
+    const baselineMapping = colorDefaults?.semanticMappings[key];
+    const changed = colorDefaults === undefined || currentMapping !== baselineMapping;
+    if (!changed) continue;
+    const paletteIndex = resolveMappingIndex(currentMapping, color);
+    if (paletteIndex === null) continue;
+    // PR #1440 review item P1-9 — clamp out-of-range indices to a valid
+    // slot before emitting the CSS-var reference. The DOM-apply path uses
+    // `safeIndex` already; the disk-rewrite pipeline must do the same so
+    // a corrupted persisted index (e.g. `paletteIndex = 99` when palette
+    // length is 16) doesn't write `var(--zd-p99)` into tokens.css.
+    const clamped = safeIndex(paletteIndex, color.palette.length);
+    if (clamped !== paletteIndex) {
+      console.error(
+        `[design-token-panel] paletteIndex ${paletteIndex} for ${cssVar} is out of range (palette length ${color.palette.length}); clamping to ${clamped}.`,
+      );
+    }
+    out[cssVar] = `var(${resolvePaletteCssVar(cluster, clamped)})`;
+  }
+
+  return out;
+}
+
+/**
+ * Resolve a `semanticMappings` value to a concrete palette index.
+ *
+ * - `number`  → used as-is.
+ * - `"bg"`    → the color state's current background index.
+ * - `"fg"`    → the color state's current foreground index.
+ * - anything else → `null` (caller skips the entry).
+ */
+function resolveMappingIndex(mapping: number | 'bg' | 'fg', color: ColorTweakState): number | null {
+  if (mapping === 'bg') return color.background;
+  if (mapping === 'fg') return color.foreground;
+  if (typeof mapping === 'number' && Number.isInteger(mapping)) return mapping;
+  return null;
+}

--- a/packages/zudo-design-token-panel/src/apply/build-apply-overrides.ts
+++ b/packages/zudo-design-token-panel/src/apply/build-apply-overrides.ts
@@ -87,7 +87,7 @@ export function buildApplyOverrides(
     if (!changed) continue;
     const paletteIndex = resolveMappingIndex(currentMapping, color);
     if (paletteIndex === null) continue;
-    // PR #1440 review item P1-9 — clamp out-of-range indices to a valid
+    // clamp out-of-range indices to a valid
     // slot before emitting the CSS-var reference. The DOM-apply path uses
     // `safeIndex` already; the disk-rewrite pipeline must do the same so
     // a corrupted persisted index (e.g. `paletteIndex = 99` when palette

--- a/packages/zudo-design-token-panel/src/apply/route-tokens-to-files.ts
+++ b/packages/zudo-design-token-panel/src/apply/route-tokens-to-files.ts
@@ -1,0 +1,133 @@
+/**
+ * Token-to-file routing — pure grouping module.
+ *
+ * Given a map of cssVar overrides (e.g. from the tweak state's serialized
+ * form), split the entries by target source file so the dev-API handler can
+ * call the rewriter once per file. The prefix → file map is supplied by the
+ * caller (typically read from `panelConfig.applyRouting`) — the package
+ * ships zero baked-in routing defaults; hosts MUST configure their own.
+ *
+ * Anything that does NOT look like a `--<prefix>-...` cssVar, OR whose prefix
+ * has no entry in the supplied routing map, lands in `rejected`. The caller
+ * surfaces those (e.g. as a non-empty `rejected[]` field on the apply
+ * response) so silent drops become visible.
+ *
+ * No IO, no DOM, no Node-specific imports — safe to bundle for the browser.
+ */
+
+import type { ApplyRoutingMap } from '../config/panel-config';
+
+/**
+ * Prefix-family identifier. Plain string — the routing map is host-supplied.
+ */
+export type TokenPrefix = string;
+
+export interface RouteGroup {
+  /** Which prefix family these tokens belong to. */
+  prefix: string;
+  /** Repo-relative path of the source CSS file the rewriter should edit. */
+  relativePath: string;
+  /** Ordered map of cssVar → value. Insertion order follows the input. */
+  tokens: Record<string, string>;
+}
+
+export interface RouteResult {
+  /** At most one group per prefix. Empty when every entry was rejected. */
+  groups: RouteGroup[];
+  /** cssVar names whose prefix is not supported. */
+  rejected: string[];
+  /**
+   * Diagnostic messages explaining each rejection. Same length as `rejected`,
+   * indexed in lockstep. Hosts surface these in the UI so silent drops
+   * become visible (PR #1440 review item P0-2).
+   */
+  rejectedReasons: string[];
+}
+
+/**
+ * Empty default routing — the package ships no baked-in prefix → file map.
+ * Hosts MUST supply `panelConfig.applyRouting` (or pass an explicit map to
+ * `routeTokensToFiles`) for the apply pipeline to do anything; without it,
+ * every entry lands in `rejected` with a clear diagnostic.
+ */
+export const TOKEN_SOURCE_FILES: Readonly<ApplyRoutingMap> = Object.freeze({});
+
+/**
+ * Return the prefix family for a cssVar, or `null` if the name does not match
+ * any prefix in the supplied routing map. A cssVar must look like
+ * `--<prefix>-<rest>` — the bare `--<prefix>` / `--<prefix>-` forms are not
+ * accepted because there is nothing to rewrite.
+ */
+function classify(cssVar: string, routing: ApplyRoutingMap): string | null {
+  if (!cssVar.startsWith('--')) return null;
+  // Walk routing keys in declaration order so a host that lists a
+  // longer-prefix entry first (e.g. `zd-special` before `zd`) wins.
+  for (const prefix of Object.keys(routing)) {
+    const needle = `--${prefix}-`;
+    if (cssVar.startsWith(needle) && cssVar.length > needle.length) {
+      return prefix;
+    }
+  }
+  return null;
+}
+
+/**
+ * Split `overrides` into per-file groups plus a rejected list.
+ *
+ * - Groups are emitted in `Object.keys(routing)` order.
+ * - Tokens within a group preserve the input's insertion order.
+ * - A group is only emitted when it has at least one token.
+ * - `rejected` preserves the input's insertion order, with a parallel
+ *   `rejectedReasons` array describing why each entry failed.
+ *
+ * @param overrides - Flat cssVar → value map.
+ * @param routing - Prefix → repo-relative path map (typically from
+ *   `panelConfig.applyRouting`). When omitted or empty, every entry lands in
+ *   `rejected` so callers surface a clear "apply not configured" error
+ *   instead of silently no-oping.
+ */
+export function routeTokensToFiles(
+  overrides: Record<string, string>,
+  routing: ApplyRoutingMap = TOKEN_SOURCE_FILES,
+): RouteResult {
+  const prefixOrder = Object.keys(routing);
+  const buckets: Record<string, Record<string, string>> = {};
+  for (const prefix of prefixOrder) buckets[prefix] = {};
+  const rejected: string[] = [];
+  const rejectedReasons: string[] = [];
+
+  for (const [cssVar, value] of Object.entries(overrides)) {
+    const prefix = classify(cssVar, routing);
+    if (prefix === null) {
+      rejected.push(cssVar);
+      if (!cssVar.startsWith('--')) {
+        rejectedReasons.push(`${cssVar}: not a CSS custom property (must start with "--")`);
+      } else if (prefixOrder.length === 0) {
+        rejectedReasons.push(
+          `${cssVar}: no applyRouting configured on PanelConfig (host has not enabled disk-rewrite)`,
+        );
+      } else {
+        rejectedReasons.push(
+          `${cssVar}: no route configured for prefix family (known prefixes: ${prefixOrder
+            .map((p) => `"${p}"`)
+            .join(', ')})`,
+        );
+      }
+      continue;
+    }
+    buckets[prefix][cssVar] = value;
+  }
+
+  const groups: RouteGroup[] = [];
+  for (const prefix of prefixOrder) {
+    const tokens = buckets[prefix];
+    if (Object.keys(tokens).length === 0) continue;
+    groups.push({
+      prefix,
+      relativePath: routing[prefix],
+      tokens,
+    });
+  }
+
+  return { groups, rejected, rejectedReasons };
+}

--- a/packages/zudo-design-token-panel/src/apply/route-tokens-to-files.ts
+++ b/packages/zudo-design-token-panel/src/apply/route-tokens-to-files.ts
@@ -39,7 +39,7 @@ export interface RouteResult {
   /**
    * Diagnostic messages explaining each rejection. Same length as `rejected`,
    * indexed in lockstep. Hosts surface these in the UI so silent drops
-   * become visible (PR #1440 review item P0-2).
+   * become visible.
    */
   rejectedReasons: string[];
 }

--- a/packages/zudo-design-token-panel/src/astro/DesignTokenPanelHost.astro
+++ b/packages/zudo-design-token-panel/src/astro/DesignTokenPanelHost.astro
@@ -1,0 +1,76 @@
+---
+/**
+ * Astro entry point for the design-token panel.
+ *
+ * Drop into a layout once. The component AND the host-adapter side-effect
+ * import are a paired unit — both lines are required, always together:
+ *
+ * ```astro
+ * ---
+ * import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+ * import { panelConfig } from './my-design-token-config';
+ * // Required side-effect import for the package's bundled chrome CSS —
+ * // Vite library mode strips the source CSS import from the emitted JS,
+ * // so consumers must re-pull the extracted stylesheet explicitly.
+ * import '@takazudo/zudo-design-token-panel/styles';
+ * ---
+ * <DesignTokenPanelHost config={panelConfig} />
+ * <script>
+ *   // Required side-effect import for the host adapter. The package's
+ *   // distributed Astro surface ships built `dist/astro/*` files, and the
+ *   // package-side hoisted <script> from those built files does not reliably
+ *   // reach production page bundles. Owning the script import in the
+ *   // consumer wrapper sidesteps that pipeline issue. The package's
+ *   // `package.json` lists `dist/astro/host-adapter.js` in `sideEffects` so
+ *   // Rollup preserves the consumer-side import regardless of whether its
+ *   // result is used. The dynamic `void import(...)` form is the recommended
+ *   // canonical wiring because it loads the host-adapter chunk off the
+ *   // critical path.
+ *   void import('@takazudo/zudo-design-token-panel/astro/host-adapter');
+ * </script>
+ * ```
+ *
+ * The component renders ONE inline `<script type="application/json">` block
+ * carrying the serialised `PanelConfig`; the host adapter (loaded via the
+ * consumer-owned import above) reads it by id at module init.
+ *
+ * History — why the host-adapter import lives in the consumer wrapper:
+ * a previous shape emitted a sibling `<script>import './host-adapter';</script>`
+ * block. Vite/Rollup processed that block, recognised the import as
+ * resolving to a sibling JS file outside the consumer's source tree,
+ * emitted an empty chunk, and never linked it from any page entry. The
+ * result was a silent runtime ReferenceError on production builds. Moving
+ * the import into the consumer wrapper hands bundling responsibility to
+ * the consumer's own Astro toolchain, which produces a real chunk that
+ * lands in the page entry.
+ *
+ * Why inline JSON instead of `define:vars` or `set:html` of a JS literal?
+ * `<script type="application/json">` is not parsed as JavaScript by the HTML
+ * parser, so we can serialise arbitrary user-supplied data without an XSS
+ * surface or escaping gymnastics — provided we close-tag-escape strings
+ * (`</` → `<\/`) defensively.
+ */
+
+import type { PanelConfig } from '../config/panel-config';
+
+export interface Props {
+  config: PanelConfig;
+}
+
+const { config } = Astro.props;
+
+// Defensive escape: any literal `<` inside a string field could let the HTML
+// parser see `</script>` or `<!--` and either close the surrounding script
+// element or enter the script-data-escaped state. JSON.stringify does not
+// escape `<` — so we replace every `<` with the JSON unicode escape
+// `<`. The browser's HTML parser sees only the literal characters
+// `\`, `u`, `0`, `0`, `3`, `c` (no `<`), and JSON.parse on the consumer side
+// decodes `<` back to `<`. Targeted replacements like
+// `</script` → `<\/script` work for the close-tag case but `<!--` → `<\!--`
+// produces an invalid JSON escape (`\!` is not in the JSON spec) and
+// JSON.parse rejects it. The unicode-escape sweep is robust against both.
+// See https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+const configJson = JSON.stringify(config).replace(/</g, '\\u003c');
+---
+
+<script type="application/json" id="tokenpanel-config" set:html={configJson} />

--- a/packages/zudo-design-token-panel/src/astro/astro-shim.d.ts
+++ b/packages/zudo-design-token-panel/src/astro/astro-shim.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Ambient declaration for `*.astro` modules so `tsc -p tsconfig.build.json`
+ * accepts the `from './DesignTokenPanelHost.astro'` re-export in `index.ts`.
+ *
+ * This shim mirrors Astro's own template — the actual component shape is
+ * resolved by the consumer's Astro toolchain at build time, not by the
+ * package's `tsc` emit. Keeping the declaration permissive here means we
+ * avoid pulling Astro itself into devDependencies just for type emission.
+ */
+
+declare module '*.astro' {
+  const Component: (props: Record<string, unknown>) => unknown;
+  export default Component;
+}

--- a/packages/zudo-design-token-panel/src/astro/host-adapter.ts
+++ b/packages/zudo-design-token-panel/src/astro/host-adapter.ts
@@ -1,0 +1,273 @@
+/**
+ * Astro host adapter.
+ *
+ * Loaded by `DesignTokenPanelHost.astro` via a per-page `<script>` block.
+ * Responsibilities:
+ *
+ *  1. Read the JSON config inlined by the Astro component (a
+ *     `<script type="application/json" id="tokenpanel-config">` element).
+ *  2. Call `configurePanel(parsedConfig)` BEFORE the lazy-load probes run, so
+ *     every downstream `getPanelConfig()` reader (storage keys, console
+ *     namespace, modal class prefix, …) sees the host's intended values.
+ *  3. Install the console API on `window[config.consoleNamespace]`
+ *     (`showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel`). The
+ *     namespace is a configured field — different consumers can pick
+ *     distinct values to prove the contract is host-agnostic.
+ *  4. Gate the panel module's dynamic import on the same probes the legacy
+ *     host script used: an existing `wasVisible()` flag or any persisted v2
+ *     overrides. When neither is set, the panel module stays out of the
+ *     initial bundle and only loads when the user calls a `window.<ns>.*`
+ *     helper from the console.
+ *
+ * Idempotency
+ * -----------
+ * The Astro `<script>` re-executes on view-transition (`astro:before-swap` /
+ * `astro:page-load`) — the consumer-side bundler emits one script per page
+ * and Astro's view-transition runtime re-runs it. We pin a window-scoped
+ * flag derived from the configured `storagePrefix` so subsequent runs short-
+ * circuit. (The panel module owns its own view-transition listener
+ * lifecycle internally; this flag is only about *adapter*-level state.)
+ *
+ * Singleton sharing
+ * -----------------
+ * `configurePanel` mutates a module-level singleton in
+ * `../config/panel-config.ts`. The dynamic import below resolves through the
+ * package's exports map back to the lib bundle's `dist/index.js`, which
+ * imports from the same `panel-config` chunk that this adapter imports —
+ * Vite's multi-entry build code-splits shared modules into a single chunk so
+ * both surfaces observe one and the same singleton. Without that property,
+ * the adapter's `configurePanel` call would not be visible to the panel.
+ *
+ * NOTE: This file is a sibling of `index.ts`; both compile under the
+ * `astro/*` entry tree of `vite.config.ts`. It is consumed only by the
+ * Astro toolchain on the consumer side (via the `<script>` import in
+ * `DesignTokenPanelHost.astro`), never by the lib bundle's `index.ts`.
+ */
+
+// Type-only import via the source entry — runtime resolution at consumer
+// build time still goes through the package self-reference below
+// (`@takazudo/zudo-design-token-panel`), kept external by `vite.config.ts`.
+import type * as DesignTokenPanelModule from '../index';
+import {
+  assertValidPanelConfig,
+  configurePanel,
+  getPanelConfig,
+  storageKey_stateV2,
+  storageKey_visible,
+  type PanelConfig,
+} from '../config/panel-config';
+
+interface DesignTokenPanelAdapterState {
+  /** Per-`storagePrefix` bind flag — re-runs of the script are no-ops. */
+  bound: boolean;
+  /** Memoised module promise so steady-state toggle/show/hide share one load. */
+  modulePromise: Promise<typeof DesignTokenPanelModule> | null;
+}
+
+interface ConsoleApiSurface {
+  showDesignPanel?: () => Promise<void>;
+  hideDesignPanel?: () => Promise<void>;
+  toggleDesignPanel?: () => Promise<void>;
+  // Allow co-existence with other helpers a host may install on the same
+  // namespace (e.g. `window.<ns>.someOtherDebugHelper()`).
+  [extra: string]: unknown;
+}
+
+type AdapterStateMap = Record<string, DesignTokenPanelAdapterState>;
+
+interface AdapterWindow extends Window {
+  __zudoDesignTokenPanelAdapter?: AdapterStateMap;
+  // Index access for the configured console namespace.
+  [namespace: string]: unknown;
+}
+
+const CONFIG_SCRIPT_ID = 'tokenpanel-config';
+
+/**
+ * Read & parse the inline JSON config. Throws if the script tag is missing
+ * or its payload is not valid JSON — both indicate a host-side wiring bug
+ * the developer should hear about loudly.
+ */
+function readInlineConfig(): PanelConfig {
+  if (typeof document === 'undefined') {
+    throw new Error(
+      '[design-token-panel] host-adapter loaded without a document; expected to run in a browser context.',
+    );
+  }
+  const el = document.getElementById(CONFIG_SCRIPT_ID);
+  if (!el) {
+    throw new Error(
+      `[design-token-panel] Inline config script #${CONFIG_SCRIPT_ID} not found. ` +
+        'Ensure <DesignTokenPanelHost config={...} /> is rendered on this page before the host script runs.',
+    );
+  }
+  const raw = el.textContent ?? '';
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `[design-token-panel] Failed to parse inline config from #${CONFIG_SCRIPT_ID}: ${
+        (err as Error).message
+      }`,
+    );
+  }
+  // PR #1440 review item P1-11 — runtime validation at the trust boundary.
+  // The TypeScript view of the JSON parse is `PanelConfig` because the host
+  // <DesignTokenPanelHost> component types the prop, but at runtime the
+  // payload is just whatever string the inline <script> tag held — typos,
+  // serialization regressions, future Astro lifecycle changes, or even a
+  // hand-edited DOM tree could produce a malformed parse. Surface it as a
+  // single clear error here instead of cryptic downstream failures (storage
+  // keys reading undefined.storagePrefix, palette length mismatch, etc.).
+  assertValidPanelConfig(parsed);
+  return parsed;
+}
+
+function getAdapterStateMap(win: AdapterWindow): AdapterStateMap {
+  if (!win.__zudoDesignTokenPanelAdapter) {
+    win.__zudoDesignTokenPanelAdapter = {};
+  }
+  return win.__zudoDesignTokenPanelAdapter;
+}
+
+function getAdapterState(win: AdapterWindow, key: string): DesignTokenPanelAdapterState {
+  const map = getAdapterStateMap(win);
+  let state = map[key];
+  if (!state) {
+    state = { bound: false, modulePromise: null };
+    map[key] = state;
+  }
+  return state;
+}
+
+function wasVisible(visibleKey: string): boolean {
+  try {
+    return window.localStorage.getItem(visibleKey) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function hasPersistedOverrides(stateV2Key: string): boolean {
+  try {
+    return window.localStorage.getItem(stateV2Key) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lazily import the panel adapter via package self-reference. First call
+ * runs the panel module's top-level bootstrap, which binds Astro
+ * view-transition listeners and re-applies persisted state. Subsequent
+ * calls return the same promise.
+ *
+ * The package self-reference is marked external in `vite.config.ts` so the
+ * import remains a runtime resolution against the consumer's
+ * `node_modules/@takazudo/zudo-design-token-panel/dist/index.js`. That
+ * resolution shares the `config/panel-config` chunk with this adapter, so
+ * the `configurePanel` call below is observed by the panel module.
+ *
+ * Singleton-sharing runtime guard: after the dynamic import resolves,
+ * compare the adapter's `getPanelConfig()` result against the panel
+ * module's view via `__panelConfigForTest()`. They MUST be the same object
+ * reference — Vite's multi-entry build code-splits the shared
+ * `config/panel-config` module into one chunk so both surfaces observe one
+ * and the same singleton. A reference mismatch indicates a future
+ * packaging refactor split the singleton across two chunks; we
+ * `console.warn` loudly so the regression is caught in dev. The check
+ * fires once per adapter-state `modulePromise` lifecycle (i.e. once per
+ * fresh module load), not on every show/hide/toggle call.
+ */
+async function loadPanelModule(state: DesignTokenPanelAdapterState) {
+  if (state.modulePromise === null) {
+    state.modulePromise = import('@takazudo/zudo-design-token-panel').then((mod) => {
+      // Cheap insurance — compare object reference, not structural equality.
+      // Both surfaces should resolve through the same `panel-config-*.js`
+      // chunk, so the active config singleton is one object visible to both.
+      try {
+        const adapterView = getPanelConfig();
+        const panelView = mod.__panelConfigForTest();
+        if (adapterView !== panelView) {
+          console.warn(
+            '[design-token-panel] Singleton-sharing check failed: the host adapter and ' +
+              'the panel module observed different PanelConfig singletons. This indicates ' +
+              "the package's `config/panel-config` module is no longer code-split into a " +
+              'single shared chunk. The panel may behave correctly today, but storage ' +
+              'keys / namespaces / branding could diverge between the two surfaces in ' +
+              'future bundles.',
+          );
+        }
+      } catch (err) {
+        // Defensive: never let the guard itself break the panel surface. If
+        // `__panelConfigForTest` is missing (consumer pinned an older dist),
+        // surface a quieter warning and continue.
+        console.warn(
+          '[design-token-panel] Singleton-sharing check could not run (likely an older ' +
+            'dist without the __panelConfigForTest accessor): ' +
+            (err as Error).message,
+        );
+      }
+      return mod;
+    });
+  }
+  return state.modulePromise;
+}
+
+function installConsoleApi(
+  win: AdapterWindow,
+  namespace: string,
+  state: DesignTokenPanelAdapterState,
+): void {
+  const existing = (win[namespace] as ConsoleApiSurface | undefined) ?? {};
+  existing.showDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.showDesignTokenPanel();
+  };
+  existing.hideDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.hideDesignTokenPanel();
+  };
+  existing.toggleDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.toggleDesignPanel();
+  };
+  win[namespace] = existing;
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap (synchronous at module init)
+// ---------------------------------------------------------------------------
+
+(function bootstrap(): void {
+  // 1. Parse and apply config FIRST so every subsequent reader (storage keys,
+  //    console namespace, …) observes the host's intended values.
+  const config = readInlineConfig();
+  configurePanel(config);
+
+  // Re-read via `getPanelConfig()` so the storage/namespace derivations use
+  // the canonical source. (`configurePanel` shallow-clones, so `config` and
+  // `getPanelConfig()` are equivalent here, but routing through the helper
+  // keeps the contract honest if the package ever adds normalisation.)
+  const cfg = getPanelConfig();
+  const win = window as unknown as AdapterWindow;
+  const state = getAdapterState(win, cfg.storagePrefix);
+
+  // 2. Install console API every time — `bound` only gates the lazy-load
+  //    probes, since the console handlers are idempotent (re-assigning the
+  //    same closures is a no-op semantically).
+  installConsoleApi(win, cfg.consoleNamespace, state);
+
+  if (state.bound) return;
+  state.bound = true;
+
+  // 3. Lazy-load gate — eagerly load the panel module when the user had it
+  //    open last session OR has persisted token overrides. Either signal
+  //    means the panel must boot before first paint to avoid an FOUT.
+  const visibleKey = storageKey_visible(cfg);
+  const stateV2Key = storageKey_stateV2(cfg);
+  if (wasVisible(visibleKey) || hasPersistedOverrides(stateV2Key)) {
+    void loadPanelModule(state);
+  }
+})();

--- a/packages/zudo-design-token-panel/src/astro/host-adapter.ts
+++ b/packages/zudo-design-token-panel/src/astro/host-adapter.ts
@@ -112,7 +112,7 @@ function readInlineConfig(): PanelConfig {
       }`,
     );
   }
-  // PR #1440 review item P1-11 — runtime validation at the trust boundary.
+  // runtime validation at the trust boundary.
   // The TypeScript view of the JSON parse is `PanelConfig` because the host
   // <DesignTokenPanelHost> component types the prop, but at runtime the
   // payload is just whatever string the inline <script> tag held — typos,

--- a/packages/zudo-design-token-panel/src/astro/index.ts
+++ b/packages/zudo-design-token-panel/src/astro/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Astro sub-export entry.
+ *
+ * Consumers import the host component via:
+ *
+ * ```astro
+ * import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+ * ```
+ *
+ * The named-export pattern is preserved verbatim through the lib build:
+ * `vite.config.ts` marks `*.astro` external (regex) so Vite leaves the
+ * `from './DesignTokenPanelHost.astro'` literal in `dist/astro/index.js`,
+ * and a postbuild copy step (`scripts/copy-astro-assets.mjs`) places the
+ * raw `.astro` file alongside it. The consumer's own Astro toolchain then
+ * resolves the relative path at build time.
+ *
+ * `PanelConfig` is re-exported here so callers don't need a deep
+ * `@takazudo/zudo-design-token-panel/dist/config/panel-config` import to
+ * type their config object.
+ */
+
+export { default as DesignTokenPanelHost } from './DesignTokenPanelHost.astro';
+export type { PanelConfig } from '../config/panel-config';
+// Re-exported so Astro-host wiring can type the entries of its
+// `colorPresets` map without reaching into an internal sub-path.
+export type { ColorScheme, ColorRef } from '../config/color-schemes';
+// Exposed so host wrappers can lazy-load the preset map AFTER the SSR
+// config blob is parsed. See `setPanelColorPresets` jsdoc in
+// `panel-config.ts` for the rationale.
+export { setPanelColorPresets } from '../config/panel-config';

--- a/packages/zudo-design-token-panel/src/config/cluster-config.ts
+++ b/packages/zudo-design-token-panel/src/config/cluster-config.ts
@@ -1,0 +1,106 @@
+/**
+ * Color-cluster type contract.
+ *
+ * Defines the JSON-serializable shape every host-supplied color cluster must
+ * conform to. The package itself ships ZERO baked-in cluster data — consumers
+ * provide their own `colorCluster` (and optional `secondaryColorCluster`) via
+ * `configurePanel({ ... })`.
+ *
+ * **JSON-serializable**
+ *
+ * `ColorClusterDataConfig` deliberately holds NO function-typed fields. The
+ * palette CSS-var name is materialised at use sites by the
+ * `resolvePaletteCssVar(cluster, i)` helper below, NOT by a function field
+ * baked into the cluster. This is the JSON-roundtrip property hosts rely on:
+ * a cluster can cross an Astro frontmatter → prop boundary, or persist to
+ * disk, without losing fidelity.
+ *
+ * The cluster also carries `colorSchemes` and `panelSettings` so a host
+ * doesn't need to vend its own scheme registry through separate imports —
+ * everything the color tab needs to render is reachable from
+ * `panelConfig.colorCluster`.
+ */
+
+import type { ColorScheme } from './color-schemes';
+
+/**
+ * Base-role keys that a cluster may declare. Subset is allowed (a cluster may
+ * ship zero base roles when its design system doesn't expose them as tokens).
+ * The state shape on disk still carries all 5 numeric fields for envelope
+ * round-trip compatibility — they're inert when the cluster doesn't reference
+ * them.
+ */
+export type BaseRoleKey = 'background' | 'foreground' | 'cursor' | 'selectionBg' | 'selectionFg';
+
+/**
+ * Panel-level scheme settings carried INSIDE the cluster (rather than on a
+ * separate import). Lets `getActiveSchemeName` / `initColorFromScheme` read
+ * everything from the cluster argument.
+ */
+export interface ClusterPanelSettings {
+  /** Scheme name to seed state from when `colorMode` is `false`. */
+  colorScheme: string;
+  /**
+   * Optional light/dark pairing. When set, the panel resolves the active
+   * scheme by reading `data-theme` on `<html>`.
+   */
+  colorMode: false | { defaultMode: 'light' | 'dark'; lightScheme: string; darkScheme: string };
+}
+
+/**
+ * JSON-serializable color-cluster data. Every field is a primitive,
+ * plain object, or array; no functions, no class instances.
+ *
+ * `colorSchemes` and `panelSettings` are required (not optional) so the
+ * shape is uniform across primary / secondary clusters. Scheme-less clusters
+ * supply `colorSchemes: {}` and a stub `panelSettings` — both unused by call
+ * sites that seed state without ever consulting a scheme registry.
+ */
+export interface ColorClusterDataConfig {
+  /** Stable id — used for debugging / logging only. */
+  id: string;
+  /**
+   * Optional human-visible label rendered in the Color tab section headings.
+   * When absent, the tab falls back to `id.toUpperCase()`. Hosts that ship
+   * their own naming can override here without forking the panel.
+   */
+  label?: string;
+  /** Expected palette size. Used for init + v1 validation. */
+  paletteSize: number;
+  /** Map of base-role name → CSS custom-property name. Partial: a cluster
+   *  declares only the roles it actually has. */
+  baseRoles: Partial<Record<BaseRoleKey, string>>;
+  /**
+   * Palette-slot CSS-var template. The token `{n}` is replaced with the
+   * palette index by `resolvePaletteCssVar` below. Examples:
+   * `--brand-p{n}`, `--demo-palette-{n}`.
+   */
+  paletteCssVarTemplate: string;
+  /** Semantic token name → default palette index. */
+  semanticDefaults: Record<string, number>;
+  /** Semantic token name → CSS custom-property name. */
+  semanticCssNames: Record<string, string>;
+  /** Fallback indices used when a scheme doesn't declare a base role. */
+  baseDefaults: Partial<Record<BaseRoleKey, number>>;
+  /** Fallback shikiTheme when a scheme lacks one. */
+  defaultShikiTheme: string;
+  /**
+   * Bundled scheme registry. The Scheme… dropdown in the color tab lists
+   * these. Pass `{}` for clusters that don't use schemes.
+   */
+  colorSchemes: Record<string, ColorScheme>;
+  /** Panel-level scheme settings — drives `getActiveSchemeName`. */
+  panelSettings: ClusterPanelSettings;
+}
+
+/**
+ * Materialise the palette-slot CSS-var name for a cluster. Pure and
+ * side-effect-free so it's safe to call from any layer (apply, clear,
+ * tab UI, tests).
+ */
+export function resolvePaletteCssVar(
+  cluster: { paletteCssVarTemplate: string },
+  index: number,
+): string {
+  return cluster.paletteCssVarTemplate.replace('{n}', String(index));
+}

--- a/packages/zudo-design-token-panel/src/config/color-scheme-utils.ts
+++ b/packages/zudo-design-token-panel/src/config/color-scheme-utils.ts
@@ -1,19 +1,18 @@
 /**
  * Color-scheme utilities for the design-token panel.
  *
- * Ported from zudo-doc (`/src/config/color-scheme-utils.ts`) and adapted to
- * zmod2:
+ * Port adaptations:
  *
  * - The upstream `@/config/settings` import is removed. Only `colorScheme` and
  *   `colorMode` were ever consumed; both are inlined here as `panelSettings`
  *   so the panel package stays self-contained.
- * - `SEMANTIC_CSS_NAMES` points at zmod2's `--zd-semantic-*` CSS custom
- *   properties (see `sub-packages/design-system/theme.css` and `tokens.css`).
- *   Upstream keys with no zmod2 counterpart (mermaid*, chat*, imageOverlay*,
+ * - `SEMANTIC_CSS_NAMES` points at this package's `--zd-semantic-*` CSS
+ *   custom properties (example tokens shipped with the package). Upstream
+ *   keys with no counterpart here (mermaid*, chat*, imageOverlay*,
  *   matchedKeyword*) are dropped.
  * - `SEMANTIC_DEFAULTS_ZD` mirrors the `--zd-semantic-*: var(--zd-pN)`
- *   mappings in `tokens.css`, so the panel's defaults on first open match the
- *   live CSS exactly (no visual regression).
+ *   mappings in the bundled tokens, so the panel's defaults on first open
+ *   match the example CSS exactly.
  */
 
 import { colorSchemes, type ColorScheme, type ColorRef } from './color-schemes';
@@ -27,9 +26,9 @@ import { colorSchemes, type ColorScheme, type ColorRef } from './color-schemes';
  * ever reads `colorScheme` and `colorMode`; the rest of the upstream settings
  * surface (i18n, sitemap, sidebars, …) is irrelevant here.
  *
- * If a future zmod2 host wants to swap the active scheme without editing this
+ * If a future host wants to swap the active scheme without editing this
  * file, expose a setter or wire it through state — for now hard-coding to
- * `Default Dark` matches the live zmod2 CSS in `tokens.css`.
+ * `Default Dark` matches the example CSS in `tokens.css`.
  */
 export const panelSettings = {
   colorScheme: 'Default Dark' as const,
@@ -45,8 +44,9 @@ export const panelSettings = {
 /**
  * Default mapping: semantic token name → palette index.
  *
- * Mirrors the `--zd-semantic-*: var(--zd-pN)` declarations in
- * `sub-packages/design-system/tokens.css`. Keep in sync.
+ * Mirrors the `--zd-semantic-*: var(--zd-pN)` declarations in the host
+ * design-system tokens (example: examples/astro/.../tokens.css). Keep in
+ * sync.
  */
 export const SEMANTIC_DEFAULTS_ZD: Record<string, number> = {
   bg: 9,
@@ -74,20 +74,18 @@ export const SEMANTIC_DEFAULTS_ZD: Record<string, number> = {
 export const SEMANTIC_DEFAULTS = SEMANTIC_DEFAULTS_ZD;
 
 /**
- * Default mapping for the zaudio cluster: semantic token name → palette index.
+ * Example default mapping for a secondary cluster: semantic token name →
+ * palette index. This is an example shape that hosts can copy or replace
+ * via `setPanelColorPresets` / `configurePanel` — not a normative table.
  *
- * Mirrors the `--zaudio-*: var(--zaudio-paN)` declarations in
- * `sub-packages/design-system/zaudio-tokens.css`. Keep in sync.
- *
- * Note the differences from zd:
+ * Note the differences from the primary defaults:
  *  - Palette is 9 slots (pa0..pa8), not 16.
- *  - No `cursor` / `selectionBg` / `selectionFg` base roles — zaudio ships
- *    none.
+ *  - No `cursor` / `selectionBg` / `selectionFg` base roles.
  *  - Semantic table is shorter and uses kebab-case CSS var names
- *    (`--zaudio-bg-deep`, etc.) — keys here stay camelCase to match the
- *    `semanticMappings` shape used by the panel.
+ *    (`--app-secondary-bg-deep`, etc.) — keys here stay camelCase to match
+ *    the `semanticMappings` shape used by the panel.
  */
-export const SEMANTIC_DEFAULTS_ZAUDIO: Record<string, number> = {
+export const SEMANTIC_DEFAULTS_SECONDARY: Record<string, number> = {
   bg: 1,
   bgDeep: 0,
   surface: 2,
@@ -100,27 +98,28 @@ export const SEMANTIC_DEFAULTS_ZAUDIO: Record<string, number> = {
 };
 
 /**
- * Semantic token name → CSS custom property in the zaudio design system.
- *
- * Source of truth: `sub-packages/design-system/zaudio-tokens.css`.
+ * Example mapping of semantic token name → CSS custom property for a
+ * secondary cluster. Hosts can override the prefix and shape via
+ * `configurePanel`.
  */
-export const SEMANTIC_CSS_NAMES_ZAUDIO: Record<string, string> = {
-  bg: '--zaudio-bg',
-  bgDeep: '--zaudio-bg-deep',
-  surface: '--zaudio-surface',
-  border: '--zaudio-border',
-  text: '--zaudio-text',
-  textSecondary: '--zaudio-text-secondary',
-  textMuted: '--zaudio-text-muted',
-  accent: '--zaudio-accent',
-  accentHover: '--zaudio-accent-hover',
+export const SEMANTIC_CSS_NAMES_SECONDARY: Record<string, string> = {
+  bg: '--app-secondary-bg',
+  bgDeep: '--app-secondary-bg-deep',
+  surface: '--app-secondary-surface',
+  border: '--app-secondary-border',
+  text: '--app-secondary-text',
+  textSecondary: '--app-secondary-text-secondary',
+  textMuted: '--app-secondary-text-muted',
+  accent: '--app-secondary-accent',
+  accentHover: '--app-secondary-accent-hover',
 };
 
 /**
- * Semantic token name → CSS custom property in zmod2's design system.
+ * Semantic token name → CSS custom property in this package's example
+ * design system.
  *
- * Source of truth: `sub-packages/design-system/tokens.css` (definitions) and
- * `sub-packages/design-system/theme.css` (Tailwind aliases).
+ * Source of truth: the example `tokens.css` shipped under
+ * `examples/astro/...`.
  */
 export const SEMANTIC_CSS_NAMES: Record<string, string> = {
   bg: '--zd-semantic-bg',

--- a/packages/zudo-design-token-panel/src/config/color-scheme-utils.ts
+++ b/packages/zudo-design-token-panel/src/config/color-scheme-utils.ts
@@ -1,0 +1,253 @@
+/**
+ * Color-scheme utilities for the design-token panel.
+ *
+ * Ported from zudo-doc (`/src/config/color-scheme-utils.ts`) and adapted to
+ * zmod2:
+ *
+ * - The upstream `@/config/settings` import is removed. Only `colorScheme` and
+ *   `colorMode` were ever consumed; both are inlined here as `panelSettings`
+ *   so the panel package stays self-contained.
+ * - `SEMANTIC_CSS_NAMES` points at zmod2's `--zd-semantic-*` CSS custom
+ *   properties (see `sub-packages/design-system/theme.css` and `tokens.css`).
+ *   Upstream keys with no zmod2 counterpart (mermaid*, chat*, imageOverlay*,
+ *   matchedKeyword*) are dropped.
+ * - `SEMANTIC_DEFAULTS_ZD` mirrors the `--zd-semantic-*: var(--zd-pN)`
+ *   mappings in `tokens.css`, so the panel's defaults on first open match the
+ *   live CSS exactly (no visual regression).
+ */
+
+import { colorSchemes, type ColorScheme, type ColorRef } from './color-schemes';
+
+// ---------------------------------------------------------------------------
+// Inlined settings (replaces upstream `@/config/settings`)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal local replacement for the upstream `settings` object. The panel only
+ * ever reads `colorScheme` and `colorMode`; the rest of the upstream settings
+ * surface (i18n, sitemap, sidebars, …) is irrelevant here.
+ *
+ * If a future zmod2 host wants to swap the active scheme without editing this
+ * file, expose a setter or wire it through state — for now hard-coding to
+ * `Default Dark` matches the live zmod2 CSS in `tokens.css`.
+ */
+export const panelSettings = {
+  colorScheme: 'Default Dark' as const,
+  colorMode: false as
+    | false
+    | { defaultMode: 'light' | 'dark'; lightScheme: string; darkScheme: string },
+};
+
+// ---------------------------------------------------------------------------
+// Semantic token mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Default mapping: semantic token name → palette index.
+ *
+ * Mirrors the `--zd-semantic-*: var(--zd-pN)` declarations in
+ * `sub-packages/design-system/tokens.css`. Keep in sync.
+ */
+export const SEMANTIC_DEFAULTS_ZD: Record<string, number> = {
+  bg: 9,
+  fg: 11,
+  surface: 10,
+  muted: 8,
+  accent: 5,
+  accentHover: 14,
+  link: 4,
+  codeBg: 0,
+  codeFg: 7,
+  success: 2,
+  danger: 1,
+  warning: 3,
+  info: 4,
+  price: 12,
+  sold: 13,
+  active: 14,
+};
+
+/**
+ * Backwards-compatible alias for callers that just want `SEMANTIC_DEFAULTS`
+ * without thinking about the suffix. Identical contents.
+ */
+export const SEMANTIC_DEFAULTS = SEMANTIC_DEFAULTS_ZD;
+
+/**
+ * Default mapping for the zaudio cluster: semantic token name → palette index.
+ *
+ * Mirrors the `--zaudio-*: var(--zaudio-paN)` declarations in
+ * `sub-packages/design-system/zaudio-tokens.css`. Keep in sync.
+ *
+ * Note the differences from zd:
+ *  - Palette is 9 slots (pa0..pa8), not 16.
+ *  - No `cursor` / `selectionBg` / `selectionFg` base roles — zaudio ships
+ *    none.
+ *  - Semantic table is shorter and uses kebab-case CSS var names
+ *    (`--zaudio-bg-deep`, etc.) — keys here stay camelCase to match the
+ *    `semanticMappings` shape used by the panel.
+ */
+export const SEMANTIC_DEFAULTS_ZAUDIO: Record<string, number> = {
+  bg: 1,
+  bgDeep: 0,
+  surface: 2,
+  border: 3,
+  text: 6,
+  textSecondary: 5,
+  textMuted: 4,
+  accent: 7,
+  accentHover: 8,
+};
+
+/**
+ * Semantic token name → CSS custom property in the zaudio design system.
+ *
+ * Source of truth: `sub-packages/design-system/zaudio-tokens.css`.
+ */
+export const SEMANTIC_CSS_NAMES_ZAUDIO: Record<string, string> = {
+  bg: '--zaudio-bg',
+  bgDeep: '--zaudio-bg-deep',
+  surface: '--zaudio-surface',
+  border: '--zaudio-border',
+  text: '--zaudio-text',
+  textSecondary: '--zaudio-text-secondary',
+  textMuted: '--zaudio-text-muted',
+  accent: '--zaudio-accent',
+  accentHover: '--zaudio-accent-hover',
+};
+
+/**
+ * Semantic token name → CSS custom property in zmod2's design system.
+ *
+ * Source of truth: `sub-packages/design-system/tokens.css` (definitions) and
+ * `sub-packages/design-system/theme.css` (Tailwind aliases).
+ */
+export const SEMANTIC_CSS_NAMES: Record<string, string> = {
+  bg: '--zd-semantic-bg',
+  fg: '--zd-semantic-fg',
+  surface: '--zd-semantic-surface',
+  muted: '--zd-semantic-muted',
+  accent: '--zd-semantic-accent',
+  accentHover: '--zd-semantic-accent-hover',
+  link: '--zd-semantic-link',
+  codeBg: '--zd-semantic-code-bg',
+  codeFg: '--zd-semantic-code-fg',
+  success: '--zd-semantic-success',
+  danger: '--zd-semantic-danger',
+  warning: '--zd-semantic-warning',
+  info: '--zd-semantic-info',
+  price: '--zd-semantic-price',
+  sold: '--zd-semantic-sold',
+  active: '--zd-semantic-active',
+};
+
+export const lightDarkPairings = [
+  { light: 'Default Light', dark: 'Default Dark', label: 'Default' },
+];
+
+// ---------------------------------------------------------------------------
+// Scheme resolution
+// ---------------------------------------------------------------------------
+
+export function getActiveScheme(): ColorScheme {
+  const scheme = colorSchemes[panelSettings.colorScheme];
+  if (!scheme) {
+    throw new Error(
+      `Unknown color scheme: "${panelSettings.colorScheme}". Available: ${Object.keys(
+        colorSchemes,
+      ).join(', ')}`,
+    );
+  }
+  return scheme;
+}
+
+/**
+ * Resolve a `ColorRef` to a concrete color string.
+ *
+ * - `number`     → `palette[value]`
+ * - `string`     → used as-is (treated as a literal CSS color)
+ * - `undefined`  → `fallback`
+ */
+export function resolveColor(
+  value: ColorRef | undefined,
+  palette: string[],
+  fallback: string,
+): string {
+  if (value === undefined) return fallback;
+  if (typeof value === 'number') return palette[value] ?? fallback;
+  return value;
+}
+
+/**
+ * Resolve all semantic tokens for a scheme, falling back to the
+ * `SEMANTIC_DEFAULTS_ZD` palette slot when the scheme doesn't override the
+ * token.
+ */
+export function resolveSemanticColors(scheme: ColorScheme): Record<string, string> {
+  const p = scheme.palette;
+  const result: Record<string, string> = {};
+  for (const [key, defaultIndex] of Object.entries(SEMANTIC_DEFAULTS_ZD)) {
+    const override = scheme.semantic?.[key as keyof NonNullable<ColorScheme['semantic']>];
+    result[key] = resolveColor(override, p, p[defaultIndex] ?? p[0]);
+  }
+  return result;
+}
+
+/**
+ * Project a scheme to a flat list of `[cssVar, value]` pairs ready to inject
+ * onto `:root`. Mirrors the upstream shape: base tokens (bg / fg / cursor /
+ * selection), the full palette, then every semantic token.
+ */
+export function schemeToCssPairs(scheme: ColorScheme): [string, string][] {
+  const p = scheme.palette;
+  const sem = resolveSemanticColors(scheme);
+  const pairs: [string, string][] = [
+    ['--zd-bg', resolveColor(scheme.background, p, p[0])],
+    ['--zd-fg', resolveColor(scheme.foreground, p, p[15])],
+    ['--zd-cursor', resolveColor(scheme.cursor, p, p[6])],
+    ['--zd-sel-bg', resolveColor(scheme.selectionBg, p, resolveColor(scheme.background, p, p[0]))],
+    ['--zd-sel-fg', resolveColor(scheme.selectionFg, p, resolveColor(scheme.foreground, p, p[15]))],
+    ...p.map((color, i) => [`--zd-p${i}`, color] as [string, string]),
+  ];
+  for (const [key, cssVar] of Object.entries(SEMANTIC_CSS_NAMES)) {
+    pairs.push([cssVar, sem[key]!]);
+  }
+  return pairs;
+}
+
+export function generateCssCustomProperties(): string {
+  const scheme = getActiveScheme();
+  const pairs = schemeToCssPairs(scheme);
+  const lines = [':root {', ...pairs.map(([prop, value]) => `  ${prop}: ${value};`), '}'];
+  return lines.join('\n');
+}
+
+export function generateLightDarkCssProperties(): string {
+  if (!panelSettings.colorMode) {
+    throw new Error('colorMode is not configured');
+  }
+  const { lightScheme, darkScheme } = panelSettings.colorMode;
+  const light = colorSchemes[lightScheme];
+  const dark = colorSchemes[darkScheme];
+  if (!light) throw new Error(`Unknown light scheme: "${lightScheme}"`);
+  if (!dark) throw new Error(`Unknown dark scheme: "${darkScheme}"`);
+
+  const lightPairs = schemeToCssPairs(light);
+  const darkPairs = schemeToCssPairs(dark);
+
+  if (lightPairs.length !== darkPairs.length) {
+    throw new Error(
+      `Light scheme has ${lightPairs.length} properties but dark scheme has ${darkPairs.length}`,
+    );
+  }
+
+  const lines = [':root {', '  color-scheme: light dark;'];
+  for (let i = 0; i < lightPairs.length; i++) {
+    const prop = lightPairs[i][0];
+    const lightVal = lightPairs[i][1];
+    const darkVal = darkPairs[i][1];
+    lines.push(`  ${prop}: light-dark(${lightVal}, ${darkVal});`);
+  }
+  lines.push('}');
+  return lines.join('\n');
+}

--- a/packages/zudo-design-token-panel/src/config/color-schemes.ts
+++ b/packages/zudo-design-token-panel/src/config/color-schemes.ts
@@ -1,0 +1,165 @@
+/**
+ * Color-scheme types and bundled presets.
+ *
+ * Ported from zudo-doc (`/src/config/color-schemes.ts`) and adapted to zmod2.
+ *
+ * Differences from upstream:
+ * - `shikiTheme` is typed as `string` (no Astro dependency).
+ * - The `semantic` object exposes only the keys that zmod2 actually has CSS
+ *   variables for (see `color-scheme-utils.ts → SEMANTIC_CSS_NAMES`). Upstream
+ *   keys with no zmod2 counterpart (mermaid*, chat*, imageOverlay*,
+ *   matchedKeyword*) are dropped.
+ * - Adds zmod2-specific semantic keys: `bg`, `fg`, `link`, `price`, `sold`.
+ */
+
+/** A color reference: palette index (number) or direct color value (string) */
+export type ColorRef = number | string;
+
+export interface ColorScheme {
+  background: ColorRef;
+  foreground: ColorRef;
+  cursor: ColorRef;
+  selectionBg: ColorRef;
+  selectionFg: ColorRef;
+  palette: [
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+  /**
+   * Shiki theme name. Loosely typed as a free-form string so we don't pull in
+   * the Astro types (zmod2 isn't an Astro app — this field is preserved for
+   * symmetry with upstream presets and for any future code-block tooling).
+   */
+  shikiTheme: string;
+  /**
+   * Optional semantic overrides — when omitted, defaults from
+   * `SEMANTIC_DEFAULTS_ZD` (in `color-scheme-utils.ts`) are used.
+   *
+   * Each field accepts a palette index (number) or a direct color value
+   * (string).
+   */
+  semantic?: {
+    bg?: ColorRef;
+    fg?: ColorRef;
+    surface?: ColorRef;
+    muted?: ColorRef;
+    accent?: ColorRef;
+    accentHover?: ColorRef;
+    link?: ColorRef;
+    codeBg?: ColorRef;
+    codeFg?: ColorRef;
+    success?: ColorRef;
+    danger?: ColorRef;
+    warning?: ColorRef;
+    info?: ColorRef;
+    price?: ColorRef;
+    sold?: ColorRef;
+  };
+}
+
+/**
+ * Bundled color schemes shipped with the panel. Each scheme provides a
+ * 16-color palette plus optional semantic overrides. The Scheme… dropdown in
+ * the color tab lists these by name.
+ *
+ * Ported from upstream zudo-doc/src/config/color-schemes.ts (Default Light /
+ * Default Dark) — palette and semantic mappings are unchanged because they
+ * follow the standard p0–p15 convention and `SEMANTIC_DEFAULTS_ZD` re-uses the
+ * same indices.
+ */
+export const colorSchemes: Record<string, ColorScheme> = {
+  'Default Light': {
+    background: 9,
+    foreground: 11,
+    cursor: 6,
+    selectionBg: 11,
+    selectionFg: 10,
+    palette: [
+      '#303030',
+      '#dd3131',
+      '#266538',
+      '#a83838',
+      '#3277c8',
+      '#a35e0f',
+      '#90a1b9',
+      '#7a5218',
+      '#6b6b6b',
+      '#e2ddda',
+      '#ece9e9',
+      '#303030',
+      '#5b99dc',
+      '#b89ee7',
+      '#8590a0',
+      '#b91c1c',
+    ],
+    shikiTheme: 'catppuccin-latte',
+    semantic: {
+      surface: 10,
+      muted: 8,
+      accent: 5,
+      accentHover: 14,
+      codeBg: 10,
+      codeFg: 11,
+      success: 2,
+      danger: 1,
+      warning: 3,
+      info: 4,
+    },
+  },
+  'Default Dark': {
+    background: 9,
+    // p11 (light gray) — not p15. Sub 1 repurposes p15 as the mercari brand
+    // red, so pinning `foreground` to p15 would paint the panel's fg swatch
+    // red and make every `fg`-mapped semantic resolve to red. p11 aligns
+    // with SEMANTIC_DEFAULTS_ZD.fg (also 11).
+    foreground: 11,
+    cursor: 6,
+    selectionBg: 10,
+    selectionFg: 11,
+    palette: [
+      '#1c1c1c',
+      '#da6871',
+      '#93bb77',
+      '#dfbb77',
+      '#5caae9',
+      '#c074d6',
+      '#90a1b9',
+      '#a0a0a0',
+      '#888888',
+      '#181818',
+      '#383838',
+      '#e0e0e0',
+      '#d69a66',
+      '#c074d6',
+      '#a7c0e3',
+      '#b91c1c',
+    ],
+    shikiTheme: 'vitesse-dark',
+    semantic: {
+      surface: 0,
+      muted: 8,
+      accent: 12,
+      accentHover: 14,
+      codeBg: 10,
+      codeFg: 11,
+      success: 2,
+      danger: 1,
+      warning: 3,
+      info: 4,
+    },
+  },
+};

--- a/packages/zudo-design-token-panel/src/config/color-schemes.ts
+++ b/packages/zudo-design-token-panel/src/config/color-schemes.ts
@@ -1,15 +1,15 @@
 /**
  * Color-scheme types and bundled presets.
  *
- * Ported from zudo-doc (`/src/config/color-schemes.ts`) and adapted to zmod2.
+ * Ported from zudo-doc (`/src/config/color-schemes.ts`).
  *
  * Differences from upstream:
  * - `shikiTheme` is typed as `string` (no Astro dependency).
- * - The `semantic` object exposes only the keys that zmod2 actually has CSS
- *   variables for (see `color-scheme-utils.ts → SEMANTIC_CSS_NAMES`). Upstream
- *   keys with no zmod2 counterpart (mermaid*, chat*, imageOverlay*,
- *   matchedKeyword*) are dropped.
- * - Adds zmod2-specific semantic keys: `bg`, `fg`, `link`, `price`, `sold`.
+ * - The `semantic` object exposes only the keys that this package has CSS
+ *   variables for (see `color-scheme-utils.ts → SEMANTIC_CSS_NAMES`).
+ *   Upstream keys with no counterpart here (mermaid*, chat*,
+ *   imageOverlay*, matchedKeyword*) are dropped.
+ * - Adds package-specific semantic keys: `bg`, `fg`, `link`, `price`, `sold`.
  */
 
 /** A color reference: palette index (number) or direct color value (string) */
@@ -40,9 +40,10 @@ export interface ColorScheme {
     string,
   ];
   /**
-   * Shiki theme name. Loosely typed as a free-form string so we don't pull in
-   * the Astro types (zmod2 isn't an Astro app — this field is preserved for
-   * symmetry with upstream presets and for any future code-block tooling).
+   * Shiki theme name. Loosely typed as a free-form string so we don't pull
+   * in the Astro types (this package isn't an Astro app — this field is
+   * preserved for symmetry with upstream presets and for any future
+   * code-block tooling).
    */
   shikiTheme: string;
   /**
@@ -122,10 +123,10 @@ export const colorSchemes: Record<string, ColorScheme> = {
   },
   'Default Dark': {
     background: 9,
-    // p11 (light gray) — not p15. Sub 1 repurposes p15 as the mercari brand
-    // red, so pinning `foreground` to p15 would paint the panel's fg swatch
-    // red and make every `fg`-mapped semantic resolve to red. p11 aligns
-    // with SEMANTIC_DEFAULTS_ZD.fg (also 11).
+    // p11 (light gray) — not p15. The example palette repurposes p15 as a
+    // brand-red accent, so pinning `foreground` to p15 would paint the
+    // panel's fg swatch red and make every `fg`-mapped semantic resolve
+    // to red. p11 aligns with SEMANTIC_DEFAULTS_ZD.fg (also 11).
     foreground: 11,
     cursor: 6,
     selectionBg: 10,
@@ -140,7 +141,7 @@ export const colorSchemes: Record<string, ColorScheme> = {
       '#90a1b9',
       '#a0a0a0',
       '#888888',
-      '#181818',
+      '18',
       '#383838',
       '#e0e0e0',
       '#d69a66',

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -1,0 +1,420 @@
+/**
+ * Panel-level runtime configuration.
+ *
+ * Centralises every project-specific identifier (storage-key prefix, console
+ * namespace, modal class prefix, schema id, export filename) plus the
+ * host-supplied token manifest and color cluster. A single `configurePanel`
+ * call swaps the panel for any host.
+ *
+ * Plumbing approach
+ * -----------------
+ * Module-level singleton (NOT Preact context). The panel is a single-instance
+ * dev tool, config is set once before the adapter mounts, and every read site
+ * is happy to pay a function call to read the current config.
+ *
+ * Idempotency
+ * -----------
+ * `configurePanel` is one-shot. Calling it twice with structurally-equal
+ * values is a silent no-op (a freshly-parsed inline JSON config can be
+ * byte-equal to the previous call but referentially distinct, e.g. on Astro
+ * view-transition reruns). Calling with structurally-different values throws.
+ *
+ * Default fallback
+ * ----------------
+ * `getPanelConfig()` returns `DEFAULT_PANEL_CONFIG` when `configurePanel` has
+ * never been called. The defaults ship intentionally minimal — a sentinel
+ * that lets the package import / boot in environments where `configurePanel`
+ * has not yet run, but with empty token manifests and a stub color cluster
+ * so the UI surfaces "no tokens configured" rather than rendering against
+ * arbitrary host-irrelevant data. Hosts MUST call `configurePanel(...)` to
+ * see useful behaviour.
+ */
+
+import type { TokenManifest } from '../tokens/manifest';
+import type { ColorScheme } from './color-schemes';
+import type { ColorClusterDataConfig } from './cluster-config';
+import { structuralEqual } from '../utils/structural-equal';
+
+/**
+ * Apply-routing map.
+ *
+ * Maps a CSS-var prefix family (without the leading `--`, without the trailing
+ * `-`) to the repo-relative source-file path the apply pipeline edits when an
+ * override matches that prefix. Hosts MUST supply their own map (or omit the
+ * field — the apply button is then disabled).
+ *
+ * Why a map (not a function): the routing has to round-trip through Astro
+ * frontmatter → island JSON, same as the rest of `PanelConfig`
+ * (JSON-serializable constraint).
+ */
+export type ApplyRoutingMap = Record<string, string>;
+
+/**
+ * The portable PanelConfig shape.
+ */
+export interface PanelConfig {
+  /** Base for every derived storage key. */
+  storagePrefix: string;
+  /** Console API namespace — installed as `window[consoleNamespace].showDesignPanel` etc. by the host adapter. */
+  consoleNamespace: string;
+  /** BEM-style prefix used by every modal in the panel (export / import / apply). */
+  modalClassPrefix: string;
+  /** `$schema` value emitted into export JSON and required on import. */
+  schemaId: string;
+  /** Default filename base — exports save as `${exportFilenameBase}.json`. */
+  exportFilenameBase: string;
+  /** Editable design tokens grouped per-tab. */
+  tokens: TokenManifest;
+  /**
+   * Primary color-cluster data. Drives the color tab + the apply / clear /
+   * load helpers in `state/tweak-state.ts`. Must be JSON-serializable.
+   */
+  colorCluster: ColorClusterDataConfig;
+  /**
+   * Optional secondary color-cluster data.
+   *
+   * Renders below the primary cluster on the Color tab and routes through
+   * the apply / clear paths under its own CSS-var family. The host
+   * controls participation:
+   *
+   *  - `undefined` (field omitted) — falls back to `null` (secondary
+   *    cluster hidden / skipped).
+   *  - `null` — explicit opt-out: the secondary palette section is hidden
+   *    and the apply/clear paths skip the secondary cluster entirely.
+   *  - A `ColorClusterDataConfig` object — host-supplied secondary cluster.
+   *
+   * Resolution helper: prefer `resolveSecondaryColorCluster()` over reading
+   * the field directly so the `undefined → null` fallback is applied
+   * consistently at every call site.
+   */
+  secondaryColorCluster?: ColorClusterDataConfig | null;
+  /**
+   * Optional host-supplied color-scheme presets.
+   *
+   * Surfaces additional named `ColorScheme` entries in the Color tab's
+   * "Scheme..." dropdown, in addition to the bundled
+   * `colorCluster.colorSchemes` registry. The two are merged at render
+   * time; on key collision the cluster's bundled scheme wins.
+   */
+  colorPresets?: Record<string, ColorScheme>;
+  /**
+   * Optional dev-API endpoint URL used by the Apply modal. When the host
+   * wires the panel into a project that ships the design-tokens-apply route,
+   * supply the URL here; the Apply button POSTs its diff payload to it. When
+   * undefined / omitted, the Apply button stays disabled with a tooltip.
+   */
+  applyEndpoint?: string;
+  /**
+   * Optional CSS-var prefix → source-file routing map. Drives
+   * `routeTokensToFiles` / the dev-API handler. Omit to disable apply
+   * entirely (the Apply button is gated on `applyEndpoint` AND a non-empty
+   * routing map).
+   */
+  applyRouting?: ApplyRoutingMap;
+}
+
+/**
+ * Empty token manifest — used as the default fallback so the panel imports
+ * cleanly without a `configurePanel(...)` call. Every tab renders an empty
+ * state until the host configures real tokens.
+ */
+const EMPTY_TOKEN_MANIFEST: TokenManifest = {
+  spacing: [],
+  typography: [],
+  size: [],
+  color: [],
+};
+
+/**
+ * Minimal stub color cluster — used as the default fallback. Carries an
+ * empty palette and empty semantic / scheme registries so the color tab
+ * shows an empty state. Hosts MUST override via
+ * `configurePanel({ colorCluster })`.
+ */
+const STUB_COLOR_CLUSTER: ColorClusterDataConfig = {
+  id: 'stub',
+  label: 'STUB',
+  paletteSize: 0,
+  baseRoles: {},
+  paletteCssVarTemplate: '--zudo-stub-p{n}',
+  semanticDefaults: {},
+  semanticCssNames: {},
+  baseDefaults: {},
+  defaultShikiTheme: 'dracula',
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false },
+};
+
+/**
+ * Default config — minimal stub values. Hosts MUST call `configurePanel(...)`
+ * with real values to see useful behaviour.
+ */
+export const DEFAULT_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'zudo-design-token-panel',
+  consoleNamespace: 'zudo',
+  modalClassPrefix: 'zudo-design-token-panel-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'zudo-design-tokens',
+  tokens: EMPTY_TOKEN_MANIFEST,
+  colorCluster: STUB_COLOR_CLUSTER,
+  // Default to null — secondary cluster is opt-in. Hosts that want one
+  // pass an explicit cluster object via `configurePanel`.
+  secondaryColorCluster: null,
+  colorPresets: {},
+  // No bundled apply endpoint / routing — hosts wire their own.
+  applyEndpoint: undefined,
+  applyRouting: undefined,
+};
+
+// ---------------------------------------------------------------------------
+// Singleton storage
+// ---------------------------------------------------------------------------
+
+let configuredConfig: PanelConfig | null = null;
+/**
+ * Holding slot for a deferred preset map handed to `setPanelColorPresets`
+ * before `configurePanel` has been called. Applied to the active config the
+ * first time `getPanelConfig()` is read after configuration.
+ */
+let pendingColorPresets: Record<string, ColorScheme> | null = null;
+
+/**
+ * Configure the panel runtime. Call exactly once per page lifecycle, before
+ * the adapter is imported / mounted. Idempotent: calling twice with
+ * structurally-equal values is a silent no-op; calling twice with structurally
+ * different values throws so config conflicts surface immediately instead of
+ * silently corrupting one of the two callers' assumptions.
+ *
+ * The re-init guard MUST use structural deep-equality, NOT referential
+ * identity. The Astro host-adapter parses the inline JSON config on every
+ * script run, including post view-transition reruns; that produces a
+ * freshly-parsed object that is byte-for-byte identical to the previous call
+ * but referentially distinct.
+ */
+export function configurePanel(config: PanelConfig): void {
+  if (configuredConfig !== null) {
+    if (structuralEqual(configuredConfig, config)) return;
+    throw new Error(
+      '[design-token-panel] configurePanel() was already called with different values. ' +
+        'Configuration is one-shot per page lifecycle.',
+    );
+  }
+  configuredConfig = pendingColorPresets
+    ? { ...config, colorPresets: pendingColorPresets }
+    : { ...config };
+  pendingColorPresets = null;
+}
+
+/**
+ * Read the active panel config. Returns the value passed to `configurePanel`
+ * if one was supplied, else `DEFAULT_PANEL_CONFIG`.
+ */
+export function getPanelConfig(): PanelConfig {
+  return configuredConfig ?? DEFAULT_PANEL_CONFIG;
+}
+
+/**
+ * Test-only: clear the singleton so unit tests can exercise different configs
+ * in isolation.
+ */
+export function __resetPanelConfigForTests(): void {
+  configuredConfig = null;
+  pendingColorPresets = null;
+}
+
+/**
+ * Resolve the active secondary color cluster.
+ *
+ *  - Explicit `null` on the config — host opted out → returns `null`.
+ *    Callers MUST treat this as "do not render / apply / clear secondary
+ *    cluster".
+ *  - Explicit cluster object — host-supplied secondary cluster → returned
+ *    verbatim.
+ *  - `undefined` (field omitted) — defaults to `null` (the package itself
+ *    ships no bundled secondary cluster).
+ */
+export function resolveSecondaryColorCluster(
+  cfg: PanelConfig = getPanelConfig(),
+): ColorClusterDataConfig | null {
+  if (cfg.secondaryColorCluster === null || cfg.secondaryColorCluster === undefined) return null;
+  return cfg.secondaryColorCluster;
+}
+
+// ---------------------------------------------------------------------------
+// Derivation helpers
+// ---------------------------------------------------------------------------
+//
+// Each helper takes a `PanelConfig` (typically `getPanelConfig()`) so call
+// sites read the *current* config at use time. Module-load-time capture would
+// freeze the value before `configurePanel` runs, defeating the singleton.
+
+/** Storage key for the v2 unified envelope (color + spacing + typography + size + position + secondary cluster). */
+export function storageKey_stateV2(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-state-v2`;
+}
+
+/** Legacy v1 key (Color-only flat state). Migrated into v2 on first load, then deleted. */
+export function storageKey_stateV1(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-state`;
+}
+
+/** Mirror of the panel's `open` boolean (synchronous mount-time read). */
+export function storageKey_open(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-open`;
+}
+
+/** Drag position `{ top, right }` so the panel reappears where the user left it. */
+export function storageKey_position(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-position`;
+}
+
+/**
+ * Adapter-level visibility-intent flag.
+ *
+ * NOTE: This key uses a literal `:` separator (NOT `-`). Every other derived
+ * key uses `-`. The colon is a historical artifact preserved for storage-key
+ * continuity.
+ */
+export function storageKey_visible(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}:visible`;
+}
+
+/** DOM id of the root element the Preact panel tree mounts into. */
+export function panelRootId(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-root`;
+}
+
+/**
+ * BEM-style modal class. Pass an empty `suffix` for the base block, or
+ * `'--export'` / `'__title'` etc. for elements / modifiers.
+ */
+export function modalClass(cfg: PanelConfig, suffix: string): string {
+  return `${cfg.modalClassPrefix}${suffix}`;
+}
+
+/** Default download filename for export. */
+export function exportFilename(cfg: PanelConfig): string {
+  return `${cfg.exportFilenameBase}.json`;
+}
+
+/**
+ * Runtime validation at the host-adapter trust boundary. The Astro inline
+ * `<script type="application/json">` payload is untrusted-by-the-types:
+ * TypeScript believes the field is `PanelConfig`, but any developer typo /
+ * serialization regression / future Astro lifecycle change can produce a
+ * malformed parse. Catching that at the entry point surfaces a single clear
+ * error instead of cryptic downstream failures.
+ *
+ * Throws with a message naming the offending field. Returns nothing — caller
+ * narrows the value via TS's control-flow analysis post-call.
+ */
+export function assertValidPanelConfig(value: unknown): asserts value is PanelConfig {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('[design-token-panel] PanelConfig must be a non-null object');
+  }
+  const cfg = value as Record<string, unknown>;
+  for (const key of [
+    'storagePrefix',
+    'consoleNamespace',
+    'modalClassPrefix',
+    'schemaId',
+    'exportFilenameBase',
+  ] as const) {
+    if (typeof cfg[key] !== 'string' || (cfg[key] as string).length === 0) {
+      throw new Error(
+        `[design-token-panel] PanelConfig.${key} must be a non-empty string (got ${typeof cfg[
+          key
+        ]})`,
+      );
+    }
+  }
+  if (cfg.tokens === null || typeof cfg.tokens !== 'object' || Array.isArray(cfg.tokens)) {
+    throw new Error('[design-token-panel] PanelConfig.tokens must be an object');
+  }
+  const tokens = cfg.tokens as Record<string, unknown>;
+  for (const slice of ['spacing', 'typography', 'size', 'color'] as const) {
+    if (!Array.isArray(tokens[slice])) {
+      throw new Error(
+        `[design-token-panel] PanelConfig.tokens.${slice} must be an array (got ${typeof tokens[
+          slice
+        ]})`,
+      );
+    }
+  }
+  if (
+    cfg.colorCluster === null ||
+    typeof cfg.colorCluster !== 'object' ||
+    Array.isArray(cfg.colorCluster)
+  ) {
+    throw new Error('[design-token-panel] PanelConfig.colorCluster must be an object');
+  }
+  const cluster = cfg.colorCluster as Record<string, unknown>;
+  if (typeof cluster.id !== 'string' || cluster.id.length === 0) {
+    throw new Error('[design-token-panel] PanelConfig.colorCluster.id must be a non-empty string');
+  }
+  if (typeof cluster.paletteSize !== 'number' || cluster.paletteSize < 0) {
+    throw new Error(
+      '[design-token-panel] PanelConfig.colorCluster.paletteSize must be a non-negative number',
+    );
+  }
+  if (typeof cluster.paletteCssVarTemplate !== 'string') {
+    throw new Error(
+      '[design-token-panel] PanelConfig.colorCluster.paletteCssVarTemplate must be a string',
+    );
+  }
+  // Optional fields — only validate when present.
+  if (cfg.applyEndpoint !== undefined && typeof cfg.applyEndpoint !== 'string') {
+    throw new Error(
+      `[design-token-panel] PanelConfig.applyEndpoint must be a string when set (got ${typeof cfg.applyEndpoint})`,
+    );
+  }
+  if (cfg.applyRouting !== undefined) {
+    if (
+      cfg.applyRouting === null ||
+      typeof cfg.applyRouting !== 'object' ||
+      Array.isArray(cfg.applyRouting)
+    ) {
+      throw new Error('[design-token-panel] PanelConfig.applyRouting must be a plain object');
+    }
+    for (const [k, v] of Object.entries(cfg.applyRouting as Record<string, unknown>)) {
+      if (typeof v !== 'string') {
+        throw new Error(
+          `[design-token-panel] PanelConfig.applyRouting[${JSON.stringify(k)}] must be a string`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Resolve the active `applyRouting` map. Returns an empty object when the host
+ * has not configured one — callers MUST treat empty as "apply disabled".
+ */
+export function resolveApplyRouting(cfg: PanelConfig = getPanelConfig()): ApplyRoutingMap {
+  return cfg.applyRouting ?? {};
+}
+
+/**
+ * Lazily attach a host-supplied color-preset map AFTER `configurePanel(...)`.
+ *
+ * Why a second entry point exists: `colorPresets` can be the largest
+ * JSON-serializable field on `PanelConfig`. Including it in the inline SSR
+ * config blob (the `<script type="application/json">` payload the host-adapter
+ * parses on every page) means every page render ships the entire preset
+ * library, even though it's only consulted when the user opens the panel's
+ * "Scheme..." dropdown. Calling `setPanelColorPresets()` from a deferred
+ * dynamic-import in the host wrapper keeps the preset data out of the initial
+ * HTML payload — lazy-loaded only when the panel actually mounts.
+ *
+ * Idempotent: setting the same map twice is a no-op. Setting a different
+ * non-empty map overwrites the previous one (no throw, unlike
+ * `configurePanel`) — the dropdown source-of-truth is whichever bundle
+ * landed last.
+ */
+export function setPanelColorPresets(presets: Record<string, ColorScheme>): void {
+  if (configuredConfig === null) {
+    pendingColorPresets = presets;
+    return;
+  }
+  configuredConfig = { ...configuredConfig, colorPresets: presets };
+}

--- a/packages/zudo-design-token-panel/src/controls/pill-slider-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/pill-slider-row.tsx
@@ -23,7 +23,7 @@ import type { TokenDef } from '../tokens/manifest';
  *
  * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
  * parent can use a single stable handler across every row, keeping React.memo
- * effective (PR #1440 review item Q3).
+ * effective.
  */
 export interface PillSliderRowProps {
   /** Token must carry `token.pill` metadata. */
@@ -93,5 +93,5 @@ function PillSliderRow({ token, value, onChange }: PillSliderRowProps) {
 }
 
 // memo'd to skip re-renders of unaffected rows; relies on the parent passing
-// a stable `onChange` (PR #1440 review item Q3).
+// a stable `onChange`.
 export default memo(PillSliderRow);

--- a/packages/zudo-design-token-panel/src/controls/pill-slider-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/pill-slider-row.tsx
@@ -1,0 +1,97 @@
+import { memo, useCallback, useEffect, useRef } from 'preact/compat';
+import SliderRow from './slider-row';
+import type { TokenDef } from '../tokens/manifest';
+
+/**
+ * Slider row variant with a "Pill" checkbox on top.
+ *
+ *   [x] Pill (9999px)
+ *   [label]  ... [9999 px]   ← inputs disabled while pill is on
+ *   [=========o==================]
+ *
+ * When the checkbox is ON the token value is pinned to `token.pill.value`
+ * (e.g. `"9999px"` for the full-radius sentinel) and the underlying slider /
+ * number input go read-only so the user can't accidentally de-pill via typing.
+ *
+ * When the checkbox is OFF the row behaves as a normal `SliderRow` — the user
+ * can drag or type any value in the manifest's min/max range.
+ *
+ * Toggling between modes preserves the last custom value (kept in a ref so we
+ * don't round-trip it through state / persistence) — this is the "without data
+ * loss" requirement from the Size sub-issue: you can flip Pill off to tweak
+ * 16px, flip back on for the sentinel, flip off again and land on 16px.
+ *
+ * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
+ * parent can use a single stable handler across every row, keeping React.memo
+ * effective (PR #1440 review item Q3).
+ */
+export interface PillSliderRowProps {
+  /** Token must carry `token.pill` metadata. */
+  token: TokenDef;
+  /** Current persisted value (the manifest default if no override yet). */
+  value: string;
+  /** Called with the row's `token.id` and the new CSS string whenever pill
+   *  toggles or slider commits. */
+  onChange: (id: string, next: string) => void;
+}
+
+function PillSliderRow({ token, value, onChange }: PillSliderRowProps) {
+  // hooks must be called unconditionally — read pill metadata via optional
+  // chaining so the early-return path below stays a non-hook branch.
+  const pill = token.pill;
+  const pillValue = pill?.value ?? '';
+  const customDefault = pill?.customDefault ?? '';
+  const isPill = pill ? value === pillValue : false;
+
+  // Remember the last custom (non-pill) value so re-checking + un-checking
+  // the pill doesn't wipe the user's tweak. Initialise from the incoming
+  // value when the row first mounts while un-pilled.
+  const lastCustomRef = useRef<string>(isPill ? customDefault : value);
+
+  // Keep the ref in sync whenever the user changes the slider while un-pilled.
+  useEffect(() => {
+    if (!isPill) lastCustomRef.current = value;
+  }, [isPill, value]);
+
+  const handleTogglePill = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.currentTarget.checked) {
+        onChange(token.id, pillValue);
+      } else {
+        onChange(token.id, lastCustomRef.current || customDefault);
+      }
+    },
+    [onChange, token.id, pillValue, customDefault],
+  );
+
+  if (!pill) {
+    // Defensive: fall back to a normal row if the caller forgot to gate.
+    return <SliderRow token={token} value={value} onChange={onChange} />;
+  }
+
+  // While pilled, disable the inner SliderRow inputs by handing it a readonly
+  // clone of the token. The row already knows how to render a readonly state
+  // (disabled inputs, greyed slider), so we reuse that instead of inventing
+  // a new disabled variant here.
+  const effectiveToken: TokenDef = isPill ? { ...token, readonly: true } : token;
+
+  return (
+    <div className="tokenpanel-row--column">
+      <label className="tokenpanel-pill-toggle">
+        <input
+          type="checkbox"
+          checked={isPill}
+          onChange={handleTogglePill}
+          className="tokenpanel-pill-toggle-checkbox"
+          aria-label={`${token.cssVar} pill toggle`}
+        />
+        <span className="tokenpanel-pill-toggle-text">Pill ({pillValue})</span>
+      </label>
+      <SliderRow token={effectiveToken} value={value} onChange={onChange} />
+    </div>
+  );
+}
+
+// memo'd to skip re-renders of unaffected rows; relies on the parent passing
+// a stable `onChange` (PR #1440 review item Q3).
+export default memo(PillSliderRow);

--- a/packages/zudo-design-token-panel/src/controls/sanitize-css-value.ts
+++ b/packages/zudo-design-token-panel/src/controls/sanitize-css-value.ts
@@ -1,0 +1,20 @@
+/**
+ * Strip characters that could break out of a CSS property-value context.
+ *
+ * Used by `<TextRow>` for free-form token inputs like `--font-sans` /
+ * `--font-mono`. Dropped characters:
+ *
+ *   - newlines (`\r`, `\n`) — would split the declaration in raw CSS text
+ *     output and are treated as whitespace anyway by `style.setProperty`.
+ *   - backslashes (`\\`)    — CSS-escape prefix; strip so the raw string the
+ *     user sees equals the raw string written back out on export.
+ *   - semicolons (`;`)      — safe for `style.setProperty` (it writes a single
+ *     declaration) but would break the exported CSS snippet.
+ *
+ * `style.setProperty` on its own is already injection-safe — it writes a single
+ * property/value pair and never parses the value as a rule. This sanitiser
+ * guards the **exported** CSS snippet and keeps stored state tidy.
+ */
+export function sanitizeCssValue(input: string): string {
+  return input.replace(/[\r\n\\;]/g, '');
+}

--- a/packages/zudo-design-token-panel/src/controls/select-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/select-row.tsx
@@ -1,0 +1,69 @@
+import { memo, useCallback } from 'preact/compat';
+import type { TokenDef } from '../tokens/manifest';
+
+/**
+ * One manifest-driven token row backed by a native `<select>`.
+ *
+ *   [label]                                     [  400 ▾]
+ *
+ * Used for tokens whose value is one of a small, enumerated set — e.g.
+ * `--font-weight-*` (100..900). The selected option string is stored verbatim
+ * in persisted state (no numeric round-tripping; font-weight values are
+ * conventionally written as bare numbers in CSS).
+ *
+ * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
+ * parent can use a single stable handler across every row, keeping React.memo
+ * effective (PR #1440 review item Q3).
+ */
+export interface SelectRowProps {
+  token: TokenDef;
+  /** Current persisted value (or the token's default if no override). */
+  value: string;
+  /** Called with the row's `token.id` and the newly selected option value. */
+  onChange: (id: string, next: string) => void;
+}
+
+function SelectRow({ token, value, onChange }: SelectRowProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      onChange(token.id, e.currentTarget.value);
+    },
+    [onChange, token.id],
+  );
+
+  const options = token.options ?? [];
+  // Make sure the current value renders even if it isn't in `options` (e.g. a
+  // legacy persisted value from an older manifest). Appending it keeps the
+  // select from silently losing the user's state.
+  const includesValue = options.includes(value);
+
+  return (
+    <div className="tokenpanel-row">
+      <span className="tokenpanel-row-label" title={token.cssVar}>
+        {token.cssVar}
+      </span>
+      <select
+        value={value}
+        onChange={handleChange}
+        disabled={token.readonly}
+        className="tokenpanel-row-select"
+        aria-label={`${token.cssVar} value`}
+      >
+        {!includesValue && (
+          <option key={`__fallback:${value}`} value={value}>
+            {value}
+          </option>
+        )}
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// memo'd to skip re-renders of unaffected rows; relies on the parent passing
+// a stable `onChange` (PR #1440 review item Q3).
+export default memo(SelectRow);

--- a/packages/zudo-design-token-panel/src/controls/select-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/select-row.tsx
@@ -13,7 +13,7 @@ import type { TokenDef } from '../tokens/manifest';
  *
  * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
  * parent can use a single stable handler across every row, keeping React.memo
- * effective (PR #1440 review item Q3).
+ * effective.
  */
 export interface SelectRowProps {
   token: TokenDef;
@@ -65,5 +65,5 @@ function SelectRow({ token, value, onChange }: SelectRowProps) {
 }
 
 // memo'd to skip re-renders of unaffected rows; relies on the parent passing
-// a stable `onChange` (PR #1440 review item Q3).
+// a stable `onChange`.
 export default memo(SelectRow);

--- a/packages/zudo-design-token-panel/src/controls/slider-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/slider-row.tsx
@@ -19,7 +19,7 @@ import { type TokenDef, formatValue, parseNumericValue } from '../tokens/manifes
  *
  * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
  * parent can use a single stable handler across every row, keeping React.memo
- * effective (PR #1440 review item Q3).
+ * effective.
  */
 export interface SliderRowProps {
   token: TokenDef;
@@ -110,7 +110,7 @@ function SliderRow({ token, value, onChange }: SliderRowProps) {
   );
 }
 
-// memo'd so a stable parent `onChange` (PR #1440 review item Q3) plus
+// memo'd so a stable parent `onChange` plus
 // stable `value`/`token` props skip re-renders of unaffected rows when one
 // row changes.
 export default memo(SliderRow);

--- a/packages/zudo-design-token-panel/src/controls/slider-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/slider-row.tsx
@@ -1,0 +1,116 @@
+import { memo, useState, useEffect, useCallback } from 'preact/compat';
+import { type TokenDef, formatValue, parseNumericValue } from '../tokens/manifest';
+
+/**
+ * One manifest-driven token row:
+ *
+ *   [label]  ... [  1.25 rem]   ← label + number input (unit suffix inside)
+ *   [=========o==================]  ← full-width range slider
+ *
+ * Range input and number input are two-way bound: dragging the slider fills
+ * the number input live, and typing a value moves the slider once it parses.
+ *
+ * The parent owns the persisted value (stored as a string like `"1.25rem"`);
+ * this row keeps a local "draft" string only for the number input, so users
+ * can type partial values (`"1."`) without the component thrashing.
+ *
+ * Read-only tokens render a disabled compact form that still shows the
+ * resolved value from the stylesheet.
+ *
+ * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
+ * parent can use a single stable handler across every row, keeping React.memo
+ * effective (PR #1440 review item Q3).
+ */
+export interface SliderRowProps {
+  token: TokenDef;
+  /** Current persisted value (or the token's default if no override). */
+  value: string;
+  /** Called with the row's `token.id` and the new CSS string (e.g.
+   *  `"0.75rem"`) whenever the user commits a change via slider or a
+   *  parseable number input. */
+  onChange: (id: string, next: string) => void;
+}
+
+function SliderRow({ token, value, onChange }: SliderRowProps) {
+  // Numeric view of the stored value, used for the slider. Falls back to the
+  // token min when the string can't be parsed (e.g. read-only clamp()).
+  const numeric = parseNumericValue(value);
+  const slidable = !token.readonly && numeric !== null;
+
+  // Draft lets the user type freely ("1.", "1.2") without the slider snapping
+  // every keystroke. We only commit (call onChange) when the draft parses.
+  const [draft, setDraft] = useState<string>(numeric !== null ? String(numeric) : value);
+
+  // Sync the draft when the external value changes (reset, preset load, etc.)
+  useEffect(() => {
+    setDraft(numeric !== null ? String(numeric) : value);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  const handleSlider = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const n = Number(e.currentTarget.value);
+      if (!Number.isFinite(n)) return;
+      setDraft(String(n));
+      onChange(token.id, formatValue(n, token.unit));
+    },
+    [onChange, token.id, token.unit],
+  );
+
+  const handleNumber = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.currentTarget.value;
+      setDraft(raw);
+      const n = parseNumericValue(raw);
+      if (n === null) return; // wait for a parseable value before committing
+      // Clamp into the token's legal range on commit to keep the slider sane.
+      const clamped = Math.min(token.max, Math.max(token.min, n));
+      onChange(token.id, formatValue(clamped, token.unit));
+    },
+    [onChange, token.id, token.min, token.max, token.unit],
+  );
+
+  return (
+    <div className="tokenpanel-row--stacked">
+      {/* Top row: label + number input */}
+      <div className="tokenpanel-row-head">
+        <span className="tokenpanel-row-label" title={token.cssVar}>
+          {token.cssVar}
+        </span>
+        <div className="tokenpanel-row-input-group">
+          <input
+            type="text"
+            inputMode="decimal"
+            value={draft}
+            onChange={handleNumber}
+            disabled={token.readonly}
+            className="tokenpanel-row-number-input"
+            aria-label={`${token.cssVar} value`}
+          />
+          <span className="tokenpanel-row-unit">
+            {token.readonly && !token.unit ? '' : token.unit}
+          </span>
+        </div>
+      </div>
+
+      {/* Bottom row: full-width slider */}
+      <input
+        type="range"
+        min={token.min}
+        max={token.max}
+        step={token.step}
+        // When unparseable, park the slider at min — it's disabled anyway.
+        value={slidable ? (numeric as number) : token.min}
+        onChange={handleSlider}
+        disabled={!slidable}
+        className="tokenpanel-row-slider"
+        aria-label={`${token.cssVar} slider`}
+      />
+    </div>
+  );
+}
+
+// memo'd so a stable parent `onChange` (PR #1440 review item Q3) plus
+// stable `value`/`token` props skip re-renders of unaffected rows when one
+// row changes.
+export default memo(SliderRow);

--- a/packages/zudo-design-token-panel/src/controls/text-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/text-row.tsx
@@ -15,7 +15,7 @@ import { sanitizeCssValue } from './sanitize-css-value';
  *
  * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
  * parent can use a single stable handler across every row, keeping React.memo
- * effective (PR #1440 review item Q3).
+ * effective.
  */
 export interface TextRowProps {
   token: TokenDef;
@@ -68,5 +68,5 @@ function TextRow({ token, value, onChange }: TextRowProps) {
 }
 
 // memo'd to skip re-renders of unaffected rows; relies on the parent passing
-// a stable `onChange` (PR #1440 review item Q3).
+// a stable `onChange`.
 export default memo(TextRow);

--- a/packages/zudo-design-token-panel/src/controls/text-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/text-row.tsx
@@ -1,0 +1,72 @@
+import { memo, useCallback, useEffect, useState } from 'preact/compat';
+import type { TokenDef } from '../tokens/manifest';
+import { sanitizeCssValue } from './sanitize-css-value';
+
+/**
+ * One manifest-driven token row backed by a free-form text input.
+ *
+ *   [label]              [ "Inter", system-ui, sans-serif        ]
+ *
+ * Used for tokens whose value is a CSS string the user types directly — e.g.
+ * `--font-sans` / `--font-mono`. The stored value is sanitised (see
+ * `sanitize-css-value.ts`) before it leaves this component so newlines,
+ * backslashes, and semicolons never reach stored state or the exported CSS
+ * snippet. `style.setProperty` is already injection-safe on its own.
+ *
+ * `onChange` is `(id, next)` — the row passes its own `token.id` back so the
+ * parent can use a single stable handler across every row, keeping React.memo
+ * effective (PR #1440 review item Q3).
+ */
+export interface TextRowProps {
+  token: TokenDef;
+  /** Current persisted value (or the token's default if no override). */
+  value: string;
+  /** Called with the row's `token.id` and the sanitised new value on every
+   *  edit. */
+  onChange: (id: string, next: string) => void;
+}
+
+function TextRow({ token, value, onChange }: TextRowProps) {
+  // Local draft so the user can type freely without us round-tripping the
+  // external value on every keystroke. We commit (sanitised) to the parent
+  // immediately so live-preview stays responsive.
+  const [draft, setDraft] = useState<string>(value);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.currentTarget.value;
+      const sanitized = sanitizeCssValue(raw);
+      setDraft(sanitized);
+      onChange(token.id, sanitized);
+    },
+    [onChange, token.id],
+  );
+
+  return (
+    <div className="tokenpanel-row">
+      <span className="tokenpanel-row-label tokenpanel-row-label--narrow" title={token.cssVar}>
+        {token.cssVar}
+      </span>
+      <input
+        type="text"
+        value={draft}
+        onChange={handleChange}
+        disabled={token.readonly}
+        className="tokenpanel-row-text-input"
+        aria-label={`${token.cssVar} value`}
+        spellcheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
+// memo'd to skip re-renders of unaffected rows; relies on the parent passing
+// a stable `onChange` (PR #1440 review item Q3).
+export default memo(TextRow);

--- a/packages/zudo-design-token-panel/src/export-modal.tsx
+++ b/packages/zudo-design-token-panel/src/export-modal.tsx
@@ -1,0 +1,222 @@
+/**
+ * Export modal — renders the current `TweakState` as a design-tokens JSON
+ * document (default schema: `zudo-design-tokens/v1`; configurable via
+ * `panelConfig.schemaId`) with a diff-only toggle and a copy-to-clipboard
+ * button.
+ *
+ * Ported verbatim from zudo-doc's
+ * `src/components/design-token-tweak/export-modal.tsx`. Intentional deltas:
+ *  - `serialize` is imported from the zmod2 serde (`./utils/design-token-serde`).
+ *  - `colorSchemes` / `initColorFromSchemeData` come from the zmod2 config.
+ *  - The filename hint is derived from `panelConfig.exportFilenameBase` via
+ *    `exportFilename(...)` (default `zudo-design-tokens.json`).
+ *  - Modal class names are derived from `panelConfig.modalClassPrefix` via
+ *    `modalClass(...)` so a single config swap re-themes every dialog.
+ *
+ * Modal lifecycle uses the native `<dialog>` element via `showModal()` /
+ * `close()`. Every dismissal path (× button, backdrop click, Escape key, the
+ * programmatic "Close" button) routes through `dialog.close()` so the native
+ * `close` event — and thus `onClose` — fires exactly once per dismissal.
+ */
+
+import { useState, useEffect, useMemo, useRef } from 'preact/compat';
+import { serialize } from './utils/design-token-serde';
+import {
+  type ColorTweakState,
+  type TweakState,
+  initColorFromSchemeData,
+} from './state/tweak-state';
+import { colorSchemes } from './config/color-schemes';
+import { exportFilename, getPanelConfig, modalClass } from './config/panel-config';
+
+export interface ExportModalProps {
+  onClose: () => void;
+  /** Full unified tweak state — the modal serializes all four categories. */
+  state: TweakState;
+  /** Color baseline used for diff-only output. Optional: callers without DOM
+   *  access (tests) can omit and we'll treat the entire color block as changed. */
+  colorDefaults?: ColorTweakState;
+}
+
+/** Resolve a color baseline for diff-only serialization. */
+function resolveColorDefaults(
+  fallback: ColorTweakState,
+  explicit?: ColorTweakState,
+): ColorTweakState {
+  if (explicit) return explicit;
+  // No explicit defaults → pick the first scheme so we still produce a
+  // sensible baseline shape. This path is only hit in edge cases; the panel
+  // always passes explicit defaults.
+  const firstScheme = Object.values(colorSchemes)[0];
+  if (firstScheme) return initColorFromSchemeData(firstScheme);
+  return fallback;
+}
+
+export function ExportModal({ onClose, state, colorDefaults }: ExportModalProps) {
+  const [copyLabel, setCopyLabel] = useState('Copy');
+  const [includeDefaults, setIncludeDefaults] = useState(false);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cfg = getPanelConfig();
+  const exportFilenameHint = exportFilename(cfg);
+
+  // Memo the serialized JSON so flipping the toggle doesn't rebuild on every
+  // re-render; `exportedAt` intentionally refreshes when the toggle flips so
+  // the displayed timestamp reflects "when you clicked copy".
+  const code = useMemo(() => {
+    const baseline = resolveColorDefaults(state.color, colorDefaults);
+    const json = serialize(state, {
+      includeDefaults,
+      colorDefaults: baseline,
+    });
+    return JSON.stringify(json, null, 2);
+  }, [state, colorDefaults, includeDefaults]);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+    // Focus the primary action so keyboard users land on the most likely
+    // target on open. Native <dialog>.close() restores focus to the trigger
+    // automatically (PR #1440 review item Q2).
+    window.requestAnimationFrame(() => {
+      copyButtonRef.current?.focus();
+    });
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleClose() {
+      onClose();
+    }
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, [onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (
+      e.clientX < rect.left ||
+      e.clientX > rect.right ||
+      e.clientY < rect.top ||
+      e.clientY > rect.bottom
+    ) {
+      dialog.close();
+    }
+  }
+
+  async function handleCopy() {
+    let ok = false;
+    // Primary: navigator.clipboard.writeText. The pre-fix code used the
+    // deprecated `document.execCommand('copy')` as the primary path and
+    // only fell back to the modern Clipboard API on textarea failure.
+    // Reorder so modern is first; legacy execCommand is the fallback for
+    // browsers that reject `clipboard.writeText` (insecure context, denied
+    // permission, focus issues inside Safari's <dialog> focus trap, etc.).
+    // PR #1440 review item Q5.
+    try {
+      await navigator.clipboard.writeText(code);
+      ok = true;
+    } catch (err: unknown) {
+      // Swallow — `err` is captured but unused. Common rejection reasons:
+      // not in a secure context, clipboard permission denied, no focus on
+      // the document. Any of these mean we should try the legacy path.
+      void err;
+    }
+    if (!ok) {
+      // Fallback: dialog-scoped offscreen textarea + execCommand. Lives
+      // inside the modal so Safari's focus trap doesn't block the select().
+      // tabindex=-1 + aria-hidden=true keep the textarea out of the
+      // keyboard tab order and assistive-tech tree while it's mounted.
+      const dialog = dialogRef.current;
+      if (dialog) {
+        try {
+          const textarea = document.createElement('textarea');
+          textarea.value = code;
+          textarea.style.cssText = 'position:fixed;opacity:0;left:-9999px';
+          textarea.tabIndex = -1;
+          textarea.setAttribute('aria-hidden', 'true');
+          dialog.appendChild(textarea);
+          textarea.focus();
+          textarea.select();
+          ok = document.execCommand('copy');
+          dialog.removeChild(textarea);
+        } catch {
+          /* ignore — both paths failed; UI shows "Failed" below */
+        }
+      }
+    }
+    setCopyLabel(ok ? 'Copied!' : 'Failed');
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => setCopyLabel('Copy'), 2000);
+  }
+
+  // Stable id for aria-labelledby (PR #1440 review item Q1). Native
+  // <dialog>.showModal() implies aria-modal=true, so only the title pointer
+  // is needed.
+  const titleId = `${cfg.modalClassPrefix}-export-title`;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClick={handleBackdropClick}
+      aria-labelledby={titleId}
+      className={`${modalClass(cfg, '')} ${modalClass(cfg, '--export')}`}
+      data-design-token-panel-modal=""
+      data-design-token-panel-modal-variant="export"
+    >
+      <h2 id={titleId} className={modalClass(cfg, '__title')}>
+        Export Design Tokens
+      </h2>
+
+      <p className={modalClass(cfg, '__hint')}>
+        Save as <code>{exportFilenameHint}</code> to feed this blob back into the panel (or hand to
+        an AI assistant).
+      </p>
+
+      <label className={modalClass(cfg, '__toggle')}>
+        <input
+          type="checkbox"
+          checked={includeDefaults}
+          onChange={(e) => setIncludeDefaults(e.currentTarget.checked)}
+        />
+        Show defaults too
+      </label>
+
+      <pre className={modalClass(cfg, '__json')}>
+        <code>{code}</code>
+      </pre>
+
+      <div className={modalClass(cfg, '__actions')}>
+        <button
+          ref={copyButtonRef}
+          type="button"
+          onClick={handleCopy}
+          className={`${modalClass(cfg, '__button')} ${modalClass(cfg, '__button--primary')}`}
+        >
+          {copyLabel}
+        </button>
+        <button
+          type="button"
+          onClick={() => dialogRef.current?.close()}
+          className={modalClass(cfg, '__button')}
+        >
+          Close
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/packages/zudo-design-token-panel/src/export-modal.tsx
+++ b/packages/zudo-design-token-panel/src/export-modal.tsx
@@ -6,8 +6,10 @@
  *
  * Ported verbatim from zudo-doc's
  * `src/components/design-token-tweak/export-modal.tsx`. Intentional deltas:
- *  - `serialize` is imported from the zmod2 serde (`./utils/design-token-serde`).
- *  - `colorSchemes` / `initColorFromSchemeData` come from the zmod2 config.
+ *  - `serialize` is imported from this package's serde
+ *    (`./utils/design-token-serde`).
+ *  - `colorSchemes` / `initColorFromSchemeData` come from this package's
+ *    config.
  *  - The filename hint is derived from `panelConfig.exportFilenameBase` via
  *    `exportFilename(...)` (default `zudo-design-tokens.json`).
  *  - Modal class names are derived from `panelConfig.modalClassPrefix` via
@@ -79,7 +81,7 @@ export function ExportModal({ onClose, state, colorDefaults }: ExportModalProps)
     dialog.showModal();
     // Focus the primary action so keyboard users land on the most likely
     // target on open. Native <dialog>.close() restores focus to the trigger
-    // automatically (PR #1440 review item Q2).
+    // automatically.
     window.requestAnimationFrame(() => {
       copyButtonRef.current?.focus();
     });
@@ -126,7 +128,6 @@ export function ExportModal({ onClose, state, colorDefaults }: ExportModalProps)
     // Reorder so modern is first; legacy execCommand is the fallback for
     // browsers that reject `clipboard.writeText` (insecure context, denied
     // permission, focus issues inside Safari's <dialog> focus trap, etc.).
-    // PR #1440 review item Q5.
     try {
       await navigator.clipboard.writeText(code);
       ok = true;
@@ -164,7 +165,7 @@ export function ExportModal({ onClose, state, colorDefaults }: ExportModalProps)
     copyTimerRef.current = setTimeout(() => setCopyLabel('Copy'), 2000);
   }
 
-  // Stable id for aria-labelledby (PR #1440 review item Q1). Native
+  // Stable id for aria-labelledby. Native
   // <dialog>.showModal() implies aria-modal=true, so only the title pointer
   // is needed.
   const titleId = `${cfg.modalClassPrefix}-export-title`;

--- a/packages/zudo-design-token-panel/src/import-modal.tsx
+++ b/packages/zudo-design-token-panel/src/import-modal.tsx
@@ -1,0 +1,258 @@
+/**
+ * Import modal — accepts a pasted design-tokens JSON document (default schema:
+ * `zudo-design-tokens/v1`; configurable via `panelConfig.schemaId`) and lifts
+ * it into a `TweakState` via `deserialize()`. Validation and unknown-token
+ * reporting are delegated to serde; this component only renders status
+ * feedback and routes the parsed state up to the shell.
+ *
+ * Ported verbatim from zudo-doc's
+ * `src/components/design-token-tweak/import-modal.tsx`. Intentional deltas:
+ *  - `deserialize` / `DesignTokenSchemaError` / `getDesignTokenSchema` come
+ *    from the zmod2 serde (`./utils/design-token-serde`); the schema id is
+ *    read at render time from `panelConfig.schemaId` instead of being a
+ *    module-level constant.
+ *  - State types import from the zmod2 state envelope.
+ *  - Modal class names are derived from `panelConfig.modalClassPrefix` via
+ *    `modalClass(...)` so a single config swap re-themes every dialog.
+ *
+ * Modal lifecycle uses the native `<dialog>` element via `showModal()` /
+ * `close()`. Every dismissal path (× button, backdrop click, Escape key, the
+ * programmatic "Close" button) routes through `dialog.close()` so the native
+ * `close` event — and thus `onClose` — fires exactly once per dismissal.
+ */
+
+import { useEffect, useRef, useState } from 'preact/compat';
+import {
+  DesignTokenSchemaError,
+  deserialize,
+  getDesignTokenSchema,
+} from './utils/design-token-serde';
+import type { ColorTweakState, TweakState } from './state/tweak-state';
+import { getPanelConfig, modalClass } from './config/panel-config';
+import { structuralEqual } from './utils/structural-equal';
+
+export interface ImportModalProps {
+  onClose: () => void;
+  /** Called with the parsed state when the user hits "Load". The caller is
+   *  responsible for applying it to the panel + persisting it. */
+  onLoad: (state: TweakState) => void;
+  /** Color baseline filled in for fields absent from the payload. */
+  colorDefaults: ColorTweakState;
+}
+
+interface InlineNote {
+  kind: 'error' | 'info';
+  text: string;
+}
+
+export function ImportModal({ onClose, onLoad, colorDefaults }: ImportModalProps) {
+  const [text, setText] = useState('');
+  const [note, setNote] = useState<InlineNote | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const cfg = getPanelConfig();
+  const expectedSchema = getDesignTokenSchema();
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    dialog.showModal();
+    // Autofocus the textarea so the user can paste immediately.
+    window.requestAnimationFrame(() => {
+      textareaRef.current?.focus();
+    });
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    function handleClose() {
+      onClose();
+    }
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, [onClose]);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDialogElement>) {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const rect = dialog.getBoundingClientRect();
+    if (
+      e.clientX < rect.left ||
+      e.clientX > rect.right ||
+      e.clientY < rect.top ||
+      e.clientY > rect.bottom
+    ) {
+      dialog.close();
+    }
+  }
+
+  function handleLoad() {
+    setNote(null);
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      setNote({ kind: 'error', text: 'Paste a JSON blob first.' });
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setNote({ kind: 'error', text: `JSON parse error: ${message}` });
+      return;
+    }
+
+    try {
+      const { state, unknownTokens, warnings } = deserialize(parsed, {
+        colorDefaults,
+      });
+
+      if (unknownTokens.length > 0) {
+        // Grouped console.warn so developers can inspect the list without
+        // drowning in separate log lines.
+        // eslint-disable-next-line no-console
+        console.groupCollapsed(
+          `[design-token-serde] ${unknownTokens.length} unknown token${
+            unknownTokens.length === 1 ? '' : 's'
+          } ignored while loading JSON`,
+        );
+        for (const name of unknownTokens) {
+          // eslint-disable-next-line no-console
+          console.warn(name);
+        }
+        // eslint-disable-next-line no-console
+        console.groupEnd();
+      }
+
+      if (warnings.length > 0) {
+        // eslint-disable-next-line no-console
+        console.warn('[design-token-serde] warnings:', warnings);
+      }
+
+      onLoad(state);
+
+      // "Nothing applied" = every spacing/typography/size override landed in
+      // unknownTokens (so the payload had data but nothing mapped), AND the
+      // color block effectively matches the baseline. Surface a stronger
+      // warning so the user isn't left thinking the import silently succeeded.
+      //
+      // The pre-fix check only verified whether the input HAD a `color` key
+      // (presence-based). That suppressed the warning even when an imported
+      // color block matched the baseline values exactly — i.e. the import
+      // was a no-op the user couldn't see. The fix compares the deserialized
+      // `state.color` against `colorDefaults` via structural deep-equal
+      // (PR #1440 review item M-14 — JSON.stringify is property-order
+      // sensitive and would miss equal-but-reordered objects on V8 minor
+      // version drift; structural compare is order-independent). See PR
+      // #1440 review item B5 for the original presence-vs-content fix.
+      const appliedCount =
+        Object.keys(state.spacing).length +
+        Object.keys(state.typography).length +
+        Object.keys(state.size).length;
+      const colorMatchesBaseline = structuralEqual(state.color, colorDefaults);
+      const nothingApplied = appliedCount === 0 && colorMatchesBaseline && unknownTokens.length > 0;
+
+      if (nothingApplied) {
+        setNote({
+          kind: 'error',
+          text: `Nothing applied — all ${unknownTokens.length} token${
+            unknownTokens.length === 1 ? '' : 's'
+          } in the payload were unknown. See console for the list.`,
+        });
+      } else if (unknownTokens.length > 0) {
+        setNote({
+          kind: 'info',
+          text: `Loaded. ${unknownTokens.length} unknown token${
+            unknownTokens.length === 1 ? '' : 's'
+          } ignored — see console for the list.`,
+        });
+      } else {
+        setNote({ kind: 'info', text: 'Loaded.' });
+      }
+    } catch (err) {
+      if (err instanceof DesignTokenSchemaError) {
+        if (err.reason === 'schema-mismatch') {
+          setNote({
+            kind: 'error',
+            text: `Schema mismatch: this panel expects "${expectedSchema}".`,
+          });
+        } else if (err.reason === 'schema-missing') {
+          setNote({
+            kind: 'error',
+            text: `Missing "$schema" key. Expected "${expectedSchema}".`,
+          });
+        } else {
+          setNote({ kind: 'error', text: 'Input is not a JSON object.' });
+        }
+        return;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      setNote({ kind: 'error', text: `Load failed: ${message}` });
+    }
+  }
+
+  // Stable id for aria-labelledby. Native <dialog>.showModal() implies
+  // aria-modal=true, so we only need to point at the title (PR #1440 review
+  // item Q1).
+  const titleId = `${cfg.modalClassPrefix}-import-title`;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClick={handleBackdropClick}
+      aria-labelledby={titleId}
+      className={`${modalClass(cfg, '')} ${modalClass(cfg, '--import')}`}
+      data-design-token-panel-modal=""
+      data-design-token-panel-modal-variant="import"
+    >
+      <h2 id={titleId} className={modalClass(cfg, '__title')}>
+        Load Design Tokens
+      </h2>
+
+      <p className={modalClass(cfg, '__hint')}>
+        Paste a <code>{expectedSchema}</code> JSON blob. Unknown tokens are ignored; schema mismatch
+        aborts the load.
+      </p>
+
+      <textarea
+        ref={textareaRef}
+        value={text}
+        onChange={(e) => setText(e.currentTarget.value)}
+        spellcheck={false}
+        className={modalClass(cfg, '__textarea')}
+        placeholder={`{ "$schema": "${expectedSchema}", ... }`}
+      />
+
+      {note && (
+        <p
+          role={note.kind === 'error' ? 'alert' : 'status'}
+          className={`${modalClass(cfg, '__status')} ${modalClass(cfg, `__status--${note.kind}`)}`}
+        >
+          {note.text}
+        </p>
+      )}
+
+      <div className={modalClass(cfg, '__actions')}>
+        <button
+          type="button"
+          onClick={handleLoad}
+          className={`${modalClass(cfg, '__button')} ${modalClass(cfg, '__button--primary')}`}
+        >
+          Load
+        </button>
+        <button
+          type="button"
+          onClick={() => dialogRef.current?.close()}
+          className={modalClass(cfg, '__button')}
+        >
+          Close
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/packages/zudo-design-token-panel/src/import-modal.tsx
+++ b/packages/zudo-design-token-panel/src/import-modal.tsx
@@ -8,10 +8,10 @@
  * Ported verbatim from zudo-doc's
  * `src/components/design-token-tweak/import-modal.tsx`. Intentional deltas:
  *  - `deserialize` / `DesignTokenSchemaError` / `getDesignTokenSchema` come
- *    from the zmod2 serde (`./utils/design-token-serde`); the schema id is
- *    read at render time from `panelConfig.schemaId` instead of being a
- *    module-level constant.
- *  - State types import from the zmod2 state envelope.
+ *    from this package's serde (`./utils/design-token-serde`); the schema
+ *    id is read at render time from `panelConfig.schemaId` instead of
+ *    being a module-level constant.
+ *  - State types import from this package's state envelope.
  *  - Modal class names are derived from `panelConfig.modalClassPrefix` via
  *    `modalClass(...)` so a single config swap re-themes every dialog.
  *
@@ -146,10 +146,9 @@ export function ImportModal({ onClose, onLoad, colorDefaults }: ImportModalProps
       // color block matched the baseline values exactly — i.e. the import
       // was a no-op the user couldn't see. The fix compares the deserialized
       // `state.color` against `colorDefaults` via structural deep-equal
-      // (PR #1440 review item M-14 — JSON.stringify is property-order
-      // sensitive and would miss equal-but-reordered objects on V8 minor
-      // version drift; structural compare is order-independent). See PR
-      // #1440 review item B5 for the original presence-vs-content fix.
+      // (JSON.stringify is property-order sensitive and would miss
+      // equal-but-reordered objects on V8 minor version drift; structural
+      // compare is order-independent).
       const appliedCount =
         Object.keys(state.spacing).length +
         Object.keys(state.typography).length +
@@ -197,8 +196,7 @@ export function ImportModal({ onClose, onLoad, colorDefaults }: ImportModalProps
   }
 
   // Stable id for aria-labelledby. Native <dialog>.showModal() implies
-  // aria-modal=true, so we only need to point at the title (PR #1440 review
-  // item Q1).
+  // aria-modal=true, so we only need to point at the title.
   const titleId = `${cfg.modalClassPrefix}-import-title`;
 
   return (

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -1,0 +1,414 @@
+/**
+ * Design-token panel adapter.
+ *
+ * Thin bridge between the package's Astro host adapter
+ * (`./astro/host-adapter.ts`) and the Preact panel component
+ * (`./panel.tsx`). Responsibilities:
+ *
+ *  1. Expose the public API consumed by the host adapter —
+ *     `showDesignTokenPanel`, `hideDesignTokenPanel`, `toggleDesignPanel`.
+ *  2. Own the Preact mount lifecycle into the panel root element (id derived
+ *     from `panelConfig.storagePrefix`; default: `#zudo-design-token-panel-root`).
+ *  3. Cooperate with `panel.tsx`'s own toggle listeners: the adapter handles
+ *     the *initial* toggle (to mount the shell lazily) and then lets
+ *     `panel.tsx` own steady-state toggling via its internal window listener.
+ *  4. Handle Astro view-transition lifecycle — unmount before swap and
+ *     re-materialise the shell on `astro:page-load` when either the panel was
+ *     previously visible or token overrides are persisted.
+ *
+ * Storage keys (all derived from `panelConfig` — see `config/panel-config.ts`):
+ *
+ *  - `${storagePrefix}:visible` (default: `zudo-design-token-panel:visible`)
+ *    — adapter's visibility intent flag. Owned here (adapter-level concept);
+ *    no collision with the panel itself, so it keeps its historical colon-as-
+ *    separator form (every other derived key uses `-`).
+ *  - v2 storage key (imported via `getStorageKeyV2()` from `./state/tweak-state`)
+ *    — existence probe for persisted token overrides. The actual key value
+ *    is owned by `tweak-state.ts` (which also writes it). Routing the probe
+ *    through the same accessor guarantees probe-key ≡ write-key.
+ *  - `${storagePrefix}-open` (default: `zudo-design-token-panel-open`) —
+ *    primarily owned by `panel.tsx` (its `useEffect` mirrors `open` into the
+ *    key on every change). The adapter is read-only at steady state, but it
+ *    *seeds* the key once before a fresh mount so `panel.tsx`'s mount-effect
+ *    picks the desired open state on first paint instead of relying on a
+ *    racy post-render toggle event.
+ */
+
+import { render } from 'preact';
+import DesignTokenTweakPanel from './panel';
+// Side-effect import: bundles panel chrome CSS + panel-private CSS variables
+// so the package is visually self-contained for any consumer (Sub 5a, #1555).
+// Modal layer CSS will follow in Sub 5b.
+import './styles/panel.css';
+import {
+  applyFullState,
+  getOpenKey,
+  getStorageKeyV2,
+  loadPersistedState,
+} from './state/tweak-state';
+import {
+  getPanelConfig,
+  panelRootId,
+  storageKey_visible,
+  type PanelConfig,
+} from './config/panel-config';
+
+// ---------------------------------------------------------------------------
+// Public DOM contract (kept in sync with astro/host-adapter.ts)
+// ---------------------------------------------------------------------------
+
+/** Root element id that hosts the Preact panel tree. Derived from `panelConfig.storagePrefix`. */
+function getPanelId(): string {
+  return panelRootId(getPanelConfig());
+}
+
+/** Adapter's visibility-intent flag. Derived from `panelConfig.storagePrefix` (colon separator). */
+function getStorageKey(): string {
+  return storageKey_visible(getPanelConfig());
+}
+
+const TOGGLE_EVENT = 'toggle-design-token-panel';
+/** Deprecated — kept so legacy callers still flip the panel. */
+const TOGGLE_EVENT_ALIAS = 'toggle-color-tweak-panel';
+
+// ---------------------------------------------------------------------------
+// Storage helpers (SSR-safe, tolerant of private mode / quota errors)
+// ---------------------------------------------------------------------------
+
+function setStoredVisibility(isVisible: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(getStorageKey(), isVisible ? '1' : '0');
+  } catch {
+    /* ignore */
+  }
+}
+
+function wasVisible(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(getStorageKey()) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function hasPersistedOverrides(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(getStorageKeyV2()) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read-only probe of the panel's own open state. We only read it so
+ * `showDesignTokenPanel` / `hideDesignTokenPanel` can avoid firing a toggle
+ * event when the panel is already in the requested state.
+ *
+ * `OPEN_KEY` is owned by `panel.tsx` for steady-state writes (its
+ * `useEffect` mirrors `open` into the key on every change). The adapter
+ * additionally seeds the key once before a fresh mount via
+ * `seedOpenStateBeforeMount` — see Issue #1549 for the timing rationale.
+ */
+function isPanelCurrentlyOpen(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(getOpenKey()) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pre-mount seed for `OPEN_KEY` (Issue #1549).
+ *
+ * On a fresh mount the adapter wants to drive the panel into the user's last
+ * known state. The historical strategy was to render first, then dispatch a
+ * `toggle-design-token-panel` event from a `queueMicrotask`. That broke when
+ * the visibility flag was set without `OPEN_KEY` being set (the canonical
+ * repro: user types `localStorage.setItem(<visible-key>, '1')` and hard-
+ * reloads, where `<visible-key>` derives from `panelConfig.storagePrefix` —
+ * default `zudo-design-token-panel:visible`): `panel.tsx` registers its
+ * toggle listener inside a `useEffect`, which Preact flushes on a
+ * `requestAnimationFrame` (or its `setTimeout(35)` polyfill — see preact/hooks
+ * `w`). A microtask drains long before that frame, so the dispatched event
+ * lands in the void and the panel never opens. Symptoms:
+ * `window.<consoleNamespace>.showDesignPanel()` had to be called manually
+ * after every reload despite `wasVisible()` already being true.
+ *
+ * The fix is to seed `OPEN_KEY` synchronously before the Preact render. The
+ * panel's `useEffect` then reads the correct value during its mount pass and
+ * sets `open=true` directly, skipping the dispatch race entirely. Steady-state
+ * toggles still use the event channel — by then the listener is attached and
+ * the existing `panel.tsx`-owned write keeps `OPEN_KEY` and `open` in lockstep.
+ *
+ * Keep this in lockstep with `OPEN_KEY` reads in `panel.tsx` (the first
+ * `useEffect` in `DesignTokenTweakPanel`).
+ */
+function seedOpenStateBeforeMount(desiredOpen: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const openKey = getOpenKey();
+    if (desiredOpen) window.localStorage.setItem(openKey, '1');
+    else window.localStorage.removeItem(openKey);
+  } catch {
+    /* ignore */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mount / unmount
+// ---------------------------------------------------------------------------
+
+function findRoot(): HTMLElement | null {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(getPanelId());
+}
+
+/**
+ * Idempotently mount the Preact shell. Returns `true` only on a fresh mount.
+ *
+ * Callers that need the panel in a specific open state on a fresh mount must
+ * call `seedOpenStateBeforeMount(...)` *before* this function — the panel's
+ * mount-effect reads `OPEN_KEY` synchronously, so the seed has to be visible
+ * by then.
+ */
+function ensureMounted(): boolean {
+  if (typeof document === 'undefined') return false;
+  const panelId = getPanelId();
+  if (document.getElementById(panelId)) return false;
+  const root = document.createElement('div');
+  root.id = panelId;
+  document.body.appendChild(root);
+  render(<DesignTokenTweakPanel />, root);
+  return true;
+}
+
+function dispatchToggle(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(TOGGLE_EVENT));
+}
+
+// ---------------------------------------------------------------------------
+// Public API (consumed by astro/host-adapter.ts)
+// ---------------------------------------------------------------------------
+
+// Re-exports for non-Astro consumers documented in README §4. The Astro
+// adapter calls configurePanel internally, but a Vite-only host needs to
+// reach it from the package root per PORTABLE-CONTRACT.md §1 (Sub 11 #1562).
+export { configurePanel, setPanelColorPresets } from './config/panel-config';
+export type { PanelConfig } from './config/panel-config';
+
+/**
+ * Internal-test-only accessor that returns this panel-module bundle's view of
+ * the active panel config singleton. Paired with the Astro host adapter's
+ * `loadPanelModule()` runtime guard (epic #1610 / Sub #1612): the adapter
+ * compares the reference returned here against its own `getPanelConfig()`
+ * result. They MUST be the same object — Vite's multi-entry build code-
+ * splits the shared `config/panel-config` module into one chunk so both
+ * surfaces observe one and the same singleton. A reference mismatch indicates
+ * a future packaging refactor split the singleton across two chunks; the
+ * adapter `console.warn`s loudly so the regression is caught in dev.
+ *
+ * Prefixed `__` to make it clear this is internal/test surface, not a
+ * documented public API.
+ */
+export function __panelConfigForTest(): PanelConfig {
+  return getPanelConfig();
+}
+// Public-facing alias for the cluster shape carried on `PanelConfig.colorCluster`.
+// The runtime type is `ColorClusterDataConfig` (defined in
+// `./config/cluster-config.ts`); the same shape is documented under the
+// historical `ColorClusterConfig` name. Surfacing the alias from the
+// package root means a host can write
+// `import type { ColorClusterConfig } from '@takazudo/zudo-design-token-panel'`
+// instead of digging into an internal sub-path.
+export type { ColorClusterConfig } from './state/tweak-state';
+// Re-exported so hosts can type the entries of their optional
+// `PanelConfig.colorPresets` map without reaching for an internal sub-path.
+export type { ColorScheme, ColorRef } from './config/color-schemes';
+// Re-export the `TokenManifest` shape so consumers can type their
+// host-supplied `panelConfig.tokens` field.
+export type { TokenManifest, TokenDef } from './tokens/manifest';
+
+export function showDesignTokenPanel(): void {
+  if (typeof window === 'undefined') return;
+  // Seed OPEN_KEY *before* a fresh mount. See `seedOpenStateBeforeMount` doc
+  // comment (Issue #1549) for why we cannot rely on a post-render dispatch.
+  const isFreshMount = !findRoot();
+  if (isFreshMount) seedOpenStateBeforeMount(true);
+  ensureMounted();
+  setStoredVisibility(true);
+  // Fresh-mount path: the seed has already driven `open=true` through
+  // `panel.tsx`'s mount-effect. Avoid the event dispatch entirely — the
+  // listener is not attached yet (Preact's `useEffect` flushes on rAF, well
+  // after our microtask), so it would land in the void.
+  if (isFreshMount) return;
+  // Steady-state path: panel is already mounted; flipping requires its
+  // listener, which is attached by now, so a synchronous dispatch is safe.
+  if (isPanelCurrentlyOpen()) return;
+  dispatchToggle();
+}
+
+export function hideDesignTokenPanel(): void {
+  if (typeof window === 'undefined') return;
+  const isFreshMount = !findRoot();
+  if (isFreshMount) seedOpenStateBeforeMount(false);
+  ensureMounted();
+  setStoredVisibility(false);
+  if (isFreshMount) return;
+  if (!isPanelCurrentlyOpen()) return;
+  dispatchToggle();
+}
+
+export function toggleDesignPanel(): void {
+  if (typeof window === 'undefined') return;
+  // Snapshot intent *before* the toggle flips `OPEN_KEY`.
+  const willBeOpen = !isPanelCurrentlyOpen();
+  const isFreshMount = !findRoot();
+  if (isFreshMount) seedOpenStateBeforeMount(willBeOpen);
+  ensureMounted();
+  setStoredVisibility(willBeOpen);
+  // On a fresh mount, the seed already drove `panel.tsx`'s mount-effect to
+  // the desired state — no event dispatch needed (and dispatching here would
+  // race the not-yet-attached listener; see Issue #1549).
+  if (isFreshMount) return;
+  dispatchToggle();
+}
+
+/**
+ * Apply persisted token overrides directly to `:root` BEFORE any Preact
+ * render. Called at adapter module init (and again on every `astro:page-load`)
+ * so the bundle's arrival is enough to kill the FOUT on hard navigation; the
+ * Preact shell still mounts separately when visibility intent requires it via
+ * `reapplyFromStorage()`.
+ *
+ * No-op when nothing is persisted. Swallows errors — missing storage or
+ * corrupt state should never block the UI thread (stylesheet defaults paint
+ * instead, same as before this helper existed).
+ */
+export function reapplyPersistedOverrides(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const persisted = loadPersistedState();
+    if (persisted) applyFullState(persisted);
+  } catch {
+    /* ignore — stylesheet defaults paint instead */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Astro lifecycle wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Full Preact unmount before Astro's `ClientRouter` swaps `<body>`.
+ *
+ * Without this, the body swap orphans the Preact tree — its `useEffect`
+ * cleanups never fire, so each navigation leaks `window`/`document`
+ * listeners and leaves a tree whose `setState` calls no longer touch any
+ * live DOM. `render(null, root)` drives a proper unmount (cleanups run),
+ * then the root itself is detached so `astro:page-load` can start clean.
+ *
+ * Visibility intent must survive the unmount: snapshot `wasVisible()`
+ * beforehand and restore it afterward so the post-swap remount decision
+ * reflects the user's last state, not an artefact of the unmount path.
+ */
+function unmountForSwap(): void {
+  const root = findRoot();
+  if (!root) return;
+  const shouldRestore = wasVisible();
+  render(null, root);
+  root.remove();
+  if (shouldRestore) setStoredVisibility(true);
+}
+
+/**
+ * Re-materialise the shell on a page load when either (a) the user had the
+ * panel visible before navigation, or (b) overrides are persisted and need
+ * reapplying even while the panel stays hidden.
+ *
+ * Overrides are applied to `:root` first (cheap, no Preact render) so the
+ * post-swap paint uses the persisted values immediately instead of waiting
+ * for the shell's mount-effect to fire. This kills the FOUT on soft-nav the
+ * same way the adapter's module-init path kills it on hard-nav.
+ */
+function reapplyFromStorage(): void {
+  reapplyPersistedOverrides();
+  if (wasVisible()) {
+    showDesignTokenPanel();
+  } else if (hasPersistedOverrides()) {
+    hideDesignTokenPanel();
+  }
+}
+
+/**
+ * Initial-mount trigger: while the shell is not yet mounted, the very first
+ * `toggle-design-token-panel` (or alias) dispatched from elsewhere — e.g. a
+ * header button click — lands here. The user's intent is to flip the panel,
+ * so we seed `OPEN_KEY` to the *opposite* of its current value before the
+ * Preact render. The mount-effect in `panel.tsx` then reads that seed and
+ * sets `open` synchronously, matching what an event-listener-driven flip
+ * would have done — without the timing race that made post-render dispatch
+ * unreliable (Issue #1549).
+ *
+ * Once the shell is mounted, this handler short-circuits and `panel.tsx`
+ * owns every subsequent toggle. The before-swap unmount resets that state
+ * so the seed-then-mount path kicks in again on the next hard-from-nothing
+ * toggle.
+ */
+function onMaybeMount(): void {
+  if (findRoot()) return; // already mounted — panel.tsx owns this event
+  const willBeOpen = !isPanelCurrentlyOpen();
+  seedOpenStateBeforeMount(willBeOpen);
+  ensureMounted();
+}
+
+interface AdapterLifecycleState {
+  bound: boolean;
+}
+
+/**
+ * Lifecycle slot for the panel module. We use a DISTINCT window key from
+ * `__zudoDesignTokenPanelAdapter` (owned by `astro/host-adapter.ts` as a
+ * per-`storagePrefix` map of `DesignTokenPanelAdapterState`). The two
+ * surfaces would otherwise declare incompatible shapes against the same
+ * key; separating the slots keeps each file's TypeScript types honest.
+ */
+type AdapterWindow = Window & {
+  __zudoDesignTokenPanelLifecycle?: AdapterLifecycleState;
+};
+
+function getAdapterState(): AdapterLifecycleState {
+  const w = window as AdapterWindow;
+  if (w.__zudoDesignTokenPanelLifecycle) return w.__zudoDesignTokenPanelLifecycle;
+  const state: AdapterLifecycleState = { bound: false };
+  w.__zudoDesignTokenPanelLifecycle = state;
+  return state;
+}
+
+if (typeof window !== 'undefined') {
+  const state = getAdapterState();
+  if (!state.bound) {
+    state.bound = true;
+
+    window.addEventListener(TOGGLE_EVENT, onMaybeMount);
+    window.addEventListener(TOGGLE_EVENT_ALIAS, onMaybeMount);
+
+    if (typeof document !== 'undefined') {
+      document.addEventListener('astro:before-swap', unmountForSwap);
+      document.addEventListener('astro:page-load', reapplyFromStorage);
+    }
+
+    // Apply persisted overrides to `:root` BEFORE any Preact render — kills
+    // the hard-navigation FOUT. `reapplyFromStorage()` below then mounts the
+    // shell only when the user had it open or has a persisted state to
+    // display (and internally reapplies overrides again, which is a cheap
+    // idempotent op — setting the same inline CSS vars twice paints once).
+    reapplyPersistedOverrides();
+    // Initial hard-load parity with the soft-nav path in `reapplyFromStorage`.
+    reapplyFromStorage();
+  }
+}

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -37,8 +37,7 @@
 import { render } from 'preact';
 import DesignTokenTweakPanel from './panel';
 // Side-effect import: bundles panel chrome CSS + panel-private CSS variables
-// so the package is visually self-contained for any consumer (Sub 5a, #1555).
-// Modal layer CSS will follow in Sub 5b.
+// so the package is visually self-contained for any consumer.
 import './styles/panel.css';
 import {
   applyFullState,
@@ -110,7 +109,8 @@ function hasPersistedOverrides(): boolean {
  * `OPEN_KEY` is owned by `panel.tsx` for steady-state writes (its
  * `useEffect` mirrors `open` into the key on every change). The adapter
  * additionally seeds the key once before a fresh mount via
- * `seedOpenStateBeforeMount` — see Issue #1549 for the timing rationale.
+ * `seedOpenStateBeforeMount` — see the seed function's docstring for the
+ * timing rationale.
  */
 function isPanelCurrentlyOpen(): boolean {
   if (typeof window === 'undefined') return false;
@@ -122,7 +122,7 @@ function isPanelCurrentlyOpen(): boolean {
 }
 
 /**
- * Pre-mount seed for `OPEN_KEY` (Issue #1549).
+ * Pre-mount seed for `OPEN_KEY`.
  *
  * On a fresh mount the adapter wants to drive the panel into the user's last
  * known state. The historical strategy was to render first, then dispatch a
@@ -197,14 +197,14 @@ function dispatchToggle(): void {
 
 // Re-exports for non-Astro consumers documented in README §4. The Astro
 // adapter calls configurePanel internally, but a Vite-only host needs to
-// reach it from the package root per PORTABLE-CONTRACT.md §1 (Sub 11 #1562).
+// reach it from the package root per PORTABLE-CONTRACT.md §1.
 export { configurePanel, setPanelColorPresets } from './config/panel-config';
 export type { PanelConfig } from './config/panel-config';
 
 /**
  * Internal-test-only accessor that returns this panel-module bundle's view of
  * the active panel config singleton. Paired with the Astro host adapter's
- * `loadPanelModule()` runtime guard (epic #1610 / Sub #1612): the adapter
+ * `loadPanelModule()` runtime guard: the adapter
  * compares the reference returned here against its own `getPanelConfig()`
  * result. They MUST be the same object — Vite's multi-entry build code-
  * splits the shared `config/panel-config` module into one chunk so both
@@ -236,7 +236,7 @@ export type { TokenManifest, TokenDef } from './tokens/manifest';
 export function showDesignTokenPanel(): void {
   if (typeof window === 'undefined') return;
   // Seed OPEN_KEY *before* a fresh mount. See `seedOpenStateBeforeMount` doc
-  // comment (Issue #1549) for why we cannot rely on a post-render dispatch.
+  // comment for why we cannot rely on a post-render dispatch.
   const isFreshMount = !findRoot();
   if (isFreshMount) seedOpenStateBeforeMount(true);
   ensureMounted();
@@ -273,7 +273,7 @@ export function toggleDesignPanel(): void {
   setStoredVisibility(willBeOpen);
   // On a fresh mount, the seed already drove `panel.tsx`'s mount-effect to
   // the desired state — no event dispatch needed (and dispatching here would
-  // race the not-yet-attached listener; see Issue #1549).
+  // race the not-yet-attached listener).
   if (isFreshMount) return;
   dispatchToggle();
 }
@@ -352,7 +352,7 @@ function reapplyFromStorage(): void {
  * Preact render. The mount-effect in `panel.tsx` then reads that seed and
  * sets `open` synchronously, matching what an event-listener-driven flip
  * would have done — without the timing race that made post-render dispatch
- * unreliable (Issue #1549).
+ * unreliable.
  *
  * Once the shell is mounted, this handler short-circuits and `panel.tsx`
  * owns every subsequent toggle. The before-swap unmount resets that state

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -72,21 +72,22 @@ function computePanelSize(
   };
 }
 
-// --- Empty-state UI (Sub S5d, #1591) ---
+// --- Empty-state UI ---
 //
 // Friendly affordance shown in the tab body when a host has not registered
 // any tokens for the active tab's category (i.e. `getPanelConfig().tokens.<cat>`
 // is an empty array). Without this, the tab renders a blank pane — opaque to
 // a developer integrating the panel for the first time. The copy points the
-// reader at `configurePanel({ tokens })` and the package README §3 quick-start.
+// reader at `configurePanel({ tokens })` and the package README quick-start
+// section.
 //
 // Scope: spacing / typography / size tabs only. The color tab is driven by
-// the host-supplied `colorCluster`, NOT by `tokens.color` — zmod's bundled
-// manifest deliberately ships `color: []` because the cluster does the work.
-// Showing the empty-state under the color tab on the strength of an empty
-// `tokens.color` array would surface a spurious "configure tokens please"
-// message on every cluster-driven host, which is exactly the regression to
-// avoid.
+// the host-supplied `colorCluster`, NOT by `tokens.color` — this package's
+// default manifest deliberately ships `color: []` because the cluster does
+// the work. Showing the empty-state under the color tab on the strength of
+// an empty `tokens.color` array would surface a spurious "configure tokens
+// please" message on every cluster-driven host, which is exactly the
+// regression to avoid.
 //
 // The `<a>` points at the package README anchor for the quick-start section.
 // It is rendered as an absolute GitHub URL so the link still resolves when
@@ -359,7 +360,7 @@ export default function DesignTokenTweakPanel() {
   );
 
   // Read host token manifest so we can swap in <EmptyState/> for tabs whose
-  // category has zero tokens registered (Sub S5d, #1591). The manifest is
+  // category has zero tokens registered. The manifest is
   // pinned by `configurePanel`'s one-shot contract, so re-reading per render
   // is cheap and never goes stale mid-session.
   const tokens = getPanelConfig().tokens;

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -88,12 +88,12 @@ function computePanelSize(
 // message on every cluster-driven host, which is exactly the regression to
 // avoid.
 //
-// The `<a>` points at the package README anchor for §3 (Quick start). It is
-// rendered as an absolute GitHub URL so the link still resolves when the
-// panel is bundled into a non-zmod consumer that ships none of the README
+// The `<a>` points at the package README anchor for the quick-start section.
+// It is rendered as an absolute GitHub URL so the link still resolves when
+// the panel is bundled into a consumer that ships none of the README
 // alongside the panel runtime.
 const README_QUICK_START_URL =
-  'https://github.com/Takazudo/zmodular/blob/main/sub-packages/design-token-panel/README.md#3-quick-start-astro';
+  'https://github.com/Takazudo/zudo-design-token-panel#quick-start-astro';
 
 function EmptyState() {
   return (
@@ -139,7 +139,7 @@ export default function DesignTokenTweakPanel() {
   // Track active drag listeners for cleanup on unmount
   const dragCleanupRef = useRef<(() => void) | null>(null);
 
-  const { persistColor, persistSpacing, persistFont, persistSize, persistZaudio } =
+  const { persistColor, persistSpacing, persistFont, persistSize, persistSecondary } =
     usePersist(setState);
 
   // Restore open state and position from localStorage after mount (avoids SSR hydration mismatch)
@@ -190,7 +190,7 @@ export default function DesignTokenTweakPanel() {
         spacing: emptyOverrides(),
         typography: emptyOverrides(),
         size: emptyOverrides(),
-        zaudio: initSecondaryFromConfig(),
+        secondary: initSecondaryFromConfig(),
       });
     }
     window.addEventListener('color-scheme-changed', handleSchemeChange);
@@ -208,15 +208,15 @@ export default function DesignTokenTweakPanel() {
     }
     // No saved state — page already has correct colors from ColorSchemeProvider.
     // Just read scheme data for panel display; don't apply (avoids oklch->hex lossy conversion).
-    // `zaudio` is always seeded — every fresh-state path includes it so the
-    // persisted envelope shape stays stable regardless of the user's path
-    // (PR #1440 review item B3).
+    // The `secondary` slice is always seeded — every fresh-state path
+    // includes it so the persisted envelope shape stays stable regardless
+    // of the user's path.
     setState({
       color: initColorFromScheme(),
       spacing: emptyOverrides(),
       typography: emptyOverrides(),
       size: emptyOverrides(),
-      zaudio: initSecondaryFromConfig(),
+      secondary: initSecondaryFromConfig(),
     });
   }, [open, state]);
 
@@ -297,14 +297,14 @@ export default function DesignTokenTweakPanel() {
   const handleResetAll = useCallback(() => {
     clearPersistedState();
     clearAppliedStyles();
-    // Always seed zaudio (PR #1440 review item B3) — every fresh-state path
-    // emits a uniform envelope shape so persistence stays consistent.
+    // Always seed the secondary slice — every fresh-state path emits a
+    // uniform envelope shape so persistence stays consistent.
     setState({
       color: initColorFromScheme(),
       spacing: emptyOverrides(),
       typography: emptyOverrides(),
       size: emptyOverrides(),
-      zaudio: initSecondaryFromConfig(),
+      secondary: initSecondaryFromConfig(),
     });
   }, []);
 
@@ -314,14 +314,14 @@ export default function DesignTokenTweakPanel() {
     // page will re-render from the fresh stylesheet.
     clearPersistedState();
     clearAppliedStyles();
-    // Always seed zaudio (PR #1440 review item B3) — every fresh-state path
-    // emits a uniform envelope shape.
+    // Always seed the secondary slice — every fresh-state path emits a
+    // uniform envelope shape.
     setState({
       color: initColorFromScheme(),
       spacing: emptyOverrides(),
       typography: emptyOverrides(),
       size: emptyOverrides(),
-      zaudio: initSecondaryFromConfig(),
+      secondary: initSecondaryFromConfig(),
     });
   }, []);
 
@@ -486,8 +486,8 @@ export default function DesignTokenTweakPanel() {
                   <ColorTab
                     state={state.color}
                     persistColor={persistColor}
-                    zaudioState={state.zaudio ?? initSecondaryFromConfig() ?? null}
-                    persistZaudio={persistZaudio}
+                    secondaryState={state.secondary ?? initSecondaryFromConfig() ?? null}
+                    persistSecondary={persistSecondary}
                   />
                 )}
                 {tab.id === 'spacing' &&

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -1,0 +1,549 @@
+import { useState, useEffect, useCallback, useRef } from 'preact/compat';
+import { ExportModal } from './export-modal';
+import { ImportModal } from './import-modal';
+import { ApplyModal } from './apply-modal';
+import ColorTab from './tabs/color-tab';
+import FontTab from './tabs/font-tab';
+import SizeTab from './tabs/size-tab';
+import SpacingTab from './tabs/spacing-tab';
+import { getPanelConfig } from './config/panel-config';
+import { usePersist } from './state/persist';
+import {
+  type TweakState,
+  type PanelPosition,
+  DEFAULT_POSITION,
+  applyFullState,
+  clampPosition,
+  clearAppliedStyles,
+  clearPersistedState,
+  emptyOverrides,
+  getOpenKey,
+  initColorFromScheme,
+  initSecondaryFromConfig,
+  loadPersistedState,
+  loadPosition,
+  savePersistedState,
+  savePosition,
+} from './state/tweak-state';
+
+// --- Tab configuration ---
+
+type TabId = 'spacing' | 'font' | 'size' | 'color';
+
+interface TabDef {
+  id: TabId;
+  label: string;
+}
+
+const TABS: readonly TabDef[] = [
+  { id: 'spacing', label: 'Spacing' },
+  { id: 'font', label: 'Font' },
+  { id: 'size', label: 'Size' },
+  { id: 'color', label: 'Color' },
+] as const;
+
+const DEFAULT_TAB: TabId = 'color';
+
+// --- Panel sizing ---
+
+/** Below this width the panel switches to narrow mode (non-draggable, centered, capped width). */
+const NARROW_BREAKPOINT = 900;
+
+function computePanelSize(
+  viewportW: number,
+  _viewportH: number,
+): {
+  width: string;
+  height: string;
+  narrow: boolean;
+} {
+  const narrow = viewportW < NARROW_BREAKPOINT;
+  if (narrow) {
+    return {
+      width: `min(calc(100vw - 16px), 500px)`,
+      height: `min(800px, calc(100vh - 32px))`,
+      narrow,
+    };
+  }
+  return {
+    width: `min(1200px, 80vw)`,
+    height: `min(800px, 80vh)`,
+    narrow,
+  };
+}
+
+// --- Empty-state UI (Sub S5d, #1591) ---
+//
+// Friendly affordance shown in the tab body when a host has not registered
+// any tokens for the active tab's category (i.e. `getPanelConfig().tokens.<cat>`
+// is an empty array). Without this, the tab renders a blank pane — opaque to
+// a developer integrating the panel for the first time. The copy points the
+// reader at `configurePanel({ tokens })` and the package README §3 quick-start.
+//
+// Scope: spacing / typography / size tabs only. The color tab is driven by
+// the host-supplied `colorCluster`, NOT by `tokens.color` — zmod's bundled
+// manifest deliberately ships `color: []` because the cluster does the work.
+// Showing the empty-state under the color tab on the strength of an empty
+// `tokens.color` array would surface a spurious "configure tokens please"
+// message on every cluster-driven host, which is exactly the regression to
+// avoid.
+//
+// The `<a>` points at the package README anchor for §3 (Quick start). It is
+// rendered as an absolute GitHub URL so the link still resolves when the
+// panel is bundled into a non-zmod consumer that ships none of the README
+// alongside the panel runtime.
+const README_QUICK_START_URL =
+  'https://github.com/Takazudo/zmodular/blob/main/sub-packages/design-token-panel/README.md#3-quick-start-astro';
+
+function EmptyState() {
+  return (
+    <div className="tokenpanel-empty-state" role="status">
+      <p className="tokenpanel-empty-state-text">
+        No tokens are registered for this tab. Pass a <code>TokenManifest</code> to{' '}
+        <code>configurePanel({'{ tokens }'})</code> — see the{' '}
+        <a
+          className="tokenpanel-empty-state-link"
+          href={README_QUICK_START_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          package README §3
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+
+// --- Main Component ---
+
+export default function DesignTokenTweakPanel() {
+  const [open, setOpen] = useState(false);
+  const [showExport, setShowExport] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [showApply, setShowApply] = useState(false);
+  const [state, setState] = useState<TweakState | null>(null);
+  const [activeTab, setActiveTab] = useState<TabId>(DEFAULT_TAB);
+  const [position, setPosition] = useState<PanelPosition>(DEFAULT_POSITION);
+  const [isNarrow, setIsNarrow] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<Record<TabId, HTMLButtonElement | null>>({
+    spacing: null,
+    font: null,
+    size: null,
+    color: null,
+  });
+  const positionRef = useRef<PanelPosition>(DEFAULT_POSITION);
+  // Keep ref in sync with state for use in drag handlers (avoids stale closure)
+  positionRef.current = position;
+  // Track active drag listeners for cleanup on unmount
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+
+  const { persistColor, persistSpacing, persistFont, persistSize, persistZaudio } =
+    usePersist(setState);
+
+  // Restore open state and position from localStorage after mount (avoids SSR hydration mismatch)
+  useEffect(() => {
+    try {
+      if (localStorage.getItem(getOpenKey()) === '1') setOpen(true);
+    } catch {
+      /* ignore */
+    }
+    const loaded = loadPosition();
+    setPosition(loaded);
+    positionRef.current = loaded;
+    // Initial narrow-check
+    setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
+  }, []);
+
+  // Persist open state
+  useEffect(() => {
+    try {
+      const openKey = getOpenKey();
+      if (open) localStorage.setItem(openKey, '1');
+      else localStorage.removeItem(openKey);
+    } catch {
+      /* ignore */
+    }
+  }, [open]);
+
+  // Toggle panel via custom event from header icon (new name + deprecated alias)
+  useEffect(() => {
+    function handleToggle() {
+      setOpen((prev) => !prev);
+    }
+    window.addEventListener('toggle-design-token-panel', handleToggle);
+    window.addEventListener('toggle-color-tweak-panel', handleToggle);
+    return () => {
+      window.removeEventListener('toggle-design-token-panel', handleToggle);
+      window.removeEventListener('toggle-color-tweak-panel', handleToggle);
+    };
+  }, []);
+
+  // Re-initialize when the color scheme or light/dark mode changes
+  useEffect(() => {
+    function handleSchemeChange() {
+      // Clear all inline style overrides so the new scheme's <style> tag takes effect
+      clearAppliedStyles();
+      setState({
+        color: initColorFromScheme(),
+        spacing: emptyOverrides(),
+        typography: emptyOverrides(),
+        size: emptyOverrides(),
+        zaudio: initSecondaryFromConfig(),
+      });
+    }
+    window.addEventListener('color-scheme-changed', handleSchemeChange);
+    return () => window.removeEventListener('color-scheme-changed', handleSchemeChange);
+  }, []);
+
+  // Initialize state on first open
+  useEffect(() => {
+    if (!open || state) return;
+    const persisted = loadPersistedState();
+    if (persisted) {
+      applyFullState(persisted);
+      setState(persisted);
+      return;
+    }
+    // No saved state — page already has correct colors from ColorSchemeProvider.
+    // Just read scheme data for panel display; don't apply (avoids oklch->hex lossy conversion).
+    // `zaudio` is always seeded — every fresh-state path includes it so the
+    // persisted envelope shape stays stable regardless of the user's path
+    // (PR #1440 review item B3).
+    setState({
+      color: initColorFromScheme(),
+      spacing: emptyOverrides(),
+      typography: emptyOverrides(),
+      size: emptyOverrides(),
+      zaudio: initSecondaryFromConfig(),
+    });
+  }, [open, state]);
+
+  // Drag handler for panel header (stable — reads position from ref)
+  const handleDragStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // Drag disabled on narrow viewports.
+    if (window.innerWidth < NARROW_BREAKPOINT) return;
+    // Skip if target is a button, select, or inside one
+    const target = e.target as HTMLElement;
+    if (target.closest("button, select, option, [role='tab']")) return;
+    e.preventDefault();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startRight = positionRef.current.right;
+    const startTop = positionRef.current.top;
+    const panelWidth = panelRef.current?.offsetWidth ?? 600;
+    const panelHeight = panelRef.current?.offsetHeight ?? 600;
+
+    function onMouseMove(ev: MouseEvent) {
+      const deltaX = ev.clientX - startX;
+      const deltaY = ev.clientY - startY;
+      const clamped = clampPosition(
+        startTop + deltaY,
+        startRight - deltaX,
+        panelWidth,
+        panelHeight,
+      );
+      setPosition(clamped);
+    }
+
+    function onMouseUp() {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      dragCleanupRef.current = null;
+      savePosition(positionRef.current);
+    }
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    dragCleanupRef.current = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, []);
+
+  // Clean up drag listeners on unmount
+  useEffect(() => {
+    return () => {
+      dragCleanupRef.current?.();
+    };
+  }, []);
+
+  // Re-clamp position on window resize + update narrow-mode flag
+  useEffect(() => {
+    function handleResize() {
+      setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
+      const panelWidth = panelRef.current?.offsetWidth ?? 600;
+      const panelHeight = panelRef.current?.offsetHeight ?? 600;
+      setPosition((prev) => {
+        const clamped = clampPosition(prev.top, prev.right, panelWidth, panelHeight);
+        savePosition(clamped);
+        return clamped;
+      });
+    }
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const handleLoadFromJson = useCallback((loaded: TweakState) => {
+    // Replace the panel state with the loaded tweak, apply CSS vars, persist
+    // to localStorage (v2). Unknown tokens have already been filtered out by
+    // deserialize().
+    applyFullState(loaded);
+    savePersistedState(loaded);
+    setState(loaded);
+  }, []);
+
+  const handleResetAll = useCallback(() => {
+    clearPersistedState();
+    clearAppliedStyles();
+    // Always seed zaudio (PR #1440 review item B3) — every fresh-state path
+    // emits a uniform envelope shape so persistence stays consistent.
+    setState({
+      color: initColorFromScheme(),
+      spacing: emptyOverrides(),
+      typography: emptyOverrides(),
+      size: emptyOverrides(),
+      zaudio: initSecondaryFromConfig(),
+    });
+  }, []);
+
+  const handleApplied = useCallback(() => {
+    // After a successful apply the on-disk CSS now matches the current tweak,
+    // so drop the persisted override envelope and any inline overrides — the
+    // page will re-render from the fresh stylesheet.
+    clearPersistedState();
+    clearAppliedStyles();
+    // Always seed zaudio (PR #1440 review item B3) — every fresh-state path
+    // emits a uniform envelope shape.
+    setState({
+      color: initColorFromScheme(),
+      spacing: emptyOverrides(),
+      typography: emptyOverrides(),
+      size: emptyOverrides(),
+      zaudio: initSecondaryFromConfig(),
+    });
+  }, []);
+
+  // --- Tab keyboard navigation (WAI-ARIA tablist pattern) ---
+  const handleTabKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      const idx = TABS.findIndex((t) => t.id === activeTab);
+      if (idx === -1) return;
+      let nextIdx: number | null = null;
+      if (e.key === 'ArrowRight') nextIdx = (idx + 1) % TABS.length;
+      else if (e.key === 'ArrowLeft') nextIdx = (idx - 1 + TABS.length) % TABS.length;
+      else if (e.key === 'Home') nextIdx = 0;
+      else if (e.key === 'End') nextIdx = TABS.length - 1;
+      if (nextIdx === null) return;
+      e.preventDefault();
+      const next = TABS[nextIdx];
+      setActiveTab(next.id);
+      // Move focus to the newly selected tab so SR announces it
+      window.requestAnimationFrame(() => {
+        tabRefs.current[next.id]?.focus();
+      });
+    },
+    [activeTab],
+  );
+
+  if (!open) return null;
+
+  const {
+    width: panelW,
+    height: panelH,
+    narrow,
+  } = computePanelSize(
+    typeof window !== 'undefined' ? window.innerWidth : 1024,
+    typeof window !== 'undefined' ? window.innerHeight : 768,
+  );
+
+  // Read host token manifest so we can swap in <EmptyState/> for tabs whose
+  // category has zero tokens registered (Sub S5d, #1591). The manifest is
+  // pinned by `configurePanel`'s one-shot contract, so re-reading per render
+  // is cheap and never goes stale mid-session.
+  const tokens = getPanelConfig().tokens;
+
+  // In narrow mode, ignore saved position — center safely near the top.
+  const panelPos =
+    narrow || isNarrow
+      ? {
+          position: 'fixed' as const,
+          top: 16,
+          left: '50%',
+          transform: 'translateX(-50%)',
+          right: 'auto' as const,
+        }
+      : { position: 'fixed' as const, top: position.top, right: position.right };
+
+  return (
+    <>
+      <div
+        ref={panelRef}
+        className="tokenpanel-shell"
+        style={{
+          ...panelPos,
+          width: panelW,
+          height: panelH,
+          maxHeight: 'calc(100vh - 32px)',
+        }}
+      >
+        {/* Header row (expert/reset) — draggable on desktop only */}
+        <div
+          className="tokenpanel-header"
+          style={{ cursor: narrow || isNarrow ? 'default' : 'move' }}
+          onMouseDown={handleDragStart}
+        >
+          <span className="tokenpanel-title">Design Tokens</span>
+          <button
+            type="button"
+            onClick={() => setShowExport(true)}
+            className="tokenpanel-action-link"
+          >
+            Export
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowImport(true)}
+            className="tokenpanel-action-link"
+          >
+            Load from JSON…
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowApply(true)}
+            className="tokenpanel-action-link"
+          >
+            Apply
+          </button>
+          <button type="button" onClick={handleResetAll} className="tokenpanel-action-link">
+            Reset
+          </button>
+          <div className="tokenpanel-spacer" />
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="tokenpanel-close-btn"
+            aria-label="Close panel"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Tab bar */}
+        <div role="tablist" aria-label="Design token categories" className="tokenpanel-tabbar">
+          {TABS.map((tab) => {
+            const isSelected = activeTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                ref={(el) => {
+                  tabRefs.current[tab.id] = el;
+                }}
+                type="button"
+                role="tab"
+                id={`dtp-tab-${tab.id}`}
+                aria-selected={isSelected}
+                aria-controls={`dtp-panel-${tab.id}`}
+                tabIndex={isSelected ? 0 : -1}
+                onClick={() => setActiveTab(tab.id)}
+                onKeyDown={handleTabKeyDown}
+                className={isSelected ? 'tokenpanel-tab-button is-active' : 'tokenpanel-tab-button'}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Tab panels */}
+        <div className="tokenpanel-body">
+          {TABS.map((tab) => {
+            const isSelected = activeTab === tab.id;
+            return (
+              <div
+                key={tab.id}
+                role="tabpanel"
+                id={`dtp-panel-${tab.id}`}
+                aria-labelledby={`dtp-tab-${tab.id}`}
+                tabIndex={0}
+                hidden={!isSelected}
+              >
+                {tab.id === 'color' && state && (
+                  <ColorTab
+                    state={state.color}
+                    persistColor={persistColor}
+                    zaudioState={state.zaudio ?? initSecondaryFromConfig() ?? null}
+                    persistZaudio={persistZaudio}
+                  />
+                )}
+                {tab.id === 'spacing' &&
+                  state &&
+                  (tokens.spacing.length === 0 ? (
+                    <EmptyState />
+                  ) : (
+                    <SpacingTab state={state.spacing} persistSpacing={persistSpacing} />
+                  ))}
+                {tab.id === 'font' &&
+                  state &&
+                  (tokens.typography.length === 0 ? (
+                    <EmptyState />
+                  ) : (
+                    <FontTab state={state.typography} persistFont={persistFont} />
+                  ))}
+                {tab.id === 'size' &&
+                  state &&
+                  (tokens.size.length === 0 ? (
+                    <EmptyState />
+                  ) : (
+                    <SizeTab state={state.size} persistSize={persistSize} />
+                  ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {showExport && state && (
+        <ExportModal
+          onClose={() => setShowExport(false)}
+          state={state}
+          colorDefaults={initColorFromScheme()}
+        />
+      )}
+
+      {showImport && state && (
+        <ImportModal
+          onClose={() => setShowImport(false)}
+          onLoad={handleLoadFromJson}
+          colorDefaults={initColorFromScheme()}
+        />
+      )}
+
+      {showApply && state && (
+        <ApplyModal
+          state={state}
+          open={showApply}
+          onClose={() => setShowApply(false)}
+          colorDefaults={initColorFromScheme()}
+          onApplied={handleApplied}
+        />
+      )}
+    </>
+  );
+}
+
+export type { TweakState } from './state/tweak-state';

--- a/packages/zudo-design-token-panel/src/state/persist.ts
+++ b/packages/zudo-design-token-panel/src/state/persist.ts
@@ -75,18 +75,19 @@ export function usePersist(setState: SetState<TweakState>) {
   );
 
   /**
-   * Optional zaudio slice — absent during Wave 1. Passing `undefined` from
-   * the updater unsets the slice so envelopes stay small when zaudio is idle.
+   * Optional secondary slice — absent until a host opts in. Passing
+   * `undefined` from the updater unsets the slice so envelopes stay small
+   * when the secondary cluster is idle.
    */
-  const persistZaudio = useCallback(
+  const persistSecondary = useCallback(
     (updater: (prev: ColorTweakState | undefined) => ColorTweakState | undefined) => {
       persist((prev) => {
-        const next = updater(prev.zaudio);
+        const next = updater(prev.secondary);
         if (next === undefined) {
-          const { zaudio: _zaudio, ...rest } = prev;
+          const { secondary: _secondary, ...rest } = prev;
           return rest;
         }
-        return { ...prev, zaudio: next };
+        return { ...prev, secondary: next };
       });
     },
     [persist],
@@ -105,7 +106,7 @@ export function usePersist(setState: SetState<TweakState>) {
     persistFont: persistTypography,
     persistSize,
     persistPanelPosition,
-    persistZaudio,
+    persistSecondary,
   };
 }
 
@@ -117,4 +118,4 @@ export type PersistTypography = ReturnType<typeof usePersist>['persistTypography
 export type PersistFont = PersistTypography;
 export type PersistSize = ReturnType<typeof usePersist>['persistSize'];
 export type PersistPanelPosition = ReturnType<typeof usePersist>['persistPanelPosition'];
-export type PersistZaudio = ReturnType<typeof usePersist>['persistZaudio'];
+export type PersistSecondary = ReturnType<typeof usePersist>['persistSecondary'];

--- a/packages/zudo-design-token-panel/src/state/persist.ts
+++ b/packages/zudo-design-token-panel/src/state/persist.ts
@@ -1,0 +1,120 @@
+/**
+ * `usePersist` hook — orchestrates setState + DOM apply + localStorage write
+ * for the design-token panel. Each callback is a persist pipeline:
+ *
+ *   updater  →  setState(updater)  →  applyFullState(next)  →  savePersistedState(next)
+ *
+ * The slice-specific helpers (`persistColor`, `persistSpacing`, etc.) wrap a
+ * slice updater into a full-state updater so callers don't have to thread the
+ * whole envelope themselves.
+ *
+ * Framework-agnostic wrt. the setState function: pass any
+ * `(updater) => void` that propagates `updater(prev)` to the caller's state.
+ * In practice the panel passes Preact's `setState` from `useState`.
+ */
+
+import { useCallback } from 'preact/hooks';
+
+import {
+  applyFullState,
+  savePersistedState,
+  type ColorTweakState,
+  type TokenOverrides,
+  type TweakState,
+} from './tweak-state';
+
+type SetState<T> = (updater: (prev: T | null) => T | null) => void;
+
+export function usePersist(setState: SetState<TweakState>) {
+  const persist = useCallback(
+    (updater: (prev: TweakState) => TweakState) => {
+      setState((prev) => {
+        if (!prev) return prev;
+        const next = updater(prev);
+        applyFullState(next);
+        savePersistedState(next);
+        return next;
+      });
+    },
+    [setState],
+  );
+
+  const persistColor = useCallback(
+    (updater: (prev: ColorTweakState) => ColorTweakState) => {
+      persist((prev) => ({ ...prev, color: updater(prev.color) }));
+    },
+    [persist],
+  );
+
+  const persistSpacing = useCallback(
+    (updater: (prev: TokenOverrides) => TokenOverrides) => {
+      persist((prev) => ({ ...prev, spacing: updater(prev.spacing) }));
+    },
+    [persist],
+  );
+
+  const persistTypography = useCallback(
+    (updater: (prev: TokenOverrides) => TokenOverrides) => {
+      persist((prev) => ({ ...prev, typography: updater(prev.typography) }));
+    },
+    [persist],
+  );
+
+  const persistSize = useCallback(
+    (updater: (prev: TokenOverrides) => TokenOverrides) => {
+      persist((prev) => ({ ...prev, size: updater(prev.size) }));
+    },
+    [persist],
+  );
+
+  const persistPanelPosition = useCallback(
+    (updater: (prev: TweakState['panelPosition']) => TweakState['panelPosition']) => {
+      persist((prev) => ({ ...prev, panelPosition: updater(prev.panelPosition) }));
+    },
+    [persist],
+  );
+
+  /**
+   * Optional zaudio slice — absent during Wave 1. Passing `undefined` from
+   * the updater unsets the slice so envelopes stay small when zaudio is idle.
+   */
+  const persistZaudio = useCallback(
+    (updater: (prev: ColorTweakState | undefined) => ColorTweakState | undefined) => {
+      persist((prev) => {
+        const next = updater(prev.zaudio);
+        if (next === undefined) {
+          const { zaudio: _zaudio, ...rest } = prev;
+          return rest;
+        }
+        return { ...prev, zaudio: next };
+      });
+    },
+    [persist],
+  );
+
+  return {
+    persist,
+    persistColor,
+    persistSpacing,
+    persistTypography,
+    // Upstream (zudo-doc) naming — the verbatim-ported FontTab imports
+    // `persistFont` / `PersistFont`. The adapted envelope still names the
+    // slice `typography`; this alias lets the port compile without touching
+    // the upstream file. Slice can be renamed in a later sub-issue if the
+    // envelope ever aligns with upstream's shape.
+    persistFont: persistTypography,
+    persistSize,
+    persistPanelPosition,
+    persistZaudio,
+  };
+}
+
+export type Persist = ReturnType<typeof usePersist>['persist'];
+export type PersistColor = ReturnType<typeof usePersist>['persistColor'];
+export type PersistSpacing = ReturnType<typeof usePersist>['persistSpacing'];
+export type PersistTypography = ReturnType<typeof usePersist>['persistTypography'];
+/** Upstream alias for `PersistTypography`. See `persistFont` above. */
+export type PersistFont = PersistTypography;
+export type PersistSize = ReturnType<typeof usePersist>['persistSize'];
+export type PersistPanelPosition = ReturnType<typeof usePersist>['persistPanelPosition'];
+export type PersistZaudio = ReturnType<typeof usePersist>['persistZaudio'];

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -1,0 +1,1009 @@
+/**
+ * Tweak-state model for the design-token panel.
+ *
+ * This module owns:
+ *  - The `ColorTweakState` shape (palette + base roles + semantic mappings + shikiTheme).
+ *  - The unified `TweakState` envelope persisted under the v2 storage key.
+ *  - Pure helpers for initialising state from a scheme, applying state to the
+ *    DOM, and clearing applied inline styles.
+ *
+ * **Parameterisation — clusters come from `panelConfig`**
+ *
+ * The primary color cluster is read from `getPanelConfig().colorCluster` at
+ * call time, so a host that calls `configurePanel({ ..., colorCluster })`
+ * sees its own data flow through the apply / clear / load helpers without
+ * further plumbing. The package itself ships zero baked-in cluster data —
+ * a stub default lives only on `DEFAULT_PANEL_CONFIG` so the package imports
+ * cleanly when no host has yet called `configurePanel`.
+ *
+ * The cluster shape is `ColorClusterDataConfig` (re-exported here as
+ * `ColorClusterConfig` for backwards-compatibility). It is fully
+ * JSON-serializable: the palette CSS-var name is materialised at use sites
+ * by `resolvePaletteCssVar(cluster, i)`. Schemes and panel scheme settings
+ * (`panelSettings.colorScheme` + `colorMode`) live on the cluster too, so a
+ * host can swap the entire color story without editing
+ * `color-scheme-utils.ts` or `color-schemes.ts`.
+ *
+ * The secondary cluster is an opt-in field on `PanelConfig`. When the host
+ * does not configure one, the secondary slice is hidden / skipped end to end.
+ *
+ * **shikiTheme kept, applyShikiTheme stubbed**
+ *
+ * The `shikiTheme` field stays on the state + persist envelope so JSON
+ * round-tripping with external exports is seamless; the UI hides it and
+ * `applyShikiTheme` is a no-op. Removing the field would churn the serde
+ * format for no real benefit.
+ */
+
+import type { ColorRef, ColorScheme } from '../config/color-schemes';
+import type { TokenDef } from '../tokens/manifest';
+import {
+  type BaseRoleKey,
+  type ColorClusterDataConfig,
+  resolvePaletteCssVar,
+} from '../config/cluster-config';
+import {
+  getPanelConfig,
+  resolveSecondaryColorCluster,
+  storageKey_open,
+  storageKey_position,
+  storageKey_stateV1,
+  storageKey_stateV2,
+} from '../config/panel-config';
+
+// Re-export the cluster types under their historical names so existing call
+// sites (build-apply-overrides.ts, apply-modal.tsx, tests) keep compiling.
+// `ColorClusterConfig` is an alias for the JSON-serializable
+// `ColorClusterDataConfig` — there is no separate runtime shape.
+export type { BaseRoleKey, ColorClusterDataConfig } from '../config/cluster-config';
+export { resolvePaletteCssVar } from '../config/cluster-config';
+export type ColorClusterConfig = ColorClusterDataConfig;
+
+// ---------------------------------------------------------------------------
+// Storage keys (derived from panelConfig at access time — see `panel-config.ts`)
+// ---------------------------------------------------------------------------
+
+/**
+ * - `getStorageKeyV1()` is the original flat-state format (Color-only).
+ * - `getStorageKeyV2()` is the new namespaced format (`{ color: ..., ... }`)
+ *   that lets other tabs (Spacing, Typography, Size) add their own sub-states
+ *   without colliding with Color.
+ *
+ * On first load at v2 we migrate v1 → v2, write the new key, and delete v1.
+ *
+ * **Lazy derivation**
+ *
+ * Each helper reads `getPanelConfig()` on every call so a `configurePanel`
+ * call that lands *after* this module is imported still influences the keys
+ * the panel hits. Capturing the values at module load would freeze them
+ * before the host has a chance to configure.
+ */
+export function getStorageKeyV1(): string {
+  return storageKey_stateV1(getPanelConfig());
+}
+
+export function getStorageKeyV2(): string {
+  return storageKey_stateV2(getPanelConfig());
+}
+
+export function getOpenKey(): string {
+  return storageKey_open(getPanelConfig());
+}
+
+export function getPositionKey(): string {
+  return storageKey_position(getPanelConfig());
+}
+
+// ---------------------------------------------------------------------------
+// Panel position
+// ---------------------------------------------------------------------------
+
+export interface PanelPosition {
+  top: number;
+  right: number;
+}
+
+export const DEFAULT_POSITION: PanelPosition = { top: 60, right: 20 };
+
+export function loadPosition(): PanelPosition {
+  try {
+    const saved = localStorage.getItem(getPositionKey());
+    if (saved) {
+      const parsed = JSON.parse(saved) as PanelPosition;
+      if (typeof parsed.top === 'number' && typeof parsed.right === 'number') {
+        return parsed;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_POSITION;
+}
+
+export function savePosition(pos: PanelPosition) {
+  try {
+    localStorage.setItem(getPositionKey(), JSON.stringify(pos));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Keep at least VISIBLE_MIN px of the panel on-screen so the user can grab it back. */
+export const VISIBLE_MIN = 60;
+
+// `_panelHeight` is currently unused — see B2 fix note below. Kept on the
+// signature (with the underscore prefix that TypeScript treats as
+// intentionally unused per `noUnusedParameters`) so callers (panel.tsx drag
+// + resize handlers) can keep passing the measured offsetHeight without
+// churn, and so a future "tall panel" carve-out has the data on hand.
+export function clampPosition(
+  top: number,
+  right: number,
+  panelWidth: number,
+  _panelHeight: number,
+): PanelPosition {
+  // Horizontal: allow panel to extend past left/right edges, keep VISIBLE_MIN
+  // px of grip visible so the user can drag it back. The header spans the
+  // full panel width, so any leftover horizontal slice contains a draggable
+  // strip of the header.
+  const minRight = -(panelWidth - VISIBLE_MIN);
+  const maxRightRaw = window.innerWidth - VISIBLE_MIN;
+  // Vertical: ASYMMETRIC with the horizontal axis on purpose.
+  //
+  // The drag handle is the panel header (`panel.tsx` attaches `onMouseDown`
+  // to `.tokenpanel-header`), which sits at the TOP of the panel. If we
+  // mirrored the horizontal lower bound — `-(panelHeight - VISIBLE_MIN)` —
+  // an upward drag would leave only the footer visible and the user could
+  // no longer grab the header to drag the panel back. The pre-fix code
+  // dodged this by hard-coding `-(VISIBLE_MIN / 2)`; the symmetric attempt
+  // in PR #1440 review item B2 reintroduced the regression that codex
+  // caught on review.
+  //
+  // The panel is also CSS-constrained to fit the viewport
+  // (`maxHeight: calc(100vh - 32px)` in panel.tsx), so we don't need the
+  // "scroll content into view" carve-out that a taller-than-viewport panel
+  // would otherwise need. `panelHeight` is therefore unused on the lower
+  // bound today.
+  //
+  // The pre-fix code's tautology bug (`panelHeight > 0 ? 0 : 0` always
+  // yielding 0) is replaced with the simpler `window.innerHeight -
+  // VISIBLE_MIN`. The original `Math.max(..., 0)` only mattered on
+  // viewports shorter than VISIBLE_MIN, which we treat as a degenerate
+  // case and don't special-case any more.
+  const minTopRaw = -(VISIBLE_MIN / 2);
+  const maxTopRaw = window.innerHeight - VISIBLE_MIN;
+  // PR #1440 review item M-13 — guard against narrow / degenerate viewports
+  // where the computed maximum would be lower than the minimum (innerHeight
+  // < VISIBLE_MIN/2). When that happens, collapse maxTop to minTop so the
+  // resulting Math.max/Math.min chain still produces a deterministic value
+  // instead of relying on argument order.
+  const maxTop = Math.max(maxTopRaw, minTopRaw);
+  const maxRight = Math.max(maxRightRaw, minRight);
+  return {
+    top: Math.max(minTopRaw, Math.min(top, maxTop)),
+    right: Math.max(minRight, Math.min(right, maxRight)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shiki — stubbed in zmod2
+// ---------------------------------------------------------------------------
+
+/**
+ * Upstream re-highlights every `<pre>` on the page when the Shiki theme
+ * changes. zmod2 does not use Shiki — we keep the function for API shape +
+ * persisted-state round-tripping, but the body is a no-op.
+ */
+export async function applyShikiTheme(_themeName: string): Promise<void> {
+  // zmod2 has no Shiki integration; preserved as a no-op for persist-envelope
+  // round-trip compatibility with zudo-doc exports.
+}
+
+/** Theme list kept identical to upstream so imported state keeps its shikiTheme. */
+export const SHIKI_THEMES = [
+  'ayu-light',
+  'catppuccin-latte',
+  'catppuccin-mocha',
+  'dracula',
+  'everforest-dark',
+  'everforest-light',
+  'github-dark',
+  'github-dark-dimmed',
+  'github-light',
+  'gruvbox-dark-medium',
+  'gruvbox-light-medium',
+  'kanagawa-dragon',
+  'kanagawa-wave',
+  'material-theme-darker',
+  'material-theme-lighter',
+  'material-theme-ocean',
+  'min-dark',
+  'min-light',
+  'monokai',
+  'night-owl',
+  'nord',
+  'one-dark-pro',
+  'one-light',
+  'poimandres',
+  'rose-pine',
+  'rose-pine-dawn',
+  'rose-pine-moon',
+  'snazzy-light',
+  'solarized-dark',
+  'solarized-light',
+  'tokyo-night',
+  'vesper',
+  'vitesse-dark',
+  'vitesse-light',
+];
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+/**
+ * ColorTweakState — palette + base roles + semantic mappings. Shape is
+ * identical to upstream so persisted JSON can round-trip across projects.
+ *
+ * The state is palette-size agnostic (just `string[]`); the cluster config
+ * below supplies the expected length for validation + defaults.
+ */
+export interface ColorTweakState {
+  palette: string[];
+  background: number;
+  foreground: number;
+  cursor: number;
+  selectionBg: number;
+  selectionFg: number;
+  semanticMappings: Record<string, number | 'bg' | 'fg'>;
+  shikiTheme: string;
+}
+
+/**
+ * Per-token override map. Keys are `TokenDef.id` (e.g. `hsp-sm`); values are
+ * raw CSS length strings (e.g. `0.75rem`). Only overridden tokens appear in
+ * the map — absent keys mean "use the stylesheet default".
+ */
+export type TokenOverrides = Record<string, string>;
+
+/**
+ * Unified persist envelope. Each tab owns its own sub-state so they can
+ * evolve independently.
+ *
+ * `panelPosition` is persisted alongside the envelope so the user's drag
+ * location survives reloads. `zaudio` carries a second (optional) color
+ * cluster used by Sub 7b — absent during Wave 1.
+ */
+export interface TweakState {
+  color: ColorTweakState;
+  spacing: TokenOverrides;
+  typography: TokenOverrides;
+  size: TokenOverrides;
+  panelPosition?: PanelPosition;
+  zaudio?: ColorTweakState;
+}
+
+/** Produce an empty overrides map — `TweakState` default for new tabs. */
+export function emptyOverrides(): TokenOverrides {
+  return {};
+}
+
+// ---------------------------------------------------------------------------
+// Color cluster config — parameterises the zd-specific upstream code
+// ---------------------------------------------------------------------------
+
+/**
+ * Cluster config used to describe one independent color system. The shape is
+ * `ColorClusterDataConfig` (re-exported above as `ColorClusterConfig` for
+ * backwards-compatibility) — a fully JSON-serializable bundle of palette
+ * template + base-role set + semantic tables + scheme registry + panel scheme
+ * settings.
+ *
+ * Primary cluster — read from `getPanelConfig().colorCluster` at every call
+ * site. The package itself ships ZERO baked-in cluster data; hosts MUST call
+ * `configurePanel({ colorCluster })` to provide one.
+ */
+
+/**
+ * Produce a fresh `ColorTweakState` for a secondary color cluster.
+ * Generalises the no-scheme seed path: the palette length, semantic
+ * defaults, and shikiTheme all derive from the supplied cluster, so any
+ * host-supplied secondary cluster (any paletteSize, any semantic
+ * vocabulary) gets a deterministic neutral grayscale seed when the cluster
+ * does not ship its own scheme registry.
+ *
+ * Palette seed strategy:
+ *  - Synthesise a deterministic neutral grayscale palette of
+ *    `cluster.paletteSize` slots. Index 0 → black, last → white, middle
+ *    slots interpolate. Functional but visually flat; hosts wanting a
+ *    designed seed should ship a scheme registry on the cluster and call
+ *    `initColorFromScheme(cluster)` instead.
+ *
+ * The base-role indices are kept on the state shape for envelope-round-trip
+ * compatibility but are inert — `applyColorState` only writes a base role
+ * when the cluster declares the corresponding `baseRoles` entry.
+ */
+export function initSecondaryDefaults(cluster: ColorClusterDataConfig): ColorTweakState {
+  // Deterministic grayscale ramp. Index 0 → black, last → white, middle
+  // slots interpolate. Functional but visually flat; hosts wanting a
+  // designed seed should ship a scheme registry on the cluster.
+  const size = Math.max(1, cluster.paletteSize);
+  const palette: string[] = Array.from({ length: size }, (_, i) => {
+    if (size === 1) return '#808080';
+    const v = Math.round((i / (size - 1)) * 255);
+    const hex = v.toString(16).padStart(2, '0');
+    return `#${hex}${hex}${hex}`;
+  });
+  return {
+    palette,
+    background: cluster.baseDefaults.background ?? 0,
+    foreground: cluster.baseDefaults.foreground ?? 0,
+    cursor: cluster.baseDefaults.cursor ?? 0,
+    selectionBg: cluster.baseDefaults.selectionBg ?? 0,
+    selectionFg: cluster.baseDefaults.selectionFg ?? 0,
+    semanticMappings: { ...cluster.semanticDefaults },
+    shikiTheme: cluster.defaultShikiTheme,
+  };
+}
+
+/**
+ * Convenience helper used by `panel.tsx` and tests: seed a fresh secondary
+ * `ColorTweakState` from the active panel config's secondary cluster.
+ * Returns `undefined` when the host opted out of the secondary cluster
+ * (`secondaryColorCluster: null` or omitted).
+ */
+export function initSecondaryFromConfig(): ColorTweakState | undefined {
+  const secondary = resolveSecondaryColorCluster();
+  return secondary ? initSecondaryDefaults(secondary) : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Color helpers
+// ---------------------------------------------------------------------------
+
+/** Convert any CSS color to hex using a canvas (cached context). */
+let _canvasCtx: CanvasRenderingContext2D | null = null;
+export function cssColorToHex(color: string): string {
+  if (!color || color === 'initial' || color === 'inherit') return '#000000';
+  if (/^#[0-9a-fA-F]{6}$/.test(color.trim())) return color.trim();
+  if (/^#[0-9a-fA-F]{3}$/.test(color.trim())) {
+    const c = color.trim();
+    return `#${c[1]}${c[1]}${c[2]}${c[2]}${c[3]}${c[3]}`;
+  }
+  try {
+    if (!_canvasCtx) _canvasCtx = document.createElement('canvas').getContext('2d');
+    if (!_canvasCtx) return '#000000';
+    _canvasCtx.fillStyle = color;
+    const resolved = _canvasCtx.fillStyle;
+    if (resolved.startsWith('#')) return resolved;
+    const match = resolved.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+    if (match) {
+      const r = parseInt(match[1], 10);
+      const g = parseInt(match[2], 10);
+      const b = parseInt(match[3], 10);
+      return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+    }
+    return '#000000';
+  } catch {
+    return '#000000';
+  }
+}
+
+export function setCssVar(name: string, value: string) {
+  document.documentElement.style.setProperty(name, value);
+}
+
+/**
+ * Resolve a `ColorRef` to a palette index. If it's already a number, use it.
+ * If it's a string, find an exact palette match or the nearest color by RGB
+ * distance. `fallback` is returned only when `ref` is undefined.
+ */
+export function colorRefToIndex(
+  ref: ColorRef | undefined,
+  palette: string[],
+  fallback: number,
+): number {
+  if (ref === undefined) return fallback;
+  if (typeof ref === 'number') return ref;
+  // String: try exact match in palette.
+  const idx = palette.indexOf(ref);
+  if (idx >= 0) return idx;
+  // No exact match — find nearest palette color by RGB distance.
+  const refHex = cssColorToHex(ref);
+  const refRgb = hexToRgb(refHex);
+  let bestIdx = fallback;
+  let bestDist = Infinity;
+  for (let i = 0; i < palette.length; i++) {
+    const pHex = cssColorToHex(palette[i]);
+    const pRgb = hexToRgb(pHex);
+    const dist = (refRgb.r - pRgb.r) ** 2 + (refRgb.g - pRgb.g) ** 2 + (refRgb.b - pRgb.b) ** 2;
+    if (dist < bestDist) {
+      bestDist = dist;
+      bestIdx = i;
+    }
+  }
+  return bestIdx;
+}
+
+/** Parse a hex color string to RGB components. */
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const h = hex.replace('#', '');
+  return {
+    r: parseInt(h.substring(0, 2), 16) || 0,
+    g: parseInt(h.substring(2, 4), 16) || 0,
+    b: parseInt(h.substring(4, 6), 16) || 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scheme → state
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the active scheme name for the given cluster, considering
+ * light/dark mode. Reads `panelSettings` from the cluster (Sub 4) so a
+ * host-supplied cluster can declare its own scheme + light/dark pairing
+ * without editing the panel package.
+ */
+export function getActiveSchemeName(
+  cluster: ColorClusterDataConfig = getPanelConfig().colorCluster,
+): string {
+  const settings = cluster.panelSettings;
+  if (settings.colorMode) {
+    const theme = document.documentElement.getAttribute('data-theme');
+    if (theme === 'light') return settings.colorMode.lightScheme;
+    if (theme === 'dark') return settings.colorMode.darkScheme;
+  }
+  return settings.colorScheme;
+}
+
+/**
+ * Initialise a `ColorTweakState` from the active color scheme for the given
+ * cluster. Defaults to the host's primary cluster (`panelConfig.colorCluster`).
+ *
+ * Reads the scheme registry from `cluster.colorSchemes`. Clusters that ship
+ * no schemes should not call this directly — they use
+ * `initSecondaryDefaults(cluster)` instead because there is no scheme to
+ * seed from.
+ */
+export function initColorFromScheme(
+  cluster: ColorClusterDataConfig = getPanelConfig().colorCluster,
+): ColorTweakState {
+  const schemes = cluster.colorSchemes;
+  // No schemes → fall back to the deterministic neutral seed. This keeps the
+  // package boot-able when no host has called `configurePanel` (the bundled
+  // stub cluster ships zero schemes), and it matches the documented contract
+  // for cluster-shaped data without a scheme registry.
+  if (Object.keys(schemes).length === 0) {
+    return initSecondaryDefaults(cluster);
+  }
+  const schemeName = getActiveSchemeName(cluster);
+  const scheme = schemes[schemeName] ?? Object.values(schemes)[0];
+  return initColorFromSchemeData(scheme, cluster);
+}
+
+export function initColorFromSchemeData(
+  scheme: ColorScheme,
+  cluster: ColorClusterDataConfig = getPanelConfig().colorCluster,
+): ColorTweakState {
+  const palette = scheme.palette.map((c) => cssColorToHex(c));
+  const semanticMappings: Record<string, number | 'bg' | 'fg'> = {};
+  for (const [key, defaultVal] of Object.entries(cluster.semanticDefaults)) {
+    const schemeVal = scheme.semantic?.[key as keyof typeof scheme.semantic];
+    if (schemeVal === undefined) {
+      semanticMappings[key] = defaultVal;
+    } else if (typeof schemeVal === 'number') {
+      semanticMappings[key] = schemeVal;
+    } else {
+      // String value — find in palette or nearest match.
+      semanticMappings[key] = colorRefToIndex(schemeVal, scheme.palette, defaultVal);
+    }
+  }
+
+  return {
+    palette,
+    background: colorRefToIndex(
+      scheme.background,
+      scheme.palette,
+      cluster.baseDefaults.background ?? 0,
+    ),
+    foreground: colorRefToIndex(
+      scheme.foreground,
+      scheme.palette,
+      cluster.baseDefaults.foreground ?? 0,
+    ),
+    cursor: colorRefToIndex(scheme.cursor, scheme.palette, cluster.baseDefaults.cursor ?? 0),
+    selectionBg: colorRefToIndex(
+      scheme.selectionBg,
+      scheme.palette,
+      cluster.baseDefaults.selectionBg ?? 0,
+    ),
+    selectionFg: colorRefToIndex(
+      scheme.selectionFg,
+      scheme.palette,
+      cluster.baseDefaults.selectionFg ?? 0,
+    ),
+    semanticMappings,
+    shikiTheme: String(scheme.shikiTheme ?? cluster.defaultShikiTheme),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Apply / clear
+// ---------------------------------------------------------------------------
+
+/** Resolve a semantic mapping to an actual color (bounds-checked). */
+export function resolveMapping(
+  mapping: number | 'bg' | 'fg',
+  palette: string[],
+  bgIndex: number,
+  fgIndex: number,
+): string {
+  const len = palette.length;
+  if (mapping === 'bg') return palette[safeIndex(bgIndex, len)] ?? '#000000';
+  if (mapping === 'fg') return palette[safeIndex(fgIndex, len)] ?? '#ffffff';
+  return palette[safeIndex(mapping, len)] ?? '#000000';
+}
+
+export function safeIndex(index: number, len: number): number {
+  return index >= 0 && index < len ? index : 0;
+}
+
+/** Apply a single `ColorTweakState` to the DOM using the given cluster config. */
+export function applyColorState(
+  state: ColorTweakState,
+  cluster: ColorClusterDataConfig = getPanelConfig().colorCluster,
+) {
+  const len = state.palette.length;
+  // Palette slots.
+  for (let i = 0; i < len; i++) {
+    setCssVar(resolvePaletteCssVar(cluster, i), state.palette[i]);
+  }
+  // Base roles — only write the roles this cluster declares. Iterate
+  // `cluster.baseRoles` (rather than hardcoding all 5) so a cluster like
+  // zaudio that ships zero base roles emits zero base-role writes.
+  for (const [key, cssName] of Object.entries(cluster.baseRoles)) {
+    if (typeof cssName !== 'string' || cssName.length === 0) continue;
+    const stateIndex = state[key as BaseRoleKey];
+    if (typeof stateIndex !== 'number') continue;
+    setCssVar(cssName, state.palette[safeIndex(stateIndex, len)]);
+  }
+  // Semantic.
+  for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
+    const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
+    setCssVar(cssName, resolveMapping(mapping, state.palette, state.background, state.foreground));
+  }
+}
+
+/**
+ * Apply a `TokenOverrides` map for a given manifest — writes inline
+ * `--css-var: value` on `:root` for every overridden token, and removes the
+ * inline property for tokens absent from the map (so the stylesheet default
+ * comes back).
+ *
+ * Read-only tokens are skipped in both directions: they are informational rows
+ * in the UI and are never written to storage.
+ */
+export function applyTokenOverrides(tokens: readonly TokenDef[], overrides: TokenOverrides) {
+  for (const t of tokens) {
+    if (t.readonly) continue;
+    const v = overrides[t.id];
+    if (typeof v === 'string' && v.length > 0) {
+      setCssVar(t.cssVar, v);
+    } else {
+      document.documentElement.style.removeProperty(t.cssVar);
+    }
+  }
+}
+
+/**
+ * Apply the full unified `TweakState` — primary color cluster + token
+ * overrides + optional zaudio cluster.
+ *
+ * Token manifests AND the primary color cluster are read from `panelConfig`
+ * at call time (Sub 3 #1553 + Sub 4 #1554) so a host that calls
+ * `configurePanel` before mount sees its own data driving the apply pass.
+ */
+export function applyFullState(state: TweakState) {
+  const config = getPanelConfig();
+  applyColorState(state.color, config.colorCluster);
+  const tokens = config.tokens;
+  applyTokenOverrides(tokens.spacing, state.spacing);
+  applyTokenOverrides(tokens.typography, state.typography);
+  applyTokenOverrides(tokens.size, state.size);
+  // Sub S5b (#1589) — secondary cluster is host-driven via
+  // `panelConfig.secondaryColorCluster`. When the host opted out (null),
+  // skip the secondary apply pass entirely; even though `state.zaudio` may
+  // still be hydrated for envelope round-trip purposes, no secondary CSS
+  // vars belong to this host.
+  const secondaryCluster = resolveSecondaryColorCluster(config);
+  if (secondaryCluster && state.zaudio) {
+    applyColorState(state.zaudio, secondaryCluster);
+  }
+}
+
+/**
+ * Strip all tweak-applied inline CSS variables so the stylesheet-provided
+ * values from the active scheme take effect again.
+ *
+ * Accepts an optional list of clusters so callers can scope the wipe to a
+ * subset; the default wipes BOTH `zd` and `zaudio` so a panel-level reset
+ * leaves no stale inline overrides on `:root` regardless of which cluster
+ * was last edited.
+ */
+export function clearAppliedStyles(
+  clusters: readonly ColorClusterDataConfig[] = (() => {
+    // Sub S5b (#1589) — default wipe set follows the host's configuration.
+    // When the host opted out of the secondary cluster (null), only the
+    // primary cluster's vars get cleared. Callers can still pass an
+    // explicit list to scope the wipe further.
+    const cfg = getPanelConfig();
+    const secondary = resolveSecondaryColorCluster(cfg);
+    return secondary ? [cfg.colorCluster, secondary] : [cfg.colorCluster];
+  })(),
+) {
+  const root = document.documentElement;
+  for (const cluster of clusters) {
+    for (let i = 0; i < cluster.paletteSize; i++) {
+      root.style.removeProperty(resolvePaletteCssVar(cluster, i));
+    }
+    for (const prop of Object.values(cluster.baseRoles)) {
+      root.style.removeProperty(prop);
+    }
+    for (const cssName of Object.values(cluster.semanticCssNames)) {
+      root.style.removeProperty(cssName);
+    }
+  }
+  // Token manifests — same contract: wipe any inline overrides so stylesheet
+  // defaults take effect again. Read from panelConfig so a host-supplied
+  // manifest's cssVars get cleared (Sub 3, #1553).
+  const tokens = getPanelConfig().tokens;
+  for (const t of tokens.spacing) {
+    if (t.readonly) continue;
+    root.style.removeProperty(t.cssVar);
+  }
+  for (const t of tokens.typography) {
+    if (t.readonly) continue;
+    root.style.removeProperty(t.cssVar);
+  }
+  for (const t of tokens.size) {
+    if (t.readonly) continue;
+    root.style.removeProperty(t.cssVar);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation + migration
+// ---------------------------------------------------------------------------
+
+/** Validate a parsed object has the minimum fields to be a `ColorTweakState`. */
+function isValidColorShape(s: unknown, paletteSize: number): s is Partial<ColorTweakState> {
+  if (!s || typeof s !== 'object') return false;
+  const o = s as Record<string, unknown>;
+  return (
+    Array.isArray(o.palette) &&
+    (o.palette as unknown[]).length === paletteSize &&
+    typeof o.background === 'number' &&
+    typeof o.foreground === 'number' &&
+    typeof o.cursor === 'number' &&
+    typeof o.selectionBg === 'number' &&
+    typeof o.selectionFg === 'number' &&
+    typeof o.semanticMappings === 'object' &&
+    o.semanticMappings !== null
+  );
+}
+
+/** Fill missing fields on a `ColorTweakState`-shaped object using defaults. */
+function hydrateColorState(
+  partial: Partial<ColorTweakState>,
+  defaults: ColorTweakState,
+): ColorTweakState {
+  // PR #1440 review item P1-10 — palette is loaded from untrusted persisted
+  // storage. Validate that every element is a string before casting; a
+  // single non-string element would otherwise reach `style.setProperty` and
+  // either crash or silently coerce. Falling back to defaults on bad data
+  // keeps the panel functional and surfaces the corruption via console.error.
+  const paletteRaw = Array.isArray(partial.palette) ? partial.palette : null;
+  let palette: string[];
+  if (
+    paletteRaw &&
+    paletteRaw.length === defaults.palette.length &&
+    paletteRaw.every((v) => typeof v === 'string')
+  ) {
+    palette = paletteRaw as string[];
+  } else {
+    if (paletteRaw && paletteRaw.some((v) => typeof v !== 'string')) {
+      console.error(
+        '[design-token-panel] Persisted palette contained non-string elements; falling back to defaults.',
+      );
+    }
+    palette = defaults.palette;
+  }
+  return {
+    palette,
+    background: typeof partial.background === 'number' ? partial.background : defaults.background,
+    foreground: typeof partial.foreground === 'number' ? partial.foreground : defaults.foreground,
+    cursor: typeof partial.cursor === 'number' ? partial.cursor : defaults.cursor,
+    selectionBg:
+      typeof partial.selectionBg === 'number' ? partial.selectionBg : defaults.selectionBg,
+    selectionFg:
+      typeof partial.selectionFg === 'number' ? partial.selectionFg : defaults.selectionFg,
+    semanticMappings:
+      partial.semanticMappings && typeof partial.semanticMappings === 'object'
+        ? { ...defaults.semanticMappings, ...partial.semanticMappings }
+        : defaults.semanticMappings,
+    shikiTheme:
+      typeof partial.shikiTheme === 'string' && partial.shikiTheme.length > 0
+        ? partial.shikiTheme
+        : defaults.shikiTheme,
+  };
+}
+
+/**
+ * Test-friendly migration entry point. Reads from a provided storage (defaults
+ * to `localStorage`) and returns the loaded+migrated `TweakState`, or `null`
+ * when no usable state exists.
+ *
+ * Rules:
+ *  1. If v2 key exists and parses → use it (v2 wins).
+ *  2. Else if v1 key exists → parse with safe defaults, lift into `state.color`,
+ *     write v2, delete v1.
+ *  3. Else → return null (caller initialises from the active scheme).
+ *
+ * Malformed JSON is caught with `console.warn` and returns null (caller falls
+ * back to fresh defaults).
+ */
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * Legacy → current id mapping for the typography slice.
+ *
+ * Sub 6 (2026-04) renamed the font-size manifest ids from panel-internal
+ * labels (`text-caption`, `text-small`, `text-body`, `text-subheading`,
+ * `text-heading`, `text-display`) to main-site Tailwind tiers (`text-xs`,
+ * `text-sm`, `text-base`, `text-lg`, `text-3xl`, `text-5xl`). The
+ * `text-micro` id was dropped entirely (no `--zd-font-xxs` equivalent in the
+ * design system).
+ *
+ * When a v2 payload comes in with the old ids we rewrite the keys here so
+ * existing persisted tweaks survive the rename without the user losing
+ * their work. Unknown / dropped ids (e.g. `text-micro`) are silently
+ * discarded — they no longer route to anything.
+ *
+ * Note: spacing + size manifest ids were NOT renamed (hsp-/vsp- ids kept
+ * their labels), so this migration only applies to the typography slice.
+ */
+const TYPOGRAPHY_ID_MIGRATIONS: Readonly<Record<string, string | null>> = {
+  'text-caption': 'text-xs',
+  'text-small': 'text-sm',
+  'text-body': 'text-base',
+  'text-subheading': 'text-lg',
+  'text-heading': 'text-3xl',
+  'text-display': 'text-5xl',
+  // Dropped — no main-site equivalent. Null signals "discard".
+  'text-micro': null,
+};
+
+/**
+ * Narrow a stored value into a `TokenOverrides` map. Accepts any plain object
+ * whose values are strings; unknown keys pass through so we don't silently
+ * drop overrides when the manifest grows at runtime (they'll just be ignored
+ * by `applyTokenOverrides`).
+ */
+function hydrateOverrides(raw: unknown): TokenOverrides {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: TokenOverrides = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * Same as `hydrateOverrides` but also rewrites legacy typography-slice keys
+ * per `TYPOGRAPHY_ID_MIGRATIONS`. If BOTH the old and new ids are present,
+ * the new id wins (user actively tweaked it post-migration). Keys mapped to
+ * `null` are dropped.
+ */
+function hydrateTypographyOverrides(raw: unknown): TokenOverrides {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: TokenOverrides = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof v !== 'string') continue;
+    if (k in TYPOGRAPHY_ID_MIGRATIONS) {
+      const target = TYPOGRAPHY_ID_MIGRATIONS[k];
+      if (target === null) continue; // dropped id
+      if (!(target in out)) {
+        // Only take the legacy value if no post-migration value already set.
+        out[target] = v;
+      }
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/** Narrow a stored value into a `PanelPosition`, or undefined if malformed. */
+function hydratePanelPosition(raw: unknown): PanelPosition | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  if (
+    typeof o.top === 'number' &&
+    typeof o.right === 'number' &&
+    Number.isFinite(o.top) &&
+    Number.isFinite(o.right)
+  ) {
+    return { top: o.top, right: o.right };
+  }
+  return undefined;
+}
+
+export function loadPersistedState(
+  storage: StorageLike = localStorage,
+  colorDefaults?: ColorTweakState,
+  cluster: ColorClusterDataConfig = getPanelConfig().colorCluster,
+): TweakState | null {
+  const STORAGE_KEY_V1 = getStorageKeyV1();
+  const STORAGE_KEY_V2 = getStorageKeyV2();
+  // 1. v2 wins.
+  const rawV2 = safeGet(storage, STORAGE_KEY_V2);
+  if (rawV2 !== null) {
+    const parsed = safeParse(rawV2);
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as {
+        color?: unknown;
+        spacing?: unknown;
+        typography?: unknown;
+        font?: unknown; // upstream alias — migrated into `typography`
+        size?: unknown;
+        panelPosition?: unknown;
+        zaudio?: unknown;
+      };
+      if (obj.color && isValidColorShape(obj.color, cluster.paletteSize)) {
+        const defaults = colorDefaults ?? tryInitColorFromScheme(cluster);
+        const typographySlice = obj.typography !== undefined ? obj.typography : obj.font;
+        const next: TweakState = {
+          color: hydrateColorState(obj.color as Partial<ColorTweakState>, defaults),
+          // New sections added after v1 migration — tolerate their absence so
+          // older v2 payloads (Color-only) still load cleanly.
+          spacing: hydrateOverrides(obj.spacing),
+          // Typography slice: run through the Sub 6 id migration so payloads
+          // persisted under the old ids (text-caption, text-body, …) survive
+          // the rename to main-site tiers (text-xs, text-base, …).
+          typography: hydrateTypographyOverrides(typographySlice),
+          size: hydrateOverrides(obj.size),
+          panelPosition: hydratePanelPosition(obj.panelPosition),
+        };
+        // Optional secondary slice (legacy field name `zaudio`) — validated
+        // against the active secondary cluster's palette size, NOT the
+        // primary cluster's. When the host opted out
+        // (`secondaryColorCluster: null` or omitted), there is no secondary
+        // cluster to validate against, so we skip hydration entirely — the
+        // apply path also skips secondary writes, and the JSON envelope
+        // simply omits the slice for opt-out hosts. Defaults come from
+        // `initSecondaryDefaults(cluster)`.
+        const secondaryCluster = resolveSecondaryColorCluster();
+        if (
+          secondaryCluster &&
+          obj.zaudio &&
+          isValidColorShape(obj.zaudio, secondaryCluster.paletteSize)
+        ) {
+          next.zaudio = hydrateColorState(
+            obj.zaudio as Partial<ColorTweakState>,
+            initSecondaryDefaults(secondaryCluster),
+          );
+        }
+        return next;
+      }
+    }
+    // v2 present but malformed — warn and fall through to v1 check.
+    console.warn(`[tweak] Malformed ${STORAGE_KEY_V2}, attempting v1 migration`);
+  }
+
+  // 2. v1 migration.
+  const rawV1 = safeGet(storage, STORAGE_KEY_V1);
+  if (rawV1 !== null) {
+    const parsed = safeParse(rawV1);
+    if (parsed && typeof parsed === 'object' && isValidColorShape(parsed, cluster.paletteSize)) {
+      const defaults = colorDefaults ?? tryInitColorFromScheme(cluster);
+      // Backfill shikiTheme like the legacy loader did.
+      const partial = parsed as Partial<ColorTweakState>;
+      if (!partial.shikiTheme) {
+        partial.shikiTheme = defaults.shikiTheme;
+      }
+      const color = hydrateColorState(partial, defaults);
+      const migrated: TweakState = {
+        color,
+        spacing: emptyOverrides(),
+        typography: emptyOverrides(),
+        size: emptyOverrides(),
+      };
+      try {
+        storage.setItem(STORAGE_KEY_V2, JSON.stringify(migrated));
+        storage.removeItem(STORAGE_KEY_V1);
+      } catch {
+        /* storage full; still return migrated state for this session */
+      }
+      return migrated;
+    }
+    // v1 unreadable — warn and drop it.
+    console.warn(`[tweak] Malformed ${STORAGE_KEY_V1}; discarding and using fresh defaults`);
+    try {
+      storage.removeItem(STORAGE_KEY_V1);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // 3. Fresh defaults.
+  return null;
+}
+
+/** Persist the full `TweakState` to v2. */
+export function savePersistedState(state: TweakState, storage: StorageLike = localStorage) {
+  try {
+    storage.setItem(getStorageKeyV2(), JSON.stringify(state));
+  } catch {
+    // Storage full.
+  }
+}
+
+/** Remove v2 (and lingering v1) keys. */
+export function clearPersistedState(storage: StorageLike = localStorage) {
+  try {
+    storage.removeItem(getStorageKeyV2());
+  } catch {
+    /* ignore */
+  }
+  try {
+    storage.removeItem(getStorageKeyV1());
+  } catch {
+    /* ignore */
+  }
+}
+
+function safeGet(storage: StorageLike, key: string): string | null {
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `initColorFromScheme` wrapper that survives JSDOM / node environments where
+ * `document` may not be fully scheme-aware. Used as a last-resort default.
+ */
+function tryInitColorFromScheme(cluster: ColorClusterDataConfig): ColorTweakState {
+  try {
+    return initColorFromScheme(cluster);
+  } catch {
+    // Fallback: a minimal black/white palette so migration stays deterministic.
+    const palette = Array.from({ length: cluster.paletteSize }, (_, i) =>
+      i === 0 ? '#000000' : i === cluster.paletteSize - 1 ? '#ffffff' : '#808080',
+    );
+    return {
+      palette,
+      background: cluster.baseDefaults.background ?? 0,
+      foreground: cluster.baseDefaults.foreground ?? 0,
+      cursor: cluster.baseDefaults.cursor ?? 0,
+      selectionBg: cluster.baseDefaults.selectionBg ?? 0,
+      selectionFg: cluster.baseDefaults.selectionFg ?? 0,
+      semanticMappings: { ...cluster.semanticDefaults },
+      shikiTheme: cluster.defaultShikiTheme,
+    };
+  }
+}

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -155,9 +155,8 @@ export function clampPosition(
   // mirrored the horizontal lower bound — `-(panelHeight - VISIBLE_MIN)` —
   // an upward drag would leave only the footer visible and the user could
   // no longer grab the header to drag the panel back. The pre-fix code
-  // dodged this by hard-coding `-(VISIBLE_MIN / 2)`; the symmetric attempt
-  // in PR #1440 review item B2 reintroduced the regression that codex
-  // caught on review.
+  // dodged this by hard-coding `-(VISIBLE_MIN / 2)`; a symmetric attempt
+  // would reintroduce that regression.
   //
   // The panel is also CSS-constrained to fit the viewport
   // (`maxHeight: calc(100vh - 32px)` in panel.tsx), so we don't need the
@@ -172,7 +171,7 @@ export function clampPosition(
   // case and don't special-case any more.
   const minTopRaw = -(VISIBLE_MIN / 2);
   const maxTopRaw = window.innerHeight - VISIBLE_MIN;
-  // PR #1440 review item M-13 — guard against narrow / degenerate viewports
+  // guard against narrow / degenerate viewports
   // where the computed maximum would be lower than the minimum (innerHeight
   // < VISIBLE_MIN/2). When that happens, collapse maxTop to minTop so the
   // resulting Math.max/Math.min chain still produces a deterministic value
@@ -186,16 +185,16 @@ export function clampPosition(
 }
 
 // ---------------------------------------------------------------------------
-// Shiki — stubbed in zmod2
+// Shiki — stubbed
 // ---------------------------------------------------------------------------
 
 /**
  * Upstream re-highlights every `<pre>` on the page when the Shiki theme
- * changes. zmod2 does not use Shiki — we keep the function for API shape +
- * persisted-state round-tripping, but the body is a no-op.
+ * changes. This package does not use Shiki — we keep the function for
+ * API shape + persisted-state round-tripping, but the body is a no-op.
  */
 export async function applyShikiTheme(_themeName: string): Promise<void> {
-  // zmod2 has no Shiki integration; preserved as a no-op for persist-envelope
+  // No Shiki integration here; preserved as a no-op for persist-envelope
   // round-trip compatibility with zudo-doc exports.
 }
 
@@ -441,7 +440,7 @@ function hexToRgb(hex: string): { r: number; g: number; b: number } {
 
 /**
  * Resolve the active scheme name for the given cluster, considering
- * light/dark mode. Reads `panelSettings` from the cluster (Sub 4) so a
+ * light/dark mode. Reads `panelSettings` from the cluster so a
  * host-supplied cluster can declare its own scheme + light/dark pairing
  * without editing the panel package.
  */
@@ -633,10 +632,10 @@ export function applyFullState(state: TweakState) {
  */
 export function clearAppliedStyles(
   clusters: readonly ColorClusterDataConfig[] = (() => {
-    // Sub S5b (#1589) — default wipe set follows the host's configuration.
-    // When the host opted out of the secondary cluster (null), only the
-    // primary cluster's vars get cleared. Callers can still pass an
-    // explicit list to scope the wipe further.
+    // Default wipe set follows the host's configuration. When the host
+    // opted out of the secondary cluster (null), only the primary
+    // cluster's vars get cleared. Callers can still pass an explicit list
+    // to scope the wipe further.
     const cfg = getPanelConfig();
     const secondary = resolveSecondaryColorCluster(cfg);
     return secondary ? [cfg.colorCluster, secondary] : [cfg.colorCluster];
@@ -656,7 +655,7 @@ export function clearAppliedStyles(
   }
   // Token manifests — same contract: wipe any inline overrides so stylesheet
   // defaults take effect again. Read from panelConfig so a host-supplied
-  // manifest's cssVars get cleared (Sub 3, #1553).
+  // manifest's cssVars get cleared.
   const tokens = getPanelConfig().tokens;
   for (const t of tokens.spacing) {
     if (t.readonly) continue;
@@ -698,7 +697,7 @@ function hydrateColorState(
   partial: Partial<ColorTweakState>,
   defaults: ColorTweakState,
 ): ColorTweakState {
-  // PR #1440 review item P1-10 — palette is loaded from untrusted persisted
+  // palette is loaded from untrusted persisted
   // storage. Validate that every element is a string before casting; a
   // single non-string element would otherwise reach `style.setProperty` and
   // either crash or silently coerce. Falling back to defaults on bad data
@@ -762,7 +761,7 @@ export interface StorageLike {
 /**
  * Legacy → current id mapping for the typography slice.
  *
- * Sub 6 (2026-04) renamed the font-size manifest ids from panel-internal
+ * An earlier port step renamed the font-size manifest ids from panel-internal
  * labels (`text-caption`, `text-small`, `text-body`, `text-subheading`,
  * `text-heading`, `text-display`) to main-site Tailwind tiers (`text-xs`,
  * `text-sm`, `text-base`, `text-lg`, `text-3xl`, `text-5xl`). The
@@ -872,7 +871,7 @@ export function loadPersistedState(
           // New sections added after v1 migration — tolerate their absence so
           // older v2 payloads (Color-only) still load cleanly.
           spacing: hydrateOverrides(obj.spacing),
-          // Typography slice: run through the Sub 6 id migration so payloads
+          // Typography slice: run through the id-migration step so payloads
           // persisted under the old ids (text-caption, text-body, …) survive
           // the rename to main-site tiers (text-xs, text-base, …).
           typography: hydrateTypographyOverrides(typographySlice),

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -271,8 +271,8 @@ export type TokenOverrides = Record<string, string>;
  * evolve independently.
  *
  * `panelPosition` is persisted alongside the envelope so the user's drag
- * location survives reloads. `zaudio` carries a second (optional) color
- * cluster used by Sub 7b — absent during Wave 1.
+ * location survives reloads. `secondary` carries a second (optional) color
+ * cluster — absent until a host opts in.
  */
 export interface TweakState {
   color: ColorTweakState;
@@ -280,7 +280,7 @@ export interface TweakState {
   typography: TokenOverrides;
   size: TokenOverrides;
   panelPosition?: PanelPosition;
-  zaudio?: ColorTweakState;
+  secondary?: ColorTweakState;
 }
 
 /** Produce an empty overrides map — `TweakState` default for new tabs. */
@@ -560,8 +560,8 @@ export function applyColorState(
     setCssVar(resolvePaletteCssVar(cluster, i), state.palette[i]);
   }
   // Base roles — only write the roles this cluster declares. Iterate
-  // `cluster.baseRoles` (rather than hardcoding all 5) so a cluster like
-  // zaudio that ships zero base roles emits zero base-role writes.
+  // `cluster.baseRoles` (rather than hardcoding all 5) so a cluster that
+  // ships zero base roles emits zero base-role writes.
   for (const [key, cssName] of Object.entries(cluster.baseRoles)) {
     if (typeof cssName !== 'string' || cssName.length === 0) continue;
     const stateIndex = state[key as BaseRoleKey];
@@ -598,11 +598,11 @@ export function applyTokenOverrides(tokens: readonly TokenDef[], overrides: Toke
 
 /**
  * Apply the full unified `TweakState` — primary color cluster + token
- * overrides + optional zaudio cluster.
+ * overrides + optional secondary cluster.
  *
  * Token manifests AND the primary color cluster are read from `panelConfig`
- * at call time (Sub 3 #1553 + Sub 4 #1554) so a host that calls
- * `configurePanel` before mount sees its own data driving the apply pass.
+ * at call time so a host that calls `configurePanel` before mount sees its
+ * own data driving the apply pass.
  */
 export function applyFullState(state: TweakState) {
   const config = getPanelConfig();
@@ -611,14 +611,14 @@ export function applyFullState(state: TweakState) {
   applyTokenOverrides(tokens.spacing, state.spacing);
   applyTokenOverrides(tokens.typography, state.typography);
   applyTokenOverrides(tokens.size, state.size);
-  // Sub S5b (#1589) — secondary cluster is host-driven via
+  // The secondary cluster is host-driven via
   // `panelConfig.secondaryColorCluster`. When the host opted out (null),
-  // skip the secondary apply pass entirely; even though `state.zaudio` may
-  // still be hydrated for envelope round-trip purposes, no secondary CSS
-  // vars belong to this host.
+  // skip the secondary apply pass entirely; even though `state.secondary`
+  // may still be hydrated for envelope round-trip purposes, no secondary
+  // CSS vars belong to this host.
   const secondaryCluster = resolveSecondaryColorCluster(config);
-  if (secondaryCluster && state.zaudio) {
-    applyColorState(state.zaudio, secondaryCluster);
+  if (secondaryCluster && state.secondary) {
+    applyColorState(state.secondary, secondaryCluster);
   }
 }
 
@@ -627,9 +627,9 @@ export function applyFullState(state: TweakState) {
  * values from the active scheme take effect again.
  *
  * Accepts an optional list of clusters so callers can scope the wipe to a
- * subset; the default wipes BOTH `zd` and `zaudio` so a panel-level reset
- * leaves no stale inline overrides on `:root` regardless of which cluster
- * was last edited.
+ * subset; the default wipes both the primary and secondary clusters so a
+ * panel-level reset leaves no stale inline overrides on `:root` regardless
+ * of which cluster was last edited.
  */
 export function clearAppliedStyles(
   clusters: readonly ColorClusterDataConfig[] = (() => {
@@ -862,7 +862,7 @@ export function loadPersistedState(
         font?: unknown; // upstream alias — migrated into `typography`
         size?: unknown;
         panelPosition?: unknown;
-        zaudio?: unknown;
+        secondary?: unknown;
       };
       if (obj.color && isValidColorShape(obj.color, cluster.paletteSize)) {
         const defaults = colorDefaults ?? tryInitColorFromScheme(cluster);
@@ -879,22 +879,21 @@ export function loadPersistedState(
           size: hydrateOverrides(obj.size),
           panelPosition: hydratePanelPosition(obj.panelPosition),
         };
-        // Optional secondary slice (legacy field name `zaudio`) — validated
-        // against the active secondary cluster's palette size, NOT the
-        // primary cluster's. When the host opted out
-        // (`secondaryColorCluster: null` or omitted), there is no secondary
-        // cluster to validate against, so we skip hydration entirely — the
-        // apply path also skips secondary writes, and the JSON envelope
-        // simply omits the slice for opt-out hosts. Defaults come from
-        // `initSecondaryDefaults(cluster)`.
+        // Optional secondary slice — validated against the active secondary
+        // cluster's palette size, NOT the primary cluster's. When the host
+        // opted out (`secondaryColorCluster: null` or omitted), there is no
+        // secondary cluster to validate against, so we skip hydration
+        // entirely — the apply path also skips secondary writes, and the
+        // JSON envelope simply omits the slice for opt-out hosts. Defaults
+        // come from `initSecondaryDefaults(cluster)`.
         const secondaryCluster = resolveSecondaryColorCluster();
         if (
           secondaryCluster &&
-          obj.zaudio &&
-          isValidColorShape(obj.zaudio, secondaryCluster.paletteSize)
+          obj.secondary &&
+          isValidColorShape(obj.secondary, secondaryCluster.paletteSize)
         ) {
-          next.zaudio = hydrateColorState(
-            obj.zaudio as Partial<ColorTweakState>,
+          next.secondary = hydrateColorState(
+            obj.secondary as Partial<ColorTweakState>,
             initSecondaryDefaults(secondaryCluster),
           );
         }

--- a/packages/zudo-design-token-panel/src/styles/panel-tokens.css
+++ b/packages/zudo-design-token-panel/src/styles/panel-tokens.css
@@ -1,55 +1,52 @@
 /**
- * Panel-private CSS custom properties (Sub 5a, #1555).
+ * Panel-private CSS custom properties.
  *
- * Migrated from `sub-packages/design-system/theme.css` so the design-token
- * panel package owns its own visual tokens instead of leaking them through
- * the host's Tailwind theme. The values are byte-for-byte identical to the
- * pre-migration `--spacing-tokentweak-*`, `--text-tokentweak-*`, and
- * `--radius-tokentweak` declarations — Sub 5a is a no-visual-change move.
+ * The design-token panel package owns its own visual tokens instead of
+ * leaking them through the host's theme. The values match what the
+ * package's example design system declares, so the default look stays
+ * identical to the example.
  *
  * Scope
  * -----
- * Declared on the panel shell + the default modal class prefix
- * (`zmod-design-token-panel-modal`, matching `DEFAULT_PANEL_CONFIG.modalClassPrefix`
- * in `config/panel-config.ts`). Keeping the declaration local to those scopes
- * — instead of `:root` — means a host's stylesheet cannot be polluted by
- * these names just because the panel bundle is loaded; the variables only
- * exist where the panel itself lives in the DOM tree.
+ * Declared on the panel shell + the default modal class prefix (matching
+ * `DEFAULT_PANEL_CONFIG.modalClassPrefix` in `config/panel-config.ts`).
+ * Keeping the declaration local to those scopes — instead of `:root` —
+ * means a host's stylesheet cannot be polluted by these names just because
+ * the panel bundle is loaded; the variables only exist where the panel
+ * itself lives in the DOM tree.
  *
- * The companion modals (apply / export / import) live as `<dialog>` elements
- * rendered as siblings of the shell, not inside `.tokenpanel-shell`. The
- * modal `<dialog>` itself carries the modal class prefix as its root class
- * (e.g. `zmod-design-token-panel-modal`), so anchoring the variables on that
- * prefix here makes the still-Tailwind-driven modal files (apply / import /
- * export — Sub 5b's scope) keep resolving `--radius-tokentweak`,
- * `--tokentweak-pad-*`, etc. without depending on `theme.css`. Sub 5b will
- * convert the modals to bundled CSS on top of the same anchor.
+ * The companion modals (apply / export / import) live as `<dialog>`
+ * elements rendered as siblings of the shell, not inside
+ * `.tokenpanel-shell`. The modal `<dialog>` itself carries the modal
+ * class prefix as its root class, so anchoring the variables on that
+ * prefix here lets the modal files keep resolving `--radius-tokentweak`,
+ * `--tokentweak-pad-*`, etc. without depending on the host theme.
  *
  * `:where()` keeps specificity at zero so a host can override any of these
  * tokens with a single-class rule.
  */
 :where(.tokenpanel-shell, [data-design-token-panel-modal]) {
   /* ----------------------------------------------------------------------
-   * Host-CSS-var indirection ladder (Sub S2, #1587)
+   * Host-CSS-var indirection ladder
    *
-   * The panel chrome was previously reading host-defined `--color-*` and
-   * `--font-mono` directly (~107 sites in panel.css). That meant a non-zmod
-   * host that does not declare those names paints the panel with no chrome
-   * styling. Wrap each one in a `--tokentweak-*` indirection that falls back
-   * to a sane default so the panel paints out-of-the-box.
+   * The panel chrome could read host-defined `--color-*` and `--font-mono`
+   * directly, but a host that does not declare those names would paint the
+   * panel with no chrome styling. Wrap each one in a `--tokentweak-*`
+   * indirection that falls back to a sane default so the panel paints
+   * out-of-the-box.
    *
    * Ladder semantics:
    *
    *   --tokentweak-color-fg: var(--color-fg, <fallback>);
    *
-   * - Host declares `--color-fg`        → that wins (zmod path, unchanged).
+   * - Host declares `--color-fg`        → that wins.
    * - Host declares `--tokentweak-color-fg` directly → that wins (panel-only
    *   override; bypasses the host's own theme).
    * - Host declares neither             → the fallback paints the panel.
    *
-   * Fallback values are picked to match what zmod's design-system declares
-   * today (see sub-packages/design-system/{tokens,theme}.css), so the panel's
-   * default look stays identical to current zmod paint.
+   * Fallback values are picked to match what the package's example
+   * design-system declares, so the panel's default look stays identical
+   * to the example.
    * ---------------------------------------------------------------------- */
   --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
   --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));

--- a/packages/zudo-design-token-panel/src/styles/panel-tokens.css
+++ b/packages/zudo-design-token-panel/src/styles/panel-tokens.css
@@ -1,0 +1,100 @@
+/**
+ * Panel-private CSS custom properties (Sub 5a, #1555).
+ *
+ * Migrated from `sub-packages/design-system/theme.css` so the design-token
+ * panel package owns its own visual tokens instead of leaking them through
+ * the host's Tailwind theme. The values are byte-for-byte identical to the
+ * pre-migration `--spacing-tokentweak-*`, `--text-tokentweak-*`, and
+ * `--radius-tokentweak` declarations — Sub 5a is a no-visual-change move.
+ *
+ * Scope
+ * -----
+ * Declared on the panel shell + the default modal class prefix
+ * (`zmod-design-token-panel-modal`, matching `DEFAULT_PANEL_CONFIG.modalClassPrefix`
+ * in `config/panel-config.ts`). Keeping the declaration local to those scopes
+ * — instead of `:root` — means a host's stylesheet cannot be polluted by
+ * these names just because the panel bundle is loaded; the variables only
+ * exist where the panel itself lives in the DOM tree.
+ *
+ * The companion modals (apply / export / import) live as `<dialog>` elements
+ * rendered as siblings of the shell, not inside `.tokenpanel-shell`. The
+ * modal `<dialog>` itself carries the modal class prefix as its root class
+ * (e.g. `zmod-design-token-panel-modal`), so anchoring the variables on that
+ * prefix here makes the still-Tailwind-driven modal files (apply / import /
+ * export — Sub 5b's scope) keep resolving `--radius-tokentweak`,
+ * `--tokentweak-pad-*`, etc. without depending on `theme.css`. Sub 5b will
+ * convert the modals to bundled CSS on top of the same anchor.
+ *
+ * `:where()` keeps specificity at zero so a host can override any of these
+ * tokens with a single-class rule.
+ */
+:where(.tokenpanel-shell, [data-design-token-panel-modal]) {
+  /* ----------------------------------------------------------------------
+   * Host-CSS-var indirection ladder (Sub S2, #1587)
+   *
+   * The panel chrome was previously reading host-defined `--color-*` and
+   * `--font-mono` directly (~107 sites in panel.css). That meant a non-zmod
+   * host that does not declare those names paints the panel with no chrome
+   * styling. Wrap each one in a `--tokentweak-*` indirection that falls back
+   * to a sane default so the panel paints out-of-the-box.
+   *
+   * Ladder semantics:
+   *
+   *   --tokentweak-color-fg: var(--color-fg, <fallback>);
+   *
+   * - Host declares `--color-fg`        → that wins (zmod path, unchanged).
+   * - Host declares `--tokentweak-color-fg` directly → that wins (panel-only
+   *   override; bypasses the host's own theme).
+   * - Host declares neither             → the fallback paints the panel.
+   *
+   * Fallback values are picked to match what zmod's design-system declares
+   * today (see sub-packages/design-system/{tokens,theme}.css), so the panel's
+   * default look stays identical to current zmod paint.
+   * ---------------------------------------------------------------------- */
+  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
+  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
+  --tokentweak-color-muted: var(--color-muted, oklch(70% 0.01 60));
+  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
+  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
+  --tokentweak-color-accent-hover: var(--color-accent-hover, oklch(55% 0.18 45));
+  --tokentweak-color-code-bg: var(--color-code-bg, oklch(17% 0.005 50));
+  --tokentweak-color-code-fg: var(--color-code-fg, oklch(87% 0.01 60));
+  --tokentweak-color-success: var(--color-success, oklch(65% 0.19 145));
+  --tokentweak-color-danger: var(--color-danger, oklch(60% 0.2 10));
+  --tokentweak-color-warning: var(--color-warning, oklch(75% 0.17 75));
+  --tokentweak-font-mono: var(
+    --font-mono,
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace
+  );
+
+  --tokentweak-pad-2xs: 0.125rem;
+  --tokentweak-pad-xs: 0.375rem;
+  --tokentweak-pad-sm: 0.5rem;
+  --tokentweak-pad-md: 0.75rem;
+  --tokentweak-pad-lg: 1rem;
+  --tokentweak-pad-xl: 1.5rem;
+  --tokentweak-pad-2xl: 2rem;
+
+  --tokentweak-gap-2xs: 0.4375rem;
+  --tokentweak-gap-xs: 0.875rem;
+  --tokentweak-gap-sm: 1.25rem;
+  --tokentweak-gap-md: 1.5rem;
+  --tokentweak-gap-lg: 1.75rem;
+  --tokentweak-gap-xl: 2.5rem;
+  --tokentweak-gap-2xl: 3.5rem;
+
+  --tokentweak-text-micro: 0.75rem;
+  --tokentweak-text-caption: 0.875rem;
+  --tokentweak-text-small: 1rem;
+  --tokentweak-text-body: 1.2rem;
+  --tokentweak-text-subheading: 1.4rem;
+  --tokentweak-text-heading: 3rem;
+  --tokentweak-text-display: 3.75rem;
+
+  --radius-tokentweak: 0.25rem;
+}

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -300,14 +300,14 @@
   gap: var(--tokentweak-pad-sm);
 }
 
-.tokenpanel-color-palette-grid--zaudio {
+.tokenpanel-color-palette-grid--secondary {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: var(--tokentweak-pad-sm);
 }
 
 @media (min-width: 768px) {
-  .tokenpanel-color-palette-grid--zaudio {
+  .tokenpanel-color-palette-grid--secondary {
     grid-template-columns: repeat(9, minmax(0, 1fr));
   }
 }
@@ -319,7 +319,7 @@
 }
 
 /* ===========================================================================
- * Color swatch (used by ZD + ZAUDIO palette grids)
+ * Color swatch (used by primary + secondary palette grids)
  * ========================================================================= */
 
 .tokenpanel-color-swatch-wrap {

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1,24 +1,23 @@
 /**
- * Design-token panel — bundled CSS (Sub 5a, #1555).
+ * Design-token panel — bundled CSS.
  *
  * Owns every chrome rule for the panel SHELL, the four TABS (Color / Spacing
  * / Font / Size), and the four CONTROL rows (slider / pill-slider / select /
- * text). The modal layer (apply / export / import) is intentionally out of
- * scope here — Sub 5b ships its bundled CSS in a follow-up.
+ * text). Modal-layer CSS is bundled in the same stylesheet further down.
  *
  * Why move this out of Tailwind?
  * ------------------------------
- * The portable-panel epic (#1550) requires the package to render correctly
- * in any consumer's CSS environment, including hosts that do not ship
- * Tailwind. Bundling chrome rules here means the consumer only has to
- * import the panel's entry — the visual styling rides along.
+ * The package needs to render correctly in any consumer's CSS environment,
+ * including hosts that do not ship Tailwind. Bundling chrome rules here
+ * means the consumer only has to import the panel's entry — the visual
+ * styling rides along.
  *
  * Token strategy
  * --------------
  * Visual tokens are declared in `panel-tokens.css` (sibling file) under
  * `.tokenpanel-shell`. The host's `--color-*` semantic tokens (bg / fg /
  * accent / muted / surface / etc.) are still referenced via `var()`; the
- * portable-panel contract (Sub 7) is what makes those names host-supplied.
+ * portable-panel contract is what makes those names host-supplied.
  * This file deliberately does NOT redeclare semantic colors — that's a
  * different layer of the stack.
  *
@@ -149,7 +148,7 @@
 }
 
 /* ===========================================================================
- * Empty-state — Sub S5d (#1591)
+ * Empty-state
  * ===========================================================================
  *
  * Friendly affordance shown in the spacing / font / size tab body when the
@@ -163,7 +162,7 @@
  * the value declared in panel-tokens.css so the empty-state still paints if
  * it ever renders outside the .tokenpanel-shell scope where the tokentweak
  * variables live (defensive — the panel always renders inside the shell
- * today, but Sub S5d's empty-state should not bake the assumption in).
+ * today, but the empty-state should not bake the assumption in).
  * ========================================================================= */
 
 .tokenpanel-empty-state {
@@ -695,21 +694,20 @@
 }
 
 /* ===========================================================================
- * Modal layer (Sub 5b, #1556 — refactored for PR #1440 review item P0-1)
+ * Modal layer
  * ===========================================================================
  *
  * Selector convention
  * -------------------
- * Sub 5a's shell rules use a flat `tokenpanel-<feature>-<part>` block + class
- * naming. The modal layer is anchored on the `[data-design-token-panel-modal]`
- * attribute (set by every modal `<dialog>` in apply-modal / export-modal /
- * import-modal). The BEM-flavoured class suffixes (e.g. `__title`, `--apply`)
- * still come from `modalClass(cfg, …)` — they enrich specificity for hosts
- * that want to layer their own rules — but the bundled stylesheet keys
- * everything on the data attribute so a consumer-supplied `modalClassPrefix`
- * does NOT detune the chrome rules. Pre-fix the rules matched a literal
- * `.zmod-design-token-panel-modal` class, which meant scaffold-style hosts
- * that overrode `modalClassPrefix` got unstyled modals.
+ * The shell rules use a flat `tokenpanel-<feature>-<part>` block + class
+ * naming. The modal layer is anchored on the
+ * `[data-design-token-panel-modal]` attribute (set by every modal
+ * `<dialog>` in apply-modal / export-modal / import-modal). The
+ * BEM-flavoured class suffixes (e.g. `__title`, `--apply`) still come from
+ * `modalClass(cfg, …)` — they enrich specificity for hosts that want to
+ * layer their own rules — but the bundled stylesheet keys everything on
+ * the data attribute so a consumer-supplied `modalClassPrefix` does NOT
+ * detune the chrome rules.
  *
  * Sub-element targeting uses attribute selectors with `[class*=...]` against
  * the BEM suffix, so the rules match regardless of which modal class prefix
@@ -717,9 +715,9 @@
  *
  * Consumer customisation
  * ----------------------
- * `panelConfig.modalClassPrefix` is one-shot per page lifecycle (Sub 2).
- * Hosts MAY override it for higher-specificity custom rules; the bundled
- * chrome below still applies because every modal element carries the
+ * `panelConfig.modalClassPrefix` is one-shot per page lifecycle. Hosts MAY
+ * override it for higher-specificity custom rules; the bundled chrome
+ * below still applies because every modal element carries the
  * `data-design-token-panel-modal*` attributes regardless of the prefix.
  *
  * If a host wants COMPLETELY custom modal chrome they can either:

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1,0 +1,935 @@
+/**
+ * Design-token panel — bundled CSS (Sub 5a, #1555).
+ *
+ * Owns every chrome rule for the panel SHELL, the four TABS (Color / Spacing
+ * / Font / Size), and the four CONTROL rows (slider / pill-slider / select /
+ * text). The modal layer (apply / export / import) is intentionally out of
+ * scope here — Sub 5b ships its bundled CSS in a follow-up.
+ *
+ * Why move this out of Tailwind?
+ * ------------------------------
+ * The portable-panel epic (#1550) requires the package to render correctly
+ * in any consumer's CSS environment, including hosts that do not ship
+ * Tailwind. Bundling chrome rules here means the consumer only has to
+ * import the panel's entry — the visual styling rides along.
+ *
+ * Token strategy
+ * --------------
+ * Visual tokens are declared in `panel-tokens.css` (sibling file) under
+ * `.tokenpanel-shell`. The host's `--color-*` semantic tokens (bg / fg /
+ * accent / muted / surface / etc.) are still referenced via `var()`; the
+ * portable-panel contract (Sub 7) is what makes those names host-supplied.
+ * This file deliberately does NOT redeclare semantic colors — that's a
+ * different layer of the stack.
+ *
+ * BEM-ish naming
+ * --------------
+ * - Block: `tokenpanel-<feature>`
+ * - Element: `tokenpanel-<feature>-<part>`
+ * - Modifier: `is-<state>` (set as a second class, e.g. `is-active`,
+ *   `is-selected`)
+ *
+ * Specificity is intentionally flat: every rule is a single class so a host
+ * can override individual surfaces without selector-weight wars.
+ */
+
+@import './panel-tokens.css';
+
+/* ===========================================================================
+ * Shell
+ * ========================================================================= */
+
+.tokenpanel-shell {
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  border-radius: var(--radius-tokentweak);
+  box-shadow: 0 4px 24px rgb(0 0 0 / 0.25);
+}
+
+.tokenpanel-header {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-md);
+  padding-inline: var(--tokentweak-pad-xl);
+  padding-block: var(--tokentweak-gap-xs);
+  border-bottom: 1px solid var(--tokentweak-color-muted);
+  flex-shrink: 0;
+}
+
+.tokenpanel-title {
+  color: var(--tokentweak-color-fg);
+  font-weight: 600;
+  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
+.tokenpanel-action-link {
+  color: var(--tokentweak-color-accent);
+  font-size: 0.75rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: color 150ms ease;
+}
+.tokenpanel-action-link:hover {
+  color: var(--tokentweak-color-accent-hover);
+}
+
+.tokenpanel-spacer {
+  flex: 1;
+}
+
+.tokenpanel-close-btn {
+  color: var(--tokentweak-color-muted);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.tokenpanel-close-btn:hover {
+  color: var(--tokentweak-color-fg);
+}
+
+/* ===========================================================================
+ * Tab bar
+ * ========================================================================= */
+
+.tokenpanel-tabbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  border-bottom: 1px solid var(--tokentweak-color-muted);
+  padding-inline: var(--tokentweak-pad-xl);
+  flex-shrink: 0;
+}
+
+.tokenpanel-tab-button {
+  border: none;
+  background: none;
+  padding-inline: var(--tokentweak-pad-md);
+  padding-block: var(--tokentweak-gap-xs);
+  font-size: 0.875rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  color: var(--tokentweak-color-muted);
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
+}
+.tokenpanel-tab-button:hover,
+.tokenpanel-tab-button:focus-visible {
+  color: var(--tokentweak-color-fg);
+  text-decoration: underline;
+}
+.tokenpanel-tab-button.is-active {
+  color: var(--tokentweak-color-fg);
+  border-bottom-color: var(--tokentweak-color-accent);
+  text-decoration: none;
+}
+
+/* ===========================================================================
+ * Tab body container
+ * ========================================================================= */
+
+.tokenpanel-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-inline: var(--tokentweak-pad-xl);
+  padding-block: var(--tokentweak-gap-sm);
+}
+
+/* ===========================================================================
+ * Empty-state — Sub S5d (#1591)
+ * ===========================================================================
+ *
+ * Friendly affordance shown in the spacing / font / size tab body when the
+ * host's `TokenManifest` ships zero tokens for that tab's category. Replaces
+ * what would otherwise be a blank pane with actionable guidance pointing at
+ * `configurePanel({ tokens })` and the package README §3 quick-start.
+ *
+ * The muted-text style intentionally re-uses `--tokentweak-color-muted` so the
+ * empty-state blends with the existing chrome's muted ladder (close-button,
+ * section headings, swatch labels). The fallback in the var() ladder mirrors
+ * the value declared in panel-tokens.css so the empty-state still paints if
+ * it ever renders outside the .tokenpanel-shell scope where the tokentweak
+ * variables live (defensive — the panel always renders inside the shell
+ * today, but Sub S5d's empty-state should not bake the assumption in).
+ * ========================================================================= */
+
+.tokenpanel-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 12rem;
+  padding-block: var(--tokentweak-gap-md);
+  padding-inline: var(--tokentweak-pad-xl);
+}
+
+.tokenpanel-empty-state-text {
+  color: var(--tokentweak-color-muted, oklch(70% 0.01 60));
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  max-width: 32rem;
+  margin: 0;
+}
+
+.tokenpanel-empty-state-text code {
+  font-family: var(--tokentweak-font-mono, Menlo, Monaco, Consolas, monospace);
+  font-size: 0.8125rem;
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-empty-state-link {
+  color: var(--tokentweak-color-accent);
+  text-decoration: underline;
+  transition: color 150ms ease;
+}
+.tokenpanel-empty-state-link:hover,
+.tokenpanel-empty-state-link:focus-visible {
+  color: var(--tokentweak-color-accent-hover);
+}
+
+/* ===========================================================================
+ * Tab content layout (shared by Spacing / Font / Size / Color)
+ * ========================================================================= */
+
+.tokenpanel-tab-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tokentweak-gap-sm);
+}
+
+.tokenpanel-tab-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-md);
+}
+
+.tokenpanel-tab-section {
+  flex-shrink: 0;
+}
+
+.tokenpanel-tab-section-heading {
+  color: var(--tokentweak-color-muted);
+  font-weight: 600;
+  margin-bottom: var(--tokentweak-gap-2xs);
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Color-tab uses a slightly bigger heading per the original spec. */
+.tokenpanel-tab-section-heading--color {
+  font-size: 1rem;
+}
+
+.tokenpanel-tab-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--tokentweak-gap-xs);
+}
+
+@media (min-width: 640px) {
+  .tokenpanel-tab-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.tokenpanel-tab-advanced {
+  flex-shrink: 0;
+}
+
+.tokenpanel-tab-advanced-summary {
+  color: var(--tokentweak-color-muted);
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tokenpanel-tab-advanced-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--tokentweak-gap-xs);
+  margin-top: var(--tokentweak-gap-2xs);
+}
+
+@media (min-width: 640px) {
+  .tokenpanel-tab-advanced-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+/* ===========================================================================
+ * Color tab — preset select + palette grids + base/semantic grids
+ * ========================================================================= */
+
+.tokenpanel-color-preset-select {
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  padding-inline: var(--tokentweak-pad-sm);
+  padding-block: 2px;
+  font-size: 0.75rem;
+  border-radius: var(--radius-tokentweak);
+  max-width: 14rem;
+  cursor: pointer;
+  transition: border-color 150ms ease;
+}
+.tokenpanel-color-preset-select:hover {
+  border-color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-palette-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: var(--tokentweak-pad-sm);
+}
+
+.tokenpanel-color-palette-grid--zaudio {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--tokentweak-pad-sm);
+}
+
+@media (min-width: 768px) {
+  .tokenpanel-color-palette-grid--zaudio {
+    grid-template-columns: repeat(9, minmax(0, 1fr));
+  }
+}
+
+.tokenpanel-color-base-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+/* ===========================================================================
+ * Color swatch (used by ZD + ZAUDIO palette grids)
+ * ========================================================================= */
+
+.tokenpanel-color-swatch-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  width: 100%;
+}
+
+.tokenpanel-color-swatch-button {
+  display: block;
+  border: 1px solid var(--tokentweak-color-muted);
+  cursor: pointer;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: var(--radius-tokentweak);
+  background: none;
+  padding: 0;
+  transition: border-color 150ms ease;
+}
+.tokenpanel-color-swatch-button:hover {
+  border-color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-swatch-label {
+  color: var(--tokentweak-color-muted);
+  font-family: var(--tokentweak-font-mono);
+  user-select: none;
+  font-size: 0.6875rem;
+  line-height: 1.1;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ===========================================================================
+ * Popover (HslPicker host, PaletteSelector listbox)
+ * ========================================================================= */
+
+.tokenpanel-popover {
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  padding: 12px;
+  border-radius: var(--radius-tokentweak);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.3);
+}
+
+/* HslPicker layout */
+
+.tokenpanel-hsl-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.tokenpanel-hsl-preview {
+  flex-shrink: 0;
+  border: 1px solid var(--tokentweak-color-muted);
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: var(--radius-tokentweak);
+}
+
+.tokenpanel-hsl-hex-input {
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  padding-inline: 6px;
+  padding-block: 4px;
+  font-family: var(--tokentweak-font-mono);
+  font-size: 1rem;
+  width: 8rem;
+  border-radius: var(--radius-tokentweak);
+}
+
+.tokenpanel-hsl-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.tokenpanel-hsl-row-label {
+  color: var(--tokentweak-color-muted);
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  width: 1rem;
+}
+
+.tokenpanel-hsl-row-slider {
+  flex: 1;
+  height: 1.5rem;
+  accent-color: var(--tokentweak-color-accent);
+}
+
+.tokenpanel-hsl-row-value {
+  color: var(--tokentweak-color-fg);
+  flex-shrink: 0;
+  text-align: right;
+  font-size: 0.875rem;
+  width: 2.5rem;
+}
+
+/* ===========================================================================
+ * PaletteSelector
+ * ========================================================================= */
+
+.tokenpanel-palette-selector {
+  position: relative;
+  width: 100%;
+}
+
+.tokenpanel-palette-trigger {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  padding-inline: 6px;
+  padding-block: 4px;
+  font-size: 0.75rem;
+  border-radius: var(--radius-tokentweak);
+  cursor: pointer;
+  transition: border-color 150ms ease;
+}
+.tokenpanel-palette-trigger:hover {
+  border-color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-palette-trigger-label {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  color: var(--tokentweak-color-fg);
+  font-family: var(--tokentweak-font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tokenpanel-palette-trigger-color {
+  flex-shrink: 0;
+  border: 1px solid var(--tokentweak-color-muted);
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+}
+
+.tokenpanel-palette-trigger-value {
+  flex-shrink: 0;
+  color: var(--tokentweak-color-muted);
+  font-family: var(--tokentweak-font-mono);
+  width: 2.5em;
+}
+
+.tokenpanel-palette-trigger-icon {
+  color: var(--tokentweak-color-muted);
+  flex-shrink: 0;
+}
+
+.tokenpanel-palette-options {
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  padding: 10px;
+  border-radius: var(--radius-tokentweak);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.3);
+}
+
+.tokenpanel-palette-options-extras {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--tokentweak-color-muted);
+}
+
+.tokenpanel-palette-extra-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-inline: 8px;
+  padding-block: 4px;
+  border-radius: 4px;
+  font-size: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background-color 150ms ease;
+}
+.tokenpanel-palette-extra-option:hover {
+  background-color: rgb(from var(--tokentweak-color-fg) r g b / 0.1);
+}
+.tokenpanel-palette-extra-option.is-selected {
+  background-color: rgb(from var(--tokentweak-color-accent) r g b / 0.2);
+}
+
+.tokenpanel-palette-extra-color {
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 3px;
+  border: 1px solid var(--tokentweak-color-muted);
+}
+
+.tokenpanel-palette-extra-label {
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-palette-options-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 5px;
+}
+
+.tokenpanel-palette-option-button {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 3px;
+  border: 1px solid var(--tokentweak-color-muted);
+  cursor: pointer;
+  padding: 0;
+  transition: box-shadow 150ms ease;
+}
+.tokenpanel-palette-option-button:hover {
+  box-shadow: 0 0 0 2px var(--tokentweak-color-fg);
+}
+.tokenpanel-palette-option-button.is-selected {
+  box-shadow: 0 0 0 2px var(--tokentweak-color-accent);
+}
+
+/* ===========================================================================
+ * Control rows (slider / pill-slider / select / text)
+ * ========================================================================= */
+
+/* Single-line row used by select-row and text-row */
+.tokenpanel-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-sm);
+}
+
+/* Stacked row (label + number on one line, slider beneath) used by slider-row */
+.tokenpanel-row--stacked {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Row used by pill-slider as outer wrapper */
+.tokenpanel-row--column {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Inner row inside .tokenpanel-row--stacked top: label + number */
+.tokenpanel-row-head {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-sm);
+}
+
+.tokenpanel-row-label {
+  color: var(--tokentweak-color-fg);
+  font-family: var(--tokentweak-font-mono);
+  flex: 1;
+  min-width: 0;
+  font-size: 0.8125rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Text-row narrows the label so the wide free-form input gets room. */
+.tokenpanel-row-label--narrow {
+  flex: 0 0 auto;
+  max-width: 12rem;
+}
+
+.tokenpanel-row-input-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.tokenpanel-row-number-input {
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  padding-inline: 6px;
+  padding-block: 2px;
+  font-family: var(--tokentweak-font-mono);
+  text-align: right;
+  font-size: 0.75rem;
+  width: 5rem;
+  border-radius: var(--radius-tokentweak);
+}
+.tokenpanel-row-number-input:disabled {
+  opacity: 0.6;
+}
+
+.tokenpanel-row-unit {
+  color: var(--tokentweak-color-muted);
+  font-family: var(--tokentweak-font-mono);
+  user-select: none;
+  font-size: 0.75rem;
+  width: 2rem;
+}
+
+.tokenpanel-row-slider {
+  width: 100%;
+  height: 1.25rem;
+  accent-color: var(--tokentweak-color-accent);
+}
+.tokenpanel-row-slider:disabled {
+  opacity: 0.5;
+}
+
+.tokenpanel-row-select {
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  padding-inline: 6px;
+  padding-block: 2px;
+  font-family: var(--tokentweak-font-mono);
+  font-size: 0.75rem;
+  width: 7rem;
+  border-radius: var(--radius-tokentweak);
+}
+.tokenpanel-row-select:disabled {
+  opacity: 0.6;
+}
+
+.tokenpanel-row-text-input {
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  padding-inline: 6px;
+  padding-block: 2px;
+  font-family: var(--tokentweak-font-mono);
+  font-size: 0.75rem;
+  flex: 1;
+  min-width: 0;
+  border-radius: var(--radius-tokentweak);
+}
+.tokenpanel-row-text-input:disabled {
+  opacity: 0.6;
+}
+
+/* Pill toggle */
+
+.tokenpanel-pill-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-xs);
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.tokenpanel-pill-toggle-checkbox {
+  accent-color: var(--tokentweak-color-accent);
+}
+
+.tokenpanel-pill-toggle-text {
+  color: var(--tokentweak-color-muted);
+  font-family: var(--tokentweak-font-mono);
+  font-size: 0.75rem;
+}
+
+/* ===========================================================================
+ * Modal layer (Sub 5b, #1556 — refactored for PR #1440 review item P0-1)
+ * ===========================================================================
+ *
+ * Selector convention
+ * -------------------
+ * Sub 5a's shell rules use a flat `tokenpanel-<feature>-<part>` block + class
+ * naming. The modal layer is anchored on the `[data-design-token-panel-modal]`
+ * attribute (set by every modal `<dialog>` in apply-modal / export-modal /
+ * import-modal). The BEM-flavoured class suffixes (e.g. `__title`, `--apply`)
+ * still come from `modalClass(cfg, …)` — they enrich specificity for hosts
+ * that want to layer their own rules — but the bundled stylesheet keys
+ * everything on the data attribute so a consumer-supplied `modalClassPrefix`
+ * does NOT detune the chrome rules. Pre-fix the rules matched a literal
+ * `.zmod-design-token-panel-modal` class, which meant scaffold-style hosts
+ * that overrode `modalClassPrefix` got unstyled modals.
+ *
+ * Sub-element targeting uses attribute selectors with `[class*=...]` against
+ * the BEM suffix, so the rules match regardless of which modal class prefix
+ * the host chose.
+ *
+ * Consumer customisation
+ * ----------------------
+ * `panelConfig.modalClassPrefix` is one-shot per page lifecycle (Sub 2).
+ * Hosts MAY override it for higher-specificity custom rules; the bundled
+ * chrome below still applies because every modal element carries the
+ * `data-design-token-panel-modal*` attributes regardless of the prefix.
+ *
+ * If a host wants COMPLETELY custom modal chrome they can either:
+ *   - ship their own modal-layer CSS that wins on specificity, OR
+ *   - declare `[data-design-token-panel-modal]` rules with their own values
+ *     (those will conflict with the bundled rules at equal specificity, with
+ *     the host's stylesheet winning by load order).
+ * ========================================================================= */
+
+[data-design-token-panel-modal] {
+  margin-inline: auto;
+  width: 100%;
+  max-width: 46rem;
+  max-height: 80vh;
+  overflow-y: auto;
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  padding: var(--tokentweak-pad-xl);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  user-select: text;
+}
+[data-design-token-panel-modal]::backdrop {
+  background-color: rgb(from var(--tokentweak-color-bg) r g b / 0.8);
+}
+
+[data-design-token-panel-modal] [class*='__header'] {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--tokentweak-pad-md);
+  margin-bottom: var(--tokentweak-gap-sm);
+}
+
+[data-design-token-panel-modal] [class*='__title'] {
+  font-size: var(--tokentweak-text-subheading);
+  font-weight: 700;
+  color: var(--tokentweak-color-fg);
+}
+
+[data-design-token-panel-modal] [class*='__hint'] {
+  font-size: var(--tokentweak-text-small);
+  color: var(--tokentweak-color-muted);
+  margin-bottom: var(--tokentweak-gap-xs);
+}
+
+[data-design-token-panel-modal] [class*='__section-heading'] {
+  font-size: var(--tokentweak-text-small);
+  font-weight: 700;
+  color: var(--tokentweak-color-fg);
+  margin-top: var(--tokentweak-gap-sm);
+  margin-bottom: var(--tokentweak-gap-2xs);
+}
+
+[data-design-token-panel-modal] [class*='__list']:not([class*='__list-item']) {
+  overflow-x: auto;
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-code-bg);
+  color: var(--tokentweak-color-code-fg);
+  padding: var(--tokentweak-pad-sm);
+  font-size: var(--tokentweak-text-small);
+  margin-bottom: var(--tokentweak-gap-xs);
+}
+
+[data-design-token-panel-modal] [class*='__list-item'] {
+  font-family: var(--tokentweak-font-mono);
+}
+
+[data-design-token-panel-modal] [class*='__actions'] {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-md);
+  margin-top: var(--tokentweak-gap-md);
+}
+
+[data-design-token-panel-modal] [class*='__toggle'] {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-xs);
+  font-size: var(--tokentweak-text-small);
+  color: var(--tokentweak-color-fg);
+  cursor: pointer;
+  margin-bottom: var(--tokentweak-gap-xs);
+}
+
+[data-design-token-panel-modal] [class*='__textarea'] {
+  width: 100%;
+  min-height: 12rem;
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-code-bg);
+  color: var(--tokentweak-color-code-fg);
+  padding: var(--tokentweak-pad-sm);
+  font-family: var(--tokentweak-font-mono);
+  font-size: var(--tokentweak-text-small);
+  resize: vertical;
+  margin-bottom: var(--tokentweak-gap-xs);
+}
+
+[data-design-token-panel-modal] [class*='__json'] {
+  overflow-x: auto;
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-code-bg);
+  color: var(--tokentweak-color-code-fg);
+  padding: var(--tokentweak-pad-sm);
+  font-size: var(--tokentweak-text-small);
+}
+
+[data-design-token-panel-modal] [class*='__status'] {
+  font-size: var(--tokentweak-text-small);
+  margin-bottom: var(--tokentweak-gap-xs);
+}
+[data-design-token-panel-modal] [class*='__status--info'] {
+  color: var(--tokentweak-color-success);
+}
+[data-design-token-panel-modal] [class*='__status--error'] {
+  color: var(--tokentweak-color-danger);
+}
+[data-design-token-panel-modal] [class*='__status--warning'] {
+  color: var(--tokentweak-color-warning);
+}
+[data-design-token-panel-modal] [class*='__status--success'] {
+  color: var(--tokentweak-color-success);
+}
+
+[data-design-token-panel-modal] [class*='__applying'] {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-sm);
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-code-bg);
+  color: var(--tokentweak-color-muted);
+  padding: var(--tokentweak-pad-sm);
+  font-size: var(--tokentweak-text-small);
+}
+
+[data-design-token-panel-modal] [class*='__spinner'] {
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--tokentweak-color-muted);
+  border-top-color: var(--tokentweak-color-fg);
+  border-radius: 50%;
+  animation: design-token-panel-modal-spin 0.75s linear infinite;
+}
+@keyframes design-token-panel-modal-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+[data-design-token-panel-modal] [class*='__revert-hint'] {
+  font-size: var(--tokentweak-text-small);
+  font-style: italic;
+  color: var(--tokentweak-color-muted);
+  margin-top: var(--tokentweak-gap-sm);
+  margin-bottom: var(--tokentweak-gap-2xs);
+}
+
+[data-design-token-panel-modal] [class*='__button'] {
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-muted);
+  padding-inline: var(--tokentweak-pad-lg);
+  padding-block: var(--tokentweak-gap-2xs);
+  font-size: var(--tokentweak-text-small);
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease,
+    background-color 150ms ease;
+}
+[data-design-token-panel-modal] [class*='__button']:hover,
+[data-design-token-panel-modal] [class*='__button']:focus-visible {
+  color: var(--tokentweak-color-fg);
+  border-color: var(--tokentweak-color-fg);
+}
+[data-design-token-panel-modal] [class*='__button']:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+[data-design-token-panel-modal] [class*='__button--primary'] {
+  border-color: var(--tokentweak-color-accent);
+  background-color: var(--tokentweak-color-accent);
+  color: var(--tokentweak-color-bg);
+}
+[data-design-token-panel-modal] [class*='__button--primary']:hover,
+[data-design-token-panel-modal] [class*='__button--primary']:focus-visible {
+  border-color: var(--tokentweak-color-accent-hover);
+  background-color: var(--tokentweak-color-accent-hover);
+  color: var(--tokentweak-color-bg);
+}
+
+[data-design-token-panel-modal] [class*='__close-button'] {
+  border: 1px solid var(--tokentweak-color-muted);
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-muted);
+  padding-inline: var(--tokentweak-pad-sm);
+  padding-block: var(--tokentweak-gap-2xs);
+  font-size: var(--tokentweak-text-small);
+  cursor: pointer;
+  transition:
+    color 150ms ease,
+    border-color 150ms ease;
+}
+[data-design-token-panel-modal] [class*='__close-button']:hover,
+[data-design-token-panel-modal] [class*='__close-button']:focus-visible {
+  color: var(--tokentweak-color-fg);
+  border-color: var(--tokentweak-color-fg);
+}

--- a/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
@@ -1,7 +1,7 @@
 /**
  * Color tab — verbatim port of zudo-doc's
  * `src/components/design-token-tweak/tabs/color-tab.tsx`, rewired to the
- * zmod2 design-token-panel module paths:
+ * design-token-panel module paths:
  *
  *   @/config/color-schemes       → ../config/color-schemes
  *   @/config/color-scheme-utils  → ../config/color-scheme-utils
@@ -16,19 +16,20 @@
  * popover. No raw-color inputs (rgb / hex text field / lab / oklch) are
  * exposed for Base or Semantic rows.
  *
- * Shiki integration is not part of zmod2 — the `shikiTheme` field stays on
- * state + persist + serde (Sub 1 keeps it for envelope round-tripping with
- * zudo-doc exports), and `applyShikiTheme` is a no-op stub. We hide the
+ * Shiki integration is out of scope — the `shikiTheme` field stays on
+ * state + persist + serde for envelope round-tripping with upstream
+ * exports, and `applyShikiTheme` is a no-op stub. We hide the
  * shikiTheme `<select>` JSX block here but leave every state/apply touch
  * point intact. `SHIKI_THEMES` is therefore no longer imported in this file
  * (would trip `noUnusedLocals`); re-add it if/when the JSX block lands.
  *
- * The zaudio cluster ships alongside ZD now (Sub 7b). The two clusters share
- * the same `ColorSwatch` + `PaletteSelector` primitives — zaudio renders a
- * 9-slot palette and 9 semantic dropdowns below the ZD sections, with no
- * Base subsection (zaudio declares zero base roles per `zaudio-tokens.css`).
- * Section headings are prefixed `ZD — ` / `ZAUDIO — ` so the two clusters
- * are visually distinct in the panel.
+ * The optional secondary cluster ships alongside the primary cluster. The
+ * two clusters share the same `ColorSwatch` + `PaletteSelector` primitives —
+ * the secondary cluster renders its palette and semantic dropdowns below
+ * the primary sections. Whether it ships a Base subsection depends on the
+ * cluster's declared base roles. Section headings are prefixed
+ * `Primary — ` / `Secondary — ` so the two clusters are visually distinct
+ * in the panel.
  */
 
 import { memo, useState, useEffect, useCallback, useMemo, useRef } from 'preact/compat';
@@ -41,19 +42,19 @@ import {
   resolvePaletteCssVar,
 } from '../state/tweak-state';
 import { getPanelConfig, resolveSecondaryColorCluster } from '../config/panel-config';
-import type { PersistColor, PersistZaudio } from '../state/persist';
+import type { PersistColor, PersistSecondary } from '../state/persist';
 
-// Sub 4 (#1554): the bundled scheme registry now lives on
+// The bundled scheme registry now lives on
 // `panelConfig.colorCluster.colorSchemes`, not on a global import. Read it
 // at render time so a host that calls `configurePanel` before mount sees
 // its own schemes in the Scheme… dropdown.
 //
-// Sub S5c (#1590): the optional preset list (zmod's historical Dracula /
-// Solarized / Tokyo Night / ... blob) was relocated out of the package
-// entirely. Hosts hand the panel a `colorPresets` map via `PanelConfig`;
-// the package itself ships zero presets. The Color tab reads the active
-// map at render time below — `presetNames` is no longer a module-level
-// constant computed from a baked-in import.
+// The optional preset list (Dracula / Solarized / Tokyo Night / ...) was
+// relocated out of the package entirely. Hosts hand the panel a
+// `colorPresets` map via `PanelConfig`; the package itself ships zero
+// presets. The Color tab reads the active map at render time below —
+// `presetNames` is no longer a module-level constant computed from a
+// baked-in import.
 
 // --- Shared popover helpers (Color-tab scoped) ---
 
@@ -227,9 +228,9 @@ function HslPicker({
  *
  * `onChange` is `(index, hex)` — the swatch passes its own palette `index`
  * back so the parent can use a single stable handler across every cell,
- * keeping React.memo effective (PR #1440 review item Q3). The same
- * component is reused by both the ZD and ZAUDIO palettes because the
- * `onChange` shape is parameterised on the parent's per-cluster handler.
+ * keeping React.memo effective. The same component is reused by both the
+ * primary and secondary palettes because the `onChange` shape is
+ * parameterised on the parent's per-cluster handler.
  */
 const ColorSwatch = memo(function ColorSwatch({
   color,
@@ -283,7 +284,7 @@ const ColorSwatch = memo(function ColorSwatch({
  * `onChange` is `(idKey, val)` — the selector passes its own `idKey` (the
  * semantic key, base-role name, etc. that identifies which row this is) back
  * so the parent can use a single stable handler across every selector,
- * keeping React.memo effective (PR #1440 review item Q3).
+ * keeping React.memo effective.
  */
 const PaletteSelector = memo(function PaletteSelector({
   label,
@@ -304,9 +305,10 @@ const PaletteSelector = memo(function PaletteSelector({
   palette: string[];
   /**
    * Maps a palette index to its full CSS custom-property name (e.g.
-   * `--zd-p7`, `--zaudio-pa3`). Used for the popover swatches' `title` /
-   * `aria-label` so assistive tech sees the real variable name, not a
-   * short `p7` key. Defaults to `--zd-p${i}` for backward compatibility.
+   * `--zd-p7`, `--app-secondary-pa3`). Used for the popover swatches'
+   * `title` / `aria-label` so assistive tech sees the real variable name,
+   * not a short `p7` key. Defaults to `--zd-p${i}` for backward
+   * compatibility.
    */
   paletteCssVar?: (i: number) => string;
   onChange: (idKey: string, val: number | 'bg' | 'fg') => void;
@@ -446,15 +448,15 @@ interface ColorTabProps {
    * `secondaryCluster` resolves to `null`, so the slice is only touched
    * inside that conditional block.
    */
-  zaudioState: ColorTweakState | null;
-  persistZaudio: PersistZaudio;
+  secondaryState: ColorTweakState | null;
+  persistSecondary: PersistSecondary;
 }
 
 export default function ColorTab({
   state,
   persistColor,
-  zaudioState,
-  persistZaudio,
+  secondaryState,
+  persistSecondary,
 }: ColorTabProps) {
   // Read the active cluster + scheme registry through panelConfig so a host
   // that calls `configurePanel` with its own colorCluster sees its data
@@ -490,8 +492,7 @@ export default function ColorTab({
   const secondaryLabel = secondaryCluster?.label ?? secondaryCluster?.id.toUpperCase() ?? '';
 
   // Stable per-cluster `paletteCssVar` callbacks — passed into memoised
-  // ColorSwatch / PaletteSelector so prop equality holds across renders
-  // (PR #1440 review item Q3).
+  // ColorSwatch / PaletteSelector so prop equality holds across renders.
   const clusterPaletteCssVar = useCallback(
     (i: number) => resolvePaletteCssVar(cluster, i),
     [cluster],
@@ -514,16 +515,14 @@ export default function ColorTab({
     [persistColor],
   );
 
-  // PR #1440 review item M-15 — drop `zaudioState` from the deps array.
-  // The pre-fix code captured `zaudioState` for a `prev ?? zaudioState`
-  // fallback, but the persist hook always invokes the updater with the
-  // latest slice value (`prev` is always defined when the slice has been
-  // initialised). The fallback was dead code AND it forced a fresh
-  // callback identity on every state change, defeating the React.memo
-  // wrapping further down the tree.
-  const handleZaudioPaletteChange = useCallback(
+  // The deps array intentionally omits `secondaryState` — the persist hook
+  // always invokes the updater with the latest slice value (`prev` is
+  // always defined when the slice has been initialised). Including
+  // `secondaryState` would force a fresh callback identity on every state
+  // change, defeating the React.memo wrapping further down the tree.
+  const handleSecondaryPaletteChange = useCallback(
     (index: number, hex: string) => {
-      persistZaudio((prev) => {
+      persistSecondary((prev) => {
         if (!prev) return prev;
         return {
           ...prev,
@@ -531,12 +530,12 @@ export default function ColorTab({
         };
       });
     },
-    [persistZaudio],
+    [persistSecondary],
   );
 
-  const handleZaudioSemanticChange = useCallback(
+  const handleSecondarySemanticChange = useCallback(
     (key: string, val: number | 'bg' | 'fg') => {
-      persistZaudio((prev) => {
+      persistSecondary((prev) => {
         if (!prev) return prev;
         return {
           ...prev,
@@ -544,12 +543,12 @@ export default function ColorTab({
         };
       });
     },
-    [persistZaudio],
+    [persistSecondary],
   );
 
   // Accepts `key: string` (broadened from the literal union) so the same
   // handler can be passed directly to memoised <PaletteSelector> rows whose
-  // (idKey, val) signature is also string-typed (PR #1440 review item Q3).
+  // (idKey, val) signature is also string-typed.
   // The runtime guard pins the actual write to the known base-role keys
   // ColorTweakState declares.
   const handleBaseIndexChange = useCallback(
@@ -633,7 +632,7 @@ export default function ColorTab({
           {state.palette.map((color, i) => (
             // ColorSwatch passes `i` back via its (index, hex) onChange so we
             // hand `handlePaletteChange` directly — no inline arrow, memo
-            // stays effective (PR #1440 review item Q3).
+            // stays effective.
             <ColorSwatch
               key={i}
               color={color}
@@ -655,11 +654,11 @@ export default function ColorTab({
           {/*
            * `background (bg)` and `foreground (fg)` are panel-only knobs that
            * pick which palette index seeds the rest of the UI; they do NOT
-           * correspond to real `--zd-*` cssVars in zmod2, so the labels read
-           * as plain English with the short key in parentheses (intentionally
-           * not the full `--zd-…` form). The `cursor`, `sel-bg`, `sel-fg`
-           * upstream rows are dropped here because nothing in zmod2 references
-           * them.
+           * correspond to real `--zd-*` cssVars in this package, so the
+           * labels read as plain English with the short key in parentheses
+           * (intentionally not the full `--zd-…` form). The `cursor`,
+           * `sel-bg`, `sel-fg` upstream rows are dropped here because
+           * nothing in this package references them.
            */}
           <div className="tokenpanel-color-base-grid">
             <PaletteSelector
@@ -711,7 +710,7 @@ export default function ColorTab({
          * config. The `data-testid` markers below give Playwright a
          * stable handle for asserting presence / absence.
          */}
-        {secondaryCluster && zaudioState && (
+        {secondaryCluster && secondaryState && (
           <>
             {/* Section D: SECONDARY — Palette */}
             <div
@@ -721,14 +720,14 @@ export default function ColorTab({
               <h3 className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
                 {secondaryLabel} — Palette
               </h3>
-              <div className="tokenpanel-color-palette-grid--zaudio">
-                {zaudioState.palette.map((color, i) => (
+              <div className="tokenpanel-color-palette-grid--secondary">
+                {secondaryState.palette.map((color, i) => (
                   <ColorSwatch
                     key={i}
                     color={color}
                     index={i}
                     label={resolvePaletteCssVar(secondaryCluster, i)}
-                    onChange={handleZaudioPaletteChange}
+                    onChange={handleSecondaryPaletteChange}
                   />
                 ))}
               </div>
@@ -749,10 +748,10 @@ export default function ColorTab({
                       key={key}
                       label={secondaryCluster.semanticCssNames[key] ?? key}
                       idKey={key}
-                      value={zaudioState.semanticMappings[key] ?? defaultVal}
-                      palette={zaudioState.palette}
+                      value={secondaryState.semanticMappings[key] ?? defaultVal}
+                      palette={secondaryState.palette}
                       paletteCssVar={secondaryPaletteCssVar}
-                      onChange={handleZaudioSemanticChange}
+                      onChange={handleSecondarySemanticChange}
                     />
                   );
                 })}
@@ -762,10 +761,10 @@ export default function ColorTab({
         )}
 
         {/*
-         * shikiTheme select — intentionally hidden in zmod2. The state field,
+         * shikiTheme select — intentionally hidden. The state field,
          * persist slice, and serde schema all still carry `shikiTheme` so
-         * imported zudo-doc envelopes round-trip cleanly, but there's no
-         * Shiki integration in zmod2 and `applyShikiTheme` is a no-op. If /
+         * imported upstream envelopes round-trip cleanly, but there's no
+         * Shiki integration here and `applyShikiTheme` is a no-op. If /
          * when Shiki lands, restore the upstream JSX block and re-import
          * `SHIKI_THEMES` from `../state/tweak-state`.
          */}

--- a/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
@@ -468,7 +468,7 @@ export default function ColorTab({
   // sections below short-circuit to nothing. When configured, this is
   // the host-supplied cluster.
   const secondaryCluster = resolveSecondaryColorCluster();
-  // Sub S5c (#1590) — host-supplied preset list. Read through the panel
+  // Host-supplied preset list. Read through the panel
   // config so a host that calls `configurePanel({ ..., colorPresets })`
   // surfaces its presets in the Scheme... dropdown. The package itself
   // ships zero presets — `colorPresets` defaults to `{}` on

--- a/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
@@ -1,0 +1,775 @@
+/**
+ * Color tab — verbatim port of zudo-doc's
+ * `src/components/design-token-tweak/tabs/color-tab.tsx`, rewired to the
+ * zmod2 design-token-panel module paths:
+ *
+ *   @/config/color-schemes       → ../config/color-schemes
+ *   @/config/color-scheme-utils  → ../config/color-scheme-utils
+ *   @/utils/color-convert        → ../utils/color-convert
+ *   ../state/tweak-state         → ../state/tweak-state (unchanged)
+ *   ../state/persist             → ../state/persist    (unchanged)
+ *
+ * Acceptance criterion (rejection-fix): every Base / Semantic Tokens row is
+ * a `PaletteSelector` — the only way to edit those values is to pick a
+ * palette index (p0–p15) or one of the `bg`/`fg` extras. The 16 Palette
+ * swatches themselves are the only inputs that edit a hex via the HSL
+ * popover. No raw-color inputs (rgb / hex text field / lab / oklch) are
+ * exposed for Base or Semantic rows.
+ *
+ * Shiki integration is not part of zmod2 — the `shikiTheme` field stays on
+ * state + persist + serde (Sub 1 keeps it for envelope round-tripping with
+ * zudo-doc exports), and `applyShikiTheme` is a no-op stub. We hide the
+ * shikiTheme `<select>` JSX block here but leave every state/apply touch
+ * point intact. `SHIKI_THEMES` is therefore no longer imported in this file
+ * (would trip `noUnusedLocals`); re-add it if/when the JSX block lands.
+ *
+ * The zaudio cluster ships alongside ZD now (Sub 7b). The two clusters share
+ * the same `ColorSwatch` + `PaletteSelector` primitives — zaudio renders a
+ * 9-slot palette and 9 semantic dropdowns below the ZD sections, with no
+ * Base subsection (zaudio declares zero base roles per `zaudio-tokens.css`).
+ * Section headings are prefixed `ZD — ` / `ZAUDIO — ` so the two clusters
+ * are visually distinct in the panel.
+ */
+
+import { memo, useState, useEffect, useCallback, useMemo, useRef } from 'preact/compat';
+import type { ColorScheme } from '../config/color-schemes';
+import { hexToHsl, hslToHex } from '../utils/color-convert';
+import {
+  type ColorTweakState,
+  applyShikiTheme,
+  initColorFromSchemeData,
+  resolvePaletteCssVar,
+} from '../state/tweak-state';
+import { getPanelConfig, resolveSecondaryColorCluster } from '../config/panel-config';
+import type { PersistColor, PersistZaudio } from '../state/persist';
+
+// Sub 4 (#1554): the bundled scheme registry now lives on
+// `panelConfig.colorCluster.colorSchemes`, not on a global import. Read it
+// at render time so a host that calls `configurePanel` before mount sees
+// its own schemes in the Scheme… dropdown.
+//
+// Sub S5c (#1590): the optional preset list (zmod's historical Dracula /
+// Solarized / Tokyo Night / ... blob) was relocated out of the package
+// entirely. Hosts hand the panel a `colorPresets` map via `PanelConfig`;
+// the package itself ships zero presets. The Color tab reads the active
+// map at render time below — `presetNames` is no longer a module-level
+// constant computed from a baked-in import.
+
+// --- Shared popover helpers (Color-tab scoped) ---
+
+/** Close popover on outside click, Escape, or ancestor scroll */
+function usePopoverClose(
+  containerRef: React.RefObject<HTMLElement | null>,
+  onClose: () => void,
+  isOpen: boolean,
+) {
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose, containerRef]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleScroll() {
+      onClose();
+    }
+    window.addEventListener('scroll', handleScroll, true);
+    return () => window.removeEventListener('scroll', handleScroll, true);
+  }, [isOpen, onClose]);
+}
+
+/**
+ * Compute fixed popover position with viewport-aware flip.
+ *
+ * Returns only the dynamic positioning bits (`position`, `left`, `top` /
+ * `bottom`, `zIndex`) plus any caller-supplied extras. Visual chrome
+ * (border-radius, box-shadow, border, background) lives on the popover's
+ * className in panel.css — the inline style is reserved for values that
+ * literally cannot be expressed in CSS today (per-anchor-rect coordinates).
+ */
+function getFixedPopoverStyle(
+  anchor: HTMLElement | null,
+  estW: number,
+  estH: number,
+  extraStyle?: React.CSSProperties,
+): React.CSSProperties {
+  if (!anchor) return { position: 'fixed', zIndex: 70, ...extraStyle };
+  const rect = anchor.getBoundingClientRect();
+  const gap = 4;
+  const pad = 8;
+  const below = window.innerHeight - rect.bottom - pad;
+  const above = rect.top - pad;
+  const flipAbove = below < estH && above > below;
+  let left = rect.left;
+  if (left + estW > window.innerWidth - pad) left = window.innerWidth - pad - estW;
+  if (left < pad) left = pad;
+  const style: React.CSSProperties = {
+    position: 'fixed',
+    left,
+    zIndex: 70,
+    ...extraStyle,
+  };
+  if (flipAbove) {
+    style.bottom = window.innerHeight - rect.top + gap;
+  } else {
+    style.top = rect.bottom + gap;
+  }
+  return style;
+}
+
+// --- UI Components ---
+
+function HslPicker({
+  color,
+  onChange,
+  onClose,
+  anchorRef,
+}: {
+  color: string;
+  onChange: (hex: string) => void;
+  onClose: () => void;
+  anchorRef: React.RefObject<HTMLElement | null>;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [hsl, setHsl] = useState(() => hexToHsl(color));
+  const [hexInput, setHexInput] = useState(color);
+
+  useEffect(() => {
+    setHsl(hexToHsl(color));
+    setHexInput(color);
+  }, [color]);
+
+  usePopoverClose(containerRef, onClose, true);
+
+  function updateFromHsl(newHsl: { h: number; s: number; l: number }) {
+    setHsl(newHsl);
+    const hex = hslToHex(newHsl.h, newHsl.s, newHsl.l);
+    setHexInput(hex);
+    onChange(hex);
+  }
+
+  function handleHexChange(value: string) {
+    setHexInput(value);
+    if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+      setHsl(hexToHsl(value));
+      onChange(value);
+    }
+  }
+
+  const sliders = [
+    { label: 'H', value: hsl.h, max: 360, key: 'h' as const },
+    { label: 'S', value: hsl.s, max: 100, key: 's' as const },
+    { label: 'L', value: hsl.l, max: 100, key: 'l' as const },
+  ];
+
+  return (
+    <div
+      ref={containerRef}
+      className="tokenpanel-popover"
+      style={getFixedPopoverStyle(anchorRef.current, 380, 280, { width: 380 })}
+    >
+      <div className="tokenpanel-hsl-header">
+        <div
+          className="tokenpanel-hsl-preview"
+          style={{ backgroundColor: hslToHex(hsl.h, hsl.s, hsl.l) }}
+        />
+        <input
+          type="text"
+          value={hexInput}
+          onChange={(e) => handleHexChange((e.target as HTMLInputElement).value)}
+          className="tokenpanel-hsl-hex-input"
+          spellcheck={false}
+          aria-label="Hex color value"
+        />
+      </div>
+      {sliders.map(({ label, value, max, key }) => (
+        <div key={key} className="tokenpanel-hsl-row">
+          <span className="tokenpanel-hsl-row-label">{label}</span>
+          <input
+            type="range"
+            min={0}
+            max={max}
+            value={value}
+            onChange={(e) =>
+              updateFromHsl({
+                ...hsl,
+                [key]: parseInt((e.target as HTMLInputElement).value, 10),
+              })
+            }
+            className="tokenpanel-hsl-row-slider"
+            aria-label={`${label === 'H' ? 'Hue' : label === 'S' ? 'Saturation' : 'Lightness'}`}
+          />
+          <span className="tokenpanel-hsl-row-value">
+            {value}
+            {key === 'h' ? '' : '%'}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Single palette swatch with HSL popover.
+ *
+ * `onChange` is `(index, hex)` — the swatch passes its own palette `index`
+ * back so the parent can use a single stable handler across every cell,
+ * keeping React.memo effective (PR #1440 review item Q3). The same
+ * component is reused by both the ZD and ZAUDIO palettes because the
+ * `onChange` shape is parameterised on the parent's per-cluster handler.
+ */
+const ColorSwatch = memo(function ColorSwatch({
+  color,
+  onChange,
+  index,
+  label,
+}: {
+  color: string;
+  onChange: (index: number, hex: string) => void;
+  index: number;
+  label: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const handleClose = useCallback(() => setIsOpen(false), []);
+  const handleHexChange = useCallback(
+    (hex: string) => {
+      onChange(index, hex);
+    },
+    [onChange, index],
+  );
+  return (
+    <div className="tokenpanel-color-swatch-wrap">
+      <button
+        ref={buttonRef}
+        type="button"
+        className="tokenpanel-color-swatch-button"
+        style={{ backgroundColor: color }}
+        onClick={() => setIsOpen((prev) => !prev)}
+        title={`${label}: ${color}`}
+        aria-label={`${label}: ${color}`}
+      />
+      {isOpen && (
+        <HslPicker
+          color={color}
+          onChange={handleHexChange}
+          onClose={handleClose}
+          anchorRef={buttonRef}
+        />
+      )}
+      <span className="tokenpanel-color-swatch-label" title={label}>
+        {label}
+      </span>
+    </div>
+  );
+});
+
+/**
+ * Palette index selector — fixed-position dropdown with viewport-aware flip.
+ *
+ * `onChange` is `(idKey, val)` — the selector passes its own `idKey` (the
+ * semantic key, base-role name, etc. that identifies which row this is) back
+ * so the parent can use a single stable handler across every selector,
+ * keeping React.memo effective (PR #1440 review item Q3).
+ */
+const PaletteSelector = memo(function PaletteSelector({
+  label,
+  idKey,
+  value,
+  palette,
+  paletteCssVar,
+  onChange,
+  extraOptions,
+  background,
+  foreground,
+}: {
+  label: string;
+  /** Stable identifier for this row, passed back to `onChange` so the
+   *  parent's handler can dispatch on it. */
+  idKey: string;
+  value: number | 'bg' | 'fg';
+  palette: string[];
+  /**
+   * Maps a palette index to its full CSS custom-property name (e.g.
+   * `--zd-p7`, `--zaudio-pa3`). Used for the popover swatches' `title` /
+   * `aria-label` so assistive tech sees the real variable name, not a
+   * short `p7` key. Defaults to `--zd-p${i}` for backward compatibility.
+   */
+  paletteCssVar?: (i: number) => string;
+  onChange: (idKey: string, val: number | 'bg' | 'fg') => void;
+  extraOptions?: ('bg' | 'fg')[];
+  background?: string;
+  foreground?: string;
+}) {
+  const resolvePaletteCssVar = paletteCssVar ?? ((i: number) => `--zd-p${i}`);
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const handleClose = useCallback(() => setIsOpen(false), []);
+
+  const resolvedColor =
+    value === 'bg'
+      ? (background ?? '#000000')
+      : value === 'fg'
+        ? (foreground ?? '#ffffff')
+        : (palette[value] ?? '#000000');
+
+  const valueLabel = value === 'bg' ? 'bg' : value === 'fg' ? 'fg' : `p${value}`;
+
+  usePopoverClose(containerRef, handleClose, isOpen);
+
+  function select(val: number | 'bg' | 'fg') {
+    onChange(idKey, val);
+    setIsOpen(false);
+  }
+
+  return (
+    <div className="tokenpanel-palette-selector" ref={containerRef}>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="tokenpanel-palette-trigger"
+        aria-label={`${label}: ${valueLabel}`}
+        title={`${label}: ${valueLabel}`}
+        aria-expanded={isOpen}
+      >
+        <span className="tokenpanel-palette-trigger-label" title={label}>
+          {label}
+        </span>
+        <div
+          className="tokenpanel-palette-trigger-color"
+          style={{ backgroundColor: resolvedColor }}
+        />
+        <span className="tokenpanel-palette-trigger-value">{valueLabel}</span>
+        <svg
+          className="tokenpanel-palette-trigger-icon"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          role="listbox"
+          aria-label={`${label} color options`}
+          className="tokenpanel-palette-options"
+          style={getFixedPopoverStyle(buttonRef.current, 440, extraOptions ? 160 : 120)}
+        >
+          {/* Extra options (bg/fg) */}
+          {extraOptions && extraOptions.length > 0 && (
+            <div className="tokenpanel-palette-options-extras">
+              {extraOptions.map((opt) => {
+                const optColor =
+                  opt === 'bg' ? (background ?? '#000000') : (foreground ?? '#ffffff');
+                const isSelected = value === opt;
+                return (
+                  <button
+                    key={opt}
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    onClick={() => select(opt)}
+                    className={
+                      isSelected
+                        ? 'tokenpanel-palette-extra-option is-selected'
+                        : 'tokenpanel-palette-extra-option'
+                    }
+                  >
+                    <div
+                      className="tokenpanel-palette-extra-color"
+                      style={{ backgroundColor: optColor }}
+                    />
+                    <span className="tokenpanel-palette-extra-label">{opt}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          {/* Palette grid */}
+          <div className="tokenpanel-palette-options-grid">
+            {palette.map((color, i) => {
+              const isSelected = value === i;
+              const cssVar = resolvePaletteCssVar(i);
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  aria-label={`${cssVar}: ${color}`}
+                  onClick={() => select(i)}
+                  title={`${cssVar}: ${color}`}
+                  className={
+                    isSelected
+                      ? 'tokenpanel-palette-option-button is-selected'
+                      : 'tokenpanel-palette-option-button'
+                  }
+                  style={{ backgroundColor: color }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+// --- Color tab body ---
+
+interface ColorTabProps {
+  state: ColorTweakState;
+  persistColor: PersistColor;
+  /**
+   * Secondary cluster state, or `null` when the host opted out of the
+   * secondary cluster. The render path below short-circuits when
+   * `secondaryCluster` resolves to `null`, so the slice is only touched
+   * inside that conditional block.
+   */
+  zaudioState: ColorTweakState | null;
+  persistZaudio: PersistZaudio;
+}
+
+export default function ColorTab({
+  state,
+  persistColor,
+  zaudioState,
+  persistZaudio,
+}: ColorTabProps) {
+  // Read the active cluster + scheme registry through panelConfig so a host
+  // that calls `configurePanel` with its own colorCluster sees its data
+  // drive both the Scheme… dropdown (bundled schemes) and the palette CSS
+  // var labels (resolvePaletteCssVar).
+  const cluster = getPanelConfig().colorCluster;
+  // Secondary cluster is host-driven. When the host opted out (null) or
+  // omitted the field, `secondaryCluster` is null and the secondary
+  // sections below short-circuit to nothing. When configured, this is
+  // the host-supplied cluster.
+  const secondaryCluster = resolveSecondaryColorCluster();
+  // Sub S5c (#1590) — host-supplied preset list. Read through the panel
+  // config so a host that calls `configurePanel({ ..., colorPresets })`
+  // surfaces its presets in the Scheme... dropdown. The package itself
+  // ships zero presets — `colorPresets` defaults to `{}` on
+  // `DEFAULT_PANEL_CONFIG` so a host that omits the field sees only
+  // `cluster.colorSchemes` (the bundled, cluster-local scheme registry).
+  const hostPresets = getPanelConfig().colorPresets ?? {};
+  // Cluster-bundled schemes win on key collision: they are the cluster
+  // owner's documented defaults (e.g. "Default Light" / "Default Dark"),
+  // and the host preset list is the broader experimentation pool.
+  const allPresets = useMemo<Record<string, ColorScheme>>(
+    () => ({ ...hostPresets, ...cluster.colorSchemes }),
+    [hostPresets, cluster.colorSchemes],
+  );
+  const bundledNames = useMemo(() => Object.keys(cluster.colorSchemes), [cluster.colorSchemes]);
+  const presetNames = useMemo(() => Object.keys(hostPresets).sort(), [hostPresets]);
+
+  // Section headings derive from `cluster.label` (or
+  // `cluster.id.toUpperCase()` as a fallback) so a host-supplied cluster
+  // gets its sections labelled with whatever the host configured.
+  const primaryLabel = cluster.label ?? cluster.id.toUpperCase();
+  const secondaryLabel = secondaryCluster?.label ?? secondaryCluster?.id.toUpperCase() ?? '';
+
+  // Stable per-cluster `paletteCssVar` callbacks — passed into memoised
+  // ColorSwatch / PaletteSelector so prop equality holds across renders
+  // (PR #1440 review item Q3).
+  const clusterPaletteCssVar = useCallback(
+    (i: number) => resolvePaletteCssVar(cluster, i),
+    [cluster],
+  );
+  // Returns `null` (instead of a no-op fn) when the host opted out so we
+  // can short-circuit the secondary section render below without a stray
+  // resolver hanging around the closure list.
+  const secondaryPaletteCssVar = useCallback(
+    (i: number) => (secondaryCluster ? resolvePaletteCssVar(secondaryCluster, i) : ''),
+    [secondaryCluster],
+  );
+
+  const handlePaletteChange = useCallback(
+    (index: number, hex: string) => {
+      persistColor((prev) => ({
+        ...prev,
+        palette: prev.palette.map((c, i) => (i === index ? hex : c)),
+      }));
+    },
+    [persistColor],
+  );
+
+  // PR #1440 review item M-15 — drop `zaudioState` from the deps array.
+  // The pre-fix code captured `zaudioState` for a `prev ?? zaudioState`
+  // fallback, but the persist hook always invokes the updater with the
+  // latest slice value (`prev` is always defined when the slice has been
+  // initialised). The fallback was dead code AND it forced a fresh
+  // callback identity on every state change, defeating the React.memo
+  // wrapping further down the tree.
+  const handleZaudioPaletteChange = useCallback(
+    (index: number, hex: string) => {
+      persistZaudio((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          palette: prev.palette.map((c, i) => (i === index ? hex : c)),
+        };
+      });
+    },
+    [persistZaudio],
+  );
+
+  const handleZaudioSemanticChange = useCallback(
+    (key: string, val: number | 'bg' | 'fg') => {
+      persistZaudio((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          semanticMappings: { ...prev.semanticMappings, [key]: val },
+        };
+      });
+    },
+    [persistZaudio],
+  );
+
+  // Accepts `key: string` (broadened from the literal union) so the same
+  // handler can be passed directly to memoised <PaletteSelector> rows whose
+  // (idKey, val) signature is also string-typed (PR #1440 review item Q3).
+  // The runtime guard pins the actual write to the known base-role keys
+  // ColorTweakState declares.
+  const handleBaseIndexChange = useCallback(
+    (key: string, val: number | 'bg' | 'fg') => {
+      if (typeof val !== 'number') return;
+      if (
+        key !== 'background' &&
+        key !== 'foreground' &&
+        key !== 'cursor' &&
+        key !== 'selectionBg' &&
+        key !== 'selectionFg'
+      ) {
+        return;
+      }
+      persistColor((prev) => ({ ...prev, [key]: val }));
+    },
+    [persistColor],
+  );
+
+  const handleSemanticChange = useCallback(
+    (key: string, val: number | 'bg' | 'fg') => {
+      persistColor((prev) => ({
+        ...prev,
+        semanticMappings: { ...prev.semanticMappings, [key]: val },
+      }));
+    },
+    [persistColor],
+  );
+
+  const handleLoadPreset = useCallback(
+    (name: string) => {
+      const scheme = allPresets[name];
+      if (!scheme) return;
+      const newState = initColorFromSchemeData(scheme);
+      persistColor(() => newState);
+      applyShikiTheme(newState.shikiTheme);
+    },
+    [persistColor],
+  );
+
+  return (
+    <div className="tokenpanel-tab-content">
+      {/* Preset loader — tab-scoped so the outer header row stays general */}
+      <div className="tokenpanel-tab-actions">
+        <select
+          onChange={(e) => {
+            const target = e.target as HTMLSelectElement;
+            const name = target.value;
+            if (name) {
+              handleLoadPreset(name);
+              target.value = '';
+            }
+          }}
+          className="tokenpanel-color-preset-select"
+          aria-label="Load color scheme preset"
+          defaultValue=""
+        >
+          <option value="" disabled>
+            Scheme...
+          </option>
+          {bundledNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+          <hr />
+          {presetNames.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Section A: Raw Palette */}
+      <div className="tokenpanel-tab-section">
+        <h3 className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+          {primaryLabel} — Palette
+        </h3>
+        <div className="tokenpanel-color-palette-grid">
+          {state.palette.map((color, i) => (
+            // ColorSwatch passes `i` back via its (index, hex) onChange so we
+            // hand `handlePaletteChange` directly — no inline arrow, memo
+            // stays effective (PR #1440 review item Q3).
+            <ColorSwatch
+              key={i}
+              color={color}
+              index={i}
+              label={resolvePaletteCssVar(cluster, i)}
+              onChange={handlePaletteChange}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Base + Semantic wrapper */}
+      <div className="tokenpanel-tab-content">
+        {/* Section B: Base Theme */}
+        <div className="tokenpanel-tab-section">
+          <h3 className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+            {primaryLabel} — Base
+          </h3>
+          {/*
+           * `background (bg)` and `foreground (fg)` are panel-only knobs that
+           * pick which palette index seeds the rest of the UI; they do NOT
+           * correspond to real `--zd-*` cssVars in zmod2, so the labels read
+           * as plain English with the short key in parentheses (intentionally
+           * not the full `--zd-…` form). The `cursor`, `sel-bg`, `sel-fg`
+           * upstream rows are dropped here because nothing in zmod2 references
+           * them.
+           */}
+          <div className="tokenpanel-color-base-grid">
+            <PaletteSelector
+              label="background (bg)"
+              idKey="background"
+              value={state.background}
+              palette={state.palette}
+              paletteCssVar={clusterPaletteCssVar}
+              onChange={handleBaseIndexChange}
+            />
+            <PaletteSelector
+              label="foreground (fg)"
+              idKey="foreground"
+              value={state.foreground}
+              palette={state.palette}
+              paletteCssVar={clusterPaletteCssVar}
+              onChange={handleBaseIndexChange}
+            />
+          </div>
+        </div>
+
+        {/* Section C: Semantic Token Mappings */}
+        <div className="tokenpanel-tab-section">
+          <h3 className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+            {primaryLabel} — Semantic Tokens
+          </h3>
+          <div className="tokenpanel-color-base-grid">
+            {Object.entries(cluster.semanticDefaults).map(([key, defaultVal]) => {
+              return (
+                <PaletteSelector
+                  key={key}
+                  label={cluster.semanticCssNames[key] ?? key}
+                  idKey={key}
+                  value={state.semanticMappings[key] ?? defaultVal}
+                  palette={state.palette}
+                  paletteCssVar={clusterPaletteCssVar}
+                  onChange={handleSemanticChange}
+                  background={state.palette[state.background]}
+                  foreground={state.palette[state.foreground]}
+                />
+              );
+            })}
+          </div>
+        </div>
+
+        {/*
+         * Secondary-cluster sections render ONLY when the host has opted
+         * in by passing a `secondaryColorCluster` object on the panel
+         * config. The `data-testid` markers below give Playwright a
+         * stable handle for asserting presence / absence.
+         */}
+        {secondaryCluster && zaudioState && (
+          <>
+            {/* Section D: SECONDARY — Palette */}
+            <div
+              className="tokenpanel-tab-section"
+              data-testid="tokenpanel-secondary-palette-section"
+            >
+              <h3 className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+                {secondaryLabel} — Palette
+              </h3>
+              <div className="tokenpanel-color-palette-grid--zaudio">
+                {zaudioState.palette.map((color, i) => (
+                  <ColorSwatch
+                    key={i}
+                    color={color}
+                    index={i}
+                    label={resolvePaletteCssVar(secondaryCluster, i)}
+                    onChange={handleZaudioPaletteChange}
+                  />
+                ))}
+              </div>
+            </div>
+
+            {/* Section E: SECONDARY — Semantic Tokens */}
+            <div
+              className="tokenpanel-tab-section"
+              data-testid="tokenpanel-secondary-semantic-section"
+            >
+              <h3 className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+                {secondaryLabel} — Semantic Tokens
+              </h3>
+              <div className="tokenpanel-color-base-grid">
+                {Object.entries(secondaryCluster.semanticDefaults).map(([key, defaultVal]) => {
+                  return (
+                    <PaletteSelector
+                      key={key}
+                      label={secondaryCluster.semanticCssNames[key] ?? key}
+                      idKey={key}
+                      value={zaudioState.semanticMappings[key] ?? defaultVal}
+                      palette={zaudioState.palette}
+                      paletteCssVar={secondaryPaletteCssVar}
+                      onChange={handleZaudioSemanticChange}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          </>
+        )}
+
+        {/*
+         * shikiTheme select — intentionally hidden in zmod2. The state field,
+         * persist slice, and serde schema all still carry `shikiTheme` so
+         * imported zudo-doc envelopes round-trip cleanly, but there's no
+         * Shiki integration in zmod2 and `applyShikiTheme` is a no-op. If /
+         * when Shiki lands, restore the upstream JSX block and re-import
+         * `SHIKI_THEMES` from `../state/tweak-state`.
+         */}
+      </div>
+    </div>
+  );
+}

--- a/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useMemo } from 'preact/compat';
+import SelectRow from '../controls/select-row';
+import SliderRow from '../controls/slider-row';
+import TextRow from '../controls/text-row';
+import { FONT_GROUP_ORDER, GROUP_TITLES, type TokenDef } from '../tokens/manifest';
+import { getPanelConfig } from '../config/panel-config';
+import type { TokenOverrides } from '../state/tweak-state';
+import type { PersistFont } from '../state/persist';
+
+interface FontTabProps {
+  state: TokenOverrides;
+  persistFont: PersistFont;
+}
+
+/**
+ * Font tab — manifest-driven.
+ *
+ * Top-level sections (in `FONT_GROUP_ORDER`):
+ *   - FONT SIZES        → slider rows (`--text-*`)
+ *   - LINE HEIGHTS      → slider rows (`--leading-*`, unitless)
+ *   - FONT WEIGHTS      → select rows (`--font-weight-*`, 100..900)
+ *   - FONT FAMILIES     → text rows   (`--font-sans`, `--font-mono`)
+ *
+ * Advanced disclosure (`<details>`, collapsed by default) reveals the Tier 1
+ * abstract scale (`--text-scale-*`). The Tier 2 font-size tokens above resolve
+ * from these via `var()` in `global.css`, so edits to the scale cascade
+ * automatically to the primary size rows without any extra wiring here.
+ */
+export default function FontTab({ state, persistFont }: FontTabProps) {
+  const handleChange = useCallback(
+    (id: string, next: string) => {
+      persistFont((prev) => ({ ...prev, [id]: next }));
+    },
+    [persistFont],
+  );
+
+  const handleResetAll = useCallback(() => {
+    persistFont(() => ({}));
+  }, [persistFont]);
+
+  // Read the manifest from runtime config (consumer-supplied per Sub 3).
+  // Note the field is `typography` (not `font`) per PORTABLE-CONTRACT.md §3.3
+  // — that's the persist envelope's slice name. Group ordering and section
+  // titles fall back to the package-bundled defaults when the manifest
+  // doesn't override them (Sub S5a, #1588).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const tokens = useMemo(() => getPanelConfig().tokens, []);
+  const fontTokens = tokens.typography;
+  const fontGroupOrder = tokens.fontGroupOrder ?? FONT_GROUP_ORDER;
+  const groupTitles = tokens.groupTitles ?? GROUP_TITLES;
+
+  // Group tokens once. Primary groups come from `fontGroupOrder`; everything
+  // flagged `advanced` goes into the disclosure section.
+  const { primary, advanced } = useMemo(() => {
+    const primary = new Map<string, TokenDef[]>();
+    const advanced: TokenDef[] = [];
+    for (const t of fontTokens) {
+      if (t.advanced) {
+        advanced.push(t);
+        continue;
+      }
+      const arr = primary.get(t.group) ?? [];
+      arr.push(t);
+      primary.set(t.group, arr);
+    }
+    return { primary, advanced };
+  }, [fontTokens]);
+
+  return (
+    <div className="tokenpanel-tab-content">
+      {/* Tab-level actions */}
+      <div className="tokenpanel-tab-actions">
+        <button type="button" onClick={handleResetAll} className="tokenpanel-action-link">
+          Reset Font
+        </button>
+      </div>
+
+      {fontGroupOrder.map((group) => {
+        const sectionTokens = primary.get(group);
+        if (!sectionTokens || sectionTokens.length === 0) return null;
+        return (
+          <section key={group} className="tokenpanel-tab-section">
+            <h3 className="tokenpanel-tab-section-heading">{groupTitles[group] ?? group}</h3>
+            <div className="tokenpanel-tab-grid">
+              {sectionTokens.map((token) => (
+                // Pass `handleChange` directly — TokenRow forwards it to the
+                // memoised row primitives whose (id, next) signature lets us
+                // share one stable handler across all rows (PR #1440 review
+                // item Q3).
+                <TokenRow
+                  key={token.id}
+                  token={token}
+                  value={state[token.id] ?? token.default}
+                  onChange={handleChange}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+
+      {advanced.length > 0 && (
+        <details className="tokenpanel-tab-advanced">
+          <summary className="tokenpanel-tab-advanced-summary">
+            {groupTitles['font-scale'] ?? 'font-scale'}
+          </summary>
+          <div className="tokenpanel-tab-advanced-grid">
+            {advanced.map((token) => (
+              <TokenRow
+                key={token.id}
+                token={token}
+                value={state[token.id] ?? token.default}
+                onChange={handleChange}
+              />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Dispatch to the right control based on `token.control`. Defaults to slider.
+ *
+ * `onChange` carries the `(id, next)` signature so the parent can use a
+ * single stable handler across every row, keeping React.memo on each row
+ * primitive effective (PR #1440 review item Q3).
+ */
+function TokenRow({
+  token,
+  value,
+  onChange,
+}: {
+  token: TokenDef;
+  value: string;
+  onChange: (id: string, next: string) => void;
+}) {
+  switch (token.control) {
+    case 'select':
+      return <SelectRow token={token} value={value} onChange={onChange} />;
+    case 'text':
+      return <TextRow token={token} value={value} onChange={onChange} />;
+    case 'slider':
+    default:
+      return <SliderRow token={token} value={value} onChange={onChange} />;
+  }
+}

--- a/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
@@ -38,11 +38,11 @@ export default function FontTab({ state, persistFont }: FontTabProps) {
     persistFont(() => ({}));
   }, [persistFont]);
 
-  // Read the manifest from runtime config (consumer-supplied per Sub 3).
+  // Read the manifest from runtime config (consumer-supplied).
   // Note the field is `typography` (not `font`) per PORTABLE-CONTRACT.md §3.3
   // — that's the persist envelope's slice name. Group ordering and section
   // titles fall back to the package-bundled defaults when the manifest
-  // doesn't override them (Sub S5a, #1588).
+  // doesn't override them.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const tokens = useMemo(() => getPanelConfig().tokens, []);
   const fontTokens = tokens.typography;
@@ -85,8 +85,7 @@ export default function FontTab({ state, persistFont }: FontTabProps) {
               {sectionTokens.map((token) => (
                 // Pass `handleChange` directly — TokenRow forwards it to the
                 // memoised row primitives whose (id, next) signature lets us
-                // share one stable handler across all rows (PR #1440 review
-                // item Q3).
+                // share one stable handler across all rows.
                 <TokenRow
                   key={token.id}
                   token={token}
@@ -125,7 +124,7 @@ export default function FontTab({ state, persistFont }: FontTabProps) {
  *
  * `onChange` carries the `(id, next)` signature so the parent can use a
  * single stable handler across every row, keeping React.memo on each row
- * primitive effective (PR #1440 review item Q3).
+ * primitive effective.
  */
 function TokenRow({
   token,

--- a/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
@@ -31,9 +31,9 @@ export default function SizeTab({ state, persistSize }: SizeTabProps) {
     persistSize(() => ({}));
   }, [persistSize]);
 
-  // Read the manifest from runtime config (consumer-supplied per Sub 3).
+  // Read the manifest from runtime config (consumer-supplied).
   // Group ordering and section titles fall back to the package-bundled
-  // defaults when the manifest doesn't override them (Sub S5a, #1588).
+  // defaults when the manifest doesn't override them.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const tokens = useMemo(() => getPanelConfig().tokens, []);
   const sizeTokens = tokens.size;
@@ -71,7 +71,7 @@ export default function SizeTab({ state, persistSize }: SizeTabProps) {
                 // Pass `handleChange` directly — every row primitive's
                 // (id, next) signature lets us share one stable handler
                 // across all rows, keeping React.memo on each row effective
-                // (PR #1440 review item Q3).
+                //.
                 if (token.pill) {
                   return (
                     <PillSliderRow

--- a/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useMemo } from 'preact/compat';
+import PillSliderRow from '../controls/pill-slider-row';
+import SliderRow from '../controls/slider-row';
+import { GROUP_TITLES, SIZE_GROUP_ORDER, type TokenDef } from '../tokens/manifest';
+import { getPanelConfig } from '../config/panel-config';
+import type { TokenOverrides } from '../state/tweak-state';
+import type { PersistSize } from '../state/persist';
+
+interface SizeTabProps {
+  state: TokenOverrides;
+  persistSize: PersistSize;
+}
+
+/**
+ * Size tab — manifest-driven like Spacing, with one pill-toggle special case
+ * (`--radius-full`).
+ *
+ * Groups: BORDER RADIUS, TRANSITIONS. If the manifest grows a new group, add
+ * it to `SIZE_GROUP_ORDER` in `tokens/manifest.ts` — no code change needed
+ * here.
+ */
+export default function SizeTab({ state, persistSize }: SizeTabProps) {
+  const handleChange = useCallback(
+    (id: string, next: string) => {
+      persistSize((prev) => ({ ...prev, [id]: next }));
+    },
+    [persistSize],
+  );
+
+  const handleResetAll = useCallback(() => {
+    persistSize(() => ({}));
+  }, [persistSize]);
+
+  // Read the manifest from runtime config (consumer-supplied per Sub 3).
+  // Group ordering and section titles fall back to the package-bundled
+  // defaults when the manifest doesn't override them (Sub S5a, #1588).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const tokens = useMemo(() => getPanelConfig().tokens, []);
+  const sizeTokens = tokens.size;
+  const sizeGroupOrder = tokens.sizeGroupOrder ?? SIZE_GROUP_ORDER;
+  const groupTitles = tokens.groupTitles ?? GROUP_TITLES;
+
+  // Group tokens once (any group id not present simply yields undefined and
+  // the render below skips it).
+  const grouped = useMemo(() => {
+    const out: Record<string, TokenDef[]> = {};
+    for (const t of sizeTokens) {
+      (out[t.group] ??= []).push(t);
+    }
+    return out;
+  }, [sizeTokens]);
+
+  return (
+    <div className="tokenpanel-tab-content">
+      {/* Tab-level actions */}
+      <div className="tokenpanel-tab-actions">
+        <button type="button" onClick={handleResetAll} className="tokenpanel-action-link">
+          Reset Size
+        </button>
+      </div>
+
+      {sizeGroupOrder.map((group) => {
+        const sectionTokens = grouped[group];
+        if (!sectionTokens || sectionTokens.length === 0) return null;
+        return (
+          <section key={group} className="tokenpanel-tab-section">
+            <h3 className="tokenpanel-tab-section-heading">{groupTitles[group] ?? group}</h3>
+            <div className="tokenpanel-tab-grid">
+              {sectionTokens.map((token) => {
+                const value = state[token.id] ?? token.default;
+                // Pass `handleChange` directly — every row primitive's
+                // (id, next) signature lets us share one stable handler
+                // across all rows, keeping React.memo on each row effective
+                // (PR #1440 review item Q3).
+                if (token.pill) {
+                  return (
+                    <PillSliderRow
+                      key={token.id}
+                      token={token}
+                      value={value}
+                      onChange={handleChange}
+                    />
+                  );
+                }
+                return (
+                  <SliderRow key={token.id} token={token} value={value} onChange={handleChange} />
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
@@ -13,7 +13,7 @@ interface SpacingTabProps {
 /**
  * Spacing tab — fully manifest-driven.
  *
- * Reads `panelConfig.tokens.spacing` (Sub 3 of #1550) at mount, groups by
+ * Reads `panelConfig.tokens.spacing` at mount, groups by
  * `group` field, renders one `SliderRow` per token, and wires each row
  * through `persistSpacing` so CSS vars + storage stay in sync.
  *
@@ -33,9 +33,9 @@ export default function SpacingTab({ state, persistSpacing }: SpacingTabProps) {
     persistSpacing(() => ({}));
   }, [persistSpacing]);
 
-  // Read the manifest from runtime config (consumer-supplied per Sub 3).
+  // Read the manifest from runtime config (consumer-supplied).
   // Group ordering and section titles fall back to the package-bundled
-  // defaults when the manifest doesn't override them (Sub S5a, #1588).
+  // defaults when the manifest doesn't override them.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const tokens = useMemo(() => getPanelConfig().tokens, []);
   const spacingTokens = tokens.spacing;
@@ -73,8 +73,7 @@ export default function SpacingTab({ state, persistSpacing }: SpacingTabProps) {
                 const value = state[token.id] ?? token.default;
                 // Pass `handleChange` directly — the row supplies its own
                 // `token.id` back via the (id, next) signature, so React.memo
-                // on SliderRow stays effective across re-renders (PR #1440
-                // review item Q3).
+                // on SliderRow stays effective across re-renders.
                 return (
                   <SliderRow key={token.id} token={token} value={value} onChange={handleChange} />
                 );

--- a/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useMemo } from 'preact/compat';
+import SliderRow from '../controls/slider-row';
+import { GROUP_ORDER, GROUP_TITLES, type TokenDef } from '../tokens/manifest';
+import { getPanelConfig } from '../config/panel-config';
+import type { TokenOverrides } from '../state/tweak-state';
+import type { PersistSpacing } from '../state/persist';
+
+interface SpacingTabProps {
+  state: TokenOverrides;
+  persistSpacing: PersistSpacing;
+}
+
+/**
+ * Spacing tab — fully manifest-driven.
+ *
+ * Reads `panelConfig.tokens.spacing` (Sub 3 of #1550) at mount, groups by
+ * `group` field, renders one `SliderRow` per token, and wires each row
+ * through `persistSpacing` so CSS vars + storage stay in sync.
+ *
+ * The token list is captured once with `useMemo([])` because `configurePanel`
+ * is one-shot per page lifecycle — a remount-grade re-config is the only
+ * legal way the manifest can change, and that resets this hook anyway.
+ */
+export default function SpacingTab({ state, persistSpacing }: SpacingTabProps) {
+  const handleChange = useCallback(
+    (id: string, next: string) => {
+      persistSpacing((prev) => ({ ...prev, [id]: next }));
+    },
+    [persistSpacing],
+  );
+
+  const handleResetAll = useCallback(() => {
+    persistSpacing(() => ({}));
+  }, [persistSpacing]);
+
+  // Read the manifest from runtime config (consumer-supplied per Sub 3).
+  // Group ordering and section titles fall back to the package-bundled
+  // defaults when the manifest doesn't override them (Sub S5a, #1588).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const tokens = useMemo(() => getPanelConfig().tokens, []);
+  const spacingTokens = tokens.spacing;
+  const groupOrder = tokens.spacingGroupOrder ?? GROUP_ORDER;
+  const groupTitles = tokens.groupTitles ?? GROUP_TITLES;
+
+  // Group tokens once so the render loop stays cheap and the display order
+  // stays stable across re-renders. Keyed by plain string so consumer-coined
+  // group ids work without changing the type.
+  const grouped = useMemo(() => {
+    const out: Record<string, TokenDef[]> = {};
+    for (const t of spacingTokens) {
+      (out[t.group] ??= []).push(t);
+    }
+    return out;
+  }, [spacingTokens]);
+
+  return (
+    <div className="tokenpanel-tab-content">
+      {/* Tab-level actions */}
+      <div className="tokenpanel-tab-actions">
+        <button type="button" onClick={handleResetAll} className="tokenpanel-action-link">
+          Reset Spacing
+        </button>
+      </div>
+
+      {groupOrder.map((group) => {
+        const sectionTokens = grouped[group];
+        if (!sectionTokens || sectionTokens.length === 0) return null;
+        return (
+          <section key={group} className="tokenpanel-tab-section">
+            <h3 className="tokenpanel-tab-section-heading">{groupTitles[group] ?? group}</h3>
+            <div className="tokenpanel-tab-grid">
+              {sectionTokens.map((token) => {
+                const value = state[token.id] ?? token.default;
+                // Pass `handleChange` directly — the row supplies its own
+                // `token.id` back via the (id, next) signature, so React.memo
+                // on SliderRow stays effective across re-renders (PR #1440
+                // review item Q3).
+                return (
+                  <SliderRow key={token.id} token={token} value={value} onChange={handleChange} />
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/zudo-design-token-panel/src/tokens/manifest.ts
+++ b/packages/zudo-design-token-panel/src/tokens/manifest.ts
@@ -1,11 +1,11 @@
 /**
  * Token manifest — type definitions, helpers, and group ordering.
  *
- * After Sub 3 of the portable epic (#1553), this module ships ZERO baked-in
- * manifest data. The four token arrays that used to live here
- * (`SPACING_TOKENS`, `FONT_TOKENS`, `SIZE_TOKENS`, `COLOR_TOKENS`) moved to
- * `./zmod-default-manifest.ts` and are wired into `panelConfig.tokens` via the
- * default-fallback config in `../config/panel-config.ts`.
+ * This module ships ZERO baked-in manifest data. The four token arrays that
+ * used to live here (`SPACING_TOKENS`, `FONT_TOKENS`, `SIZE_TOKENS`,
+ * `COLOR_TOKENS`) live in the package-default manifest and are wired into
+ * `panelConfig.tokens` via the default-fallback config in
+ * `../config/panel-config.ts`.
  *
  * Consumers supply their own manifest by passing a `TokenManifest` to
  * `configurePanel({...})` (see PORTABLE-CONTRACT.md §3). The package consumes
@@ -23,15 +23,15 @@
 /**
  * Manifest-group identifier.
  *
- * Sub S5a (#1588) opened this from the previously-closed union of zmod's
- * group ids (`'hsp' | 'vsp' | …`) to plain `string` so non-zmod consumers can
- * coin their own group ids without forking the package types. Tab components
- * key section headers off whatever string each `TokenDef.group` carries; the
- * display order and human title for an unknown group come from
- * `TokenManifest.spacingGroupOrder` / `fontGroupOrder` / `sizeGroupOrder` /
- * `groupTitles` (the consumer-supplied overrides), falling back to the
- * package-bundled `GROUP_ORDER` / `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` /
- * `GROUP_TITLES` defaults so existing zmod consumers keep working unchanged.
+ * Open `string` (rather than a closed union of historical group ids) so
+ * consumers can coin their own group ids without forking the package
+ * types. Tab components key section headers off whatever string each
+ * `TokenDef.group` carries; the display order and human title for an
+ * unknown group come from `TokenManifest.spacingGroupOrder` /
+ * `fontGroupOrder` / `sizeGroupOrder` / `groupTitles` (the
+ * consumer-supplied overrides), falling back to the package-bundled
+ * `GROUP_ORDER` / `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` / `GROUP_TITLES`
+ * defaults so existing default-shaped manifests keep working unchanged.
  */
 export type TokenGroup = string;
 
@@ -101,17 +101,18 @@ export interface TokenDef {
  *    project's source array MAY still use the historical `FONT_TOKENS` name
  *    — only the field on `TokenManifest` is what the contract pins.)
  *  - `size` → size tab rows
- *  - `color` → color-tab per-token rows (zmod ships an empty array because
- *    color is driven by the cluster; cluster-less hosts populate this).
+ *  - `color` → color-tab per-token rows (this package's default manifest
+ *    ships an empty array because color is driven by the cluster;
+ *    cluster-less hosts populate this).
  *
- * Optional ordering / titles fields (added in Sub S5a, #1588): consumers may
- * supply their own per-tab group ordering and section-heading text. When
- * absent, the spacing / font / size tabs fall back to the package-bundled
- * `GROUP_ORDER` / `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` / `GROUP_TITLES`
- * defaults so existing zmod-shaped manifests keep rendering exactly as
- * before. Non-zmod consumers that coin their own group ids MUST populate at
- * least the tab they care about and SHOULD populate `groupTitles` so the
- * section headers carry human-readable labels.
+ * Optional ordering / titles fields: consumers may supply their own per-tab
+ * group ordering and section-heading text. When absent, the spacing /
+ * font / size tabs fall back to the package-bundled `GROUP_ORDER` /
+ * `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` / `GROUP_TITLES` defaults so
+ * existing default-shaped manifests keep rendering exactly as before.
+ * Consumers that coin their own group ids MUST populate at least the tab
+ * they care about and SHOULD populate `groupTitles` so the section
+ * headers carry human-readable labels.
  */
 export interface TokenManifest {
   spacing: readonly TokenDef[];

--- a/packages/zudo-design-token-panel/src/tokens/manifest.ts
+++ b/packages/zudo-design-token-panel/src/tokens/manifest.ts
@@ -1,0 +1,198 @@
+/**
+ * Token manifest — type definitions, helpers, and group ordering.
+ *
+ * After Sub 3 of the portable epic (#1553), this module ships ZERO baked-in
+ * manifest data. The four token arrays that used to live here
+ * (`SPACING_TOKENS`, `FONT_TOKENS`, `SIZE_TOKENS`, `COLOR_TOKENS`) moved to
+ * `./zmod-default-manifest.ts` and are wired into `panelConfig.tokens` via the
+ * default-fallback config in `../config/panel-config.ts`.
+ *
+ * Consumers supply their own manifest by passing a `TokenManifest` to
+ * `configurePanel({...})` (see PORTABLE-CONTRACT.md §3). The package consumes
+ * whatever the host hands in; tab components, `applyTokenOverrides`, and
+ * `serialize`/`deserialize` all read from `getPanelConfig().tokens` at use
+ * time so a host that calls `configurePanel` before mount sees its own data
+ * everywhere.
+ *
+ * What stays here:
+ *  - Public types: `TokenDef`, `TokenGroup`, `TokenControl`, `TokenManifest`.
+ *  - Helpers: `parseNumericValue`, `formatValue`, `buildTokenIndex`.
+ *  - Group ordering / titles consumed by the spacing / font / size tabs.
+ */
+
+/**
+ * Manifest-group identifier.
+ *
+ * Sub S5a (#1588) opened this from the previously-closed union of zmod's
+ * group ids (`'hsp' | 'vsp' | …`) to plain `string` so non-zmod consumers can
+ * coin their own group ids without forking the package types. Tab components
+ * key section headers off whatever string each `TokenDef.group` carries; the
+ * display order and human title for an unknown group come from
+ * `TokenManifest.spacingGroupOrder` / `fontGroupOrder` / `sizeGroupOrder` /
+ * `groupTitles` (the consumer-supplied overrides), falling back to the
+ * package-bundled `GROUP_ORDER` / `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` /
+ * `GROUP_TITLES` defaults so existing zmod consumers keep working unchanged.
+ */
+export type TokenGroup = string;
+
+/**
+ * Control kind for a token row.
+ *
+ * - `"slider"` — default; numeric range input paired with a number field.
+ * - `"select"` — native `<select>` with `options` (e.g. font-weight 100..900).
+ * - `"text"`   — free-form text input (e.g. font-family CSS string).
+ *
+ * `min`/`max`/`step`/`unit` are only meaningful for the slider control. They
+ * stay on the interface with zero defaults for non-slider rows so the manifest
+ * shape stays uniform.
+ */
+export type TokenControl = 'slider' | 'select' | 'text';
+
+export interface TokenDef {
+  /** Stable id used as the Record key in persisted state (e.g. `hsp-2xs`). */
+  id: string;
+  /** CSS custom property name written to `:root` (e.g. `--zd-spacing-hgap-2xs`). */
+  cssVar: string;
+  /** Display label shown in the panel row. */
+  label: string;
+  /** Manifest group — tab components use this for section headers. */
+  group: TokenGroup;
+  /** Default value as a CSS length string (e.g. `0.125rem`). */
+  default: string;
+  /** Slider min (numeric, in `unit`). Unused when `readonly`. */
+  min: number;
+  /** Slider max (numeric, in `unit`). Unused when `readonly`. */
+  max: number;
+  /** Slider step (numeric, in `unit`). Unused when `readonly`. */
+  step: number;
+  /** Unit suffix (e.g. `rem`, `px`). Read-only rows may use an empty string. */
+  unit: string;
+  /** Read-only tokens are displayed but not editable (e.g. `clamp()` expressions). */
+  readonly?: true;
+  /** Which control renders this token. Defaults to `"slider"` when absent. */
+  control?: TokenControl;
+  /** Select options — only used when `control === "select"`. */
+  options?: readonly string[];
+  /** Hide behind the per-tab Advanced `<details>` disclosure (font tab). */
+  advanced?: true;
+  /**
+   * Opt-in "Pill" toggle. When present the control shows a checkbox that flips
+   * between `value` (checked — e.g. `9999px` for full-radius pills) and a
+   * slider-editable custom value (unchecked). Currently used for
+   * `--radius-full`, where a slider alone can't meaningfully drive a 9999px
+   * sentinel.
+   */
+  pill?: {
+    /** CSS string applied when the pill checkbox is ON. */
+    value: string;
+    /** CSS string the slider falls back to when the pill is toggled OFF and
+     *  there is no prior custom value yet. */
+    customDefault: string;
+  };
+}
+
+/**
+ * Consumer-supplied token manifest (PORTABLE-CONTRACT.md §3.1).
+ *
+ * Each field is the per-tab token list:
+ *  - `spacing` → spacing tab rows
+ *  - `typography` → font tab rows (NOTE: field name is `typography`, not
+ *    `font`. This follows the persist envelope's slice name. The host
+ *    project's source array MAY still use the historical `FONT_TOKENS` name
+ *    — only the field on `TokenManifest` is what the contract pins.)
+ *  - `size` → size tab rows
+ *  - `color` → color-tab per-token rows (zmod ships an empty array because
+ *    color is driven by the cluster; cluster-less hosts populate this).
+ *
+ * Optional ordering / titles fields (added in Sub S5a, #1588): consumers may
+ * supply their own per-tab group ordering and section-heading text. When
+ * absent, the spacing / font / size tabs fall back to the package-bundled
+ * `GROUP_ORDER` / `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` / `GROUP_TITLES`
+ * defaults so existing zmod-shaped manifests keep rendering exactly as
+ * before. Non-zmod consumers that coin their own group ids MUST populate at
+ * least the tab they care about and SHOULD populate `groupTitles` so the
+ * section headers carry human-readable labels.
+ */
+export interface TokenManifest {
+  spacing: readonly TokenDef[];
+  typography: readonly TokenDef[];
+  size: readonly TokenDef[];
+  color: readonly TokenDef[];
+  /** Optional spacing-tab group order. Defaults to `GROUP_ORDER`. */
+  spacingGroupOrder?: readonly string[];
+  /** Optional font-tab primary group order. Defaults to `FONT_GROUP_ORDER`. */
+  fontGroupOrder?: readonly string[];
+  /** Optional size-tab group order. Defaults to `SIZE_GROUP_ORDER`. */
+  sizeGroupOrder?: readonly string[];
+  /** Optional human-readable section titles keyed by group id. Defaults to `GROUP_TITLES`. */
+  groupTitles?: Readonly<Record<string, string>>;
+}
+
+/** Convenience: build a lookup map keyed by token id. */
+export function buildTokenIndex(
+  ...groups: readonly (readonly TokenDef[])[]
+): Record<string, TokenDef> {
+  const out: Record<string, TokenDef> = {};
+  for (const group of groups) {
+    for (const t of group) {
+      out[t.id] = t;
+    }
+  }
+  return out;
+}
+
+/** Human-readable section titles for grouped rendering. */
+export const GROUP_TITLES: Record<TokenGroup, string> = {
+  hsp: 'HORIZONTAL SPACING (HSP)',
+  vsp: 'VERTICAL SPACING (VSP)',
+  icon: 'ICONS',
+  layout: 'LAYOUT',
+  'font-size': 'FONT SIZES',
+  'line-height': 'LINE HEIGHTS',
+  'font-weight': 'FONT WEIGHTS',
+  'font-family': 'FONT FAMILIES',
+  'font-scale': 'ADVANCED — SCALE (TIER 1)',
+  radius: 'BORDER RADIUS',
+  transition: 'TRANSITIONS',
+};
+
+/** Stable display order of groups within the Spacing tab. */
+export const GROUP_ORDER: readonly TokenGroup[] = ['hsp', 'vsp', 'icon', 'layout'] as const;
+
+/** Stable display order of primary groups within the Font tab.
+ *  The `font-scale` group is rendered separately under an Advanced disclosure. */
+export const FONT_GROUP_ORDER: readonly TokenGroup[] = [
+  'font-size',
+  'line-height',
+  'font-weight',
+  'font-family',
+] as const;
+
+/** Stable display order of size-tab groups. */
+export const SIZE_GROUP_ORDER: readonly TokenGroup[] = ['radius', 'transition'] as const;
+
+// --- Value parsing helpers (shared across controls + persist) ---
+
+/**
+ * Parse a CSS length string like `"1.5rem"` into its numeric part.
+ * Returns `null` for anything non-numeric (e.g. `clamp(...)`, `"0"` counts as 0).
+ *
+ * Intentionally permissive: strips any non-numeric suffix after the leading
+ * number, which is exactly what our slider rows need (user-typed `"1.5rem"` →
+ * 1.5, `"12px"` → 12). Falls back to `null` for unparseable input so the caller
+ * can decide the error UX.
+ */
+export function parseNumericValue(value: string): number | null {
+  const match = value.trim().match(/^(-?\d+(?:\.\d+)?)/);
+  if (!match) return null;
+  const n = Number(match[1]);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Format a numeric slider value back into the stored string form. */
+export function formatValue(n: number, unit: string): string {
+  // Trim needless trailing zeros but keep the value readable.
+  // `Number.prototype.toString` already drops zeros for decimals, which is
+  // what we want here.
+  return `${n}${unit}`;
+}

--- a/packages/zudo-design-token-panel/src/utils/__tests__/design-token-serde.test.ts
+++ b/packages/zudo-design-token-panel/src/utils/__tests__/design-token-serde.test.ts
@@ -16,11 +16,12 @@ beforeEach(() => {
 
 /**
  * Ported from zudo-doc's `src/utils/__tests__/design-token-serde.test.ts`.
- * Adaptations for zmod2:
- *   - `font` slice renamed to `typography` to match the Sub 1 envelope.
+ * Port adaptations:
+ *   - `font` slice renamed to `typography` to match this package's
+ *     envelope.
  *   - `$schema` value is `zudo-design-tokens/v1` (asserted via the exported
  *     constant, not a hard-coded string).
- *   - Sub 6 retargeted the spacing/font manifest at Tier-1 `--zd-*` tokens:
+ *   - The spacing/font manifest targets Tier-1 `--zd-*` tokens:
  *     `--spacing-hsp-md` → `--zd-spacing-hgap-md` (default `40px`),
  *     `--text-body` → `--zd-font-base-size` (id also renamed `text-body` →
  *     `text-base`, default `1.4rem`). `--radius-lg` is unchanged.

--- a/packages/zudo-design-token-panel/src/utils/__tests__/design-token-serde.test.ts
+++ b/packages/zudo-design-token-panel/src/utils/__tests__/design-token-serde.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DesignTokenSchemaError,
+  deserialize,
+  getDesignTokenSchema,
+  serialize,
+  type DesignTokenJson,
+} from '../design-token-serde';
+import type { ColorTweakState, TweakState } from '../../state/tweak-state';
+import { __resetPanelConfigForTests } from '../../config/panel-config';
+import { installFixturePanelConfig } from '../../__tests__/_test-helpers';
+
+beforeEach(() => {
+  installFixturePanelConfig();
+});
+
+/**
+ * Ported from zudo-doc's `src/utils/__tests__/design-token-serde.test.ts`.
+ * Adaptations for zmod2:
+ *   - `font` slice renamed to `typography` to match the Sub 1 envelope.
+ *   - `$schema` value is `zudo-design-tokens/v1` (asserted via the exported
+ *     constant, not a hard-coded string).
+ *   - Sub 6 retargeted the spacing/font manifest at Tier-1 `--zd-*` tokens:
+ *     `--spacing-hsp-md` → `--zd-spacing-hgap-md` (default `40px`),
+ *     `--text-body` → `--zd-font-base-size` (id also renamed `text-body` →
+ *     `text-base`, default `1.4rem`). `--radius-lg` is unchanged.
+ */
+
+/** Fully-populated 16-color palette whose entries look obviously synthetic so
+ *  tests can spot a palette leak at a glance. */
+const PALETTE_BASELINE = Array.from(
+  { length: 16 },
+  (_, i) => `#${i.toString(16).padStart(2, '0').repeat(3)}`,
+);
+
+const COLOR_BASELINE: ColorTweakState = {
+  palette: PALETTE_BASELINE,
+  background: 0,
+  foreground: 15,
+  cursor: 6,
+  selectionBg: 0,
+  selectionFg: 15,
+  semanticMappings: {
+    surface: 0,
+    muted: 8,
+    accent: 5,
+    accentHover: 14,
+    codeBg: 10,
+    codeFg: 11,
+    active: 14,
+  },
+  shikiTheme: 'dracula',
+};
+
+function cloneBaseline(): ColorTweakState {
+  return {
+    ...COLOR_BASELINE,
+    palette: [...COLOR_BASELINE.palette],
+    semanticMappings: { ...COLOR_BASELINE.semanticMappings },
+  };
+}
+
+function makeState(overrides: Partial<TweakState> = {}): TweakState {
+  return {
+    color: cloneBaseline(),
+    spacing: {},
+    typography: {},
+    size: {},
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+  vi.restoreAllMocks();
+});
+
+describe('serialize', () => {
+  it('always includes $schema and exportedAt', () => {
+    const state = makeState();
+    const json = serialize(state, { colorDefaults: COLOR_BASELINE });
+    expect(json.$schema).toBe(getDesignTokenSchema());
+    expect(typeof json.exportedAt).toBe('string');
+    expect(() => new Date(json.exportedAt).toISOString()).not.toThrow();
+  });
+
+  it('emits nothing in color / spacing / typography / size when state matches baseline', () => {
+    const json = serialize(makeState(), { colorDefaults: COLOR_BASELINE });
+    expect(json.color).toBeUndefined();
+    expect(json.spacing).toBeUndefined();
+    expect(json.typography).toBeUndefined();
+    expect(json.size).toBeUndefined();
+  });
+
+  it('emits only changed spacing tokens by default (diff-only)', () => {
+    const state = makeState({ spacing: { 'hsp-md': '50px' } });
+    const json = serialize(state, { colorDefaults: COLOR_BASELINE });
+    expect(json.spacing).toEqual({ '--zd-spacing-hgap-md': '50px' });
+  });
+
+  it('drops spacing overrides that match the manifest default', () => {
+    // 40px is the declared default for --zd-spacing-hgap-md, so it should
+    // NOT appear in diff-only output.
+    const state = makeState({ spacing: { 'hsp-md': '40px' } });
+    const json = serialize(state, { colorDefaults: COLOR_BASELINE });
+    expect(json.spacing).toBeUndefined();
+  });
+
+  it('emits full token blocks when includeDefaults=true', () => {
+    const json = serialize(makeState(), {
+      colorDefaults: COLOR_BASELINE,
+      includeDefaults: true,
+    });
+    expect(json.color).toBeDefined();
+    expect(json.color?.palette).toHaveLength(16);
+    expect(json.spacing?.['--zd-spacing-hgap-md']).toBe('40px');
+    expect(json.typography?.['--zd-font-base-size']).toBe('1.4rem');
+    expect(json.size?.['--radius-lg']).toBe('8px');
+  });
+
+  it('emits the palette when any hex differs', () => {
+    const color = cloneBaseline();
+    color.palette[5] = '#ff00ff';
+    const json = serialize(makeState({ color }), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(json.color?.palette).toHaveLength(16);
+    expect(json.color?.palette?.[5]).toBe('#ff00ff');
+  });
+
+  it('emits only differing base-color fields', () => {
+    const color = cloneBaseline();
+    color.cursor = 9;
+    const json = serialize(makeState({ color }), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(json.color?.base).toEqual({ cursor: 9 });
+    expect(json.color?.palette).toBeUndefined();
+  });
+
+  it('emits only differing semantic mappings', () => {
+    const color = cloneBaseline();
+    color.semanticMappings.accent = 7;
+    const json = serialize(makeState({ color }), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(json.color?.semantic).toEqual({ accent: 7 });
+  });
+
+  it('emits an active remap and round-trips it cleanly through deserialize', () => {
+    const color = cloneBaseline();
+    color.semanticMappings.active = 5; // was 14
+    const json = serialize(makeState({ color }), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(json.color?.semantic).toEqual({ active: 5 });
+
+    const text = JSON.stringify(json);
+    const parsed = JSON.parse(text);
+    const { state, unknownTokens } = deserialize(parsed, {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(state.color.semanticMappings.active).toBe(5);
+  });
+
+  it('emits shikiTheme only when it differs', () => {
+    const color = cloneBaseline();
+    color.shikiTheme = 'vitesse-dark';
+    const json = serialize(makeState({ color }), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(json.color?.shikiTheme).toBe('vitesse-dark');
+  });
+});
+
+describe('deserialize', () => {
+  it('round-trips a diff-only export cleanly', () => {
+    const original = makeState({
+      spacing: { 'hsp-md': '50px', 'vsp-sm': '24px' },
+      typography: { 'text-base': '1.3rem' },
+      size: { 'radius-lg': '12px' },
+    });
+    original.color.cursor = 9;
+
+    const json = serialize(original, { colorDefaults: COLOR_BASELINE });
+    const text = JSON.stringify(json);
+    const parsed = JSON.parse(text);
+    const { state, unknownTokens } = deserialize(parsed, {
+      colorDefaults: COLOR_BASELINE,
+    });
+
+    expect(unknownTokens).toEqual([]);
+    expect(state.spacing).toEqual(original.spacing);
+    expect(state.typography).toEqual(original.typography);
+    expect(state.size).toEqual(original.size);
+    expect(state.color.cursor).toBe(9);
+    expect(state.color.palette).toEqual(COLOR_BASELINE.palette);
+  });
+
+  it('collects unknown CSS var names in unknownTokens', () => {
+    const payload: DesignTokenJson = {
+      $schema: getDesignTokenSchema(),
+      exportedAt: new Date().toISOString(),
+      spacing: {
+        '--zd-spacing-hgap-md': '50px',
+        '--spacing-nope': '1rem',
+      },
+      size: {
+        '--radius-imaginary': '20px',
+      },
+    };
+    const { state, unknownTokens } = deserialize(payload, {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(state.spacing).toEqual({ 'hsp-md': '50px' });
+    expect(state.size).toEqual({});
+    expect(unknownTokens.sort()).toEqual(['--radius-imaginary', '--spacing-nope'].sort());
+  });
+
+  it('throws schema-mismatch when $schema is wrong', () => {
+    expect(() =>
+      deserialize(
+        { $schema: 'zudo-doc-design-tokens/v1', exportedAt: 'x' },
+        { colorDefaults: COLOR_BASELINE },
+      ),
+    ).toThrowError(DesignTokenSchemaError);
+  });
+
+  it('throws schema-missing when $schema is absent', () => {
+    try {
+      deserialize({ exportedAt: 'x' }, { colorDefaults: COLOR_BASELINE });
+      throw new Error('expected to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DesignTokenSchemaError);
+      expect((err as DesignTokenSchemaError).reason).toBe('schema-missing');
+    }
+  });
+
+  it('throws not-object for non-object input', () => {
+    expect(() => deserialize('hello')).toThrowError(DesignTokenSchemaError);
+    expect(() => deserialize(null)).toThrowError(DesignTokenSchemaError);
+    expect(() => deserialize(42)).toThrowError(DesignTokenSchemaError);
+  });
+
+  it('falls back to baseline for absent color fields', () => {
+    const payload: DesignTokenJson = {
+      $schema: getDesignTokenSchema(),
+      exportedAt: new Date().toISOString(),
+      color: { base: { cursor: 3 } },
+    };
+    const { state } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.cursor).toBe(3);
+    expect(state.color.background).toBe(COLOR_BASELINE.background);
+    expect(state.color.palette).toEqual(COLOR_BASELINE.palette);
+    expect(state.color.shikiTheme).toBe(COLOR_BASELINE.shikiTheme);
+  });
+
+  it("warns-then-ignores palette arrays that aren't exactly 16 long", () => {
+    const payload: DesignTokenJson = {
+      $schema: getDesignTokenSchema(),
+      exportedAt: new Date().toISOString(),
+      color: { palette: ['#111', '#222'] },
+    };
+    const { state, warnings } = deserialize(payload, {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(state.color.palette).toEqual(COLOR_BASELINE.palette);
+    expect(warnings.some((w) => w.includes('palette'))).toBe(true);
+  });
+
+  it("warns when palette has 16 entries but some aren't strings", () => {
+    // Craft a 16-long array whose 3rd slot is a number — previously this fell
+    // back silently because the length check was looser.
+    const rawPalette: unknown[] = Array.from({ length: 16 }, (_, i) =>
+      i === 2 ? 42 : `#${i.toString(16).padStart(2, '0').repeat(3)}`,
+    );
+    const payload = {
+      $schema: getDesignTokenSchema(),
+      exportedAt: new Date().toISOString(),
+      color: { palette: rawPalette },
+    };
+    const { state, warnings } = deserialize(payload, {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(state.color.palette).toEqual(COLOR_BASELINE.palette);
+    expect(warnings.some((w) => w.includes('non-string'))).toBe(true);
+  });
+});

--- a/packages/zudo-design-token-panel/src/utils/color-convert.ts
+++ b/packages/zudo-design-token-panel/src/utils/color-convert.ts
@@ -1,0 +1,52 @@
+export function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l: Math.round(l * 100) };
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+  return { h: Math.round(h * 360), s: Math.round(s * 100), l: Math.round(l * 100) };
+}
+
+export function hslToHex(h: number, s: number, l: number): string {
+  h = ((h % 360) + 360) % 360;
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = ln - c / 2;
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}

--- a/packages/zudo-design-token-panel/src/utils/design-token-serde.ts
+++ b/packages/zudo-design-token-panel/src/utils/design-token-serde.ts
@@ -1,7 +1,7 @@
 /**
  * Design-token SerDe — unified JSON export / import for the design-token panel.
  *
- * Supersedes the legacy flat-cssVar-map serde that shipped with Sub 0. The
+ * Supersedes the legacy flat-cssVar-map serde. The
  * JSON format is a single document covering all four token categories (color,
  * spacing, typography, size) so an AI assistant can consume or emit a whole
  * design-token tweak in one round-trip.
@@ -25,18 +25,20 @@
  * Read-only manifest tokens (e.g. `--spacing-0` with `clamp()`) are skipped in
  * both directions.
  *
- * Port note (zmod2)
- * -----------------
+ * Port note
+ * ---------
  * Ported verbatim from zudo-doc's `src/utils/design-token-serde.ts`. The only
  * intentional deltas are:
  *  - `$schema` string is `zudo-design-tokens/v1` (not zudo-doc's value) so
- *    payloads round-trip inside zmod2 without cross-repo schema noise.
- *  - The `font` slice upstream is called `typography` here to match the zmod2
- *    state envelope introduced in Sub 1 (`FONT_TOKENS` stays as the manifest
- *    constant name because the underlying CSS var family is still "font-*").
- *  - `shikiTheme` still round-trips even though zmod2 has no Shiki
- *    integration — see `state/tweak-state.ts`'s `applyShikiTheme` stub for
- *    the rationale.
+ *    payloads round-trip inside this package without cross-repo schema
+ *    noise.
+ *  - The `font` slice upstream is called `typography` here to match this
+ *    package's state envelope (`FONT_TOKENS` stays as the manifest
+ *    constant name because the underlying CSS var family is still
+ *    "font-*").
+ *  - `shikiTheme` still round-trips even though this package has no Shiki
+ *    integration — see `state/tweak-state.ts`'s `applyShikiTheme` stub
+ *    for the rationale.
  */
 
 import type { TokenDef } from '../tokens/manifest';
@@ -47,8 +49,7 @@ import { getPanelConfig } from '../config/panel-config';
  *  `../state/tweak-state`) to avoid pulling the tweak-state runtime module into
  *  the serde's dependency chain. The serde itself only needs a type-only view
  *  of the state envelope; keeping this function local lets the serde's test
- *  suite exercise it in isolation even when other Wave-1 subs still have
- *  outstanding state/* stubs. */
+ *  suite exercise it in isolation. */
 function emptyOverrides(): TokenOverrides {
   return {};
 }
@@ -56,7 +57,7 @@ function emptyOverrides(): TokenOverrides {
 /**
  * Read the active design-token schema id at call time.
  *
- * Sub 2 of the portable epic (#1552) replaced the old
+ * An earlier port step replaced the old
  * `DESIGN_TOKEN_SCHEMA` literal-typed const with this getter so the value
  * tracks the runtime `panelConfig.schemaId` instead of being frozen at module
  * import. Call sites read the current value on every serialize/deserialize
@@ -169,7 +170,7 @@ export function serialize(state: TweakState, opts: SerializeOptions = {}): Desig
   const color = serializeColor(state.color, opts);
   if (color) out.color = color;
 
-  // Read manifests from runtime config (Sub 3, #1553) so a host-supplied
+  // Read manifests from runtime config so a host-supplied
   // manifest drives the diff pass instead of frozen module-load arrays.
   const tokens = getPanelConfig().tokens;
 
@@ -253,8 +254,9 @@ function serializeColor(
   }
 
   // Shiki theme — include only when different. Kept in the wire format even
-  // though zmod2's `applyShikiTheme` is a no-op so that JSON blobs round-trip
-  // cleanly with zudo-doc exports and with Sub 1's persist envelope.
+  // though this package's `applyShikiTheme` is a no-op so that JSON blobs
+  // round-trip cleanly with zudo-doc exports and with the persist
+  // envelope.
   if (full || !baseline || color.shikiTheme !== baseline.shikiTheme) {
     out.shikiTheme = color.shikiTheme;
     changed = true;
@@ -336,7 +338,7 @@ export function deserialize(input: unknown, opts: DeserializeOptions = {}): Dese
   const baseline = opts.colorDefaults ?? neutralColorDefaults();
 
   const color = deserializeColor(obj.color, baseline, warnings);
-  // Read manifests from runtime config (Sub 3, #1553).
+  // Read manifests from runtime config.
   const tokens = getPanelConfig().tokens;
   const spacing = deserializeOverrides(
     obj.spacing,

--- a/packages/zudo-design-token-panel/src/utils/design-token-serde.ts
+++ b/packages/zudo-design-token-panel/src/utils/design-token-serde.ts
@@ -1,0 +1,497 @@
+/**
+ * Design-token SerDe — unified JSON export / import for the design-token panel.
+ *
+ * Supersedes the legacy flat-cssVar-map serde that shipped with Sub 0. The
+ * JSON format is a single document covering all four token categories (color,
+ * spacing, typography, size) so an AI assistant can consume or emit a whole
+ * design-token tweak in one round-trip.
+ *
+ * Format: `$schema = "zudo-design-tokens/v1"`.
+ *
+ * Diff-only by default
+ * --------------------
+ * `serialize()` only emits tokens the user has actually changed relative to
+ * the provided `colorDefaults` (for the color block) and the manifest defaults
+ * (for spacing / typography / size). Pass `includeDefaults: true` to dump the
+ * full state instead. The whole-category keys (`color`, `spacing`,
+ * `typography`, `size`) are omitted entirely when nothing in them differs.
+ *
+ * Spacing / typography / size keys use CSS variable names
+ * (`"--zd-spacing-hgap-md"`) — the external schema — rather than the
+ * internal token id (`"hsp-md"`). This keeps the file human-readable and
+ * agnostic of our internal manifest. `deserialize()` maps them back; unknown
+ * CSS vars are reported via `unknownTokens` so the UI can surface them.
+ *
+ * Read-only manifest tokens (e.g. `--spacing-0` with `clamp()`) are skipped in
+ * both directions.
+ *
+ * Port note (zmod2)
+ * -----------------
+ * Ported verbatim from zudo-doc's `src/utils/design-token-serde.ts`. The only
+ * intentional deltas are:
+ *  - `$schema` string is `zudo-design-tokens/v1` (not zudo-doc's value) so
+ *    payloads round-trip inside zmod2 without cross-repo schema noise.
+ *  - The `font` slice upstream is called `typography` here to match the zmod2
+ *    state envelope introduced in Sub 1 (`FONT_TOKENS` stays as the manifest
+ *    constant name because the underlying CSS var family is still "font-*").
+ *  - `shikiTheme` still round-trips even though zmod2 has no Shiki
+ *    integration — see `state/tweak-state.ts`'s `applyShikiTheme` stub for
+ *    the rationale.
+ */
+
+import type { TokenDef } from '../tokens/manifest';
+import type { ColorTweakState, TokenOverrides, TweakState } from '../state/tweak-state';
+import { getPanelConfig } from '../config/panel-config';
+
+/** Local alias for an empty override map — inlined (rather than imported from
+ *  `../state/tweak-state`) to avoid pulling the tweak-state runtime module into
+ *  the serde's dependency chain. The serde itself only needs a type-only view
+ *  of the state envelope; keeping this function local lets the serde's test
+ *  suite exercise it in isolation even when other Wave-1 subs still have
+ *  outstanding state/* stubs. */
+function emptyOverrides(): TokenOverrides {
+  return {};
+}
+
+/**
+ * Read the active design-token schema id at call time.
+ *
+ * Sub 2 of the portable epic (#1552) replaced the old
+ * `DESIGN_TOKEN_SCHEMA` literal-typed const with this getter so the value
+ * tracks the runtime `panelConfig.schemaId` instead of being frozen at module
+ * import. Call sites read the current value on every serialize/deserialize
+ * pass; the literal-typed `as const` was widened to plain `string` because
+ * the schema id is now host-supplied.
+ */
+export function getDesignTokenSchema(): string {
+  return getPanelConfig().schemaId;
+}
+
+/** External JSON value for a base-color / semantic-color entry. */
+type ColorSlotValue = number | 'bg' | 'fg';
+
+export interface DesignTokenJsonColorBase {
+  bg?: number;
+  fg?: number;
+  cursor?: number;
+  /** Dashed keys mirror the external docs; they are quoted in source. */
+  'sel-bg'?: number;
+  'sel-fg'?: number;
+}
+
+export interface DesignTokenJsonColor {
+  palette?: string[];
+  base?: DesignTokenJsonColorBase;
+  /** Palette-index (or "bg"/"fg") mappings, same keys as `SEMANTIC_DEFAULTS`. */
+  semantic?: Record<string, ColorSlotValue>;
+  shikiTheme?: string;
+}
+
+/** External token map keyed by CSS var name. */
+export type DesignTokenJsonOverrides = Record<string, string>;
+
+export interface DesignTokenJson {
+  $schema: string;
+  exportedAt: string;
+  color?: DesignTokenJsonColor;
+  spacing?: DesignTokenJsonOverrides;
+  typography?: DesignTokenJsonOverrides;
+  size?: DesignTokenJsonOverrides;
+}
+
+export interface SerializeOptions {
+  /** When true, dump full state (all palette entries, all token manifest
+   *  defaults merged in). Default: diff-only. */
+  includeDefaults?: boolean;
+  /** Color baseline to diff against — typically the current scheme's initial
+   *  state. Required for meaningful color-diff output; callers that don't have
+   *  it available (e.g. tests without DOM) can omit it and we'll treat the
+   *  whole color block as changed. */
+  colorDefaults?: ColorTweakState;
+  /** Override the `exportedAt` stamp (test-only). */
+  now?: () => Date;
+}
+
+export interface DeserializeResult {
+  /** The reconstructed tweak state, with unknown-token values dropped. */
+  state: TweakState;
+  /** CSS var names present in the payload that don't match any known token. */
+  unknownTokens: string[];
+  /** Human-readable errors that did not prevent a state from being produced
+   *  (e.g. "semantic mapping dropped because value isn't a number"). */
+  warnings: string[];
+}
+
+export interface DeserializeOptions {
+  /** Color baseline used to fill in fields absent from the payload (diff-only
+   *  exports are missing most fields by design). Typically the current
+   *  scheme's initial state. */
+  colorDefaults?: ColorTweakState;
+}
+
+/** Thrown when the payload is not a v1 schema object. The error `.reason`
+ *  helps the UI render a precise inline message. */
+export class DesignTokenSchemaError extends Error {
+  readonly reason: 'not-object' | 'schema-missing' | 'schema-mismatch';
+  readonly actualSchema?: unknown;
+  constructor(
+    reason: 'not-object' | 'schema-missing' | 'schema-mismatch',
+    message: string,
+    actualSchema?: unknown,
+  ) {
+    super(message);
+    this.name = 'DesignTokenSchemaError';
+    this.reason = reason;
+    this.actualSchema = actualSchema;
+    // Preserve `instanceof` across the Error prototype boundary in ES5/ES2022
+    // mixed-output bundlers.
+    Object.setPrototypeOf(this, DesignTokenSchemaError.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialize
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce the external JSON document for a given tweak state.
+ *
+ * By default this is diff-only against `opts.colorDefaults` + manifest
+ * defaults; set `opts.includeDefaults = true` to dump everything.
+ */
+export function serialize(state: TweakState, opts: SerializeOptions = {}): DesignTokenJson {
+  const now = opts.now ? opts.now() : new Date();
+  const out: DesignTokenJson = {
+    $schema: getDesignTokenSchema(),
+    exportedAt: now.toISOString(),
+  };
+
+  const color = serializeColor(state.color, opts);
+  if (color) out.color = color;
+
+  // Read manifests from runtime config (Sub 3, #1553) so a host-supplied
+  // manifest drives the diff pass instead of frozen module-load arrays.
+  const tokens = getPanelConfig().tokens;
+
+  const spacing = serializeOverrides(tokens.spacing, state.spacing, opts);
+  if (spacing) out.spacing = spacing;
+
+  const typography = serializeOverrides(tokens.typography, state.typography, opts);
+  if (typography) out.typography = typography;
+
+  const size = serializeOverrides(tokens.size, state.size, opts);
+  if (size) out.size = size;
+
+  return out;
+}
+
+function serializeColor(
+  color: ColorTweakState,
+  opts: SerializeOptions,
+): DesignTokenJsonColor | undefined {
+  const baseline = opts.colorDefaults;
+  const full = opts.includeDefaults === true;
+
+  const out: DesignTokenJsonColor = {};
+  let changed = false;
+
+  // Palette — include the full array if any slot differs (or always when
+  // showing defaults). Keeping the array length stable preserves index
+  // stability.
+  const paletteChanged =
+    full ||
+    !baseline ||
+    baseline.palette.length !== color.palette.length ||
+    color.palette.some((c, i) => c !== baseline.palette[i]);
+  if (paletteChanged) {
+    out.palette = [...color.palette];
+    changed = true;
+  }
+
+  // Base — include only differing fields (or all, in full mode).
+  const base: DesignTokenJsonColorBase = {};
+  let baseChanged = false;
+  const baseEntries: ReadonlyArray<
+    readonly [keyof DesignTokenJsonColorBase, number, number | undefined]
+  > = [
+    ['bg', color.background, baseline?.background],
+    ['fg', color.foreground, baseline?.foreground],
+    ['cursor', color.cursor, baseline?.cursor],
+    ['sel-bg', color.selectionBg, baseline?.selectionBg],
+    ['sel-fg', color.selectionFg, baseline?.selectionFg],
+  ];
+  for (const [key, value, baselineValue] of baseEntries) {
+    if (full || baseline === undefined || value !== baselineValue) {
+      base[key] = value;
+      baseChanged = true;
+    }
+  }
+  if (baseChanged) {
+    out.base = base;
+    changed = true;
+  }
+
+  // Semantic — include only differing mappings.
+  const semantic: Record<string, ColorSlotValue> = {};
+  let semanticChanged = false;
+  const semKeys = new Set<string>([
+    ...Object.keys(color.semanticMappings),
+    ...(baseline ? Object.keys(baseline.semanticMappings) : []),
+  ]);
+  for (const key of semKeys) {
+    const cur = color.semanticMappings[key];
+    if (cur === undefined) continue;
+    const base = baseline?.semanticMappings[key];
+    if (full || base === undefined || cur !== base) {
+      semantic[key] = cur;
+      semanticChanged = true;
+    }
+  }
+  if (semanticChanged) {
+    out.semantic = semantic;
+    changed = true;
+  }
+
+  // Shiki theme — include only when different. Kept in the wire format even
+  // though zmod2's `applyShikiTheme` is a no-op so that JSON blobs round-trip
+  // cleanly with zudo-doc exports and with Sub 1's persist envelope.
+  if (full || !baseline || color.shikiTheme !== baseline.shikiTheme) {
+    out.shikiTheme = color.shikiTheme;
+    changed = true;
+  }
+
+  return changed ? out : undefined;
+}
+
+function serializeOverrides(
+  manifest: readonly TokenDef[],
+  overrides: TokenOverrides,
+  opts: SerializeOptions,
+): DesignTokenJsonOverrides | undefined {
+  const full = opts.includeDefaults === true;
+  const out: DesignTokenJsonOverrides = {};
+  let wrote = false;
+
+  if (full) {
+    // Dump every editable token: override if set, else manifest default.
+    for (const t of manifest) {
+      if (t.readonly) continue;
+      const v = overrides[t.id];
+      out[t.cssVar] = typeof v === 'string' && v.length > 0 ? v : t.default;
+      wrote = true;
+    }
+  } else {
+    // Diff-only: emit only user-modified tokens.
+    for (const t of manifest) {
+      if (t.readonly) continue;
+      const v = overrides[t.id];
+      if (typeof v === 'string' && v.length > 0 && v !== t.default) {
+        out[t.cssVar] = v;
+        wrote = true;
+      }
+    }
+  }
+
+  return wrote ? out : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Deserialize
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a design-token JSON document and lift it back into a tweak state.
+ *
+ * Throws `DesignTokenSchemaError` on schema mismatch / non-object input. Any
+ * CSS var name that doesn't match a known manifest entry is collected into
+ * `unknownTokens` (the caller can surface these as a warning).
+ *
+ * Missing fields fall back to `opts.colorDefaults` (or, absent that, a
+ * minimal neutral default) so the result is always a valid `TweakState`.
+ */
+export function deserialize(input: unknown, opts: DeserializeOptions = {}): DeserializeResult {
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw new DesignTokenSchemaError('not-object', 'Input is not a JSON object.');
+  }
+
+  const expectedSchema = getDesignTokenSchema();
+  const obj = input as Record<string, unknown>;
+  const schema = obj.$schema;
+  if (schema === undefined) {
+    throw new DesignTokenSchemaError(
+      'schema-missing',
+      `Missing "$schema" key. Expected "${expectedSchema}".`,
+    );
+  }
+  if (schema !== expectedSchema) {
+    throw new DesignTokenSchemaError(
+      'schema-mismatch',
+      `Unsupported "$schema" value: ${JSON.stringify(schema)}. Expected "${expectedSchema}".`,
+      schema,
+    );
+  }
+
+  const warnings: string[] = [];
+  const unknownTokens: string[] = [];
+  const baseline = opts.colorDefaults ?? neutralColorDefaults();
+
+  const color = deserializeColor(obj.color, baseline, warnings);
+  // Read manifests from runtime config (Sub 3, #1553).
+  const tokens = getPanelConfig().tokens;
+  const spacing = deserializeOverrides(
+    obj.spacing,
+    tokens.spacing,
+    'spacing',
+    unknownTokens,
+    warnings,
+  );
+  const typography = deserializeOverrides(
+    obj.typography,
+    tokens.typography,
+    'typography',
+    unknownTokens,
+    warnings,
+  );
+  const size = deserializeOverrides(obj.size, tokens.size, 'size', unknownTokens, warnings);
+
+  return {
+    state: { color, spacing, typography, size },
+    unknownTokens,
+    warnings,
+  };
+}
+
+function deserializeColor(
+  raw: unknown,
+  baseline: ColorTweakState,
+  warnings: string[],
+): ColorTweakState {
+  if (!raw || typeof raw !== 'object') {
+    // No color block at all — user probably diffed only spacing/typography/size.
+    return {
+      ...baseline,
+      palette: [...baseline.palette],
+      semanticMappings: { ...baseline.semanticMappings },
+    };
+  }
+  const c = raw as Record<string, unknown>;
+
+  // Palette
+  let palette = [...baseline.palette];
+  if (Array.isArray(c.palette)) {
+    const parsed = c.palette.filter((v): v is string => typeof v === 'string');
+    if (parsed.length === baseline.palette.length && parsed.length === c.palette.length) {
+      palette = parsed;
+    } else if (c.palette.length > 0) {
+      // Either the wrong array length OR baseline-sized but some weren't
+      // strings.
+      const detail =
+        parsed.length < c.palette.length
+          ? `${c.palette.length - parsed.length} non-string entries dropped, leaving ${parsed.length}`
+          : `${c.palette.length} entries`;
+      warnings.push(
+        `color.palette: expected ${baseline.palette.length} string entries; got ${detail}. Palette ignored.`,
+      );
+    }
+  }
+
+  // Base colors
+  const base = c.base && typeof c.base === 'object' ? (c.base as Record<string, unknown>) : {};
+  const background = numOr(base.bg, baseline.background);
+  const foreground = numOr(base.fg, baseline.foreground);
+  const cursor = numOr(base.cursor, baseline.cursor);
+  const selectionBg = numOr(base['sel-bg'], baseline.selectionBg);
+  const selectionFg = numOr(base['sel-fg'], baseline.selectionFg);
+
+  // Semantic mappings — merge over baseline so diff-only exports still
+  // produce a complete map.
+  const semanticMappings: Record<string, number | 'bg' | 'fg'> = {
+    ...baseline.semanticMappings,
+  };
+  if (c.semantic && typeof c.semantic === 'object') {
+    for (const [key, val] of Object.entries(c.semantic as Record<string, unknown>)) {
+      if (typeof val === 'number') {
+        semanticMappings[key] = val;
+      } else if (val === 'bg' || val === 'fg') {
+        semanticMappings[key] = val;
+      } else {
+        warnings.push(
+          `color.semantic.${key} has unsupported value ${JSON.stringify(val)}; kept baseline.`,
+        );
+      }
+    }
+  }
+
+  const shikiTheme =
+    typeof c.shikiTheme === 'string' && c.shikiTheme.length > 0
+      ? c.shikiTheme
+      : baseline.shikiTheme;
+
+  return {
+    palette,
+    background,
+    foreground,
+    cursor,
+    selectionBg,
+    selectionFg,
+    semanticMappings,
+    shikiTheme,
+  };
+}
+
+function deserializeOverrides(
+  raw: unknown,
+  manifest: readonly TokenDef[],
+  label: string,
+  unknownTokens: string[],
+  warnings: string[],
+): TokenOverrides {
+  if (!raw || typeof raw !== 'object') return emptyOverrides();
+
+  // Build cssVar → TokenDef lookup (skip readonly — they're not editable).
+  const byVar = new Map<string, TokenDef>();
+  for (const t of manifest) {
+    if (t.readonly) continue;
+    byVar.set(t.cssVar, t);
+  }
+
+  const out: TokenOverrides = {};
+  for (const [cssVar, value] of Object.entries(raw as Record<string, unknown>)) {
+    const t = byVar.get(cssVar);
+    if (!t) {
+      unknownTokens.push(cssVar);
+      continue;
+    }
+    if (typeof value !== 'string' || value.length === 0) {
+      warnings.push(`${label}.${cssVar} is not a non-empty string; ignored.`);
+      continue;
+    }
+    out[t.id] = value;
+  }
+  return out;
+}
+
+function numOr(v: unknown, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+/**
+ * Minimal color state used as the last-resort baseline when the caller can't
+ * provide one (e.g. unit tests without a DOM). Matches the default palette
+ * fallback in `tweak-state.ts`'s `tryInitColorFromScheme`.
+ */
+function neutralColorDefaults(): ColorTweakState {
+  const palette = Array.from({ length: 16 }, (_, i) =>
+    i === 0 ? '#000000' : i === 15 ? '#ffffff' : '#808080',
+  );
+  return {
+    palette,
+    background: 0,
+    foreground: 15,
+    cursor: 6,
+    selectionBg: 0,
+    selectionFg: 15,
+    semanticMappings: {},
+    shikiTheme: 'dracula',
+  };
+}

--- a/packages/zudo-design-token-panel/src/utils/structural-equal.ts
+++ b/packages/zudo-design-token-panel/src/utils/structural-equal.ts
@@ -1,7 +1,7 @@
 /**
  * Structural deep-equality for plain JSON-shaped values.
  *
- * Used by `configurePanel`'s re-init guard (PR #1440 review item P0-4) so a
+ * Used by `configurePanel`'s re-init guard so a
  * second `configurePanel(parsedConfig)` call from Astro view-transition reruns
  * — which produces a freshly-parsed object that is byte-for-byte identical to
  * the previous one but referentially distinct — does not throw.

--- a/packages/zudo-design-token-panel/src/utils/structural-equal.ts
+++ b/packages/zudo-design-token-panel/src/utils/structural-equal.ts
@@ -1,0 +1,50 @@
+/**
+ * Structural deep-equality for plain JSON-shaped values.
+ *
+ * Used by `configurePanel`'s re-init guard (PR #1440 review item P0-4) so a
+ * second `configurePanel(parsedConfig)` call from Astro view-transition reruns
+ * — which produces a freshly-parsed object that is byte-for-byte identical to
+ * the previous one but referentially distinct — does not throw.
+ *
+ * Scope:
+ *  - Primitives compared with `Object.is` (so `NaN === NaN` and `+0 !== -0`,
+ *    matching the JSON serialization round-trip behaviour we care about).
+ *  - Arrays compared element-wise (length-first short-circuit).
+ *  - Plain objects compared key-set-then-value (own enumerable string keys).
+ *  - Functions, class instances, Maps, Sets, Symbols are NOT supported. The
+ *    panel config contract (PORTABLE-CONTRACT.md §1, §4.2) bans these from
+ *    `PanelConfig`, so a structural compare that bails on them is fine.
+ *
+ * Returns `false` for any value that is `null` vs. non-null or whose typeof
+ * differs (string vs. number etc.).
+ */
+export function structuralEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return false;
+
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!structuralEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+
+  const aKeys = Object.keys(a as Record<string, unknown>);
+  const bKeys = Object.keys(b as Record<string, unknown>);
+  if (aKeys.length !== bKeys.length) return false;
+  // Use a Set for O(1) lookups so 100-key payloads stay cheap on the
+  // view-transition hot path.
+  const bKeySet = new Set(bKeys);
+  for (const k of aKeys) {
+    if (!bKeySet.has(k)) return false;
+    if (!structuralEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/zudo-design-token-panel/tsconfig.build.json
+++ b/packages/zudo-design-token-panel/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**", "**/*.test.ts", "**/*.test.tsx"]
+}

--- a/packages/zudo-design-token-panel/tsconfig.json
+++ b/packages/zudo-design-token-panel/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "baseUrl": ".",
+    "paths": {
+      "react": ["./node_modules/preact/compat", "../../node_modules/preact/compat"],
+      "react/jsx-runtime": [
+        "./node_modules/preact/jsx-runtime",
+        "../../node_modules/preact/jsx-runtime"
+      ],
+      "react/jsx-dev-runtime": [
+        "./node_modules/preact/jsx-dev-runtime",
+        "../../node_modules/preact/jsx-dev-runtime"
+      ],
+      "react-dom": ["./node_modules/preact/compat", "../../node_modules/preact/compat"],
+      "react-dom/*": ["./node_modules/preact/compat/*", "../../node_modules/preact/compat/*"]
+    },
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/zudo-design-token-panel/tsconfig.json
+++ b/packages/zudo-design-token-panel/tsconfig.json
@@ -24,7 +24,8 @@
         "../../node_modules/preact/jsx-dev-runtime"
       ],
       "react-dom": ["./node_modules/preact/compat", "../../node_modules/preact/compat"],
-      "react-dom/*": ["./node_modules/preact/compat/*", "../../node_modules/preact/compat/*"]
+      "react-dom/*": ["./node_modules/preact/compat/*", "../../node_modules/preact/compat/*"],
+      "@takazudo/zudo-design-token-panel": ["./src/index.tsx"]
     },
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/packages/zudo-design-token-panel/vite.config.ts
+++ b/packages/zudo-design-token-panel/vite.config.ts
@@ -53,8 +53,10 @@ export default defineConfig({
         // `index.ts`, so it would not be discovered without an explicit entry.
         'astro/index': 'src/astro/index.ts',
         'astro/host-adapter': 'src/astro/host-adapter.ts',
-        // Server-side apply pipeline — Node-only, zero framework deps.
-        'server/index': 'src/server/index.ts',
+        // NOTE: the upstream zmod port also emitted a `server/index` entry
+        // for the apply-pipeline server modules. That tree is deferred to a
+        // follow-up epic; this package currently ships only the panel UI
+        // and Astro adapter.
       },
       formats: ['es'],
     },

--- a/packages/zudo-design-token-panel/vite.config.ts
+++ b/packages/zudo-design-token-panel/vite.config.ts
@@ -1,0 +1,91 @@
+import { defineConfig } from 'vite';
+
+/**
+ * Vite config for `@takazudo/zudo-design-token-panel`.
+ *
+ * Three responsibilities:
+ *
+ * 1. **Lib bundle** — `vite build` emits `dist/index.js` plus `dist/astro/index.js`,
+ *    `dist/astro/host-adapter.js`, and `dist/server/index.js` (ESM, multi-entry)
+ *    with Preact externalised so consumers contribute their own copy via the
+ *    peerDependency. The CSS side-effect import in `src/index.tsx` lands as a
+ *    co-emitted chunk under `dist/`. Type emission is handled separately by
+ *    `tsc -p tsconfig.build.json` (vite-plugin-dts intentionally avoided —
+ *    explicit tsc gives single-source-of-truth control over the .d.ts shape).
+ *
+ *    Note: the `bin/server` entry from the upstream zmod port is intentionally
+ *    deferred to a follow-up epic — this package currently ships the panel UI,
+ *    Astro adapter, and server Apply API, but not the standalone CLI bin.
+ *
+ * 2. **resolve.alias for vitest** — kept so `pnpm test` resolves the
+ *    alias-smoke test's intentional `from 'react'` import against
+ *    preact/compat. Source files no longer rely on this alias —
+ *    they import from `'preact/compat'` directly so emitted `.d.ts` files
+ *    stay react-free (vite's resolve.alias is a runtime concept; tsc ignores
+ *    it).
+ *
+ * 3. **esbuild jsx config** — `automatic` runtime + `jsxImportSource: 'preact'`
+ *    so .tsx files compile against `preact/jsx-runtime` (matches
+ *    tsconfig.json). Vite does not auto-pick this up from tsconfig in lib
+ *    mode when there is no React-flavoured plugin installed, so we set it
+ *    explicitly here.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+      'react/jsx-runtime': 'preact/jsx-runtime',
+      'react/jsx-dev-runtime': 'preact/jsx-dev-runtime',
+    },
+  },
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'preact',
+  },
+  build: {
+    lib: {
+      entry: {
+        index: 'src/index.tsx',
+        // Astro sub-export entry plus the host adapter as a stand-alone chunk.
+        // The adapter is consumed only by the Astro toolchain on the consumer
+        // side (via `<script>` import in `DesignTokenPanelHost.astro`), not by
+        // `index.ts`, so it would not be discovered without an explicit entry.
+        'astro/index': 'src/astro/index.ts',
+        'astro/host-adapter': 'src/astro/host-adapter.ts',
+        // Server-side apply pipeline — Node-only, zero framework deps.
+        'server/index': 'src/server/index.ts',
+      },
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: [
+        'preact',
+        'preact/compat',
+        'preact/hooks',
+        'preact/jsx-runtime',
+        // Leave `from './DesignTokenPanelHost.astro'` literal in the
+        // emitted `astro/index.js` so the consumer's Astro toolchain
+        // resolves the .astro file. Vite lib mode does not compile .astro;
+        // a postbuild copy script (`scripts/copy-astro-assets.mjs`) places
+        // the raw file alongside the emitted JS.
+        /\.astro$/,
+        // Package self-reference for the host adapter's lazy
+        // dynamic import. Stays as a runtime resolution against the
+        // consumer's `node_modules/.../dist/index.js` so the panel module
+        // shares the `config/panel-config` chunk (and its singleton) with
+        // the adapter.
+        '@takazudo/zudo-design-token-panel',
+        // Node built-ins used by the server entry. Mark both the
+        // `node:` protocol form and the bare specifier form as external so
+        // Rollup leaves them as-is in the emitted ESM bundle.
+        /^node:/,
+        'fs',
+        'path',
+        'fs/promises',
+        'crypto',
+        'os',
+      ],
+    },
+  },
+});

--- a/packages/zudo-design-token-panel/vitest.config.ts
+++ b/packages/zudo-design-token-panel/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
+
+/**
+ * Vitest config — inherits the Preact compat alias from vite.config so that
+ * test files importing `from "react"` resolve against `preact/compat`.
+ */
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    },
+  }),
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,12 @@ importers:
 
   packages/zudo-design-token-panel:
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
       preact:
         specifier: ^10.29.1
         version: 10.29.1
@@ -97,12 +103,15 @@ importers:
         version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.5(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@22.19.17)(jsdom@25.0.1)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
 
 packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@astrojs/check@0.9.8':
     resolution: {integrity: sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==}
@@ -277,6 +286,34 @@ packages:
 
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -1203,6 +1240,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -1252,6 +1293,9 @@ packages:
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1276,6 +1320,10 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001791:
     resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
@@ -1338,6 +1386,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1397,6 +1449,10 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1557,6 +1613,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -1569,6 +1629,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -1577,6 +1640,10 @@ packages:
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1622,6 +1689,10 @@ packages:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
@@ -1643,8 +1714,24 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1743,10 +1830,17 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1760,8 +1854,20 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1775,6 +1881,18 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -1816,6 +1934,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -1824,6 +1946,14 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -1881,6 +2011,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -1899,6 +2032,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2027,6 +2169,9 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -2051,6 +2196,10 @@ packages:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -2242,6 +2391,14 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
@@ -2288,6 +2445,9 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2387,6 +2547,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -2506,6 +2670,12 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -2515,6 +2685,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -2603,6 +2777,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
@@ -2631,6 +2808,21 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2981,8 +3173,29 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -2996,6 +3209,25 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -3052,6 +3284,14 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@astrojs/check@0.9.8(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -3345,6 +3585,26 @@ snapshots:
       fast-string-width: 1.1.0
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -4153,6 +4413,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -4282,6 +4544,8 @@ snapshots:
       - uploadthing
       - yaml
 
+  asynckit@0.4.0: {}
+
   axobject-query@4.1.0: {}
 
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
@@ -4301,6 +4565,11 @@ snapshots:
       electron-to-chromium: 1.5.344
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   caniuse-lite@1.0.30001791: {}
 
@@ -4355,6 +4624,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -4408,6 +4681,11 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -4595,11 +4873,18 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   dayjs@1.11.20: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4610,6 +4895,8 @@ snapshots:
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
+
+  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -4651,6 +4938,12 @@ snapshots:
 
   dset@3.1.4: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.344: {}
 
   emmet@2.4.11:
@@ -4669,7 +4962,22 @@ snapshots:
 
   entities@6.0.1: {}
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -4793,8 +5101,18 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -4802,7 +5120,27 @@ snapshots:
 
   get-east-asian-width@1.5.0: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
   github-slugger@2.0.0: {}
+
+  gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -4826,6 +5164,16 @@ snapshots:
       uncrypto: 0.1.3
 
   hachure-fill@0.5.2: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4957,11 +5305,29 @@ snapshots:
 
   he@1.2.0: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iconv-lite@0.6.3:
     dependencies:
@@ -5000,6 +5366,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
@@ -5016,6 +5384,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -5105,6 +5501,8 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
@@ -5126,6 +5524,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@16.4.2: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -5631,6 +6031,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   minisearch@7.2.0: {}
 
   mlly@1.8.2:
@@ -5670,6 +6076,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nwsapi@2.2.23: {}
 
   obug@2.1.1: {}
 
@@ -5779,6 +6187,8 @@ snapshots:
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  punycode@2.3.1: {}
 
   radix3@1.1.2: {}
 
@@ -5998,11 +6408,19 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   section-matter@1.0.0:
     dependencies:
@@ -6117,6 +6535,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
@@ -6135,6 +6555,20 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -6290,7 +6724,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  vitest@4.1.5(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
+  vitest@4.1.5(@types/node@22.19.17)(jsdom@25.0.1)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
@@ -6314,6 +6748,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
 
@@ -6414,7 +6849,24 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-pm-runs@1.1.0: {}
 
@@ -6428,6 +6880,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,21 @@ importers:
         specifier: ^5.9.0
         version: 5.9.3
 
+  packages/zudo-design-token-panel:
+    devDependencies:
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+
 packages:
 
   '@antfu/install-pkg@1.1.0':
@@ -879,6 +894,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
 
@@ -972,6 +990,9 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -1069,6 +1090,9 @@ packages:
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1113,6 +1137,35 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1186,6 +1239,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -1225,6 +1282,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -1635,6 +1696,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2472,6 +2537,9 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-code-frame@1.3.0:
     resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
 
@@ -2499,6 +2567,12 @@ packages:
   stack-trace@1.0.0-pre2:
     resolution: {integrity: sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==}
     engines: {node: '>=16'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2539,6 +2613,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -2550,6 +2627,10 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2767,6 +2848,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -2865,6 +2987,11 @@ packages:
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -3685,6 +3812,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.4':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -3752,6 +3881,11 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -3874,6 +4008,8 @@ snapshots:
     dependencies:
       '@types/ms': 2.1.0
 
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -3919,6 +4055,47 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -4007,6 +4184,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -4126,6 +4305,8 @@ snapshots:
   caniuse-lite@1.0.30001791: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -4575,6 +4756,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -5873,6 +6056,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   simple-code-frame@1.3.0:
     dependencies:
       kolorist: 1.8.0
@@ -5890,6 +6075,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stack-trace@1.0.0-pre2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5934,6 +6123,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyexec@1.1.1: {}
@@ -5942,6 +6133,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   trim-lines@3.0.1: {}
 
@@ -6097,6 +6290,33 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
+  vitest@4.1.5(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
@@ -6197,6 +6417,11 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/4
- super-epic
    - https://github.com/Takazudo/zudo-design-token-panel/issues/2 (super-epic base: base/initial-port)

---

## Summary

Epic 2 of the OSS initial port — ports the design-token-panel package from the internal reference (zmod4) to the public OSS package `@takazudo/zudo-design-token-panel` at `packages/zudo-design-token-panel/`.

This delivers a buildable, testable, OSS-ready workspace package that downstream example apps (Astro, Vite, Next) can consume in subsequent epics. `src/bin/` and `src/server/` are intentionally deferred to Epic 3 (#5); the `/server` export is dropped from `package.json` and `vite.config.ts` for this epic and will return in Epic 3.

## What landed

- **Package skeleton** — `packages/zudo-design-token-panel/` with `package.json` named `@takazudo/zudo-design-token-panel`, `private: false`, `publishConfig.access: public`, repository / homepage / bugs / MIT license. Mirrored `tsconfig{,,build}.json`, `vite.config.ts`, `vitest.config.ts` from the reference, paths re-rooted; dropped the `@takazudo-modular/design-system` workspace dep.
- **Source tree** — full panel runtime ported from the reference: tests, apply pipeline, Astro adapter, config, controls, state, styles, tabs, tokens, utils, plus the four entry points (`index`, `panel`, `apply-modal`, `export-modal`, `import-modal`). Reference-specific data files (`zmod-default-cluster.ts`, `zaudio-cluster.ts`, `zmod-default-manifest.ts`) were dropped — they will be example fixtures in Epic 5 (Astro example app).
- **Build pipeline** — `vite build && tsc -p tsconfig.build.json && node scripts/copy-astro-assets.mjs` produces `dist/index.{js,d.ts}`, `dist/astro/{index,host-adapter}.{js,d.ts}`, `dist/astro/DesignTokenPanelHost.astro`, `dist/zudo-design-token-panel.css`. `exports` map mirrors the reference (panel root, `/astro`, `/astro/host-adapter`, `/astro/DesignTokenPanelHost.astro`, `/styles`, `/styles.css`); `/server` deferred to Epic 3.
- **Default config rework** — `DEFAULT_PANEL_CONFIG` now ships neutral defaults plus a stub cluster with `paletteSize: 0`, so OSS hosts must call `configurePanel` for useful behavior. `initColorFromScheme` falls back to `initSecondaryDefaults` when `cluster.colorSchemes` is empty so the stub cluster does not crash on mount; `initSecondaryDefaults` produces a deterministic grayscale ramp for any cluster.
- **OSS-readiness pass** — full source rename of the secondary-cluster identifier from `zaudio` to `secondary` (state slice key, persist callback, panel/color-tab props, CSS class `.tokenpanel-color-palette-grid--secondary`, exported semantic-defaults constants `SEMANTIC_DEFAULTS_SECONDARY` / `SEMANTIC_CSS_NAMES_SECONDARY`); reference-project name leaks (zmod, zmod2, zmodular, zaudio, @takazudo-modular) and internal sub-issue / PR / epic id citations scrubbed across all source comments. All four mandatory greps return zero.
- **Docs** — `README.md` and `PORTABLE-CONTRACT.md` ported and sanitized: install instructions assume `pnpm add @takazudo/zudo-design-token-panel preact` from a sibling repo, code examples neutralized to myapp-style placeholders, the migration recipe and worked-example sections rewritten for OSS adoption.

## Test status

- `pnpm --filter @takazudo/zudo-design-token-panel test` — 103 passing across 15 files
- `pnpm --filter @takazudo/zudo-design-token-panel exec tsc --noEmit` — clean
- `pnpm --filter @takazudo/zudo-design-token-panel build` — green; CI green (42s)

Reference-coupled tests dropped per spec: `zmod-default-manifest-ordering`, `zaudio-cluster`, `storage-key-continuity`. Additional reference-coupled tests dropped during the source-tree port: `consumer-color-cluster`, `css-export-contract`, `build-apply-overrides`, `apply-token-overrides`, `size-manifest`, `token-manifest`. The surviving 103 tests cover the portable surface (panel config, state, UI, exports, persistence, serde, design-token routing).

## Next

Epic 3 (#5) ports `src/bin/` and `src/server/` and restores the `/server` export. After all sibling epic-PRs land, the super-epic base `base/initial-port` is reviewed and merged into `main`.