### PR TITLE
[Initial Port][Epic] Port web-app-update bin (design-token-panel-server)

### DIFF
--- a/packages/zudo-design-token-panel/README.md
+++ b/packages/zudo-design-token-panel/README.md
@@ -84,110 +84,146 @@ The package's CSS is self-contained — it ships its own bundled stylesheet unde
 
 ## 3. Apply pipeline (the bin)
 
-The **bin server** is the recommended — and only supported — way to apply panel tweaks back to disk. When a user clicks "Apply" in the panel UI, the token diff POSTs to your dev-API endpoint, which the bin processes atomically (all-or-nothing write, never a half-rewritten state).
+The **bin server** is the recommended — and only supported — way to apply panel tweaks back to disk. When a user clicks "Apply" in the panel UI, the token diff POSTs to a small loopback HTTP server that the bin runs alongside your dev server. The bin computes every file rewrite in memory first and only then commits to disk via atomic temp-file renames, so a failed apply never leaves a half-rewritten CSS file behind.
 
 ### 3.1 CLI usage
 
-The bin ships as an executable in the `design-token-panel` package. Start it with:
+Install the package alongside your existing dev tooling:
 
-```bash
-# After pnpm install, the bin is available via:
-node dist/bin/server.js \
-  --routing <routing-file.json> \
-  --write-root <dir> \
-  --allow-origin <origin> \
-  [--root <dir>] [--host <addr>] [--port <number>] [--quiet]
-
-# Or use the npm bin field:
-design-token-panel-server \
-  --routing <routing-file.json> \
-  --write-root <dir> \
-  --allow-origin <origin>
+```sh
+pnpm add -D @takazudo/zudo-design-token-panel
 ```
 
-**Flags** (authoritative source: [`src/bin/parse-args.ts`](./src/bin/parse-args.ts)):
+The package ships an executable named `design-token-panel-server`. Print the help text from inside your consumer repo with either:
 
-| Flag | Required | Purpose | Example |
+```sh
+npx design-token-panel-server --help
+# or, with pnpm:
+pnpm exec design-token-panel-server --help
+```
+
+**Flags:**
+
+| Flag | Required | Purpose | Default |
 |---|---|---|---|
-| `--routing` | yes | Path to JSON file mapping CSS-var prefixes → source files. See §3.2. | `./apply.routing.json` |
-| `--write-root` | yes | The single directory the bin is allowed to write into. All resolved routing paths must sit inside this tree. Absolute, or relative to `--root`. | `sub-packages/design-system` |
-| `--allow-origin` | yes (≥ 1) | Origin allowed to POST to `/apply`. Repeatable — pass once per dev origin (scheme + host + port, no trailing slash). At least one is required for any browser to apply. | `--allow-origin http://localhost:34434` |
-| `--root` | no | Repo root used as the CWD reference for routing/write-root paths. Default: the bin's current working directory. | `--root /path/to/repo` |
-| `--host` | no | Bind address. Default: `127.0.0.1` (loopback). Use `0.0.0.0` to expose on the LAN (off by default). | `--host 0.0.0.0` |
-| `--port` | no | TCP port to bind. Default: `24681`. The example apps in this repo use `24682`/`24683`/`24684` to avoid collision when running multiple bins side by side. | `--port 9876` |
-| `--quiet` | no | Suppress per-request logs. | `--quiet` |
-| `--help` / `-h` | no | Print usage and exit 0. | `--help` |
+| `--routing <path>` | yes | Path to the routing JSON file (cluster id → repo-relative CSS file path). Absolute, or relative to `--root`. See §3.2. | — |
+| `--write-root <dir>` | no | Sandbox directory: the bin refuses to write outside this tree. Absolute, or relative to `--root`. | `--root` |
+| `--root <dir>` | no | Repo-root reference used to resolve `--routing` and `--write-root`. | `process.cwd()` |
+| `--port <number>` | no | TCP port to bind. `0` asks the OS for an ephemeral port (the bin logs the assigned port on startup). | `24681` |
+| `--host <addr>` | no | Bind address. Use `0.0.0.0` to expose on the LAN (off by default). | `127.0.0.1` |
+| `--allow-origin <origin>` | repeatable | Origin allowed to POST to `/apply` (scheme + host + port, no trailing slash). At least one is required for any browser to apply. | none (all origins denied) |
+| `--quiet` | no | Suppress the startup banner and the per-apply summary log line. | off |
+| `--help`, `-h` | no | Print usage and exit 0. | — |
+
+Generic invocation, run from your consumer repo root:
+
+```sh
+npx design-token-panel-server \
+  --routing ./panel-routing.json \
+  --write-root ./tokens \
+  --allow-origin http://localhost:5173
+```
 
 The bin reads the routing JSON once at startup and does not hot-reload it. Restart the bin if you edit the routing file.
 
 ### 3.2 Routing configuration
 
-Both the **panel UI** (for preview and button state) and the **bin** (for actual write) must agree on which CSS-var prefixes write to which files. The canonical way to enforce this is a shared JSON file:
+The routing JSON is a top-level object mapping **cluster id** → **repo-relative CSS file path**. Each path receives the apply pipeline's serialised writes for that cluster. The cluster ids must match the cluster ids used in your `PanelConfig.applyRouting` (the panel UI loads from this same JSON file — see §5).
+
+Generic example:
 
 ```json
 {
-  "myapp": "src/styles/tokens.css",
-  "myapp-extra": "src/styles/extra-tokens.css"
+  "main": "tokens/tokens.css",
+  "secondary": "tokens/secondary-tokens.css"
 }
 ```
 
-The host imports this file as a static JSON module; the bin reads it via `--routing`:
+Each path is resolved against `--root` (which defaults to `process.cwd()`) and must end up inside `--write-root` after resolution — see §3.3.
+
+The host imports the same file as a static JSON module so the panel UI and the bin agree on the routing without two declarations to keep in sync:
 
 ```ts
-// host/src/lib/panel-config.ts
-import routing from './apply.routing.json' assert { type: 'json' };
+import routing from './panel-routing.json' assert { type: 'json' };
 import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
 
 export const panelConfig: PanelConfig = {
   // ... other fields ...
-  applyRouting: routing,  // UI uses this for routing validation + button state
-  applyEndpoint: '/api/dev/design-tokens-apply',
+  applyRouting: routing,
+  applyEndpoint: 'http://127.0.0.1:24681/apply',
 };
 ```
 
-```bash
-# bin invocation uses the same file
-design-token-panel-server \
-  --routing /absolute/path/to/apply.routing.json \
-  --write-root src/styles \
-  --allow-origin http://localhost:34434
-```
+`applyEndpoint` is the URL the **browser** POSTs to. By default the bin listens on `http://127.0.0.1:24681`, so the panel default of `http://127.0.0.1:24681/apply` "just works" when you keep the bin's defaults. Change `--port` or `--host` and you must update `applyEndpoint` to match.
 
-Note: `applyEndpoint` above is the **panel UI config** — the URL the browser POSTs to (typically a dev-only API route on your host server that forwards to the bin). It is unrelated to the bin's CLI flags. The bin itself binds its own loopback HTTP listener at `--host`/`--port` and accepts POSTs from origins listed via `--allow-origin`.
-
-See [`PORTABLE-CONTRACT.md` §5.4](./PORTABLE-CONTRACT.md#54-routing-config--single-source-of-truth) for the authoritative routing schema.
+For the full token-overrides payload schema and the `PanelConfig` shape, see §5 and §6.
 
 ### 3.3 Security model
 
-The bin is **dev-only** and intended for use only on `localhost` (loopback by default):
+The bin is **dev-only** and is built with three independent guards:
 
-- **Loopback default:** binds to `127.0.0.1:24681` so only local requests are accepted. Token diffs are never exposed over the network by default. Override with `--host`/`--port` if needed.
-- **Sandbox (`--write-root`):** the bin enforces a strict write sandbox via the explicit `--write-root` flag. Every resolved routing path must sit inside that directory tree. Attempts to escape (`../../etc/passwd`) are rejected with a 400 and a descriptive error.
-- **Path sanitization:** every token name is validated (`--` prefix, no spaces, no slashes). Invalid names are rejected before any file I/O.
-- **Atomic writes:** computed changes are kept in memory. Only after every file is validated and computed is any file written. If a write fails partway, previously-written files are restored from the in-memory snapshot — disk cannot land in a half-rewritten state.
+- **Loopback default.** Binds to `127.0.0.1` so only requests from the same machine are accepted. Override with `--host` if you actually want LAN access.
+- **Write sandbox (`--write-root`).** Every routing entry is resolved against `--root` and verified to sit strictly inside `--write-root` before any file I/O happens. An entry whose resolved path escapes the sandbox — via `..` segments or an absolute path that points elsewhere — fails the apply with a 400 and a descriptive error message. `--write-root` defaults to `--root`, so routing entries are sandboxed to your repo root unless you narrow it further.
+- **CORS allow-list.** By default, **all origins are denied**. To let a browser POST to `/apply` you must list its origin explicitly with `--allow-origin <url>` (repeatable). Without a matching `--allow-origin`, the OPTIONS preflight returns 403 and POST returns 403 — no `Access-Control-Allow-Origin` header is emitted. Origin matching is **verbatim** on the full scheme + host + port string: `http://localhost:5173` and `http://127.0.0.1:5173` are different origins.
 
-**CORS:** the bin requires explicit `--allow-origin <origin>` (repeatable) for any browser POST to `/apply`. Each request's `Origin` header is matched **verbatim** against the configured allow-list — `http://localhost:8080` and `http://127.0.0.1:8080` are different origins, and trailing slashes matter, so pass each dev origin you actually serve from. Requests without a matching `--allow-origin` value receive a 403 with no `Access-Control-Allow-Origin` header. Same-origin requests (e.g. when host and bin share a port behind a reverse proxy) still need the origin listed; no special-case bypass exists.
+**Atomic writes.** The bin serialises per-file writes through a small mutex and uses a write-temp-file-then-rename strategy, so a failure mid-write never leaves a half-rewritten CSS file on disk. If any file in a multi-file apply fails to write, every file that was already persisted is restored from the in-memory snapshot taken before the apply started.
 
 ### 3.4 Lifecycle & signal handling
 
-The **host owns the supervisor.** The bin is a subprocess of the dev server (typically started via `concurrently` in the host's build script). When the host dev server shuts down, the bin should exit cleanly.
+While the bin is running it exposes a tiny HTTP surface:
 
-- **SIGTERM / SIGINT:** when the host sends `SIGTERM` or `SIGINT`, the bin exits gracefully (existing connections allowed to finish, no new requests accepted).
-- **EADDRINUSE:** if the port is already bound, the bin logs a clear error and exits with code 1. The host's supervisor (e.g. `concurrently`) can then retry or escalate as configured.
+- **`GET /healthz`** — returns `200 OK` with `{"ok":true,"writeRoot":"…","routing":"…","port":…}` once the listener is up. Useful for dev-server readiness checks.
+- **`OPTIONS /apply`** — CORS preflight. Returns `204` with `Access-Control-Allow-{Origin,Methods,Headers,Max-Age}` headers when the request's `Origin` is on the allow-list, and `403` otherwise.
+- **`POST /apply`** — applies a token-overrides payload via the apply pipeline. The body is `application/json` with a top-level `tokens` object whose keys are CSS-var names (e.g. `--brand-primary`) and whose values are CSS values. See §6 for the full token-manifest schema and §6.6 for apply-time behaviour. A non-JSON content type returns `415`; an unallowed origin returns `403`.
+- **Anything else** — `404` for unknown paths and `405` for unsupported methods on `/apply`.
 
-Example setup with `concurrently` (mirrors the canonical example-app form — see the example apps under `examples/` in this repo):
+The bin is intended to run as a subprocess of your dev server (`concurrently`, `npm-run-all`, a custom Node wrapper, etc.) and exits cleanly under host control:
+
+- **SIGINT / SIGTERM.** The HTTP server stops accepting new connections, in-flight requests are allowed to drain, then the process exits 0. A 5-second belt-and-suspenders timeout force-exits if `close` hangs on a lingering keep-alive socket.
+- **EADDRINUSE.** If the requested `--port` is already bound, the bin writes a friendly `port <n> already in use` line to stderr and exits with code 1, so the host supervisor can decide whether to retry or escalate.
+
+### 3.5 Running the bin from a non-Astro host (Vite, Next, Rollup, anything)
+
+The bin is framework-agnostic. Any consumer that has a long-running dev server can launch the bin alongside it. Two common shapes:
+
+**A) `concurrently` (or `npm-run-all`) in `package.json`:**
 
 ```json
 {
   "scripts": {
-    "dev": "concurrently -k -n astro,tokens-bin -c blue,green \"astro dev --port 44324\" \"design-token-panel-server --write-root . --routing ./apply.routing.json --port 24682 --allow-origin http://localhost:44324\""
+    "dev": "concurrently --kill-others-on-fail --names dev,panel \"vite\" \"design-token-panel-server --routing panel-routing.json --write-root ./tokens --allow-origin http://localhost:5173\""
   }
 }
 ```
 
-`concurrently -k` ensures that when one process exits the others are killed too, so SIGTERM propagates from the host runner to the bin.
+`--kill-others-on-fail` (or `concurrently -k`) ensures SIGINT propagates from the host runner to the bin when you Ctrl-C the dev server.
 
-The example apps under `examples/` (Astro, Vite + React, Next.js) demonstrate this wiring live.
+**B) A small Node wrapper that spawns the bin as a child process and proxies `SIGINT`:**
+
+```ts
+// scripts/dev-with-panel.ts
+import { spawn } from 'node:child_process';
+
+const bin = spawn(
+  'design-token-panel-server',
+  [
+    '--routing', 'panel-routing.json',
+    '--write-root', './tokens',
+    '--allow-origin', 'http://localhost:5173',
+  ],
+  { stdio: 'inherit', shell: false },
+);
+
+const forward = (signal: NodeJS.Signals): void => {
+  bin.kill(signal);
+};
+process.on('SIGINT', forward);
+process.on('SIGTERM', forward);
+
+bin.on('exit', (code) => process.exit(code ?? 0));
+```
+
+Whichever shape you pick, the wiring is the same: the bin listens on `http://127.0.0.1:24681/apply` by default, and the panel runtime POSTs to `PanelConfig.applyEndpoint`. Keep the bin's defaults and the default endpoint matches; if you change `--port` or `--host`, update `applyEndpoint` accordingly.
 
 ---
 

