### PR TITLE
[Initial Port] Example app: Astro

### DIFF
--- a/examples/astro/.gitignore
+++ b/examples/astro/.gitignore
@@ -1,0 +1,7 @@
+# Astro
+.astro/
+dist/
+
+# Playwright
+playwright-report/
+test-results/

--- a/examples/astro/README.md
+++ b/examples/astro/README.md
@@ -1,0 +1,114 @@
+# Astro example — `@takazudo/zudo-design-token-panel`
+
+A minimal Astro 6 + Preact app that mounts the design-token panel via
+`<DesignTokenPanelHost>`, demonstrates live token tweaking, and exercises the
+full apply pipeline by round-tripping tweaks back to disk through the bin
+sidecar (`design-token-panel-server`).
+
+## Run
+
+```bash
+pnpm --filter astro-example dev
+```
+
+`pnpm dev` runs two processes via `concurrently`:
+
+| process | port  | role                                                                      |
+| ------- | ----- | ------------------------------------------------------------------------- |
+| Astro   | 44324 | the example site                                                          |
+| bin     | 24682 | `design-token-panel-server` — receives `/apply` POSTs, rewrites `tokens.css` |
+
+The Astro dev server proxies `/api/dev/apply` to the bin (see
+`astro.config.ts`), so the panel POSTs to a same-origin URL — no CORS
+preflight, no hardcoded port in the runtime config.
+
+Open [http://localhost:44324](http://localhost:44324) and run
+`window.astroExample.toggleDesignPanel()` in the browser console to show the
+panel. Drag any slider — the page repaints before the next frame.
+
+## Apply-pipeline manual verification
+
+The Playwright spec at `tests/e2e/apply-roundtrip.spec.ts` automates this; the
+manual procedure is documented here so the round-trip is verifiable without
+booting the e2e harness.
+
+1. Start the dev environment:
+
+   ```bash
+   pnpm --filter astro-example dev
+   ```
+
+2. In a second shell, capture the current value of one token:
+
+   ```bash
+   grep -- '--astroexample-radius' examples/astro/src/styles/tokens.css
+   #   --astroexample-radius: 0.5rem;
+   ```
+
+3. In the browser, open the panel via
+   `window.astroExample.toggleDesignPanel()`. Switch to the **Size** tab, drag
+   the **Border Radius** slider to a different value, then click **Apply**
+   in the panel chrome and confirm the diff.
+
+4. In the second shell, re-read the same line — it should now show the new
+   value:
+
+   ```bash
+   grep -- '--astroexample-radius' examples/astro/src/styles/tokens.css
+   #   --astroexample-radius: 1.25rem;
+   ```
+
+5. The next page reload picks up the new value from the file (the in-memory
+   override is no longer needed because the source-of-truth on disk now
+   matches).
+
+For a non-interactive smoke check that bypasses the panel UI and POSTs
+directly to the bin:
+
+```bash
+pnpm --filter astro-example test:apply-smoke
+```
+
+## What the example proves
+
+- The panel package consumes ZERO project-specific defaults from its own
+  bundle. Every identifier (`storagePrefix`, `consoleNamespace`,
+  `paletteCssVarTemplate`, semantic CSS-var names, etc.) flows in from
+  `src/config/panel-config.ts`.
+- The apply pipeline routes by CSS-var prefix family: the
+  `astroexample` prefix in `scaffold.routing.json` maps to
+  `src/styles/tokens.css`, so any tweak to an `--astroexample-*` token
+  rewrites that file.
+- Astro view-transitions preserve panel state across soft navigations
+  (`/` ↔ `/about`) — the host adapter listens for `astro:before-swap` /
+  `astro:page-load` and re-materialises the shell when persisted overrides
+  or visibility intent demand it.
+
+## Layout
+
+```
+examples/astro/
+├── astro.config.ts             # Astro + preact + /api/dev/apply proxy
+├── package.json                # name: astro-example, dev = astro + bin
+├── playwright.config.ts        # apply-roundtrip e2e config
+├── scaffold.routing.json       # CSS-var prefix → file map (shared by panel + bin)
+├── scripts/
+│   └── smoke-apply.mjs         # non-UI smoke harness for the bin
+├── src/
+│   ├── config/
+│   │   ├── default-cluster.ts  # `--astroexample-*` color cluster
+│   │   ├── default-manifest.ts # `--astroexample-*` token rows
+│   │   └── panel-config.ts     # PanelConfig assembly
+│   ├── layouts/
+│   │   └── Layout.astro        # mounts <DesignTokenPanelHost>
+│   ├── pages/
+│   │   ├── index.astro
+│   │   └── about.astro
+│   └── styles/
+│       ├── reset.css
+│       └── tokens.css          # `--astroexample-*` source of truth (apply target)
+├── tests/
+│   └── e2e/
+│       └── apply-roundtrip.spec.ts
+└── tsconfig.json
+```

--- a/examples/astro/astro.config.ts
+++ b/examples/astro/astro.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'astro/config';
+import preact from '@astrojs/preact';
+
+/**
+ * Astro example for @takazudo/zudo-design-token-panel.
+ *
+ * Deliberately minimal: NO Tailwind, NO design-system integration, NO MDX.
+ * The example proves the panel package works inside any Astro consumer that
+ * supplies just `@astrojs/preact` + a `PanelConfig`.
+ *
+ * Apply-pipeline proxy
+ * --------------------
+ * `panelConfig.applyEndpoint` is set to the relative path `/api/dev/apply` so
+ * the panel POSTs to the same origin as the Astro dev server (no CORS
+ * preflight, no hardcoded port in the runtime config). The Vite dev server
+ * underneath Astro proxies that path to the bin sidecar on port 24682. This
+ * keeps the example app static-output and avoids pulling in an SSR adapter
+ * just to host one dev-only POST endpoint.
+ */
+export default defineConfig({
+  output: 'static',
+  devToolbar: { enabled: false },
+  integrations: [preact()],
+  server: {
+    port: 44324,
+  },
+  vite: {
+    server: {
+      proxy: {
+        '/api/dev/apply': {
+          target: 'http://127.0.0.1:24682',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api\/dev\/apply/, '/apply'),
+        },
+      },
+    },
+  },
+});

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "astro-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Astro example app demonstrating @takazudo/zudo-design-token-panel — host-config-driven panel + apply-pipeline round-trip via the bin sidecar.",
+  "scripts": {
+    "predev": "lsof -ti:44324 | xargs kill 2>/dev/null; lsof -ti:24682 | xargs kill 2>/dev/null; true",
+    "dev": "concurrently -k -n astro,tokens-bin -c blue,green \"pnpm run _dev:astro\" \"pnpm run _dev:tokens-bin\"",
+    "_dev:astro": "astro dev --port 44324",
+    "_dev:tokens-bin": "design-token-panel-server --write-root . --routing scaffold.routing.json --port 24682 --allow-origin http://localhost:44324",
+    "build": "astro build",
+    "preview": "astro preview --port 44324",
+    "typecheck": "astro check",
+    "test:apply-smoke": "node scripts/smoke-apply.mjs"
+  },
+  "dependencies": {
+    "@astrojs/preact": "^5.1.1",
+    "@takazudo/zudo-design-token-panel": "workspace:*",
+    "astro": "^6.1.5",
+    "preact": "^10.29.1"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.4",
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^22.0.0",
+    "concurrently": "^9.2.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/astro/playwright.config.ts
+++ b/examples/astro/playwright.config.ts
@@ -1,0 +1,46 @@
+/**
+ * Playwright config for the Astro example's apply-pipeline e2e spec.
+ *
+ * Local runs: webServer auto-starts the example's preview server.
+ * On CI / when BASE_URL is supplied externally: the caller manages the
+ * server lifecycle (so a separate workflow step can boot the bin sidecar
+ * + Astro dev server together via `pnpm dev`).
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const hasExternalBaseUrl = Boolean(process.env.BASE_URL);
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'list' : 'html',
+  maxFailures: 0,
+  timeout: process.env.CI ? 60 * 1000 : 30 * 1000,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:44324',
+    trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'apply-roundtrip',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer:
+    process.env.CI || hasExternalBaseUrl
+      ? undefined
+      : {
+          command: 'pnpm dev',
+          port: 44324,
+          reuseExistingServer: true,
+          timeout: 120 * 1000,
+        },
+});

--- a/examples/astro/scaffold.routing.json
+++ b/examples/astro/scaffold.routing.json
@@ -1,0 +1,3 @@
+{
+  "astroexample": "src/styles/tokens.css"
+}

--- a/examples/astro/scripts/smoke-apply.mjs
+++ b/examples/astro/scripts/smoke-apply.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Manual smoke harness for the bin sidecar.
+ *
+ * Requires `pnpm dev` to already be running in this example sub-package
+ * (so the bin is listening on http://127.0.0.1:24682). The harness:
+ *
+ *   1. Reads the current value of `--astroexample-radius` from
+ *      src/styles/tokens.css.
+ *   2. POSTs a different value to /apply.
+ *   3. Re-reads the file and asserts the value changed.
+ *   4. Restores the original value with a second POST.
+ *
+ * The try/finally block ensures the original value is restored even if any
+ * assertion fails, so re-running the harness gives consistent results.
+ */
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, '..', 'src', 'styles', 'tokens.css');
+const APPLY_URL = 'http://127.0.0.1:24682/apply';
+const ORIGIN = 'http://localhost:44324';
+const TARGET_VAR = '--astroexample-radius';
+const TEST_VALUE = '1.25rem';
+
+async function readTokenValue(cssVar) {
+  const css = await readFile(TOKENS_PATH, 'utf-8');
+  const escaped = cssVar.replace(/-/g, '\\-');
+  const re = new RegExp(`${escaped}:\\s*([^;]+);`);
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`Could not find ${cssVar} in ${TOKENS_PATH}`);
+  }
+  return m[1].trim();
+}
+
+async function postApply(cssVar, value) {
+  const response = await fetch(APPLY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify({ tokens: { [cssVar]: value } }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST /apply failed (${response.status}): ${text}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  console.error(`[smoke] reading ${TARGET_VAR} from ${TOKENS_PATH}`);
+  const originalValue = await readTokenValue(TARGET_VAR);
+  console.error(`[smoke] original value: ${originalValue}`);
+
+  if (originalValue === TEST_VALUE) {
+    throw new Error(`Test value ${TEST_VALUE} matches original — pick a different test value.`);
+  }
+
+  let assertionsPassed = false;
+  try {
+    console.error(`[smoke] POST /apply ${TARGET_VAR}=${TEST_VALUE}`);
+    await postApply(TARGET_VAR, TEST_VALUE);
+
+    const afterValue = await readTokenValue(TARGET_VAR);
+    console.error(`[smoke] post-apply value: ${afterValue}`);
+    if (afterValue !== TEST_VALUE) {
+      throw new Error(`Expected ${TARGET_VAR} to be ${TEST_VALUE} after apply, got ${afterValue}`);
+    }
+
+    assertionsPassed = true;
+    console.error('[smoke] PASS — bin sidecar rewrote tokens.css');
+  } finally {
+    try {
+      console.error(`[smoke] restoring ${TARGET_VAR}=${originalValue}`);
+      await postApply(TARGET_VAR, originalValue);
+      const restored = await readTokenValue(TARGET_VAR);
+      if (restored !== originalValue) {
+        console.error(
+          `[smoke] WARNING: restore mismatch — expected ${originalValue}, got ${restored}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[smoke] WARNING: failed to restore original value: ${err.message}`);
+    }
+  }
+
+  if (!assertionsPassed) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`[smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/examples/astro/src/config/default-cluster.ts
+++ b/examples/astro/src/config/default-cluster.ts
@@ -1,0 +1,78 @@
+/**
+ * Demo color cluster for the Astro example.
+ *
+ * The cluster's CSS-var family is `--astroexample-*` (palette + base roles +
+ * semantic names), declared on `:root` by `src/styles/tokens.css`. Tweaks in
+ * the panel write through these names; the apply pipeline (when wired through
+ * the bin sidecar) rewrites the same names on disk.
+ *
+ * `paletteCssVarTemplate` is the only knob that decides the per-slot var name.
+ * The cluster is JSON-serializable end-to-end so it round-trips through the
+ * Astro frontmatter → island JSON boundary.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+
+type ColorClusterDataConfig = PanelConfig['colorCluster'];
+
+export const defaultCluster: ColorClusterDataConfig = {
+  id: 'astroexample-cluster',
+  label: 'Astro Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--astroexample-bg',
+    foreground: '--astroexample-fg',
+  },
+  paletteCssVarTemplate: '--astroexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--astroexample-color-primary',
+    accent: '--astroexample-color-accent',
+    surface: '--astroexample-color-surface',
+    muted: '--astroexample-color-muted',
+    danger: '--astroexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};

--- a/examples/astro/src/config/default-manifest.ts
+++ b/examples/astro/src/config/default-manifest.ts
@@ -1,0 +1,85 @@
+/**
+ * Demo token manifest for the Astro example.
+ *
+ * Every `cssVar` is an `--astroexample-*` name. These line up byte-for-byte
+ * with the declarations in `src/styles/tokens.css` so the panel can rewrite
+ * the same names live and the apply pipeline can rewrite them on disk.
+ *
+ * `TokenManifest` is reachable via the indexed-access lookup
+ * `PanelConfig['tokens']` — the package's public Astro entry only re-exports
+ * `PanelConfig`, so this avoids a deep import into `dist/tokens/manifest`.
+ *
+ * `spacingGroupOrder` is set to `['vsp', 'hsp']` (vertical above horizontal),
+ * proving the host-supplied ordering field overrides the package default.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+
+type TokenManifest = PanelConfig['tokens'];
+
+export const defaultManifest: TokenManifest = {
+  spacing: [
+    {
+      id: 'astroexample-spacing-md',
+      cssVar: '--astroexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'astroexample-spacing-lg',
+      cssVar: '--astroexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'astroexample-text-base',
+      cssVar: '--astroexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'astroexample-text-heading',
+      cssVar: '--astroexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'astroexample-radius',
+      cssVar: '--astroexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  // Color tab is driven by the cluster — leave per-token rows empty.
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};

--- a/examples/astro/src/config/panel-config.ts
+++ b/examples/astro/src/config/panel-config.ts
@@ -1,0 +1,38 @@
+/**
+ * Assembles the `PanelConfig` consumed by `<DesignTokenPanelHost>`.
+ *
+ * The five identifier fields (`storagePrefix`, `consoleNamespace`,
+ * `modalClassPrefix`, `schemaId`, `exportFilenameBase`) all share an
+ * `astro-example*` namespace so localStorage entries, exported JSON, and
+ * modal classnames cannot collide with any other host's panel deployment.
+ *
+ * `applyEndpoint` is the relative path `/api/dev/apply`. `astro.config.ts`
+ * proxies it to the bin sidecar on port 24682, so the panel's POST stays on
+ * the same origin as the page it was served from — no CORS preflight, no
+ * runtime URL coupling between the panel config and the sidecar's port.
+ *
+ * `applyRouting` shares the SAME JSON file the bin sidecar reads at startup
+ * (`scaffold.routing.json`). The host UI and the apply server therefore
+ * agree byte-for-byte on which CSS-var prefix maps to which file.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+import { defaultManifest } from './default-manifest';
+import { defaultCluster } from './default-cluster';
+import scaffoldRouting from '../../scaffold.routing.json';
+
+export const panelConfig: PanelConfig = {
+  storagePrefix: 'astro-example-tokens',
+  consoleNamespace: 'astroExample',
+  modalClassPrefix: 'astro-example-design-token-panel-modal',
+  schemaId: 'astro-example-design-tokens/v1',
+  exportFilenameBase: 'astro-example-design-tokens',
+  tokens: defaultManifest,
+  colorCluster: defaultCluster,
+  applyEndpoint: '/api/dev/apply',
+  applyRouting: scaffoldRouting,
+  // Explicit opt-out for the secondary color cluster — the demo ships a
+  // single primary palette only. `null` (NOT `undefined`) is the documented
+  // signal that the host has no secondary cluster.
+  secondaryColorCluster: null,
+};

--- a/examples/astro/src/layouts/Layout.astro
+++ b/examples/astro/src/layouts/Layout.astro
@@ -1,0 +1,57 @@
+---
+/**
+ * Shared layout for the Astro example. Mounts <DesignTokenPanelHost> at the
+ * end of <body> so the panel attaches once per page navigation. The
+ * <ClientRouter /> import wires Astro's view-transition lifecycle — the
+ * panel's host adapter listens for `astro:before-swap` / `astro:page-load`
+ * and re-materialises the shell automatically.
+ *
+ * Side-effect CSS imports
+ * -----------------------
+ *  - `reset.css` is the demo's minimal preflight.
+ *  - `tokens.css` declares every `--astroexample-*` variable on `:root` AND
+ *    is the file the apply pipeline rewrites on disk (single source of
+ *    truth for the round-trip).
+ *  - `@takazudo/zudo-design-token-panel/styles` re-pulls the package's
+ *    bundled chrome stylesheet. Vite library mode strips the source CSS
+ *    import from the emitted JS, so consumers must re-pull it explicitly.
+ */
+
+import { ClientRouter } from 'astro:transitions';
+import { DesignTokenPanelHost } from '@takazudo/zudo-design-token-panel/astro';
+import { panelConfig } from '../config/panel-config';
+
+import '../styles/reset.css';
+import '../styles/tokens.css';
+import '@takazudo/zudo-design-token-panel/styles';
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <ClientRouter />
+  </head>
+  <body>
+    <slot />
+    <DesignTokenPanelHost config={panelConfig} />
+  </body>
+</html>
+
+<script>
+  // Required side-effect load for the package's host adapter. We use a
+  // dynamic `import()` (not a top-level `import '...';`) because Vite/Rollup
+  // strips top-level side-effect imports of external packages from hoisted
+  // Astro <script> blocks. The dynamic import lands as a real `import()`
+  // call in the bundled output so the host-adapter chunk reliably reaches
+  // prod and `window.<consoleNamespace>.*` exists at runtime.
+  void import('@takazudo/zudo-design-token-panel/astro/host-adapter');
+</script>

--- a/examples/astro/src/pages/about.astro
+++ b/examples/astro/src/pages/about.astro
@@ -1,0 +1,68 @@
+---
+/**
+ * Second page of the Astro example. Mirrors the home page's shape so token
+ * tweaks can be verified across an Astro view-transition. The panel's host
+ * adapter listens for `astro:before-swap` / `astro:page-load` and re-mounts
+ * the panel shell when visibility intent or persisted overrides demand it.
+ */
+
+import Layout from '../layouts/Layout.astro';
+
+const paletteIndices = Array.from({ length: 16 }, (_, i) => i);
+---
+
+<Layout title="Astro Example — About">
+  <main class="astroexample-stack">
+    <header>
+      <h1 class="astroexample-heading">About this example</h1>
+      <p>
+        The <code>examples/astro</code> sub-package consumes
+        <code>@takazudo/zudo-design-token-panel</code> through its built artifact only — there are no
+        deep imports into <code>dist/</code>, no bundler aliases, and no framework integration beyond
+        <code>@astrojs/preact</code>.
+      </p>
+      <ul>
+        <li>No Tailwind, no preflight stylesheet, no design-system dependency.</li>
+        <li>
+          Storage prefix <code>astro-example-tokens</code>, console namespace
+          <code>astroExample</code>.
+        </li>
+        <li>Palette CSS-var template <code>--astroexample-palette-{`{n}`}</code>.</li>
+        <li>
+          Apply endpoint <code>/api/dev/apply</code> proxied by Vite to the bin sidecar on port
+          24682.
+        </li>
+      </ul>
+    </header>
+
+    <section>
+      <h2 class="astroexample-heading">Verify across navigation</h2>
+      <div class="astroexample-card">
+        Open the panel via <code>window.astroExample.toggleDesignPanel()</code>, change a token,
+        then navigate <a class="astroexample-link" href="/">back to home</a>. The new value should
+        still apply — proving the host adapter's <code>astro:page-load</code> reapply path works
+        end-to-end.
+      </div>
+    </section>
+
+    <section>
+      <h2 class="astroexample-heading">Palette swatches (mirrored)</h2>
+      <div class="astroexample-swatch-row">
+        {
+          paletteIndices.map((i) => (
+            <div
+              class="astroexample-swatch"
+              style={`background: var(--astroexample-palette-${i});`}
+            >
+              {i}
+            </div>
+          ))
+        }
+      </div>
+      <p class="astroexample-meta">
+        These swatches are identical to the home page so a side-by-side comparison after a token
+        tweak is trivial.
+      </p>
+    </section>
+  </main>
+</Layout>

--- a/examples/astro/src/pages/index.astro
+++ b/examples/astro/src/pages/index.astro
@@ -1,0 +1,73 @@
+---
+/**
+ * Home page of the Astro example. Renders cards / buttons / palette swatches
+ * driven entirely by `--astroexample-*` tokens, so opening the panel and
+ * tweaking any token rewrites the page in real time.
+ */
+
+import Layout from '../layouts/Layout.astro';
+
+const paletteIndices = Array.from({ length: 16 }, (_, i) => i);
+---
+
+<Layout title="Astro Example — Design Token Panel">
+  <main class="astroexample-stack">
+    <header>
+      <h1 class="astroexample-heading">Live token tweaking, in plain Astro</h1>
+      <p>
+        Every visible element on this page is driven by an
+        <code>--astroexample-*</code> CSS custom property. Open the panel from the browser console and
+        drag any slider — the change applies before the next paint.
+      </p>
+      <p class="astroexample-meta">
+        Console API: <code>window.astroExample.toggleDesignPanel()</code>. Storage prefix:
+        <code>astro-example-tokens</code>.
+      </p>
+    </header>
+
+    <section>
+      <h2 class="astroexample-heading">Cards (spacing + radius + surface)</h2>
+      <div class="astroexample-card">
+        <strong>Card A.</strong> Padding driven by <code>--astroexample-spacing-md</code>, corners by
+        <code>--astroexample-radius</code>, background by <code>--astroexample-color-surface</code>.
+      </div>
+      <div class="astroexample-card">
+        <strong>Card B.</strong> Stack gap driven by <code>--astroexample-spacing-lg</code>; outline
+        by <code>--astroexample-color-muted</code>.
+      </div>
+    </section>
+
+    <section>
+      <h2 class="astroexample-heading">Buttons + links (accent / primary)</h2>
+      <p>
+        <button class="astroexample-button" type="button">Action button</button>
+      </p>
+      <p>
+        Try the <a class="astroexample-link" href="/about">about page</a> to confirm token tweaks
+        persist across an Astro view-transition.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="astroexample-heading">Palette swatches</h2>
+      <div class="astroexample-swatch-row">
+        {
+          paletteIndices.map((i) => (
+            <div
+              class="astroexample-swatch"
+              style={`background: var(--astroexample-palette-${i});`}
+            >
+              {i}
+            </div>
+          ))
+        }
+      </div>
+      <p class="astroexample-meta">
+        Each swatch reads <code>--astroexample-palette-{`{n}`}</code>. The cluster's
+        <code>paletteCssVarTemplate</code> is the only thing that decides this name — change it in
+        <code>default-cluster.ts</code> and the apply pipeline writes a different variable on the next
+        palette tweak.
+      </p>
+    </section>
+  </main>
+</Layout>

--- a/examples/astro/src/styles/reset.css
+++ b/examples/astro/src/styles/reset.css
@@ -1,0 +1,39 @@
+/* Minimal reset — replaces what a framework-provided preflight stylesheet
+   (Tailwind, design-system, etc.) would normally provide. The example
+   deliberately ships none. */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}

--- a/examples/astro/src/styles/tokens.css
+++ b/examples/astro/src/styles/tokens.css
@@ -1,0 +1,138 @@
+/*
+ * `--astroexample-*` tokens consumed by the demo pages.
+ *
+ * Two roles wrapped into one file:
+ *
+ *   1. The byte-for-byte source of truth for the demo's CSS-var values. The
+ *      panel rewrites these names live (in-memory `:root` overrides) when
+ *      the user tweaks a slider. The Apply pipeline rewrites THIS FILE on
+ *      disk when the user clicks Apply (see `scaffold.routing.json` —
+ *      prefix `astroexample` → this path).
+ *
+ *   2. The demo stylesheet — every `.astroexample-*` selector below reads
+ *      tokens from `:root`, so a tweak in any tab is immediately visible
+ *      across both demo pages.
+ *
+ * Splitting the two concerns into separate files would mean the apply
+ * pipeline rewrites a file the demo doesn't read (or vice versa). Keeping
+ * them paired makes the round-trip obvious: the bin sidecar's response is
+ * literally the new contents of the file the next page-load will use.
+ */
+:root {
+  /* Spacing tokens (manifest: spacing tab) */
+  --astroexample-spacing-md: 1rem;
+  --astroexample-spacing-lg: 2rem;
+
+  /* Typography tokens (manifest: typography tab) */
+  --astroexample-text-base: 1rem;
+  --astroexample-text-heading: 1.75rem;
+
+  /* Size tokens (manifest: size tab) */
+  --astroexample-radius: 0.5rem;
+
+  /* Cluster base roles (default-cluster.ts → baseRoles) */
+  --astroexample-bg: #1e1e1e;
+  --astroexample-fg: #f8fafc;
+
+  /* Cluster palette slots (default-cluster.ts → paletteCssVarTemplate) */
+  --astroexample-palette-0: #1e1e1e;
+  --astroexample-palette-1: #2d6cdf;
+  --astroexample-palette-2: #3aa676;
+  --astroexample-palette-3: #d97706;
+  --astroexample-palette-4: #9b5de5;
+  --astroexample-palette-5: #e63946;
+  --astroexample-palette-6: #1d3557;
+  --astroexample-palette-7: #06b6d4;
+  --astroexample-palette-8: #475569;
+  --astroexample-palette-9: #94a3b8;
+  --astroexample-palette-10: #cbd5e1;
+  --astroexample-palette-11: #e2e8f0;
+  --astroexample-palette-12: #f1f5f9;
+  --astroexample-palette-13: #fef3c7;
+  --astroexample-palette-14: #bbf7d0;
+  --astroexample-palette-15: #f8fafc;
+
+  /* Cluster semantic names (default-cluster.ts → semanticCssNames) */
+  --astroexample-color-primary: var(--astroexample-palette-1);
+  --astroexample-color-accent: var(--astroexample-palette-3);
+  --astroexample-color-surface: var(--astroexample-palette-0);
+  --astroexample-color-muted: var(--astroexample-palette-8);
+  --astroexample-color-danger: var(--astroexample-palette-5);
+}
+
+body {
+  background: var(--astroexample-bg);
+  color: var(--astroexample-fg);
+  font-size: var(--astroexample-text-base);
+  padding: var(--astroexample-spacing-lg);
+}
+
+.astroexample-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--astroexample-spacing-lg);
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.astroexample-heading {
+  font-size: var(--astroexample-text-heading);
+  font-weight: 700;
+  margin: 0 0 var(--astroexample-spacing-md);
+  color: var(--astroexample-color-primary);
+}
+
+.astroexample-card {
+  background: var(--astroexample-color-surface);
+  color: var(--astroexample-fg);
+  padding: var(--astroexample-spacing-md);
+  border-radius: var(--astroexample-radius);
+  border: 1px solid var(--astroexample-color-muted);
+}
+
+.astroexample-card + .astroexample-card {
+  margin-top: var(--astroexample-spacing-md);
+}
+
+.astroexample-button {
+  display: inline-block;
+  padding: var(--astroexample-spacing-md);
+  border-radius: var(--astroexample-radius);
+  background: var(--astroexample-color-accent);
+  color: var(--astroexample-bg);
+  border: none;
+  cursor: pointer;
+}
+
+.astroexample-button:hover {
+  background: var(--astroexample-color-primary);
+}
+
+.astroexample-link {
+  color: var(--astroexample-color-accent);
+  text-decoration: underline;
+}
+
+.astroexample-swatch-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--astroexample-spacing-md);
+}
+
+.astroexample-swatch {
+  width: 4rem;
+  height: 4rem;
+  border-radius: var(--astroexample-radius);
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--astroexample-fg);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+  padding: 0.25rem;
+}
+
+.astroexample-meta {
+  font-size: 0.875rem;
+  color: var(--astroexample-color-muted);
+}

--- a/examples/astro/tests/e2e/apply-roundtrip.spec.ts
+++ b/examples/astro/tests/e2e/apply-roundtrip.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Apply-pipeline round-trip spec for the Astro example.
+ *
+ * Drives the panel UI to tweak a token, click Apply, and asserts the demo
+ * tokens CSS file on disk (`src/styles/tokens.css`) was rewritten by the
+ * bin sidecar. The full bin → file rewrite path is what the spec proves;
+ * the panel's in-memory `:root` override is exercised as a side effect.
+ *
+ * Prerequisites
+ * -------------
+ *  - Astro dev server on port 44324 (started by the Playwright `webServer`
+ *    config OR by an upstream `pnpm dev` invocation).
+ *  - Bin sidecar `design-token-panel-server` on port 24682, with
+ *    `--write-root .` and `--routing scaffold.routing.json` pointing at
+ *    this example's tree.
+ *
+ * Both are wired by `pnpm dev` (concurrently), so the local-run flow is:
+ *
+ *   pnpm --filter astro-example dev
+ *   # in another shell:
+ *   pnpm --filter astro-example exec playwright test
+ *
+ * Try/finally restores the original token value so re-running the spec is
+ * idempotent. The original value is captured at the start; if any assertion
+ * fails before restoration, the after-hook still rewrites the original
+ * value via the bin so the file on disk lands in a known-good state.
+ */
+
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, '..', '..', 'src', 'styles', 'tokens.css');
+const APPLY_URL = 'http://127.0.0.1:24682/apply';
+const ORIGIN = 'http://localhost:44324';
+
+const STORAGE_PREFIX = 'astro-example-tokens';
+const STORAGE_KEY_VISIBLE = `${STORAGE_PREFIX}:visible`;
+
+async function readTokenValue(cssVar: string): Promise<string> {
+  const css = await readFile(TOKENS_PATH, 'utf-8');
+  const escaped = cssVar.replace(/-/g, '\\-');
+  const re = new RegExp(`${escaped}:\\s*([^;]+);`);
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`Could not find ${cssVar} in ${TOKENS_PATH}`);
+  }
+  return m[1].trim();
+}
+
+async function postApply(cssVar: string, value: string): Promise<void> {
+  const response = await fetch(APPLY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify({ tokens: { [cssVar]: value } }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST /apply failed (${response.status}): ${text}`);
+  }
+}
+
+test.describe('Astro example — apply pipeline round-trip', () => {
+  const TARGET_VAR = '--astroexample-radius';
+  const TEST_VALUE = '1.25rem';
+  let originalValue = '';
+
+  test.beforeAll(async () => {
+    originalValue = await readTokenValue(TARGET_VAR);
+    if (originalValue === TEST_VALUE) {
+      throw new Error(
+        `Test value ${TEST_VALUE} matches original — pick a different test value.`,
+      );
+    }
+  });
+
+  test.afterAll(async () => {
+    // Restore the original token value via the bin so the test file lands
+    // in a known-good state regardless of how the test exited.
+    if (originalValue) {
+      try {
+        await postApply(TARGET_VAR, originalValue);
+      } catch {
+        // Best-effort restoration — the in-band assertion already failed if
+        // we get here; surfacing the secondary error would mask the primary.
+      }
+    }
+  });
+
+  test('panel-driven Apply rewrites the on-disk token value', async ({ page }) => {
+    // Step 1: seed visibility intent so the host adapter eagerly mounts the
+    // panel pre-paint (avoids needing a console-API call in the spec body).
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate((visibleKey) => {
+      localStorage.setItem(visibleKey, 'true');
+    }, STORAGE_KEY_VISIBLE);
+
+    // Step 2: hard-reload — adapter must mount the panel before paint.
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Step 3: open the Size tab and set the radius slider to TEST_VALUE.
+    // The panel ships role-tagged tabs; pick the Size tab and drive the
+    // first numeric input within it. The exact selector path depends on
+    // the panel's rendered DOM; the deferred verification step in the
+    // README covers the click-Apply phase manually.
+    const sizeTab = page.getByRole('tab', { name: /size/i });
+    await sizeTab.waitFor({ state: 'visible', timeout: 5000 });
+    await sizeTab.click();
+
+    const radiusInput = page.getByLabel(/border radius/i).first();
+    await radiusInput.waitFor({ state: 'visible', timeout: 5000 });
+    await radiusInput.fill('1.25');
+
+    // Step 4: click the Apply button in the panel chrome and confirm in
+    // the resulting modal.
+    const applyButton = page.getByRole('button', { name: /^apply$/i }).first();
+    await applyButton.waitFor({ state: 'visible', timeout: 5000 });
+    await applyButton.click();
+
+    const confirmButton = page.getByRole('button', { name: /confirm|apply now|write/i }).first();
+    await confirmButton.waitFor({ state: 'visible', timeout: 5000 });
+    await confirmButton.click();
+
+    // Step 5: poll the file on disk for the rewritten value. The bin
+    // writes atomically via a temp-file rename, so the new contents
+    // appear in a single fs operation; polling avoids a race with the
+    // server's HTTP response landing before the rename completes.
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await readTokenValue(TARGET_VAR);
+          } catch {
+            return '';
+          }
+        },
+        { timeout: 5000, intervals: [100, 250, 500] },
+      )
+      .toBe(TEST_VALUE);
+  });
+});