--- a/packages/zudo-design-token-panel/package.json
+++ b/packages/zudo-design-token-panel/package.json
@@ -18,6 +18,9 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "design-token-panel-server": "./dist/bin/server.js"
+  },
   "sideEffects": [
     "**/*.css",
     "./dist/astro/host-adapter.js",
@@ -37,6 +40,10 @@
       "import": "./dist/astro/host-adapter.js"
     },
     "./astro/DesignTokenPanelHost.astro": "./dist/astro/DesignTokenPanelHost.astro",
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
     "./styles": "./dist/zudo-design-token-panel.css",
     "./styles.css": "./dist/zudo-design-token-panel.css"
   },
@@ -44,7 +51,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json && node scripts/copy-astro-assets.mjs",
+    "build": "vite build && tsc -p tsconfig.build.json && node scripts/copy-astro-assets.mjs && chmod +x dist/bin/server.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/zudo-design-token-panel/src/bin/__tests__/cors.test.ts
+++ b/packages/zudo-design-token-panel/src/bin/__tests__/cors.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { buildCorsHeaders, isOriginAllowed } from '../cors';
+
+describe('isOriginAllowed', () => {
+  it('returns true for an exact match in the allow list', () => {
+    expect(isOriginAllowed('http://localhost:34434', ['http://localhost:34434'])).toBe(true);
+  });
+
+  it('returns false when the origin is not in the allow list', () => {
+    expect(isOriginAllowed('http://evil.com', ['http://localhost:34434'])).toBe(false);
+  });
+
+  it('treats scheme casing as case-sensitive (HTTP vs http differ)', () => {
+    expect(isOriginAllowed('HTTP://x.com', ['http://x.com'])).toBe(false);
+  });
+
+  it('treats port as case-sensitive — different ports are different origins', () => {
+    expect(isOriginAllowed('http://x.com:3000', ['http://x.com:3001'])).toBe(false);
+  });
+
+  it('returns false for a null origin', () => {
+    expect(isOriginAllowed(null, ['http://x.com'])).toBe(false);
+  });
+
+  it('returns false for an undefined origin', () => {
+    expect(isOriginAllowed(undefined, ['http://x.com'])).toBe(false);
+  });
+
+  it('returns false for an empty origin string', () => {
+    expect(isOriginAllowed('', ['http://x.com'])).toBe(false);
+  });
+
+  it('returns false when the allow list is empty', () => {
+    expect(isOriginAllowed('http://x.com', [])).toBe(false);
+  });
+
+  it('returns true when the origin is one of multiple entries', () => {
+    expect(isOriginAllowed('http://b.com', ['http://a.com', 'http://b.com', 'http://c.com'])).toBe(
+      true,
+    );
+  });
+});
+
+describe('buildCorsHeaders', () => {
+  it('returns the four ACA-* headers with the echoed origin', () => {
+    const headers = buildCorsHeaders('http://localhost:34434');
+    expect(headers['Access-Control-Allow-Origin']).toBe('http://localhost:34434');
+    expect(headers['Access-Control-Allow-Methods']).toBe('POST, OPTIONS');
+    expect(headers['Access-Control-Allow-Headers']).toBe('content-type');
+    expect(headers['Access-Control-Max-Age']).toBe('600');
+  });
+
+  it('echoes whichever origin is passed in (caller is responsible for gating)', () => {
+    const headers = buildCorsHeaders('http://other.example');
+    expect(headers['Access-Control-Allow-Origin']).toBe('http://other.example');
+  });
+
+  it('returns exactly the four ACA-* keys (no extras)', () => {
+    const headers = buildCorsHeaders('http://x.com');
+    expect(Object.keys(headers).sort()).toEqual([
+      'Access-Control-Allow-Headers',
+      'Access-Control-Allow-Methods',
+      'Access-Control-Allow-Origin',
+      'Access-Control-Max-Age',
+    ]);
+  });
+});

--- a/packages/zudo-design-token-panel/src/bin/__tests__/parse-args.test.ts
+++ b/packages/zudo-design-token-panel/src/bin/__tests__/parse-args.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { HELP_TEXT, parseArgs } from '../parse-args';
+
+describe('parseArgs', () => {
+  it('throws when --write-root is missing', () => {
+    expect(() => parseArgs(['--routing', './r.json'])).toThrow(/write-root/i);
+  });
+
+  it('throws when --routing is missing', () => {
+    expect(() => parseArgs(['--write-root', './w'])).toThrow(/routing/i);
+  });
+
+  it('accumulates repeated --allow-origin into allowOrigins', () => {
+    const args = parseArgs([
+      '--write-root',
+      './w',
+      '--routing',
+      './r.json',
+      '--allow-origin',
+      'http://localhost:34434',
+      '--allow-origin',
+      'http://example.com',
+    ]);
+    expect(args.allowOrigins).toEqual(['http://localhost:34434', 'http://example.com']);
+  });
+
+  it('defaults --port to 24681', () => {
+    const args = parseArgs(['--write-root', './w', '--routing', './r.json']);
+    expect(args.port).toBe(24681);
+  });
+
+  it('defaults --host to 127.0.0.1', () => {
+    const args = parseArgs(['--write-root', './w', '--routing', './r.json']);
+    expect(args.host).toBe('127.0.0.1');
+  });
+
+  it('returns help: true and HELP_TEXT is non-empty when --help is passed', () => {
+    const args = parseArgs(['--help']);
+    expect(args.help).toBe(true);
+    expect(typeof HELP_TEXT).toBe('string');
+    expect(HELP_TEXT.length).toBeGreaterThan(0);
+  });
+
+  it('sets quiet: true when --quiet is passed', () => {
+    const args = parseArgs(['--write-root', './w', '--routing', './r.json', '--quiet']);
+    expect(args.quiet).toBe(true);
+  });
+
+  it('throws when --port value is non-numeric', () => {
+    expect(() =>
+      parseArgs(['--write-root', './w', '--routing', './r.json', '--port', 'abc']),
+    ).toThrow(/port/i);
+  });
+
+  it('accepts a numeric --port', () => {
+    const args = parseArgs(['--write-root', './w', '--routing', './r.json', '--port', '12345']);
+    expect(args.port).toBe(12345);
+  });
+
+  it('accepts --host', () => {
+    const args = parseArgs(['--write-root', './w', '--routing', './r.json', '--host', '0.0.0.0']);
+    expect(args.host).toBe('0.0.0.0');
+  });
+
+  it('accepts --root', () => {
+    const args = parseArgs(['--root', '/abs/repo', '--write-root', './w', '--routing', './r.json']);
+    expect(args.root).toBe('/abs/repo');
+  });
+
+  it('throws on unknown options', () => {
+    expect(() => parseArgs(['--write-root', './w', '--routing', './r.json', '--bogus'])).toThrow(
+      /unknown option/i,
+    );
+  });
+
+  it('throws when a flag is missing its value', () => {
+    expect(() => parseArgs(['--write-root'])).toThrow(/write-root/i);
+  });
+
+  it('throws when --port is out of range', () => {
+    expect(() =>
+      parseArgs(['--write-root', './w', '--routing', './r.json', '--port', '-1']),
+    ).toThrow(/port/i);
+    expect(() =>
+      parseArgs(['--write-root', './w', '--routing', './r.json', '--port', '70000']),
+    ).toThrow(/port/i);
+  });
+
+  it('accepts --port 0 as an "OS-assigned port" sentinel', () => {
+    // 0 means "let the kernel pick a free port"; the bin's startup
+    // log line surfaces the actual port for callers (e.g. integration tests).
+    const args = parseArgs(['--write-root', './w', '--routing', './r.json', '--port', '0']);
+    expect(args.port).toBe(0);
+  });
+});

--- a/packages/zudo-design-token-panel/src/bin/__tests__/server.integration.test.ts
+++ b/packages/zudo-design-token-panel/src/bin/__tests__/server.integration.test.ts
@@ -1,0 +1,382 @@
+// @vitest-environment node
+/**
+ * Child-process integration test for the bin entry.
+ *
+ * Spawns the BUILT `dist/bin/server.js` (NOT the TS source) so we exercise
+ * the full build wiring: shebang banner, chmod +x, and Vite's bundled output.
+ * If you change anything in `src/bin/`, run
+ * `pnpm --filter @takazudo/zudo-design-token-panel build` BEFORE re-running
+ * this file — the test refuses to run if the bin output is missing.
+ *
+ * The tests prefer `--port 0` and parse the OS-assigned port from the bin's
+ * startup log, except for the EADDRINUSE case where we deliberately reuse a
+ * fixed port to provoke the collision.
+ */
+import { spawn, type ChildProcessByStdio } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import type { Readable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BIN_PATH = resolve(HERE, '../../../dist/bin/server.js');
+const STARTUP_LINE_RE = /listening on https?:\/\/[^:]+:(\d+)/;
+
+/**
+ * The bin is always spawned with `stdio: ['ignore', 'pipe', 'pipe']`, so its
+ * stdin is null and stdout/stderr are readable streams. That matches the
+ * `ChildProcessByStdio<null, Readable, Readable>` overload from `node:child_process`.
+ */
+type BinChild = ChildProcessByStdio<null, Readable, Readable>;
+
+interface SpawnedBin {
+  child: BinChild;
+  port: number;
+  stdout: string[];
+  stderr: string[];
+}
+
+/**
+ * Pick a random high port unlikely to clash with anything in the dev env.
+ * We deliberately avoid the OS ephemeral range (49152-65535 on macOS) and
+ * common dev-server ports.
+ */
+function pickFixedPort(): number {
+  return 40000 + Math.floor(Math.random() * 5000);
+}
+
+/**
+ * Wait for `cond` to return true, polling `interval` ms, up to `timeout` ms.
+ * Throws with a descriptive message on timeout.
+ */
+async function waitFor(
+  cond: () => boolean,
+  {
+    timeout = 5000,
+    interval = 25,
+    label = 'condition',
+  }: { timeout?: number; interval?: number; label?: string } = {},
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    if (cond()) return;
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(`waitFor timed out after ${timeout}ms: ${label}`);
+}
+
+/**
+ * Spawn the built bin, capture stdout/stderr, and resolve once the bin has
+ * printed its startup line. Returns the live (OS-assigned) port parsed from
+ * that line.
+ *
+ * If the bin exits before printing the startup line (e.g. EADDRINUSE), the
+ * helper still resolves — callers that expect a live server should assert
+ * `child.exitCode === null` before using it. Callers that expect failure
+ * (the EADDRINUSE test) get back the captured stderr to inspect.
+ */
+async function spawnBin(args: string[]): Promise<SpawnedBin> {
+  const child = spawn('node', [BIN_PATH, ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exited = false;
+
+  child.stdout.setEncoding('utf-8');
+  child.stderr.setEncoding('utf-8');
+  child.stdout.on('data', (chunk: string) => stdout.push(chunk));
+  child.stderr.on('data', (chunk: string) => stderr.push(chunk));
+  child.on('exit', () => {
+    exited = true;
+  });
+
+  let port = -1;
+  try {
+    await waitFor(
+      () => {
+        if (exited) return true;
+        const match = stdout.join('').match(STARTUP_LINE_RE);
+        if (match) {
+          port = Number(match[1]);
+          return true;
+        }
+        return false;
+      },
+      { timeout: 5000, label: 'bin startup line or exit' },
+    );
+  } catch (err) {
+    // Surface what the child printed so failures are debuggable.
+    throw new Error(
+      `${(err as Error).message}\nstdout: ${stdout.join('')}\nstderr: ${stderr.join('')}`,
+    );
+  }
+
+  return { child, port, stdout, stderr };
+}
+
+/**
+ * Best-effort termination: SIGTERM, then SIGKILL after a short grace period.
+ * Resolves once the child has actually exited so the next test starts clean.
+ */
+async function killBin(child: BinChild): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill('SIGTERM');
+  try {
+    await waitFor(() => child.exitCode !== null || child.signalCode !== null, {
+      timeout: 2000,
+      label: 'child SIGTERM exit',
+    });
+  } catch {
+    child.kill('SIGKILL');
+    await waitFor(() => child.exitCode !== null || child.signalCode !== null, {
+      timeout: 1000,
+      label: 'child SIGKILL exit',
+    });
+  }
+}
+
+interface TmpFixture {
+  dir: string;
+  routingPath: string;
+  tokensPath: string;
+}
+
+function makeTmpFixture(): TmpFixture {
+  const dir = mkdtempSync(join(tmpdir(), 'dtp-bin-it-'));
+  const tokensPath = join(dir, 'tokens.css');
+  writeFileSync(tokensPath, ':root {\n  --x-color: red;\n}\n', 'utf-8');
+  const routingPath = join(dir, 'routing.json');
+  writeFileSync(routingPath, JSON.stringify({ x: 'tokens.css' }), 'utf-8');
+  return { dir, routingPath, tokensPath };
+}
+
+beforeAll(() => {
+  if (!existsSync(BIN_PATH)) {
+    throw new Error(
+      `[design-token-panel integration test] missing ${BIN_PATH}. ` +
+        'Run `pnpm --filter @takazudo/zudo-design-token-panel build` first.',
+    );
+  }
+});
+
+describe('design-token-panel-server bin (integration)', () => {
+  const cleanupTasks: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    // Run cleanup in reverse order (children first, then tmpdirs).
+    for (const task of cleanupTasks.reverse()) {
+      try {
+        await task();
+      } catch {
+        // Swallow cleanup errors so one stuck child doesn't mask test results.
+      }
+    }
+    cleanupTasks.length = 0;
+  });
+
+  it('POST /apply happy path rewrites tokens.css and returns the apply envelope', async () => {
+    const fix = makeTmpFixture();
+    cleanupTasks.push(() => rmSync(fix.dir, { recursive: true, force: true }));
+
+    const allowOrigin = 'http://localhost:9999';
+    const bin = await spawnBin([
+      '--root',
+      fix.dir,
+      '--write-root',
+      fix.dir,
+      '--routing',
+      fix.routingPath,
+      '--port',
+      '0',
+      '--allow-origin',
+      allowOrigin,
+    ]);
+    cleanupTasks.push(() => killBin(bin.child));
+    expect(bin.child.exitCode).toBeNull();
+    expect(bin.port).toBeGreaterThan(0);
+
+    const response = await fetch(`http://127.0.0.1:${bin.port}/apply`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: allowOrigin,
+      },
+      body: JSON.stringify({ tokens: { '--x-color': 'blue' } }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      updated: Array<{ file: string; changed: string[] }>;
+    };
+    expect(body.ok).toBe(true);
+    expect(Array.isArray(body.updated)).toBe(true);
+    expect(body.updated.length).toBeGreaterThan(0);
+    expect(body.updated[0].changed).toContain('--x-color');
+
+    const css = readFileSync(fix.tokensPath, 'utf-8');
+    expect(css).toContain('--x-color: blue');
+    expect(css).not.toContain('--x-color: red');
+  }, 10_000);
+
+  it('POST /apply from a disallowed origin is rejected with 403 and no CORS header', async () => {
+    const fix = makeTmpFixture();
+    cleanupTasks.push(() => rmSync(fix.dir, { recursive: true, force: true }));
+
+    const bin = await spawnBin([
+      '--root',
+      fix.dir,
+      '--write-root',
+      fix.dir,
+      '--routing',
+      fix.routingPath,
+      '--port',
+      '0',
+      '--allow-origin',
+      'http://localhost:9999',
+    ]);
+    cleanupTasks.push(() => killBin(bin.child));
+
+    const response = await fetch(`http://127.0.0.1:${bin.port}/apply`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://evil.example',
+      },
+      body: JSON.stringify({ tokens: { '--x-color': 'blue' } }),
+    });
+    expect(response.status).toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  }, 10_000);
+
+  it('OPTIONS /apply preflight from a disallowed origin returns 403', async () => {
+    const fix = makeTmpFixture();
+    cleanupTasks.push(() => rmSync(fix.dir, { recursive: true, force: true }));
+
+    const bin = await spawnBin([
+      '--root',
+      fix.dir,
+      '--write-root',
+      fix.dir,
+      '--routing',
+      fix.routingPath,
+      '--port',
+      '0',
+      '--allow-origin',
+      'http://localhost:9999',
+    ]);
+    cleanupTasks.push(() => killBin(bin.child));
+
+    const response = await fetch(`http://127.0.0.1:${bin.port}/apply`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://evil.example',
+        'Access-Control-Request-Method': 'POST',
+      },
+    });
+    expect(response.status).toBe(403);
+  }, 10_000);
+
+  it('GET /healthz returns 200 with the writeRoot/routing/port shape', async () => {
+    const fix = makeTmpFixture();
+    cleanupTasks.push(() => rmSync(fix.dir, { recursive: true, force: true }));
+
+    const bin = await spawnBin([
+      '--root',
+      fix.dir,
+      '--write-root',
+      fix.dir,
+      '--routing',
+      fix.routingPath,
+      '--port',
+      '0',
+      '--allow-origin',
+      'http://localhost:9999',
+    ]);
+    cleanupTasks.push(() => killBin(bin.child));
+
+    const response = await fetch(`http://127.0.0.1:${bin.port}/healthz`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      writeRoot: string;
+      routing: string;
+      port: number;
+    };
+    expect(body.ok).toBe(true);
+    // The bin's healthz currently surfaces the REQUESTED port (0 here).
+    // We don't pin that — the contract for the test is just that the
+    // payload has the documented keys with reasonable types.
+    expect(typeof body.writeRoot).toBe('string');
+    expect(typeof body.routing).toBe('string');
+    expect(typeof body.port).toBe('number');
+  }, 10_000);
+
+  it('a second bin on the same fixed port exits 1 with EADDRINUSE on stderr', async () => {
+    const fix = makeTmpFixture();
+    cleanupTasks.push(() => rmSync(fix.dir, { recursive: true, force: true }));
+
+    // Defensively retry up to a few different fixed ports — if something
+    // else on the machine is squatting on our random pick, the test would
+    // misattribute the failure to the bin.
+    let firstBin: SpawnedBin | null = null;
+    let chosenPort = -1;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const candidate = pickFixedPort();
+      const bin = await spawnBin([
+        '--root',
+        fix.dir,
+        '--write-root',
+        fix.dir,
+        '--routing',
+        fix.routingPath,
+        '--port',
+        String(candidate),
+        '--allow-origin',
+        'http://localhost:9999',
+      ]);
+      if (bin.child.exitCode === null) {
+        firstBin = bin;
+        chosenPort = candidate;
+        break;
+      }
+      // Exited immediately — likely EADDRINUSE on a squatted port. Try
+      // another candidate.
+      await killBin(bin.child);
+    }
+    if (!firstBin || chosenPort < 0) {
+      throw new Error('Could not bind any candidate fixed port for EADDRINUSE test');
+    }
+    cleanupTasks.push(() => killBin(firstBin!.child));
+
+    // Spawn the second instance on the same port and wait for it to exit.
+    const second = spawn(
+      'node',
+      [
+        BIN_PATH,
+        '--root',
+        fix.dir,
+        '--write-root',
+        fix.dir,
+        '--routing',
+        fix.routingPath,
+        '--port',
+        String(chosenPort),
+        '--allow-origin',
+        'http://localhost:9999',
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    cleanupTasks.push(() => killBin(second));
+    const secondStderr: string[] = [];
+    second.stderr.setEncoding('utf-8');
+    second.stderr.on('data', (chunk: string) => secondStderr.push(chunk));
+    const exitCode = await new Promise<number | null>((resolveExit) => {
+      second.on('exit', (code) => resolveExit(code));
+    });
+    expect(exitCode).toBe(1);
+    expect(secondStderr.join('')).toMatch(/EADDRINUSE|already in use/i);
+  }, 10_000);
+});

--- a/packages/zudo-design-token-panel/src/bin/cors.ts
+++ b/packages/zudo-design-token-panel/src/bin/cors.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure CORS helpers for the `design-token-panel-server` bin.
+ *
+ * Origin matching is **case-sensitive on the entire scheme + host + port**
+ * string — wildcards and pattern matching are intentionally not supported.
+ * The browser sends the origin verbatim; the bin operator declares the exact
+ * allowed origins via repeated `--allow-origin` flags.
+ */
+
+/**
+ * @param origin    The `Origin` header from the incoming request, or
+ *                  null/undefined if the header was absent.
+ * @param allowList The exact-match allow-list configured at bin startup.
+ * @returns true iff `origin` is a non-empty string present in `allowList`.
+ */
+export function isOriginAllowed(
+  origin: string | null | undefined,
+  allowList: readonly string[],
+): boolean {
+  if (typeof origin !== 'string' || origin.length === 0) return false;
+  if (allowList.length === 0) return false;
+  return allowList.includes(origin);
+}
+
+/**
+ * Build the four `Access-Control-Allow-*` headers for a successful CORS
+ * response (preflight 204 OR the wrapped POST /apply response). The caller
+ * is responsible for only calling this when `isOriginAllowed` returned true,
+ * so the echoed origin value is always one the operator has explicitly
+ * permitted.
+ */
+export function buildCorsHeaders(origin: string): Record<string, string> {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'content-type',
+    'Access-Control-Max-Age': '600',
+  };
+}