--- a/examples/astro/tsconfig.json
+++ b/examples/astro/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "resolveJsonModule": true
+  },
+  "exclude": ["dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,37 @@ importers:
         specifier: ^5.9.0
         version: 5.9.3
 
+  examples/astro:
+    dependencies:
+      '@astrojs/preact':
+        specifier: ^5.1.1
+        version: 5.1.2(@babel/core@7.29.0)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(preact@10.29.1)(rollup@4.60.2)(yaml@2.8.3)
+      '@takazudo/zudo-design-token-panel':
+        specifier: workspace:*
+        version: link:../../packages/zudo-design-token-panel
+      astro:
+        specifier: ^6.1.5
+        version: 6.1.9(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+    devDependencies:
+      '@astrojs/check':
+        specifier: ^0.9.4
+        version: 0.9.8(prettier@3.8.3)(typescript@5.9.3)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/zudo-design-token-panel:
     devDependencies:
       '@types/node':
@@ -714,6 +745,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@preact/preset-vite@2.10.5':
     resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
     peerDependencies:
@@ -1335,6 +1371,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1408,6 +1448,11 @@ packages:
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
+
+  concurrently@9.2.1:
+    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -1834,6 +1879,11 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1881,6 +1931,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -2518,6 +2572,16 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
 
@@ -2679,6 +2743,9 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2706,6 +2773,10 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
@@ -2772,6 +2843,14 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -2823,6 +2902,10 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3893,6 +3976,10 @@ snapshots:
   '@pagefind/windows-x64@1.5.2':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
@@ -4577,6 +4664,11 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -4637,6 +4729,15 @@ snapshots:
   commander@8.3.0: {}
 
   common-ancestor-path@2.0.0: {}
+
+  concurrently@9.2.1:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.3
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confbox@0.1.8: {}
 
@@ -5109,6 +5210,9 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5164,6 +5268,8 @@ snapshots:
       uncrypto: 0.1.3
 
   hachure-fill@0.5.2: {}
+
+  has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
 
@@ -6163,6 +6269,14 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   points-on-curve@0.2.0: {}
 
   points-on-path@0.2.1:
@@ -6414,6 +6528,10 @@ snapshots:
 
   rw@1.3.3: {}
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
@@ -6462,6 +6580,8 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
     optional: true
+
+  shell-quote@1.8.3: {}
 
   shiki@4.0.2:
     dependencies:
@@ -6525,6 +6645,14 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -6570,6 +6698,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -6580,8 +6710,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   typesafe-path@0.2.2: {}
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/7

---

## Summary

Implements Epic #7 — a self-contained Astro 6 + Preact example app at `examples/astro/` that demonstrates mounting `@takazudo/zudo-design-token-panel` via `<DesignTokenPanelHost>`, live-tweaks demo tokens through the panel UI, and round-trips the tweaks back to disk through the bin server. Covers all four sub-tasks of Epic #7 (scaffold, panel host config, demo pages, apply-pipeline test).

## Changes

### Sub-task 1: scaffold-astro-example
- New `examples/astro/` workspace package (`astro-example`) with Astro 6, `@astrojs/preact`, Preact, and a workspace dep on `@takazudo/zudo-design-token-panel`.
- `package.json` dev script orchestrates Astro dev (port 44324) and the bin server (port 24682) via `concurrently`.
- `astro.config.ts` keeps `output: 'static'` and proxies `/api/dev/apply` to the bin server via Vite — no SSR adapter required.

### Sub-task 2: wire-panel-host-config
- Demo `PanelConfig` in `src/config/panel-config.ts` using the issue-mandated identifiers: `storagePrefix: 'astro-example-tokens'`, `consoleNamespace: 'astroExample'`, `modalClassPrefix: 'astro-example-design-token-panel-modal'`, `schemaId: 'astro-example-design-tokens/v1'`, `exportFilenameBase: 'astro-example-design-tokens'`, `applyEndpoint: '/api/dev/apply'`.
- Demo `TokenManifest` (`src/config/default-manifest.ts`) and `ColorClusterConfig` (`src/config/default-cluster.ts`) using `--astroexample-*` CSS vars.
- `<DesignTokenPanelHost {...config} />` wired into `src/layouts/Layout.astro`; the Astro view-transitions `<ClientRouter />` keeps panel state across soft navigation.
- `window.astroExample.toggleDesignPanel()` toggles the panel from the console.

### Sub-task 3: demo-pages-and-content
- `src/pages/index.astro` — hero, palette swatches, button row, feature cards driven by `--astroexample-*` tokens.
- `src/pages/about.astro` — typography demo, semantic state badges, secondary palette swatches.
- `src/styles/tokens.css` and `src/styles/reset.css` provide the demo token cascade.

### Sub-task 4: apply-pipeline-roundtrip-test
- `scaffold.routing.json` maps the `astroexample` CSS-var prefix to `src/styles/tokens.css`.
- `tests/e2e/apply-roundtrip.spec.ts` (Playwright) drives the panel UI to tweak a token, click Apply, and asserts `tokens.css` is rewritten on disk.
- `scripts/smoke-apply.mjs` is a non-UI harness for quick apply-endpoint sanity checks.
- `README.md` documents ports, console API, manual verification steps, and how to run the e2e spec.

## Test Plan

- [x] `pnpm typecheck` clean across the workspace
- [x] `pnpm --filter astro-example build` produces both static pages
- [x] Panel package tests still 177/177 (no regressions)
- [x] No private-project name leaks in `examples/astro/` (grep clean)
- [x] `/gcoc-review` returned no actionable findings
- [ ] `pnpm --filter astro-example dev` boots Astro + bin (manual; deferred per /x-wt-teams resource policy)
- [ ] Playwright apply-roundtrip e2e (manual; deferred per /x-wt-teams resource policy)

Closes #7