--- a/packages/zudo-design-token-panel/src/bin/parse-args.ts
+++ b/packages/zudo-design-token-panel/src/bin/parse-args.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure-function argv parser for the `design-token-panel-server` bin.
+ *
+ * No external dependencies — only standard JS/TS — so this module is trivially
+ * unit-testable and can be imported safely from non-Node contexts (although in
+ * practice the bin file is the only consumer).
+ *
+ * Surface (matches the parse-args contract):
+ *
+ *   --root <dir>             repo root; default: process.cwd() (parser leaves null)
+ *   --write-root <path>      REQUIRED; absolute or relative-to-root
+ *   --routing <path>         REQUIRED; routing JSON file path
+ *   --port <number>          default 24681
+ *   --host <addr>            default 127.0.0.1
+ *   --allow-origin <origin>  repeatable; required at least once for browser POST
+ *   --quiet                  suppress per-request logs
+ *   --help                   print usage and exit 0
+ *
+ * On invalid input, throws a descriptive `Error`. The bin entry catches it,
+ * writes the message to stderr, and exits 1.
+ */
+
+const DEFAULT_PORT = 24681;
+const DEFAULT_HOST = '127.0.0.1';
+
+export interface ParsedArgs {
+  root: string | null;
+  writeRoot: string | null;
+  routing: string | null;
+  port: number;
+  host: string;
+  allowOrigins: string[];
+  quiet: boolean;
+  help: boolean;
+}
+
+export const HELP_TEXT = `Usage: design-token-panel-server [options]
+
+Run a small Node http server that wraps the design-token apply handler.
+
+Options:
+  --root <dir>              Repo root used as the CWD reference for routing
+                            paths. Defaults to the current working directory.
+  --write-root <path>       REQUIRED. Absolute or root-relative path to the
+                            single directory the bin is allowed to write into.
+  --routing <path>          REQUIRED. Path to the routing JSON file
+                            (prefix -> repo-relative CSS file path).
+  --port <number>           TCP port to bind. Default: ${DEFAULT_PORT}.
+  --host <addr>             Host/interface to bind. Default: ${DEFAULT_HOST}.
+                            Use 0.0.0.0 to expose on the LAN (off by default).
+  --allow-origin <origin>   Origin allowed to POST to /apply. Repeatable.
+                            At least one is required for any browser to apply.
+  --quiet                   Suppress per-request logs.
+  --help                    Print this message and exit.
+
+Examples:
+  design-token-panel-server \\
+    --write-root tokens \\
+    --routing ./my.routing.json \\
+    --allow-origin http://localhost:34434
+`;
+
+/**
+ * Parse a raw argv array (typically `process.argv.slice(2)`) into a
+ * `ParsedArgs` record. Throws on malformed input — the bin handles the throw.
+ */
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const result: ParsedArgs = {
+    root: null,
+    writeRoot: null,
+    routing: null,
+    port: DEFAULT_PORT,
+    host: DEFAULT_HOST,
+    allowOrigins: [],
+    quiet: false,
+    help: false,
+  };
+
+  let i = 0;
+  while (i < argv.length) {
+    const token = argv[i];
+    switch (token) {
+      case '--help':
+      case '-h':
+        result.help = true;
+        i += 1;
+        break;
+      case '--quiet':
+        result.quiet = true;
+        i += 1;
+        break;
+      case '--root':
+        result.root = takeValue(argv, i, '--root');
+        i += 2;
+        break;
+      case '--write-root':
+        result.writeRoot = takeValue(argv, i, '--write-root');
+        i += 2;
+        break;
+      case '--routing':
+        result.routing = takeValue(argv, i, '--routing');
+        i += 2;
+        break;
+      case '--host':
+        result.host = takeValue(argv, i, '--host');
+        i += 2;
+        break;
+      case '--port': {
+        const raw = takeValue(argv, i, '--port');
+        const n = Number(raw);
+        // 0 is a sentinel meaning "let the OS pick a free port" — the
+        // integration tests rely on this; consumers can read the actual port
+        // from the bin's startup log line.
+        if (!Number.isInteger(n) || n < 0 || n > 65535) {
+          throw new Error(`--port must be an integer in 0..65535 (got ${JSON.stringify(raw)})`);
+        }
+        result.port = n;
+        i += 2;
+        break;
+      }
+      case '--allow-origin': {
+        const value = takeValue(argv, i, '--allow-origin');
+        result.allowOrigins.push(value);
+        i += 2;
+        break;
+      }
+      default:
+        throw new Error(`Unknown option: ${token}`);
+    }
+  }
+
+  // --help short-circuits validation so `--help` works on a bare invocation.
+  if (result.help) return result;
+
+  if (!result.writeRoot) {
+    throw new Error('--write-root is required (the only directory the bin will write into)');
+  }
+  if (!result.routing) {
+    throw new Error('--routing is required (path to the routing JSON file)');
+  }
+
+  return result;
+}
+
+function takeValue(argv: readonly string[], i: number, flag: string): string {
+  const v = argv[i + 1];
+  if (typeof v !== 'string' || v.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return v;
+}

--- a/packages/zudo-design-token-panel/src/bin/server.ts
+++ b/packages/zudo-design-token-panel/src/bin/server.ts
@@ -1,0 +1,322 @@
+/**
+ * `design-token-panel-server` bin entry.
+ *
+ * The `#!/usr/bin/env node` shebang is intentionally NOT in this source file —
+ * Vite/Rollup re-injects it via `output.banner` (see vite.config.ts) onto the
+ * emitted `dist/bin/server.js`. That keeps the bundled file as the single
+ * source of truth for the executable header and avoids esbuild rejecting a
+ * double-shebang in the build output.
+ *
+ * Wraps the framework-agnostic `createApplyHandler` from `../server` in a tiny
+ * Node `http` server that:
+ *
+ *   - parses argv via `parseArgs`
+ *   - resolves --root / --write-root / --routing
+ *   - loads the routing JSON via `loadRoutingFromFile`
+ *   - serves OPTIONS/POST /apply with CORS gating, plus GET /healthz, plus
+ *     404/405 for everything else
+ *   - logs apply outcomes (unless --quiet)
+ *   - exits 1 with a friendly stderr message on EADDRINUSE
+ *   - shuts down gracefully on SIGINT/SIGTERM
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+import { resolve } from 'node:path';
+import { createApplyHandler, loadRoutingFromFile } from '../server';
+import { buildCorsHeaders, isOriginAllowed } from './cors';
+import { HELP_TEXT, parseArgs, type ParsedArgs } from './parse-args';
+
+const APPLY_PATH = '/apply';
+const HEALTHZ_PATH = '/healthz';
+
+interface RuntimeConfig {
+  rootDir: string;
+  writeRoot: string;
+  routingPath: string;
+  port: number;
+  host: string;
+  allowOrigins: string[];
+  quiet: boolean;
+}
+
+function buildRuntimeConfig(parsed: ParsedArgs): RuntimeConfig {
+  // Defaults that depend on process state are resolved here, not in the
+  // parser, so `parseArgs` stays a pure function.
+  const rootDir = resolve(parsed.root ?? process.cwd());
+  // writeRoot / routing are required → parseArgs already enforced non-null.
+  const writeRoot = resolve(rootDir, parsed.writeRoot as string);
+  const routingPath = resolve(rootDir, parsed.routing as string);
+  return {
+    rootDir,
+    writeRoot,
+    routingPath,
+    port: parsed.port,
+    host: parsed.host,
+    allowOrigins: parsed.allowOrigins,
+    quiet: parsed.quiet,
+  };
+}
+
+function jsonReply(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Content-Length', Buffer.byteLength(payload).toString());
+  res.end(payload);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolveBody, rejectBody) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => resolveBody(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', rejectBody);
+  });
+}
+
+function buildFetchHeaders(req: IncomingMessage): Headers {
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (Array.isArray(value)) {
+      for (const v of value) headers.append(key, v);
+    } else if (typeof value === 'string') {
+      headers.set(key, value);
+    }
+  }
+  return headers;
+}
+
+async function pipeFetchResponse(
+  res: ServerResponse,
+  fetchResponse: Response,
+  extraHeaders: Record<string, string>,
+): Promise<void> {
+  res.statusCode = fetchResponse.status;
+  fetchResponse.headers.forEach((value, key) => {
+    res.setHeader(key, value);
+  });
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    res.setHeader(key, value);
+  }
+  const text = await fetchResponse.text();
+  res.end(text);
+}
+
+function logApplyOutcome(quiet: boolean, payload: string): void {
+  if (quiet) return;
+  try {
+    const parsed = JSON.parse(payload) as {
+      ok?: boolean;
+      updated?: Array<{ file: string; changed?: string[] }>;
+    };
+    if (!parsed.ok || !Array.isArray(parsed.updated)) return;
+    const totalTokens = parsed.updated.reduce(
+      (sum, entry) => sum + (Array.isArray(entry.changed) ? entry.changed.length : 0),
+      0,
+    );
+    const fileCount = parsed.updated.length;
+    const changedFiles = parsed.updated
+      .filter((entry) => Array.isArray(entry.changed) && entry.changed.length > 0)
+      .map((entry) => entry.file);
+    console.log(
+      `[design-token-panel] applied ${totalTokens} tokens to ${fileCount} files ` +
+        `(changed: ${changedFiles.length > 0 ? changedFiles.join(', ') : 'none'})`,
+    );
+  } catch {
+    // Non-JSON or malformed apply response — skip the friendly summary log.
+  }
+}
+
+interface Deps {
+  applyHandler: (req: Request) => Promise<Response>;
+  config: RuntimeConfig;
+}
+
+function buildRequestListener(deps: Deps) {
+  const { applyHandler, config } = deps;
+  return async function requestListener(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = req.url ?? '/';
+    const method = (req.method ?? 'GET').toUpperCase();
+    const origin = typeof req.headers.origin === 'string' ? req.headers.origin : null;
+
+    try {
+      // ----- /healthz -----
+      if (url === HEALTHZ_PATH && method === 'GET') {
+        jsonReply(res, 200, {
+          ok: true,
+          writeRoot: config.writeRoot,
+          routing: config.routingPath,
+          port: config.port,
+        });
+        return;
+      }
+
+      // ----- /apply -----
+      if (url === APPLY_PATH) {
+        if (method === 'OPTIONS') {
+          if (!isOriginAllowed(origin, config.allowOrigins)) {
+            jsonReply(res, 403, { ok: false, error: 'Origin not allowed' });
+            return;
+          }
+          const corsHeaders = buildCorsHeaders(origin as string);
+          for (const [key, value] of Object.entries(corsHeaders)) {
+            res.setHeader(key, value);
+          }
+          res.statusCode = 204;
+          res.end();
+          return;
+        }
+
+        if (method !== 'POST') {
+          res.setHeader('Allow', 'POST, OPTIONS');
+          jsonReply(res, 405, { ok: false, error: 'Method not allowed' });
+          return;
+        }
+
+        // POST /apply
+        const contentType = req.headers['content-type'];
+        if (
+          typeof contentType !== 'string' ||
+          !contentType.toLowerCase().includes('application/json')
+        ) {
+          jsonReply(res, 415, { ok: false, error: 'Content-Type must be application/json' });
+          return;
+        }
+
+        if (!isOriginAllowed(origin, config.allowOrigins)) {
+          jsonReply(res, 403, { ok: false, error: 'Origin not allowed' });
+          return;
+        }
+
+        const bodyText = await readBody(req);
+        const fetchRequest = new Request(`http://localhost${APPLY_PATH}`, {
+          method: 'POST',
+          headers: buildFetchHeaders(req),
+          body: bodyText,
+        });
+
+        const fetchResponse = await applyHandler(fetchRequest);
+        const responseBody = await fetchResponse.clone().text();
+        const corsHeaders = buildCorsHeaders(origin as string);
+        await pipeFetchResponse(res, fetchResponse, corsHeaders);
+        logApplyOutcome(config.quiet, responseBody);
+        return;
+      }
+
+      // ----- /apply with other methods is handled above; fall through -----
+
+      // 404 for any other path
+      jsonReply(res, 404, { ok: false, error: 'Not found' });
+    } catch (err) {
+      console.error('[design-token-panel] Unhandled error:', err);
+      if (!res.headersSent) {
+        jsonReply(res, 500, { ok: false, error: 'Internal server error' });
+      } else {
+        res.end();
+      }
+    }
+  };
+}
+
+function attachLifecycle(server: Server, port: number): void {
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EADDRINUSE') {
+      console.error(`[design-token-panel] port ${port} already in use`);
+      process.exit(1);
+    }
+    console.error('[design-token-panel] Server error:', err);
+    process.exit(1);
+  });
+
+  const shutdown = (signal: NodeJS.Signals): void => {
+    server.close(() => {
+      // Bare `process.exit(0)` here is intentional — once the http server
+      // has closed all sockets, there is nothing left for Node to do.
+      process.exit(0);
+    });
+    // Belt + suspenders: if `close` hangs (lingering keep-alive socket etc.)
+    // give it a generous window then force-exit so SIGINT/SIGTERM stays
+    // responsive in noisy dev environments.
+    setTimeout(() => {
+      console.error(`[design-token-panel] force-exiting after ${signal}`);
+      process.exit(0);
+    }, 5000).unref();
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+function main(): void {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`[design-token-panel] ${(err as Error).message}`);
+    console.error('');
+    console.error('Run --help for usage.');
+    process.exit(1);
+  }
+
+  if (parsed.help) {
+    process.stdout.write(HELP_TEXT);
+    process.exit(0);
+  }
+
+  const config = buildRuntimeConfig(parsed);
+
+  let routing;
+  try {
+    routing = loadRoutingFromFile(config.routingPath);
+  } catch (err) {
+    console.error(`[design-token-panel] Failed to load routing: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  const applyHandler = createApplyHandler({
+    rootDir: config.rootDir,
+    writeRoot: config.writeRoot,
+    routing,
+  });
+
+  const server = createServer(buildRequestListener({ applyHandler, config }));
+  attachLifecycle(server, config.port);
+
+  server.listen(config.port, config.host, () => {
+    if (!config.quiet) {
+      // Resolve the actual bound port from the server's address. When the user
+      // passes --port 0, the kernel assigns a free port and `config.port`
+      // (the requested value) stays at 0 — printing that here would be a lie.
+      // We surface the live port instead so --port 0 callers can read the
+      // assigned port from this line.
+      const addr = server.address();
+      const livePort = typeof addr === 'object' && addr ? addr.port : config.port;
+      console.log(
+        `[design-token-panel] listening on http://${config.host}:${livePort} ` +
+          `(writeRoot: ${config.writeRoot})`,
+      );
+      if (config.allowOrigins.length === 0) {
+        console.log(
+          '[design-token-panel] WARNING: no --allow-origin set; browser POST /apply will be rejected.',
+        );
+      }
+    }
+  });
+}
+
+// Only run when executed directly (preserves importability for tests).
+const invokedDirectly = (() => {
+  if (typeof process.argv[1] !== 'string') return false;
+  try {
+    // Node ESM doesn't expose `require.main === module`; compare resolved URLs.
+    const argvUrl = new URL(`file://${resolve(process.argv[1])}`).href;
+    const metaUrl = import.meta.url;
+    return argvUrl === metaUrl;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  main();
+}

--- a/packages/zudo-design-token-panel/src/server/__tests__/create-apply-handler.test.ts
+++ b/packages/zudo-design-token-panel/src/server/__tests__/create-apply-handler.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { createApplyHandler } from '../create-apply-handler';
+
+// ----- fixtures & helpers -----------------------------------------------------
+
+const TOKENS_CSS_FIXTURE = `/**
+ * Zudo Design System - CSS Tokens
+ */
+
+:root {
+  --zd-p5: oklch(65% 0.2 45); /* accent */
+  --zd-p6: oklch(52% 0.01 50);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --zd-p5: oklch(10% 0 0);
+  }
+}
+`;
+
+const SECONDARY_TOKENS_CSS_FIXTURE = `:root {
+  --secondary-pa7: oklch(65% 0.2 35);
+  --secondary-pa8: oklch(50% 0.2 35);
+}
+`;
+
+async function makeTmpRepo(): Promise<string> {
+  const dir = join(tmpdir(), `dtp-server-test-${randomBytes(6).toString('hex')}`);
+  await fs.mkdir(join(dir, 'tokens'), { recursive: true });
+  await fs.writeFile(
+    join(dir, 'tokens/tokens.css'),
+    TOKENS_CSS_FIXTURE,
+    'utf-8',
+  );
+  await fs.writeFile(
+    join(dir, 'tokens/secondary-tokens.css'),
+    SECONDARY_TOKENS_CSS_FIXTURE,
+    'utf-8',
+  );
+  return dir;
+}
+
+async function rmTmpRepo(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+function makeRequest(body: unknown, { rawBody }: { rawBody?: string } = {}): Request {
+  const payload = rawBody ?? JSON.stringify(body);
+  return new Request('http://localhost/api/dev/design-tokens-apply', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: payload,
+  });
+}
+
+async function readResponseJson(res: Response): Promise<Record<string, unknown>> {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+// ----- tests ------------------------------------------------------------------
+
+describe('createApplyHandler', () => {
+  let tmpRepo: string;
+  let handler: (req: Request) => Promise<Response>;
+
+  beforeEach(async () => {
+    tmpRepo = await makeTmpRepo();
+    handler = createApplyHandler({
+      rootDir: tmpRepo,
+      writeRoot: resolve(tmpRepo, 'tokens'),
+      routing: {
+        zd: 'tokens/tokens.css',
+        secondary: 'tokens/secondary-tokens.css',
+      },
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (tmpRepo) await rmTmpRepo(tmpRepo);
+  });
+
+  // ----- 400 validation cases ------------------------------------------------
+
+  it('returns 400 on invalid JSON', async () => {
+    const res = await handler(makeRequest(undefined, { rawBody: '{not json' }));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(false);
+    expect(String(json.error)).toMatch(/Invalid JSON/i);
+  });
+
+  it('returns 400 when body is not an object', async () => {
+    const res = await handler(makeRequest([1, 2, 3]));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(false);
+    expect(String(json.error)).toMatch(/must be a JSON object/i);
+  });
+
+  it('returns 400 when tokens is missing', async () => {
+    const res = await handler(makeRequest({ nope: true }));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(String(json.error)).toMatch(/tokens/i);
+  });
+
+  it('returns 400 when tokens is empty', async () => {
+    const res = await handler(makeRequest({ tokens: {} }));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(String(json.error)).toMatch(/at least one/i);
+  });
+
+  it('returns 400 when a key has an invalid shape (invalid token name)', async () => {
+    const res = await handler(makeRequest({ tokens: { 'not-a-var': 'red' } }));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(String(json.error)).toMatch(/Invalid cssVar/i);
+  });
+
+  it('returns 400 with rejected list when the prefix is unsupported', async () => {
+    const res = await handler(makeRequest({ tokens: { '--foo-bar': 'red' } }));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(false);
+    expect(json.rejected).toEqual(['--foo-bar']);
+  });
+
+  // ----- 400 path escape -----------------------------------------------------
+
+  it('returns 400 when routing produces a path outside writeRoot', async () => {
+    // Override routing with a path that escapes the writeRoot.
+    const evilHandler = createApplyHandler({
+      rootDir: tmpRepo,
+      writeRoot: resolve(tmpRepo, 'tokens'),
+      routing: {
+        zd: '../../etc/passwd.css',
+      },
+    });
+    const res = await evilHandler(makeRequest({ tokens: { '--zd-p5': 'red' } }));
+    expect(res.status).toBe(400);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(false);
+    expect(String(json.error)).toMatch(/Path not allowed/i);
+  });
+
+  // ----- 409 no :root block --------------------------------------------------
+
+  it('returns 409 when the target file has no top-level :root block', async () => {
+    const absPath = join(tmpRepo, 'tokens/tokens.css');
+    const rootless = `/* no root block here */\nhtml { color: red; }\n`;
+    await fs.writeFile(absPath, rootless, 'utf-8');
+
+    const res = await handler(makeRequest({ tokens: { '--zd-p5': 'oklch(70% 0.3 50)' } }));
+    expect(res.status).toBe(409);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(false);
+    expect(String(json.error)).toMatch(/:root/);
+
+    // File must remain unchanged.
+    const after = await fs.readFile(absPath, 'utf-8');
+    expect(after).toBe(rootless);
+  });
+
+  // ----- 200 happy path ------------------------------------------------------
+
+  it('writes to target files and reports changed entries (happy path)', async () => {
+    const res = await handler(
+      makeRequest({
+        tokens: {
+          '--zd-p5': 'oklch(70% 0.3 50)',
+          '--secondary-pa7': 'oklch(70% 0.3 40)',
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(true);
+    expect(json.unknownCssVars).toEqual([]);
+    expect(json.unchangedCssVars).toEqual([]);
+    expect(json.updated).toEqual([
+      expect.objectContaining({
+        file: 'tokens/tokens.css',
+        changed: ['--zd-p5'],
+      }),
+      expect.objectContaining({
+        file: 'tokens/secondary-tokens.css',
+        changed: ['--secondary-pa7'],
+      }),
+    ]);
+
+    const tokensCss = await fs.readFile(
+      join(tmpRepo, 'tokens/tokens.css'),
+      'utf-8',
+    );
+    expect(tokensCss).toContain('--zd-p5: oklch(70% 0.3 50);');
+    // --zd-p6 was NOT supplied and must remain untouched.
+    expect(tokensCss).toContain('--zd-p6: oklch(52% 0.01 50);');
+    // The nested @media :root block must be untouched.
+    expect(tokensCss).toContain('--zd-p5: oklch(10% 0 0);');
+
+    const secondaryCss = await fs.readFile(
+      join(tmpRepo, 'tokens/secondary-tokens.css'),
+      'utf-8',
+    );
+    expect(secondaryCss).toContain('--secondary-pa7: oklch(70% 0.3 40);');
+    expect(secondaryCss).toContain('--secondary-pa8: oklch(50% 0.2 35);');
+  });
+
+  // ----- idempotent re-apply -------------------------------------------------
+
+  it('reports values already matching the file as unchanged (idempotent re-apply)', async () => {
+    const absPath = join(tmpRepo, 'tokens/tokens.css');
+    const before = await fs.stat(absPath);
+
+    const res = await handler(makeRequest({ tokens: { '--zd-p5': 'oklch(65% 0.2 45)' } }));
+    expect(res.status).toBe(200);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(true);
+    expect(json.unchangedCssVars).toEqual(['--zd-p5']);
+    expect(json.unknownCssVars).toEqual([]);
+    expect(json.updated).toEqual([
+      expect.objectContaining({
+        file: 'tokens/tokens.css',
+        changed: [],
+        unchanged: ['--zd-p5'],
+      }),
+    ]);
+
+    // No tmp file should be left behind after a skipped write.
+    const dir = await fs.readdir(join(tmpRepo, 'tokens'));
+    expect(dir.some((f) => f.startsWith('.tmp-'))).toBe(false);
+
+    // File content must be byte-identical.
+    const after = await fs.readFile(absPath, 'utf-8');
+    expect(after).toBe(TOKENS_CSS_FIXTURE);
+
+    // mtime should be unchanged (no rename happened).
+    const afterStat = await fs.stat(absPath);
+    expect(afterStat.mtimeMs).toBe(before.mtimeMs);
+  });
+
+  // ----- atomic rollback when file 2 of 2 fails to write --------------------
+
+  it('rolls back previously-written files when a later write fails (atomic rollback)', async () => {
+    const tokensAbsPath = join(tmpRepo, 'tokens/tokens.css');
+    const secondaryAbsPath = join(tmpRepo, 'tokens/secondary-tokens.css');
+
+    const originalTokensCss = await fs.readFile(tokensAbsPath, 'utf-8');
+
+    // The first writeFile call succeeds (tokens.css), the second throws.
+    let writeCount = 0;
+    const writeSpy = vi.spyOn(fs, 'writeFile').mockImplementation(async (path, data, enc) => {
+      writeCount++;
+      if (writeCount === 2) {
+        throw Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+      }
+      // Call the real implementation for the first write.
+      await (fs.writeFile as unknown as (...a: unknown[]) => Promise<void>).call(
+        null,
+        path,
+        data,
+        enc,
+      );
+    });
+
+    // Restore mocks before the spy intercepts the actual rename too — we only
+    // want to simulate the writeFile failure, not rename. We test atomicity at
+    // the handler level: the first file gets written (rename applied to disk),
+    // then the handler should roll it back when the second file write fails.
+    // However, for a cleaner unit-test setup, we'll simulate via the spy on
+    // writeFile only for tmp writes and let the real rename run.
+    writeSpy.mockRestore();
+
+    // Alternative approach: spy on the second-call rename to fail.
+    let renameCount = 0;
+    const renameSpy = vi.spyOn(fs, 'rename').mockImplementation(async (src, dest) => {
+      renameCount++;
+      if (renameCount === 2) {
+        throw Object.assign(new Error('rename fail'), { code: 'ENOSPC' });
+      }
+      // Let the first rename go through normally.
+      await (fs.rename as unknown as (...a: unknown[]) => Promise<void>).call(null, src, dest);
+    });
+
+    const res = await handler(
+      makeRequest({
+        tokens: {
+          '--zd-p5': 'oklch(99% 0.0 0)',
+          '--secondary-pa7': 'oklch(99% 0.0 0)',
+        },
+      }),
+    );
+
+    renameSpy.mockRestore();
+
+    // The handler must report a 500.
+    expect(res.status).toBe(500);
+    const json = await readResponseJson(res);
+    expect(json.ok).toBe(false);
+
+    // After rollback, tokens.css must be back to its original contents.
+    const afterTokensCss = await fs.readFile(tokensAbsPath, 'utf-8');
+    expect(afterTokensCss).toBe(originalTokensCss);
+
+    // secondary-tokens.css must never have been mutated (the failing write was for it).
+    const afterSecondaryCss = await fs.readFile(secondaryAbsPath, 'utf-8');
+    expect(afterSecondaryCss).toBe(SECONDARY_TOKENS_CSS_FIXTURE);
+
+    expect(renameCount).toBeGreaterThan(0);
+  });
+});

--- a/packages/zudo-design-token-panel/src/server/__tests__/load-routing.test.ts
+++ b/packages/zudo-design-token-panel/src/server/__tests__/load-routing.test.ts
@@ -1,0 +1,137 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadRoutingFromFile, type ApplyRoutingMap } from '../load-routing';
+
+/**
+ * Temporary directory used by every test in this suite.
+ * Created before each test, removed after.
+ */
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `dtp-load-routing-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeTmp(filename: string, content: string): string {
+  const p = join(tmpDir, filename);
+  writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+describe('loadRoutingFromFile', () => {
+  describe('valid JSON', () => {
+    it('parses a single-entry routing map', () => {
+      const path = writeTmp(
+        'valid.json',
+        JSON.stringify({ zd: 'tokens/tokens.css' }),
+      );
+      const result = loadRoutingFromFile(path);
+      expect(result).toEqual<ApplyRoutingMap>({ zd: 'tokens/tokens.css' });
+    });
+
+    it('parses a multi-entry routing map', () => {
+      const path = writeTmp(
+        'multi.json',
+        JSON.stringify({
+          zd: 'tokens/tokens.css',
+          secondary: 'tokens/secondary-tokens.css',
+        }),
+      );
+      const result = loadRoutingFromFile(path);
+      expect(result).toEqual<ApplyRoutingMap>({
+        zd: 'tokens/tokens.css',
+        secondary: 'tokens/secondary-tokens.css',
+      });
+    });
+  });
+
+  describe('malformed JSON', () => {
+    it('throws a descriptive error for invalid JSON syntax', () => {
+      const path = writeTmp('bad.json', '{ "zd": ');
+      expect(() => loadRoutingFromFile(path)).toThrowError(/invalid JSON/i);
+    });
+
+    it('includes the file path in the error message for invalid JSON', () => {
+      const path = writeTmp('bad2.json', 'not-json-at-all');
+      expect(() => loadRoutingFromFile(path)).toThrowError(path);
+    });
+  });
+
+  describe('non-object root', () => {
+    it('throws when root is an array', () => {
+      const path = writeTmp('array.json', JSON.stringify(['zd', 'tokens.css']));
+      expect(() => loadRoutingFromFile(path)).toThrowError(/array/);
+    });
+
+    it('throws when root is null', () => {
+      const path = writeTmp('null.json', 'null');
+      expect(() => loadRoutingFromFile(path)).toThrowError(/null/);
+    });
+
+    it('throws when root is a string', () => {
+      const path = writeTmp('string.json', '"just a string"');
+      expect(() => loadRoutingFromFile(path)).toThrowError(/string/);
+    });
+
+    it('throws when root is a number', () => {
+      const path = writeTmp('number.json', '42');
+      expect(() => loadRoutingFromFile(path)).toThrowError(/number/);
+    });
+  });
+
+  describe('non-string values', () => {
+    it('throws when a value is a number', () => {
+      const path = writeTmp('num-val.json', JSON.stringify({ zd: 42 }));
+      expect(() => loadRoutingFromFile(path)).toThrowError(/key "zd"/);
+    });
+
+    it('throws when a value is null', () => {
+      const path = writeTmp('null-val.json', JSON.stringify({ zd: null }));
+      expect(() => loadRoutingFromFile(path)).toThrowError(/key "zd"/);
+    });
+
+    it('throws when a value is an object', () => {
+      const path = writeTmp('obj-val.json', JSON.stringify({ zd: { nested: true } }));
+      expect(() => loadRoutingFromFile(path)).toThrowError(/key "zd"/);
+    });
+
+    it('throws when a value is an empty string', () => {
+      const path = writeTmp('empty-str-val.json', JSON.stringify({ zd: '' }));
+      expect(() => loadRoutingFromFile(path)).toThrowError(/key "zd"/);
+    });
+
+    it('throws when a value is a whitespace-only string', () => {
+      const path = writeTmp('ws-val.json', JSON.stringify({ zd: '   ' }));
+      expect(() => loadRoutingFromFile(path)).toThrowError(/key "zd"/);
+    });
+  });
+
+  describe('empty map', () => {
+    it('throws for an empty object', () => {
+      const path = writeTmp('empty.json', '{}');
+      expect(() => loadRoutingFromFile(path)).toThrowError(/must not be empty/);
+    });
+  });
+
+  describe('non-existent file', () => {
+    it('throws when the file does not exist', () => {
+      const path = join(tmpDir, 'does-not-exist.json');
+      expect(() => loadRoutingFromFile(path)).toThrowError(/cannot read file/);
+    });
+
+    it('includes the file path in the error message', () => {
+      const path = join(tmpDir, 'missing.json');
+      expect(() => loadRoutingFromFile(path)).toThrowError(path);
+    });
+  });
+});

--- a/packages/zudo-design-token-panel/src/server/__tests__/path-safety.test.ts
+++ b/packages/zudo-design-token-panel/src/server/__tests__/path-safety.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  CSS_VAR_NAME_RE,
+  isPathSafe,
+  isValidCssVarName,
+  validateAndSanitizeTokens,
+} from '../path-safety';
+
+describe('isPathSafe', () => {
+  const writeRoot = resolve('/repo/tokens');
+
+  it('accepts a .css file directly under writeRoot', () => {
+    expect(isPathSafe(writeRoot, resolve(writeRoot, 'tokens.css'))).toBe(true);
+  });
+
+  it('accepts a .css file in a subdirectory under writeRoot', () => {
+    expect(isPathSafe(writeRoot, resolve(writeRoot, 'sub/nested.css'))).toBe(true);
+  });
+
+  it('accepts a .css file whose name happens to start with two dots', () => {
+    expect(isPathSafe(writeRoot, resolve(writeRoot, '..hidden.css'))).toBe(true);
+  });
+
+  it('rejects a non-.css file', () => {
+    expect(isPathSafe(writeRoot, resolve(writeRoot, 'tokens.json'))).toBe(false);
+  });
+
+  it('rejects writeRoot itself (not a file)', () => {
+    expect(isPathSafe(writeRoot, writeRoot)).toBe(false);
+  });
+
+  it('rejects a sibling-directory escape (tokens-evil/)', () => {
+    expect(isPathSafe(writeRoot, resolve('/repo/tokens-evil/tokens.css'))).toBe(false);
+  });
+
+  it('rejects a parent-directory escape', () => {
+    expect(isPathSafe(writeRoot, resolve('/repo/other.css'))).toBe(false);
+  });
+
+  it('rejects an unrelated absolute path', () => {
+    expect(isPathSafe(writeRoot, resolve('/etc/passwd.css'))).toBe(false);
+  });
+});
+
+describe('CSS_VAR_NAME_RE / isValidCssVarName', () => {
+  it('accepts well-formed custom properties', () => {
+    expect(CSS_VAR_NAME_RE.test('--zd-p5')).toBe(true);
+    expect(isValidCssVarName('--secondary_pa-7')).toBe(true);
+  });
+
+  it('rejects names without the leading double-dash', () => {
+    expect(isValidCssVarName('zd-p5')).toBe(false);
+    expect(isValidCssVarName('-zd-p5')).toBe(false);
+  });
+
+  it('rejects names with disallowed characters', () => {
+    expect(isValidCssVarName('--zd p5')).toBe(false);
+    expect(isValidCssVarName('--zd@p5')).toBe(false);
+    expect(isValidCssVarName('--')).toBe(false);
+  });
+
+  it('rejects non-string values', () => {
+    expect(isValidCssVarName(undefined)).toBe(false);
+    expect(isValidCssVarName(null)).toBe(false);
+    expect(isValidCssVarName(42)).toBe(false);
+  });
+});
+
+describe('validateAndSanitizeTokens', () => {
+  it('accepts a well-formed map and returns the sanitized copy', () => {
+    const result = validateAndSanitizeTokens({
+      '--zd-p5': 'oklch(65% 0.2 45)',
+      '--zd-p6': 'oklch(52% 0.01 50)',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.sanitized).toEqual({
+      '--zd-p5': 'oklch(65% 0.2 45)',
+      '--zd-p6': 'oklch(52% 0.01 50)',
+    });
+  });
+
+  it('returns an error for an invalid CSS var name', () => {
+    const result = validateAndSanitizeTokens({ 'zd-p5': 'red' });
+    expect(result.error).toMatch(/Invalid cssVar name/);
+    expect(result.sanitized).toBeUndefined();
+  });
+
+  it('returns an error for a non-string value', () => {
+    const result = validateAndSanitizeTokens({ '--zd-p5': 42 });
+    expect(result.error).toMatch(/must be a string/);
+    expect(result.sanitized).toBeUndefined();
+  });
+});

--- a/packages/zudo-design-token-panel/src/server/create-apply-handler.ts
+++ b/packages/zudo-design-token-panel/src/server/create-apply-handler.ts
@@ -1,0 +1,278 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { serializeFileWrite } from './serialize-write';
+import { isPathSafe, validateAndSanitizeTokens } from './path-safety';
+import { applyTokenOverridesOrThrow, NoRootBlockError } from '../apply/apply-token-overrides';
+import { routeTokensToFiles } from '../apply/route-tokens-to-files';
+import type { ApplyRoutingMap } from '../config/panel-config';
+
+// ----- Types ------------------------------------------------------------------
+
+export interface ApplyHandlerOptions {
+  /**
+   * Absolute path to the repository root. Used as the CWD reference when
+   * resolving `routing` paths and normalising `file` values in the response.
+   */
+  rootDir: string;
+  /**
+   * Absolute path to the directory that is allowed to contain CSS token files.
+   * Paths resolved from `routing` must sit strictly inside this directory
+   * (enforced by `isPathSafe`).
+   */
+  writeRoot: string;
+  /**
+   * Prefix → repo-relative CSS file path map. Matches the shape of
+   * `PanelConfig.applyRouting` (e.g. `{ zd: 'tokens/tokens.css' }`).
+   */
+  routing: ApplyRoutingMap;
+}
+
+export interface PerFileResult {
+  file: string;
+  changed: string[];
+  unchanged: string[];
+  unknown: string[];
+}
+
+// ----- Helpers ----------------------------------------------------------------
+
+interface ComputedRewrite {
+  absPath: string;
+  relPath: string;
+  /** Original on-disk contents — kept for rollback after a partial write. */
+  original: string;
+  /** Post-rewrite contents to be written iff `changed.length > 0`. */
+  updated: string;
+  changed: string[];
+  unchanged: string[];
+  unknown: string[];
+}
+
+function jsonResponse(data: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function computeRewrite(
+  absPath: string,
+  relPath: string,
+  tokens: Record<string, string>,
+): Promise<ComputedRewrite> {
+  const content = await fs.readFile(absPath, 'utf-8');
+  const result = applyTokenOverridesOrThrow(content, tokens);
+  return {
+    absPath,
+    relPath,
+    original: content,
+    updated: result.updated,
+    changed: result.changed,
+    unchanged: result.unchanged,
+    unknown: result.unknown,
+  };
+}
+
+async function persistRewrite(rewrite: ComputedRewrite): Promise<void> {
+  if (rewrite.changed.length === 0) return;
+  return serializeFileWrite(rewrite.absPath, async () => {
+    const dir = dirname(rewrite.absPath);
+    const tmpPath = join(dir, `.tmp-${randomBytes(8).toString('hex')}.css`);
+    try {
+      await fs.writeFile(tmpPath, rewrite.updated, 'utf-8');
+      await fs.rename(tmpPath, rewrite.absPath);
+    } catch (err) {
+      try {
+        await fs.unlink(tmpPath);
+      } catch {
+        // ignore cleanup failure
+      }
+      throw err;
+    }
+  });
+}
+
+async function restoreOriginal(
+  rewrite: ComputedRewrite,
+): Promise<{ ok: true } | { ok: false; error: unknown }> {
+  return serializeFileWrite(rewrite.absPath, async () => {
+    const dir = dirname(rewrite.absPath);
+    const tmpPath = join(dir, `.tmp-${randomBytes(8).toString('hex')}.css`);
+    try {
+      await fs.writeFile(tmpPath, rewrite.original, 'utf-8');
+      await fs.rename(tmpPath, rewrite.absPath);
+      return { ok: true } as const;
+    } catch (err) {
+      console.error('[design-token-panel/server] Restore failed for', rewrite.relPath, err);
+      try {
+        await fs.unlink(tmpPath);
+      } catch {
+        // ignore cleanup failure
+      }
+      return { ok: false, error: err } as const;
+    }
+  });
+}
+
+// ----- Factory ----------------------------------------------------------------
+
+/**
+ * Create a framework-agnostic Fetch API handler for the design-token apply
+ * endpoint.
+ *
+ * The returned function accepts a standard `Request` and returns a
+ * `Promise<Response>`. No Astro, Express, http, or Vite dependencies.
+ *
+ * @example
+ * ```ts
+ * import { createApplyHandler } from '@takazudo/zudo-design-token-panel/server';
+ *
+ * const handler = createApplyHandler({
+ *   rootDir: process.cwd(),
+ *   writeRoot: resolve(process.cwd(), 'tokens'),
+ *   routing: { zd: 'tokens/tokens.css' },
+ * });
+ *
+ * // Vite / Astro / any Fetch-compatible router:
+ * export const POST = ({ request }: { request: Request }) => handler(request);
+ * ```
+ */
+export function createApplyHandler(
+  options: ApplyHandlerOptions,
+): (req: Request) => Promise<Response> {
+  const { rootDir, writeRoot, routing } = options;
+
+  return async function handleApply(request: Request): Promise<Response> {
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return jsonResponse({ ok: false, error: 'Invalid JSON in request body' }, 400);
+    }
+
+    if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+      return jsonResponse({ ok: false, error: 'Request body must be a JSON object' }, 400);
+    }
+
+    const { tokens } = body as { tokens: unknown };
+
+    if (typeof tokens !== 'object' || tokens === null || Array.isArray(tokens)) {
+      return jsonResponse({ ok: false, error: 'tokens must be a JSON object' }, 400);
+    }
+
+    const entries = Object.entries(tokens as Record<string, unknown>);
+    if (entries.length === 0) {
+      return jsonResponse({ ok: false, error: 'tokens must contain at least one entry' }, 400);
+    }
+
+    const { sanitized, error } = validateAndSanitizeTokens(tokens as Record<string, unknown>);
+    if (error || !sanitized) {
+      return jsonResponse({ ok: false, error: error ?? 'Invalid tokens' }, 400);
+    }
+
+    // Prefix-based routing: unknown prefixes land in `rejected`.
+    const { groups, rejected } = routeTokensToFiles(sanitized, routing);
+    if (rejected.length > 0) {
+      return jsonResponse({ ok: false, error: 'Unsupported cssVar prefix', rejected }, 400);
+    }
+    if (groups.length === 0) {
+      // Defensive: validation above should have caught this.
+      return jsonResponse({ ok: false, error: 'No routable tokens supplied' }, 400);
+    }
+
+    // Resolve + path-safety check up-front so we never start a partial apply.
+    const resolved: Array<{
+      absPath: string;
+      relPath: string;
+      groupTokens: Record<string, string>;
+    }> = [];
+    for (const group of groups) {
+      const absPath = resolve(rootDir, group.relativePath);
+      if (!isPathSafe(writeRoot, absPath)) {
+        return jsonResponse({ ok: false, error: `Path not allowed: ${group.relativePath}` }, 400);
+      }
+      resolved.push({ absPath, relPath: group.relativePath, groupTokens: group.tokens });
+    }
+
+    // Compute every file's rewrite IN MEMORY first. If any compute step
+    // throws (no :root block, IO error, etc.) we return an error before
+    // mutating disk so the handler is atomic on the failure path.
+    const computed: ComputedRewrite[] = [];
+    for (const { absPath, relPath, groupTokens } of resolved) {
+      try {
+        computed.push(await computeRewrite(absPath, relPath, groupTokens));
+      } catch (err) {
+        if (err instanceof NoRootBlockError) {
+          console.error('[design-token-panel/server] No :root block in', relPath);
+          return jsonResponse(
+            {
+              ok: false,
+              error: `No top-level :root { ... } block in ${relPath}`,
+            },
+            409,
+          );
+        }
+        console.error(`[design-token-panel/server] Error computing ${relPath}:`, err);
+        return jsonResponse({ ok: false, error: 'Failed to read or parse source file' }, 500);
+      }
+    }
+
+    // Write phase — persist each computed rewrite. On any failure, roll back
+    // every previously-written file from the in-memory `original` snapshot.
+    const persisted: ComputedRewrite[] = [];
+    for (const rewrite of computed) {
+      try {
+        await persistRewrite(rewrite);
+        persisted.push(rewrite);
+      } catch (err) {
+        console.error(`[design-token-panel/server] Write failed for ${rewrite.relPath}:`, err);
+        // Roll back already-persisted files in reverse order. Collect any
+        // restore failures so the response truthfully reports partial state
+        // instead of falsely claiming a clean rollback.
+        const restoreFailures: string[] = [];
+        for (let i = persisted.length - 1; i >= 0; i--) {
+          const result = await restoreOriginal(persisted[i]);
+          if (!result.ok) restoreFailures.push(persisted[i].relPath);
+        }
+        if (restoreFailures.length > 0) {
+          return jsonResponse(
+            {
+              ok: false,
+              error: `Failed to write file ${rewrite.relPath}; rollback also failed for ${restoreFailures.length} file(s) — disk state is inconsistent. Inspect the listed files manually.`,
+              failedFile: rewrite.relPath,
+              restoreFailures,
+            },
+            500,
+          );
+        }
+        return jsonResponse(
+          {
+            ok: false,
+            error: `Failed to write file ${rewrite.relPath}; previously-written files were restored.`,
+            failedFile: rewrite.relPath,
+          },
+          500,
+        );
+      }
+    }
+
+    const unknownCssVars: string[] = computed.flatMap((r) => r.unknown);
+    const unchangedCssVars: string[] = computed.flatMap((r) => r.unchanged);
+
+    // Normalise `file` paths in the response to repo-relative form.
+    const updated: PerFileResult[] = computed.map((r) => ({
+      file: r.relPath.startsWith('/') ? relative(rootDir, r.relPath) : r.relPath,
+      changed: r.changed,
+      unchanged: r.unchanged,
+      unknown: r.unknown,
+    }));
+
+    return jsonResponse({
+      ok: true,
+      updated,
+      unknownCssVars,
+      unchangedCssVars,
+    });
+  };
+}

--- a/packages/zudo-design-token-panel/src/server/index.ts
+++ b/packages/zudo-design-token-panel/src/server/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @takazudo/zudo-design-token-panel/server
+ *
+ * Node-only server-side apply pipeline. Zero framework dependencies —
+ * the handler factory uses standard Fetch API types (Node 18+).
+ *
+ * @example
+ * ```ts
+ * import { createApplyHandler } from '@takazudo/zudo-design-token-panel/server';
+ * import { resolve } from 'node:path';
+ *
+ * const handler = createApplyHandler({
+ *   rootDir: process.cwd(),
+ *   writeRoot: resolve(process.cwd(), 'tokens'),
+ *   routing: { zd: 'tokens/tokens.css' },
+ * });
+ * ```
+ */
+
+export { createApplyHandler } from './create-apply-handler';
+export type { ApplyHandlerOptions, PerFileResult } from './create-apply-handler';
+export { serializeFileWrite } from './serialize-write';
+export {
+  CSS_VAR_NAME_RE,
+  isPathSafe,
+  isValidCssVarName,
+  validateAndSanitizeTokens,
+} from './path-safety';
+export { loadRoutingFromFile, type ApplyRoutingMap } from './load-routing';

--- a/packages/zudo-design-token-panel/src/server/load-routing.ts
+++ b/packages/zudo-design-token-panel/src/server/load-routing.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+
+/**
+ * CSS-var prefix family → host-relative CSS file path.
+ *
+ * Shape: `{ "<prefix>": "<host-relative-css-path>", ... }`.
+ * Both the panel UI (`PanelConfig.applyRouting`) and the bin (`--routing` flag)
+ * share this type so the two readers stay in sync.
+ *
+ * Same logical shape as `ApplyRoutingMap` in `config/panel-config.ts`
+ * (which is `Record<string, string>`). Exported from the server entry so
+ * bin code and consumer tooling can import it from `./server` without
+ * pulling in the full panel client bundle.
+ */
+export type ApplyRoutingMap = Record<string, string>;
+
+/**
+ * Read a routing JSON file from disk, validate its shape, and return the map.
+ *
+ * Throws a descriptive `Error` for any of:
+ *   - file does not exist / is unreadable
+ *   - invalid JSON syntax
+ *   - root value is not a plain object (null, array, primitive, etc.)
+ *   - any value in the map is not a non-empty string
+ *   - the map itself is empty (at least one prefix entry is required)
+ *
+ * Intended for Node.js / Vite plugin / bin contexts only — not for
+ * browser-side code (uses `node:fs`).
+ *
+ * @param absPath - Absolute path to the JSON file.
+ * @returns The validated routing map.
+ *
+ * @example
+ * ```ts
+ * import { loadRoutingFromFile } from '@takazudo/zudo-design-token-panel/server';
+ *
+ * const routing = loadRoutingFromFile('/abs/path/to/my.routing.json');
+ * // → { zd: 'tokens/tokens.css', ... }
+ * ```
+ */
+export function loadRoutingFromFile(absPath: string): ApplyRoutingMap {
+  let raw: string;
+  try {
+    raw = readFileSync(absPath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `[design-token-panel] loadRoutingFromFile: cannot read file at ${absPath}\n` +
+        `  Cause: ${(err as NodeJS.ErrnoException).message}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `[design-token-panel] loadRoutingFromFile: invalid JSON in ${absPath}\n` +
+        `  Cause: ${(err as SyntaxError).message}`,
+    );
+  }
+
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(
+      `[design-token-panel] loadRoutingFromFile: root value must be a plain object, ` +
+        `got ${parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed} ` +
+        `(in ${absPath})`,
+    );
+  }
+
+  const map = parsed as Record<string, unknown>;
+  const keys = Object.keys(map);
+
+  if (keys.length === 0) {
+    throw new Error(
+      `[design-token-panel] loadRoutingFromFile: routing map must not be empty (in ${absPath})`,
+    );
+  }
+
+  for (const key of keys) {
+    const value = map[key];
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(
+        `[design-token-panel] loadRoutingFromFile: every value must be a non-empty string, ` +
+          `but key "${key}" has value ${JSON.stringify(value)} (in ${absPath})`,
+      );
+    }
+  }
+
+  return map as ApplyRoutingMap;
+}

--- a/packages/zudo-design-token-panel/src/server/path-safety.ts
+++ b/packages/zudo-design-token-panel/src/server/path-safety.ts
@@ -1,0 +1,64 @@
+import { isAbsolute, relative, sep } from 'node:path';
+import { sanitizeCssValue } from '../controls/sanitize-css-value';
+
+// ----- Validation patterns ----------------------------------------------------
+
+export const CSS_VAR_NAME_RE = /^--[a-zA-Z0-9_-]+$/;
+
+export function isValidCssVarName(v: unknown): v is string {
+  return typeof v === 'string' && CSS_VAR_NAME_RE.test(v);
+}
+
+/**
+ * A resolved path is safe iff it sits strictly inside the write-root
+ * directory AND ends with `.css`. Cross-platform: uses `path.relative` to
+ * normalize separators and detect both escape attempts and (on Windows)
+ * different-drive resolutions. The naive `startsWith(${writeRoot}/)` check
+ * silently fails on Windows where the platform separator is a backslash.
+ *
+ * Reject conditions:
+ *   - resolvedPath does not end with `.css`
+ *   - resolvedPath equals writeRoot (relative is empty / `.`)
+ *   - relative is absolute (different drive or unrelated root on Windows)
+ *   - relative starts with `..` followed by a separator (escape) or is `..`
+ *     itself. Note that filenames such as `..hidden.css` directly under
+ *     writeRoot remain valid because `..hidden.css` is not `..` and does not
+ *     start with a separator.
+ */
+export function isPathSafe(writeRoot: string, resolvedPath: string): boolean {
+  if (!resolvedPath.endsWith('.css')) return false;
+  const rel = relative(writeRoot, resolvedPath);
+  if (rel === '' || rel === '.') return false;
+  if (isAbsolute(rel)) return false;
+  if (rel === '..' || rel.startsWith(`..${sep}`) || rel.startsWith('../')) return false;
+  return true;
+}
+
+/**
+ * Validate the incoming `tokens` map and return a sanitized copy.
+ *
+ * - Keys must match `CSS_VAR_NAME_RE` (`--[a-zA-Z0-9_-]+`).
+ * - Values must be strings. Each value runs through `sanitizeCssValue`.
+ *   If sanitization changed the value, we still accept the sanitized form —
+ *   rejecting here would surface as a confusing 400 for callers whose color
+ *   picker briefly emits a trailing newline.
+ *
+ * Returns `{ sanitized }` on success, or `{ error }` describing the first
+ * offending key.
+ */
+export function validateAndSanitizeTokens(tokens: Record<string, unknown>): {
+  sanitized?: Record<string, string>;
+  error?: string;
+} {
+  const sanitized: Record<string, string> = {};
+  for (const [key, rawValue] of Object.entries(tokens)) {
+    if (!isValidCssVarName(key)) {
+      return { error: `Invalid cssVar name: ${JSON.stringify(key)}` };
+    }
+    if (typeof rawValue !== 'string') {
+      return { error: `Value for ${key} must be a string` };
+    }
+    sanitized[key] = sanitizeCssValue(rawValue);
+  }
+  return { sanitized };
+}

--- a/packages/zudo-design-token-panel/src/server/serialize-write.ts
+++ b/packages/zudo-design-token-panel/src/server/serialize-write.ts
@@ -1,0 +1,21 @@
+const inflight = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialize file writes per absolute path. Concurrent calls for the same path
+ * are chained so the next read-modify-write only starts after the previous
+ * one settles (success or error). Calls for different paths run in parallel.
+ */
+export async function serializeFileWrite<T>(absPath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = inflight.get(absPath) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  const swallowed = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  inflight.set(absPath, swallowed);
+  try {
+    return await next;
+  } finally {
+    if (inflight.get(absPath) === swallowed) inflight.delete(absPath);
+  }
+}

--- a/packages/zudo-design-token-panel/vite.config.ts
+++ b/packages/zudo-design-token-panel/vite.config.ts
@@ -5,17 +5,21 @@ import { defineConfig } from 'vite';
  *
  * Three responsibilities:
  *
- * 1. **Lib bundle** — `vite build` emits `dist/index.js` plus `dist/astro/index.js`,
- *    `dist/astro/host-adapter.js`, and `dist/server/index.js` (ESM, multi-entry)
- *    with Preact externalised so consumers contribute their own copy via the
- *    peerDependency. The CSS side-effect import in `src/index.tsx` lands as a
- *    co-emitted chunk under `dist/`. Type emission is handled separately by
- *    `tsc -p tsconfig.build.json` (vite-plugin-dts intentionally avoided —
- *    explicit tsc gives single-source-of-truth control over the .d.ts shape).
+ * 1. **Lib bundle** — `vite build` emits `dist/index.js`, `dist/astro/index.js`,
+ *    `dist/astro/host-adapter.js`, `dist/server/index.js`, and the standalone
+ *    bin entry `dist/bin/server.js` (ESM, multi-entry) with Preact externalised
+ *    so consumers contribute their own copy via the peerDependency. The CSS
+ *    side-effect import in `src/index.tsx` lands as a co-emitted chunk under
+ *    `dist/`. Type emission is handled separately by `tsc -p tsconfig.build.json`
+ *    (vite-plugin-dts intentionally avoided — explicit tsc gives single-source-
+ *    of-truth control over the .d.ts shape).
  *
- *    Note: the `bin/server` entry from the upstream zmod port is intentionally
- *    deferred to a follow-up epic — this package currently ships the panel UI,
- *    Astro adapter, and server Apply API, but not the standalone CLI bin.
+ *    The `dist/bin/server.js` chunk is the executable invoked via the
+ *    `design-token-panel-server` bin field. It receives a
+ *    `#!/usr/bin/env node` shebang via Rollup's `output.banner` (only that
+ *    chunk; the panel/astro/server entries stay shebang-free). `pnpm build`
+ *    follows up with `chmod +x dist/bin/server.js` so the file is directly
+ *    executable.
  *
  * 2. **resolve.alias for vitest** — kept so `pnpm test` resolves the
  *    alias-smoke test's intentional `from 'react'` import against
@@ -53,10 +57,13 @@ export default defineConfig({
         // `index.ts`, so it would not be discovered without an explicit entry.
         'astro/index': 'src/astro/index.ts',
         'astro/host-adapter': 'src/astro/host-adapter.ts',
-        // NOTE: the upstream zmod port also emitted a `server/index` entry
-        // for the apply-pipeline server modules. That tree is deferred to a
-        // follow-up epic; this package currently ships only the panel UI
-        // and Astro adapter.
+        // Server-side apply pipeline entry (Node-only). Exposed via the
+        // `./server` export.
+        'server/index': 'src/server/index.ts',
+        // Standalone CLI bin entry. Receives a `#!/usr/bin/env node` shebang
+        // banner only on this chunk (see `output.banner` below) and
+        // `chmod +x` in the package build script.
+        'bin/server': 'src/bin/server.ts',
       },
       formats: ['es'],
     },
@@ -87,7 +94,15 @@ export default defineConfig({
         'fs/promises',
         'crypto',
         'os',
+        'http',
+        'url',
       ],
+      output: {
+        // Inject the `#!/usr/bin/env node` shebang ONLY for the bin entry.
+        // The other chunks (panel UI, astro adapter, server library) are
+        // imported as ESM modules and must NOT carry a shebang.
+        banner: (chunk) => (chunk.fileName === 'bin/server.js' ? '#!/usr/bin/env node' : ''),
+      },
     },
   },
 });


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/5
- super-epic
    - https://github.com/Takazudo/zudo-design-token-panel/issues/2

---

## Summary

Ports the standalone Node HTTP bin `design-token-panel-server` and its server-side apply-pipeline modules into `@takazudo/zudo-design-token-panel`. The bin receives apply-pipeline POSTs from the browser panel and atomically rewrites token CSS files on disk under a configurable sandbox.

## Scope

### `packages/zudo-design-token-panel/src/server/` — apply pipeline (Node-only)

- `create-apply-handler.ts` — framework-agnostic POST handler that consumes `{file, ops}` apply payloads and routes them through `load-routing` + `path-safety` + `serialize-write` for atomic per-file rewrites.
- `load-routing.ts` — JSON loader for the cluster-id → repo-relative-CSS-path map.
- `path-safety.ts` — sandbox check (`writeRoot` containment, `.css` extension required, no parent-escape, no absolute paths, no `..`).
- `serialize-write.ts` — per-path serialized writes via temp-file + rename atomicity.
- `index.ts` — barrel for the new `./server` export.

### `packages/zudo-design-token-panel/src/bin/` — standalone CLI

- `server.ts` — Node `http` server wrapper around `createApplyHandler`. Handles `POST /apply`, `OPTIONS /apply` preflight, `GET /healthz`, plus 404/405 fallbacks. Graceful SIGINT/SIGTERM shutdown. Friendly EADDRINUSE message + exit 1.
- `parse-args.ts` — argv parser. `--routing` is REQUIRED (no fallback); `--root`, `--write-root`, `--port`, `--host`, `--allow-origin` (repeatable), `--quiet`, `--help`. Defaults: port 24681, host 127.0.0.1.
- `cors.ts` — exact-match origin allow-list, deny-by-default.

### Package wiring

- `package.json` — added `bin` field (`design-token-panel-server` → `./dist/bin/server.js`), added `./server` exports entry, build script extended with `chmod +x dist/bin/server.js`.
- `vite.config.ts` — added `bin/server` and `server/index` lib entries, externalised `http` and `url`, injected `#!/usr/bin/env node` shebang via `output.banner` (only on the bin chunk).

### Tests

- 6 unit-test files: `bin/__tests__/{cors,parse-args}.test.ts`, `server/__tests__/{create-apply-handler,load-routing,path-safety}.test.ts`.
- 1 integration test: `bin/__tests__/server.integration.test.ts` — spawns the built `dist/bin/server.js` as a child process and exercises POST happy path, disallowed-origin POST 403, OPTIONS preflight 403, GET /healthz, and EADDRINUSE collision.
- Total suite: 21 test files, 177 tests passing on the merged base. Typecheck clean.

### README §3 (Apply pipeline)

Rewrote to drop reference-monorepo specifics and describe the OSS-standalone surface: lead-in covers the panel POSTing directly to the bin's loopback listener; 3.1 `pnpm add -D` install + `npx design-token-panel-server --help` invocation with the full flag table; 3.2 generic routing example (`main`/`secondary` → `tokens/...`); 3.3 security reorganised around three guards (loopback, write sandbox, CORS allow-list) with deny-by-default and atomic temp+rename + in-memory rollback documented; 3.4 HTTP surface (healthz body, OPTIONS/POST/404/405) plus signal handling and EADDRINUSE; NEW 3.5 non-Astro recipe with `concurrently` script and a Node `child_process` wrapper that proxies SIGINT.

## Confidentiality

`grep -rEi` for upstream-monorepo identifiers (`zmod`, `zmodular`, `zaudio`, `takazudo-modular`, `sub-packages`, internal issue ids `#1440 #1441 #1462 #1550 #1584 #1601 #1620 #1621`) returns zero matches across all touched files.

## Verification

- `pnpm --filter @takazudo/zudo-design-token-panel build` — clean. `dist/bin/server.js` first line is `#!/usr/bin/env node`, file mode `0755`.
- `pnpm --filter @takazudo/zudo-design-token-panel test` — 21/21 files, 177/177 tests pass.
- `pnpm --filter @takazudo/zudo-design-token-panel typecheck` — 0 errors.
- `/gcoc-review` over `base/initial-port..HEAD` — no high/medium priority findings; path safety, atomic write, CORS, security, error handling, breaking changes, performance, and README accuracy all called out as solid.

## Branch graph

```
main
  └── base/initial-port            (super-epic anchor — #2)
        └── base/initial-port-bin  (THIS PR → merges into base/initial-port)
              ├── (merged) initial-port-bin/bin-port  — source + wiring + tests
              └── (merged) initial-port-bin/bin-docs  — README §3 rewrite
```