### PR TITLE
[Initial Port][Epic] Example app: Vite + React

### DIFF
--- a/examples/vite-react/.gitignore
+++ b/examples/vite-react/.gitignore
@@ -1,0 +1,6 @@
+# Vite
+dist/
+
+# Playwright
+playwright-report/
+test-results/

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -1,0 +1,120 @@
+# Vite + React example — `@takazudo/zudo-design-token-panel`
+
+A minimal Vite 6 + React 18 app that mounts the design-token panel as a Preact
+island from a `useEffect`, demonstrates live token tweaking, and exercises the
+full apply pipeline by round-tripping tweaks back to disk through the bin
+sidecar (`design-token-panel-server`).
+
+## Run
+
+```bash
+pnpm --filter vite-react-example dev
+```
+
+`pnpm dev` runs two processes via `concurrently`:
+
+| process | port  | role                                                                            |
+| ------- | ----- | ------------------------------------------------------------------------------- |
+| Vite    | 44325 | the example site                                                                |
+| bin     | 24683 | `design-token-panel-server` — receives `/apply` POSTs, rewrites `tokens.css`    |
+
+The Vite dev server proxies `/api/dev/apply` to the bin (see `vite.config.ts`),
+so the panel POSTs to a same-origin URL — no CORS preflight, no hardcoded port
+in the runtime config.
+
+Open [http://localhost:44325](http://localhost:44325) and run
+`window.viteReactExample.toggleDesignPanel()` in the browser console to show
+the panel. Drag any slider — the page repaints before the next frame.
+
+## Apply-pipeline manual verification
+
+The Playwright spec at `tests/e2e/apply-roundtrip.spec.ts` automates this; the
+manual procedure is documented here so the round-trip is verifiable without
+booting the e2e harness.
+
+1. Start the dev environment:
+
+   ```bash
+   pnpm --filter vite-react-example dev
+   ```
+
+2. In a second shell, capture the current value of one token:
+
+   ```bash
+   grep -- '--vitereact-radius' examples/vite-react/src/styles/tokens.css
+   #   --vitereact-radius: 0.5rem;
+   ```
+
+3. In the browser, open the panel via
+   `window.viteReactExample.toggleDesignPanel()`. Switch to the **Size** tab,
+   drag the **Border Radius** slider to a different value, then click
+   **Apply** in the panel chrome and confirm the diff.
+
+4. In the second shell, re-read the same line — it should now show the new
+   value:
+
+   ```bash
+   grep -- '--vitereact-radius' examples/vite-react/src/styles/tokens.css
+   #   --vitereact-radius: 1.25rem;
+   ```
+
+5. The next page reload picks up the new value from the file (the in-memory
+   override is no longer needed because the source-of-truth on disk now
+   matches).
+
+For a non-interactive smoke check that bypasses the panel UI and POSTs
+directly to the bin:
+
+```bash
+pnpm --filter vite-react-example test:apply-smoke
+```
+
+## What the example proves
+
+- The panel package consumes ZERO project-specific defaults from its own
+  bundle. Every identifier (`storagePrefix`, `consoleNamespace`,
+  `paletteCssVarTemplate`, semantic CSS-var names, etc.) flows in from
+  `src/config/panel-config.ts`.
+- The apply pipeline routes by CSS-var prefix family: the `vitereact` prefix
+  in `scaffold.routing.json` maps to `src/styles/tokens.css`, so any tweak to
+  a `--vitereact-*` token rewrites that file.
+- The panel works inside a real React 18 app **without** a `react ->
+  preact/compat` alias. The host React tree never owns the panel's render
+  surface — `mountPanel()` lazy-imports the panel module and Preact mounts
+  inside its own root element, fully isolated from React reconciliation.
+- React 18 StrictMode is enabled (the new-Vite default). The host adapter is
+  StrictMode-safe via the per-`storagePrefix` bind flag pinned on
+  `window.__zudoDesignTokenPanelAdapter` — the `useEffect` that calls
+  `mountPanel()` is invoked twice in dev, but the second call short-circuits.
+- Panel state survives React rerenders. The "Verify across rerender" section
+  on the home page exposes a counter button + a child-subtree toggle so the
+  panel's persistence across React reconciliation is observable in the UI.
+
+## Layout
+
+```
+examples/vite-react/
+├── index.html                  # Vite entry (#root + /src/main.tsx)
+├── package.json                # name: vite-react-example, dev = vite + bin
+├── playwright.config.ts        # apply-roundtrip e2e config
+├── scaffold.routing.json       # CSS-var prefix → file map (shared by panel + bin)
+├── scripts/
+│   └── smoke-apply.mjs         # non-UI smoke harness for the bin
+├── src/
+│   ├── App.tsx                 # demo content + useEffect mount
+│   ├── config/
+│   │   ├── default-cluster.ts  # `--vitereact-*` color cluster
+│   │   ├── default-manifest.ts # `--vitereact-*` token rows
+│   │   └── panel-config.ts     # PanelConfig assembly
+│   ├── lib/
+│   │   └── mount-panel.ts      # adapter (console API + lazy-load + StrictMode bind flag)
+│   ├── main.tsx                # configurePanel(...) THEN ReactDOM.createRoot(...).render
+│   └── styles/
+│       ├── reset.css
+│       └── tokens.css          # `--vitereact-*` source of truth (apply target)
+├── tests/
+│   └── e2e/
+│       └── apply-roundtrip.spec.ts
+├── tsconfig.json
+└── vite.config.ts              # React plugin + /api/dev/apply proxy → 24683
+```

--- a/examples/vite-react/index.html
+++ b/examples/vite-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Vite + React Example — Design Token Panel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "vite-react-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Vite + React example app demonstrating @takazudo/zudo-design-token-panel — host-config-driven panel mounted as a Preact island from a useEffect, plus apply-pipeline round-trip via the bin sidecar.",
+  "scripts": {
+    "predev": "lsof -ti:44325 | xargs kill 2>/dev/null; lsof -ti:24683 | xargs kill 2>/dev/null; true",
+    "dev": "concurrently -k -n vite,tokens-bin -c blue,green \"pnpm run _dev:vite\" \"pnpm run _dev:tokens-bin\"",
+    "_dev:vite": "vite --port 44325",
+    "_dev:tokens-bin": "design-token-panel-server --write-root . --routing scaffold.routing.json --port 24683 --allow-origin http://localhost:44325",
+    "build": "vite build",
+    "preview": "vite preview --port 44325",
+    "typecheck": "tsc --noEmit",
+    "test:apply-smoke": "node scripts/smoke-apply.mjs"
+  },
+  "dependencies": {
+    "@takazudo/zudo-design-token-panel": "workspace:*",
+    "preact": "^10.29.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^22.0.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "concurrently": "^9.2.1",
+    "typescript": "^5.9.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/vite-react/playwright.config.ts
+++ b/examples/vite-react/playwright.config.ts
@@ -1,0 +1,46 @@
+/**
+ * Playwright config for the Vite + React example's apply-pipeline e2e spec.
+ *
+ * Local runs: webServer auto-starts the example's dev server.
+ * On CI / when BASE_URL is supplied externally: the caller manages the
+ * server lifecycle (so a separate workflow step can boot the bin sidecar
+ * + Vite dev server together via `pnpm dev`).
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const hasExternalBaseUrl = Boolean(process.env.BASE_URL);
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'list' : 'html',
+  maxFailures: 0,
+  timeout: process.env.CI ? 60 * 1000 : 30 * 1000,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:44325',
+    trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'apply-roundtrip',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer:
+    process.env.CI || hasExternalBaseUrl
+      ? undefined
+      : {
+          command: 'pnpm dev',
+          port: 44325,
+          reuseExistingServer: true,
+          timeout: 120 * 1000,
+        },
+});

--- a/examples/vite-react/scaffold.routing.json
+++ b/examples/vite-react/scaffold.routing.json
@@ -1,0 +1,3 @@
+{
+  "vitereact": "src/styles/tokens.css"
+}

--- a/examples/vite-react/scripts/smoke-apply.mjs
+++ b/examples/vite-react/scripts/smoke-apply.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Manual smoke harness for the bin sidecar.
+ *
+ * Requires `pnpm dev` to already be running in this example sub-package
+ * (so the bin is listening on http://127.0.0.1:24683). The harness:
+ *
+ *   1. Reads the current value of `--vitereact-radius` from
+ *      src/styles/tokens.css.
+ *   2. POSTs a different value to /apply.
+ *   3. Re-reads the file and asserts the value changed.
+ *   4. Restores the original value with a second POST.
+ *
+ * The try/finally block ensures the original value is restored even if any
+ * assertion fails, so re-running the harness gives consistent results.
+ */
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, '..', 'src', 'styles', 'tokens.css');
+const APPLY_URL = 'http://127.0.0.1:24683/apply';
+const ORIGIN = 'http://localhost:44325';
+const TARGET_VAR = '--vitereact-radius';
+const TEST_VALUE = '1.25rem';
+
+async function readTokenValue(cssVar) {
+  const css = await readFile(TOKENS_PATH, 'utf-8');
+  const escaped = cssVar.replace(/-/g, '\\-');
+  const re = new RegExp(`${escaped}:\\s*([^;]+);`);
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`Could not find ${cssVar} in ${TOKENS_PATH}`);
+  }
+  return m[1].trim();
+}
+
+async function postApply(cssVar, value) {
+  const response = await fetch(APPLY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify({ tokens: { [cssVar]: value } }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST /apply failed (${response.status}): ${text}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  console.error(`[smoke] reading ${TARGET_VAR} from ${TOKENS_PATH}`);
+  const originalValue = await readTokenValue(TARGET_VAR);
+  console.error(`[smoke] original value: ${originalValue}`);
+
+  if (originalValue === TEST_VALUE) {
+    throw new Error(`Test value ${TEST_VALUE} matches original — pick a different test value.`);
+  }
+
+  let assertionsPassed = false;
+  try {
+    console.error(`[smoke] POST /apply ${TARGET_VAR}=${TEST_VALUE}`);
+    await postApply(TARGET_VAR, TEST_VALUE);
+
+    const afterValue = await readTokenValue(TARGET_VAR);
+    console.error(`[smoke] post-apply value: ${afterValue}`);
+    if (afterValue !== TEST_VALUE) {
+      throw new Error(`Expected ${TARGET_VAR} to be ${TEST_VALUE} after apply, got ${afterValue}`);
+    }
+
+    assertionsPassed = true;
+    console.error('[smoke] PASS — bin sidecar rewrote tokens.css');
+  } finally {
+    try {
+      console.error(`[smoke] restoring ${TARGET_VAR}=${originalValue}`);
+      await postApply(TARGET_VAR, originalValue);
+      const restored = await readTokenValue(TARGET_VAR);
+      if (restored !== originalValue) {
+        console.error(
+          `[smoke] WARNING: restore mismatch — expected ${originalValue}, got ${restored}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[smoke] WARNING: failed to restore original value: ${err.message}`);
+    }
+  }
+
+  if (!assertionsPassed) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`[smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -9,13 +9,24 @@
  * panel adapter installs window-level state that lives for the page
  * lifetime, so a per-mount cleanup would be wrong.
  *
- * Sub-task 2 ships only this skeleton + the panel mount. The demo content
- * (cards, buttons, palette swatches, rerender section) is filled in by
- * sub-task 3, which replaces the placeholder body below.
+ * The page renders three flavors of demo content:
+ *
+ *   - Cards, buttons, palette swatches — the same shape the Astro home
+ *     page ships, mirrored under the `--vitereact-*` namespace.
+ *   - A "verify across rerender" section with a counter button. Clicking
+ *     it triggers a React `setState` re-render. Because every visible
+ *     element reads `--vitereact-*` from `:root` (NOT from React props),
+ *     panel-driven token tweaks survive the rerender unchanged. This is
+ *     the Vite + React analog of the Astro example's `/about` page that
+ *     proves view-transitions don't disturb panel state.
+ *   - Panel state survives unmount/remount of arbitrary subtrees too —
+ *     the rerender section also toggles a child component to confirm.
  */
 
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { mountPanel } from './lib/mount-panel';
+
+const PALETTE_INDICES = Array.from({ length: 16 }, (_, i) => i);
 
 export function App() {
   useEffect(() => {
@@ -28,12 +39,133 @@ export function App() {
   }, []);
 
   return (
-    <main>
-      <h1>Vite + React Example — Design Token Panel</h1>
-      <p>
-        Open the panel from the browser console:{' '}
-        <code>window.viteReactExample.toggleDesignPanel()</code>.
-      </p>
+    <main className="vitereact-stack">
+      <header>
+        <h1 className="vitereact-heading">Live token tweaking, in plain Vite + React</h1>
+        <p>
+          Every visible element on this page is driven by a{' '}
+          <code>--vitereact-*</code> CSS custom property. Open the panel from
+          the browser console and drag any slider — the change applies before
+          the next paint, and survives React rerenders because the CSS vars
+          live on <code>:root</code>, not in React state.
+        </p>
+        <p className="vitereact-meta">
+          Console API: <code>window.viteReactExample.toggleDesignPanel()</code>.
+          Storage prefix: <code>vite-react-example-tokens</code>.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="vitereact-heading">Cards (spacing + radius + surface)</h2>
+        <div className="vitereact-card">
+          <strong>Card A.</strong> Padding driven by{' '}
+          <code>--vitereact-spacing-md</code>, corners by{' '}
+          <code>--vitereact-radius</code>, background by{' '}
+          <code>--vitereact-color-surface</code>.
+        </div>
+        <div className="vitereact-card">
+          <strong>Card B.</strong> Stack gap driven by{' '}
+          <code>--vitereact-spacing-lg</code>; outline by{' '}
+          <code>--vitereact-color-muted</code>.
+        </div>
+      </section>
+
+      <section>
+        <h2 className="vitereact-heading">Buttons + links (accent / primary)</h2>
+        <p>
+          <button className="vitereact-button" type="button">
+            Action button
+          </button>
+        </p>
+        <p>
+          The styled{' '}
+          <a className="vitereact-link" href="#rerender-verify">
+            rerender-verify section
+          </a>{' '}
+          below proves the panel's tokens persist across React state changes.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="vitereact-heading">Palette swatches</h2>
+        <div className="vitereact-swatch-row">
+          {PALETTE_INDICES.map((i) => (
+            <div
+              key={i}
+              className="vitereact-swatch"
+              style={{ background: `var(--vitereact-palette-${i})` }}
+            >
+              {i}
+            </div>
+          ))}
+        </div>
+        <p className="vitereact-meta">
+          Each swatch reads <code>--vitereact-palette-{'{n}'}</code>. The
+          cluster's <code>paletteCssVarTemplate</code> is the only thing that
+          decides this name — change it in <code>default-cluster.ts</code> and
+          the apply pipeline writes a different variable on the next palette
+          tweak.
+        </p>
+      </section>
+
+      <RerenderVerify />
     </main>
+  );
+}
+
+/**
+ * Verify across rerender. This component is the Vite + React analog of the
+ * Astro example's `/about` page (which exists to confirm view-transitions
+ * don't disturb panel state). Vite + React has no view-transitions; instead
+ * we verify that:
+ *
+ *   1. A `setState`-driven rerender keeps the panel's `:root` overrides in
+ *      place (the React tree doesn't own those vars, so it can't lose
+ *      them).
+ *   2. A child subtree that mounts/unmounts arbitrarily on the same render
+ *      cycle does not disturb the panel either — the panel's mount root is
+ *      a sibling appended by the panel adapter, not a child of the React
+ *      tree, so React reconciliation cannot touch it.
+ */
+function RerenderVerify() {
+  const [count, setCount] = useState(0);
+  const [showChild, setShowChild] = useState(true);
+
+  const bump = useCallback(() => {
+    setCount((c) => c + 1);
+  }, []);
+
+  const toggleChild = useCallback(() => {
+    setShowChild((v) => !v);
+  }, []);
+
+  return (
+    <section id="rerender-verify">
+      <h2 className="vitereact-heading">Verify across rerender</h2>
+      <div className="vitereact-card">
+        Click the button to trigger a React rerender. Tweak any panel slider,
+        then click again — the tweaked value should still apply, because the
+        page reads CSS custom properties from <code>:root</code> rather than
+        from React props. Toggle the child subtree to confirm React mount
+        churn doesn't disturb the panel either.
+      </div>
+      <p>
+        <button type="button" className="vitereact-button" onClick={bump}>
+          Rerender ({' '}
+          <span className="vitereact-rerender-counter">{count}</span> )
+        </button>{' '}
+        <button type="button" className="vitereact-button" onClick={toggleChild}>
+          Toggle child subtree
+        </button>
+      </p>
+      {showChild && (
+        <div className="vitereact-card">
+          <strong>Child subtree present.</strong> This block mounts and
+          unmounts on every toggle. The panel's own DOM root is appended by
+          the adapter outside the React tree, so React reconciliation can
+          never touch it.
+        </div>
+      )}
+    </section>
   );
 }

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -1,0 +1,39 @@
+/**
+ * Root component for the Vite + React example.
+ *
+ * Mounts the design-token panel adapter from a `useEffect` (the React-shaped
+ * equivalent of the `<script>` block the Astro example ships in
+ * `DesignTokenPanelHost.astro`). The effect runs once after the first paint,
+ * is StrictMode-safe via the per-`storagePrefix` bind flag pinned on
+ * `window.__zudoDesignTokenPanelAdapter`, and has no cleanup function — the
+ * panel adapter installs window-level state that lives for the page
+ * lifetime, so a per-mount cleanup would be wrong.
+ *
+ * Sub-task 2 ships only this skeleton + the panel mount. The demo content
+ * (cards, buttons, palette swatches, rerender section) is filled in by
+ * sub-task 3, which replaces the placeholder body below.
+ */
+
+import { useEffect } from 'react';
+import { mountPanel } from './lib/mount-panel';
+
+export function App() {
+  useEffect(() => {
+    mountPanel();
+    // No cleanup: the panel adapter installs window-level console handlers
+    // and (lazily) a singleton panel module. Both are intended to live for
+    // the page lifetime, so a tear-down on unmount would defeat the whole
+    // contract. StrictMode double-invocation is handled inside mountPanel
+    // via the per-storagePrefix bind flag.
+  }, []);
+
+  return (
+    <main>
+      <h1>Vite + React Example — Design Token Panel</h1>
+      <p>
+        Open the panel from the browser console:{' '}
+        <code>window.viteReactExample.toggleDesignPanel()</code>.
+      </p>
+    </main>
+  );
+}

--- a/examples/vite-react/src/config/default-cluster.ts
+++ b/examples/vite-react/src/config/default-cluster.ts
@@ -1,0 +1,78 @@
+/**
+ * Demo color cluster for the Vite + React example.
+ *
+ * The cluster's CSS-var family is `--vitereact-*` (palette + base roles +
+ * semantic names), declared on `:root` by `src/styles/tokens.css`. Tweaks in
+ * the panel write through these names; the apply pipeline (when wired through
+ * the bin sidecar) rewrites the same names on disk.
+ *
+ * `paletteCssVarTemplate` is the only knob that decides the per-slot var name.
+ * The cluster is JSON-serializable end-to-end so it round-trips through the
+ * apply pipeline.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+
+type ColorClusterDataConfig = PanelConfig['colorCluster'];
+
+export const defaultCluster: ColorClusterDataConfig = {
+  id: 'vitereact-cluster',
+  label: 'Vite + React Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--vitereact-bg',
+    foreground: '--vitereact-fg',
+  },
+  paletteCssVarTemplate: '--vitereact-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--vitereact-color-primary',
+    accent: '--vitereact-color-accent',
+    surface: '--vitereact-color-surface',
+    muted: '--vitereact-color-muted',
+    danger: '--vitereact-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};

--- a/examples/vite-react/src/config/default-manifest.ts
+++ b/examples/vite-react/src/config/default-manifest.ts
@@ -1,0 +1,85 @@
+/**
+ * Demo token manifest for the Vite + React example.
+ *
+ * Every `cssVar` is a `--vitereact-*` name. These line up byte-for-byte
+ * with the declarations in `src/styles/tokens.css` so the panel can rewrite
+ * the same names live and the apply pipeline can rewrite them on disk.
+ *
+ * `TokenManifest` is reachable via the indexed-access lookup
+ * `PanelConfig['tokens']` — the package's main entry only re-exports
+ * `PanelConfig`, so this avoids a deep import into `dist/tokens/manifest`.
+ *
+ * `spacingGroupOrder` is set to `['vsp', 'hsp']` (vertical above horizontal),
+ * proving the host-supplied ordering field overrides the package default.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+
+type TokenManifest = PanelConfig['tokens'];
+
+export const defaultManifest: TokenManifest = {
+  spacing: [
+    {
+      id: 'vitereact-spacing-md',
+      cssVar: '--vitereact-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'vitereact-spacing-lg',
+      cssVar: '--vitereact-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'vitereact-text-base',
+      cssVar: '--vitereact-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'vitereact-text-heading',
+      cssVar: '--vitereact-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'vitereact-radius',
+      cssVar: '--vitereact-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  // Color tab is driven by the cluster — leave per-token rows empty.
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};

--- a/examples/vite-react/src/config/panel-config.ts
+++ b/examples/vite-react/src/config/panel-config.ts
@@ -1,0 +1,45 @@
+/**
+ * Assembles the `PanelConfig` consumed by the Vite + React example.
+ *
+ * Unlike the Astro example — which inlines this object as JSON via a
+ * `<script type="application/json">` tag and reads it back from the host
+ * adapter — this React example consumes the config directly as a TS module.
+ * `src/main.tsx` calls `configurePanel(panelConfig)` BEFORE the first React
+ * render, and `src/lib/mount-panel.ts` reads it via `getPanelConfig()`.
+ *
+ * The five identifier fields (`storagePrefix`, `consoleNamespace`,
+ * `modalClassPrefix`, `schemaId`, `exportFilenameBase`) all share a
+ * `vite-react-example*` namespace so localStorage entries, exported JSON,
+ * and modal classnames cannot collide with any other host's panel
+ * deployment.
+ *
+ * `applyEndpoint` is the relative path `/api/dev/apply`. `vite.config.ts`
+ * proxies it to the bin sidecar on port 24683, so the panel's POST stays on
+ * the same origin as the page it was served from — no CORS preflight, no
+ * runtime URL coupling between the panel config and the sidecar's port.
+ *
+ * `applyRouting` shares the SAME JSON file the bin sidecar reads at startup
+ * (`scaffold.routing.json`). The host UI and the apply server therefore
+ * agree byte-for-byte on which CSS-var prefix maps to which file.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+import { defaultManifest } from './default-manifest';
+import { defaultCluster } from './default-cluster';
+import scaffoldRouting from '../../scaffold.routing.json';
+
+export const panelConfig: PanelConfig = {
+  storagePrefix: 'vite-react-example-tokens',
+  consoleNamespace: 'viteReactExample',
+  modalClassPrefix: 'vite-react-example-design-token-panel-modal',
+  schemaId: 'vite-react-example-design-tokens/v1',
+  exportFilenameBase: 'vite-react-example-design-tokens',
+  tokens: defaultManifest,
+  colorCluster: defaultCluster,
+  applyEndpoint: '/api/dev/apply',
+  applyRouting: scaffoldRouting,
+  // Explicit opt-out for the secondary color cluster — the demo ships a
+  // single primary palette only. `null` (NOT `undefined`) is the documented
+  // signal that the host has no secondary cluster.
+  secondaryColorCluster: null,
+};

--- a/examples/vite-react/src/lib/mount-panel.ts
+++ b/examples/vite-react/src/lib/mount-panel.ts
@@ -1,0 +1,214 @@
+/**
+ * Vite + React host adapter for `@takazudo/zudo-design-token-panel`.
+ *
+ * The Astro example ships a package-provided host adapter
+ * (`@takazudo/zudo-design-token-panel/astro/host-adapter`) that runs from a
+ * per-page `<script>` block in `DesignTokenPanelHost.astro`. Vite + React has
+ * no equivalent host component — the panel is mounted as a Preact island
+ * from a React `useEffect`. So the adapter logic is ported here.
+ *
+ * Responsibilities (mirror the Astro adapter):
+ *
+ *  1. The host application MUST have already called `configurePanel(...)` in
+ *     `src/main.tsx` BEFORE this function runs. The active config is passed
+ *     in as `cfg` rather than read via a `getPanelConfig()` accessor — the
+ *     package's main entry doesn't re-export `getPanelConfig` to consumers
+ *     (only `configurePanel` is public), so the host application is the
+ *     single source of truth for the config object during adapter setup.
+ *  2. Install the console API on `window[cfg.consoleNamespace]`
+ *     (`showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel`). The
+ *     namespace is a configured field — different consumers can pick
+ *     distinct values to prove the contract is host-agnostic.
+ *  3. Gate the panel module's dynamic import on the same probes the Astro
+ *     adapter uses: an existing `wasVisible()` flag or any persisted v2
+ *     overrides. When neither is set, the panel module stays out of the
+ *     initial bundle and only loads when the user calls a `window.<ns>.*`
+ *     helper from the console.
+ *  4. After the dynamic import resolves, call `reapplyPersistedOverrides()`
+ *     so the panel applies persisted overrides ASAP (kills the FOUT on
+ *     hard navigation when the user has tweaks saved).
+ *
+ * StrictMode safety
+ * -----------------
+ * React 18 StrictMode (enabled in `src/main.tsx`, the new-Vite default)
+ * deliberately invokes mount effects twice in development to surface
+ * cleanup-bug regressions. The `mountPanel` export is therefore called
+ * twice on the first render in dev. We pin a per-`storagePrefix` flag on
+ * `window.__zudoDesignTokenPanelAdapter` (same map shape the package's
+ * Astro adapter uses) so the lazy-load probes only fire once. The console
+ * API re-installation is idempotent — re-assigning the same closures is
+ * semantically a no-op — so leaving it ungated is fine.
+ *
+ * Storage-key formatters
+ * ----------------------
+ * `storageKey_visible(prefix)` and `storageKey_stateV2(prefix)` are not
+ * publicly exported by the package's main entry (they live in
+ * `src/config/panel-config.ts`). The formatters are trivial 1-line string
+ * concatenations, so we replicate them here. The canonical definitions in
+ * the package source MUST match these exactly:
+ *
+ *   storageKey_visible(cfg) -> `${cfg.storagePrefix}:visible`   (literal `:`)
+ *   storageKey_stateV2(cfg) -> `${cfg.storagePrefix}-state-v2`  (literal `-`)
+ *
+ * Note the asymmetry: the visible-key uses `:` while every other derived
+ * key uses `-`. It is a historical artifact preserved for storage-key
+ * continuity — see the comment on `storageKey_visible` in the package.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+import { panelConfig } from '../config/panel-config';
+
+// Mirrors the panel-module's main entry shape we lazy-import below.
+type DesignTokenPanelModule = typeof import('@takazudo/zudo-design-token-panel');
+
+interface DesignTokenPanelAdapterState {
+  /** Per-`storagePrefix` bind flag — re-runs of mountPanel are no-ops. */
+  bound: boolean;
+  /** Memoised module promise so steady-state toggle/show/hide share one load. */
+  modulePromise: Promise<DesignTokenPanelModule> | null;
+}
+
+interface ConsoleApiSurface {
+  showDesignPanel?: () => Promise<void>;
+  hideDesignPanel?: () => Promise<void>;
+  toggleDesignPanel?: () => Promise<void>;
+  // Allow co-existence with other helpers a host may install on the same
+  // namespace (e.g. `window.<ns>.someOtherDebugHelper()`).
+  [extra: string]: unknown;
+}
+
+type AdapterStateMap = Record<string, DesignTokenPanelAdapterState>;
+
+interface AdapterWindow extends Window {
+  __zudoDesignTokenPanelAdapter?: AdapterStateMap;
+  // Index access for the configured console namespace.
+  [namespace: string]: unknown;
+}
+
+function storageKey_visible(cfg: PanelConfig): string {
+  // Mirrors packages/zudo-design-token-panel/src/config/panel-config.ts —
+  // the literal `:` separator (NOT `-`) is intentional and historical.
+  return `${cfg.storagePrefix}:visible`;
+}
+
+function storageKey_stateV2(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-state-v2`;
+}
+
+function getAdapterStateMap(win: AdapterWindow): AdapterStateMap {
+  if (!win.__zudoDesignTokenPanelAdapter) {
+    win.__zudoDesignTokenPanelAdapter = {};
+  }
+  return win.__zudoDesignTokenPanelAdapter;
+}
+
+function getAdapterState(win: AdapterWindow, key: string): DesignTokenPanelAdapterState {
+  const map = getAdapterStateMap(win);
+  let state = map[key];
+  if (!state) {
+    state = { bound: false, modulePromise: null };
+    map[key] = state;
+  }
+  return state;
+}
+
+function wasVisible(visibleKey: string): boolean {
+  try {
+    return window.localStorage.getItem(visibleKey) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function hasPersistedOverrides(stateV2Key: string): boolean {
+  try {
+    return window.localStorage.getItem(stateV2Key) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lazily import the panel module. First call runs the panel module's
+ * top-level bootstrap (which binds its own toggle/window listeners and
+ * re-applies persisted state). Subsequent calls return the same promise.
+ *
+ * After the import resolves, call `reapplyPersistedOverrides()` so the
+ * panel applies persisted overrides ASAP (matches the eager-reapply path
+ * the Astro adapter triggers via the package's main-entry side effects).
+ */
+async function loadPanelModule(state: DesignTokenPanelAdapterState) {
+  if (state.modulePromise === null) {
+    state.modulePromise = import('@takazudo/zudo-design-token-panel').then((mod) => {
+      try {
+        mod.reapplyPersistedOverrides();
+      } catch (err) {
+        // Defensive: never let a bad persist-state read kill the panel
+        // surface. The panel will still mount with stylesheet defaults.
+        console.warn(
+          '[design-token-panel] reapplyPersistedOverrides() threw: ' + (err as Error).message,
+        );
+      }
+      return mod;
+    });
+  }
+  return state.modulePromise;
+}
+
+function installConsoleApi(
+  win: AdapterWindow,
+  namespace: string,
+  state: DesignTokenPanelAdapterState,
+): void {
+  const existing = (win[namespace] as ConsoleApiSurface | undefined) ?? {};
+  existing.showDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.showDesignTokenPanel();
+  };
+  existing.hideDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.hideDesignTokenPanel();
+  };
+  existing.toggleDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.toggleDesignPanel();
+  };
+  win[namespace] = existing;
+}
+
+/**
+ * Bind the host adapter for the active panel config. Safe to call multiple
+ * times — the per-`storagePrefix` `bound` flag short-circuits repeat calls,
+ * which is exactly what React 18 StrictMode requires (mount effects run
+ * twice in dev). Returns nothing; the cleanup function from the calling
+ * `useEffect` should also be a no-op.
+ *
+ * Reads the active config from the same module that `src/main.tsx` already
+ * passed to `configurePanel(...)`, so the adapter and the panel module
+ * agree on storagePrefix / consoleNamespace / etc. without re-deriving them
+ * from a global accessor.
+ */
+export function mountPanel(): void {
+  if (typeof window === 'undefined') return;
+
+  const cfg = panelConfig;
+  const win = window as unknown as AdapterWindow;
+  const state = getAdapterState(win, cfg.storagePrefix);
+
+  // Install console API every time — `bound` only gates the lazy-load
+  // probes, since the console handlers are idempotent (re-assigning the
+  // same closures is a no-op semantically).
+  installConsoleApi(win, cfg.consoleNamespace, state);
+
+  if (state.bound) return;
+  state.bound = true;
+
+  // Lazy-load gate — eagerly load the panel module when the user had it
+  // open last session OR has persisted token overrides. Either signal
+  // means the panel must boot before first paint to avoid an FOUT.
+  const visibleKey = storageKey_visible(cfg);
+  const stateV2Key = storageKey_stateV2(cfg);
+  if (wasVisible(visibleKey) || hasPersistedOverrides(stateV2Key)) {
+    void loadPanelModule(state);
+  }
+}

--- a/examples/vite-react/src/lib/mount-panel.ts
+++ b/examples/vite-react/src/lib/mount-panel.ts
@@ -9,12 +9,14 @@
  *
  * Responsibilities (mirror the Astro adapter):
  *
- *  1. The host application MUST have already called `configurePanel(...)` in
- *     `src/main.tsx` BEFORE this function runs. The active config is passed
- *     in as `cfg` rather than read via a `getPanelConfig()` accessor — the
- *     package's main entry doesn't re-export `getPanelConfig` to consumers
- *     (only `configurePanel` is public), so the host application is the
- *     single source of truth for the config object during adapter setup.
+ *  1. Own the `configurePanel(panelConfig)` call. The package's main entry
+ *     reads `getPanelConfig()` only from inside functions invoked at
+ *     panel-show time (never at module-init time), so calling
+ *     configurePanel from inside the dynamic-import resolution is safe and
+ *     keeps the panel JS out of the initial chunk. The host application is
+ *     therefore the single source of truth for the config object — it
+ *     imports `panelConfig` from the local `../config/panel-config` module
+ *     and this adapter wires it through.
  *  2. Install the console API on `window[cfg.consoleNamespace]`
  *     (`showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel`). The
  *     namespace is a configured field — different consumers can pick
@@ -24,9 +26,11 @@
  *     overrides. When neither is set, the panel module stays out of the
  *     initial bundle and only loads when the user calls a `window.<ns>.*`
  *     helper from the console.
- *  4. After the dynamic import resolves, call `reapplyPersistedOverrides()`
- *     so the panel applies persisted overrides ASAP (kills the FOUT on
- *     hard navigation when the user has tweaks saved).
+ *  4. After the dynamic import resolves, call `configurePanel(panelConfig)`
+ *     on the freshly imported module BEFORE any other panel API runs, then
+ *     call `reapplyPersistedOverrides()` so the panel applies persisted
+ *     overrides ASAP (kills the FOUT on hard navigation when the user has
+ *     tweaks saved).
  *
  * StrictMode safety
  * -----------------
@@ -130,16 +134,33 @@ function hasPersistedOverrides(stateV2Key: string): boolean {
 
 /**
  * Lazily import the panel module. First call runs the panel module's
- * top-level bootstrap (which binds its own toggle/window listeners and
- * re-applies persisted state). Subsequent calls return the same promise.
+ * top-level bootstrap (which binds its own toggle/window listeners) and
+ * configures the panel-config singleton with the host's `panelConfig`
+ * BEFORE any panel API runs. Subsequent calls return the same promise so
+ * `configurePanel` runs exactly once per `storagePrefix`-scoped state —
+ * which matches the package's one-shot configurePanel contract.
  *
- * After the import resolves, call `reapplyPersistedOverrides()` so the
+ * Why configurePanel runs HERE (not eagerly in main.tsx): the package
+ * main entry only reads `getPanelConfig()` from inside functions invoked
+ * at panel-show time (panel.tsx renders, storage-key derivations, …) —
+ * never at module-init time. Calling configurePanel inside the
+ * dynamic-import resolution therefore lands the host's config in the
+ * singleton before any reader sees it, while keeping the panel JS out of
+ * the initial chunk (a static `import { configurePanel }` in main.tsx
+ * pulled the whole module in and Vite folded the dynamic import back
+ * into the same chunk — see the Rollup warning we removed).
+ *
+ * After configurePanel runs, call `reapplyPersistedOverrides()` so the
  * panel applies persisted overrides ASAP (matches the eager-reapply path
  * the Astro adapter triggers via the package's main-entry side effects).
  */
 async function loadPanelModule(state: DesignTokenPanelAdapterState) {
   if (state.modulePromise === null) {
     state.modulePromise = import('@takazudo/zudo-design-token-panel').then((mod) => {
+      // Configure FIRST — every other panel API below reads
+      // getPanelConfig() and must observe the host's intended values, not
+      // the package's DEFAULT_PANEL_CONFIG sentinel.
+      mod.configurePanel(panelConfig);
       try {
         mod.reapplyPersistedOverrides();
       } catch (err) {
@@ -183,10 +204,11 @@ function installConsoleApi(
  * twice in dev). Returns nothing; the cleanup function from the calling
  * `useEffect` should also be a no-op.
  *
- * Reads the active config from the same module that `src/main.tsx` already
- * passed to `configurePanel(...)`, so the adapter and the panel module
- * agree on storagePrefix / consoleNamespace / etc. without re-deriving them
- * from a global accessor.
+ * Reads the active config from the local `panelConfig` module so storage
+ * keys / console namespace / etc. are derived from the same object that
+ * `loadPanelModule()` will pass to `configurePanel(...)` once the panel
+ * module finishes loading. The two derivations are guaranteed coherent
+ * because there is exactly one `panelConfig` import in this file.
  */
 export function mountPanel(): void {
   if (typeof window === 'undefined') return;

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -1,0 +1,48 @@
+/**
+ * Vite + React entry.
+ *
+ * The order below matters and is the entire point of the example:
+ *
+ *   1. Side-effect import of the demo's reset + tokens stylesheets and the
+ *      panel package's bundled chrome stylesheet. Vite's library mode strips
+ *      the panel's source CSS import from the emitted JS, so consumers must
+ *      re-pull it explicitly via the `/styles` sub-export.
+ *   2. `configurePanel(panelConfig)` runs SYNCHRONOUSLY before the first
+ *      React render. Every consumer of `getPanelConfig()` (storage keys,
+ *      console namespace, modal class prefix, …) therefore observes the
+ *      host's intended values for any read that happens during render or in
+ *      a mount effect. The Astro example achieves the same ordering via an
+ *      inline JSON `<script>` parsed by the package-provided host adapter;
+ *      because we have no host component here, we wire it directly in TS.
+ *   3. `ReactDOM.createRoot(...).render(<App />)` mounts the React tree.
+ *      `<App />`'s mount effect then calls `mountPanel()` to install the
+ *      window console API and lazy-load the panel module on demand.
+ */
+
+import { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+import { configurePanel } from '@takazudo/zudo-design-token-panel';
+
+import './styles/reset.css';
+import './styles/tokens.css';
+import '@takazudo/zudo-design-token-panel/styles';
+
+import { panelConfig } from './config/panel-config';
+import { App } from './App';
+
+// Configure BEFORE the first render so any reader of getPanelConfig()
+// observes the host's intended values. configurePanel shallow-clones, so
+// later mutations of `panelConfig` would NOT propagate — the singleton is
+// frozen-by-copy at this call.
+configurePanel(panelConfig);
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Vite + React example: #root element missing in index.html');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -1,40 +1,33 @@
 /**
  * Vite + React entry.
  *
- * The order below matters and is the entire point of the example:
+ * The only static-side-effect imports here are stylesheets (the demo's
+ * reset + tokens CSS plus the panel package's bundled chrome CSS via
+ * `/styles`). The panel JS is intentionally NOT imported statically: doing
+ * so pulls the entire panel module — Preact runtime, all tabs, all modals
+ * — into the initial chunk and Vite folds the dynamic import in
+ * `lib/mount-panel.ts` back into the same chunk (Rollup warning:
+ * "dynamic import will not move module into another chunk"), defeating
+ * the lazy-load demonstration the issue calls for.
  *
- *   1. Side-effect import of the demo's reset + tokens stylesheets and the
- *      panel package's bundled chrome stylesheet. Vite's library mode strips
- *      the panel's source CSS import from the emitted JS, so consumers must
- *      re-pull it explicitly via the `/styles` sub-export.
- *   2. `configurePanel(panelConfig)` runs SYNCHRONOUSLY before the first
- *      React render. Every consumer of `getPanelConfig()` (storage keys,
- *      console namespace, modal class prefix, …) therefore observes the
- *      host's intended values for any read that happens during render or in
- *      a mount effect. The Astro example achieves the same ordering via an
- *      inline JSON `<script>` parsed by the package-provided host adapter;
- *      because we have no host component here, we wire it directly in TS.
- *   3. `ReactDOM.createRoot(...).render(<App />)` mounts the React tree.
- *      `<App />`'s mount effect then calls `mountPanel()` to install the
- *      window console API and lazy-load the panel module on demand.
+ * Instead, `mount-panel.ts` is the single place that reaches into the
+ * panel package. Its `loadPanelModule()` dynamically imports the package
+ * and calls `configurePanel(panelConfig)` from the imported reference
+ * BEFORE any panel API runs. The package's main entry reads
+ * `getPanelConfig()` only from inside functions invoked at panel-show
+ * time (never at module-init time), so deferring configurePanel into the
+ * dynamic-import resolution is safe — every panel-API call sees the
+ * host's intended config.
  */
 
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
-import { configurePanel } from '@takazudo/zudo-design-token-panel';
 
 import './styles/reset.css';
 import './styles/tokens.css';
 import '@takazudo/zudo-design-token-panel/styles';
 
-import { panelConfig } from './config/panel-config';
 import { App } from './App';
-
-// Configure BEFORE the first render so any reader of getPanelConfig()
-// observes the host's intended values. configurePanel shallow-clones, so
-// later mutations of `panelConfig` would NOT propagate — the singleton is
-// frozen-by-copy at this call.
-configurePanel(panelConfig);
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/examples/vite-react/src/styles/reset.css
+++ b/examples/vite-react/src/styles/reset.css
@@ -1,0 +1,39 @@
+/* Minimal reset — replaces what a framework-provided preflight stylesheet
+   (Tailwind, design-system, etc.) would normally provide. The example
+   deliberately ships none. */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}

--- a/examples/vite-react/src/styles/tokens.css
+++ b/examples/vite-react/src/styles/tokens.css
@@ -1,0 +1,145 @@
+/*
+ * `--vitereact-*` tokens consumed by the demo page.
+ *
+ * Two roles wrapped into one file:
+ *
+ *   1. The byte-for-byte source of truth for the demo's CSS-var values. The
+ *      panel rewrites these names live (in-memory `:root` overrides) when
+ *      the user tweaks a slider. The Apply pipeline rewrites THIS FILE on
+ *      disk when the user clicks Apply (see `scaffold.routing.json` —
+ *      prefix `vitereact` → this path).
+ *
+ *   2. The demo stylesheet — every `.vitereact-*` selector below reads
+ *      tokens from `:root`, so a tweak in any tab is immediately visible
+ *      across the page (and across React rerenders, since the React tree
+ *      doesn't own these vars).
+ *
+ * Splitting the two concerns into separate files would mean the apply
+ * pipeline rewrites a file the demo doesn't read (or vice versa). Keeping
+ * them paired makes the round-trip obvious: the bin sidecar's response is
+ * literally the new contents of the file the next page-load will use.
+ */
+:root {
+  /* Spacing tokens (manifest: spacing tab) */
+  --vitereact-spacing-md: 1rem;
+  --vitereact-spacing-lg: 2rem;
+
+  /* Typography tokens (manifest: typography tab) */
+  --vitereact-text-base: 1rem;
+  --vitereact-text-heading: 1.75rem;
+
+  /* Size tokens (manifest: size tab) */
+  --vitereact-radius: 0.5rem;
+
+  /* Cluster base roles (default-cluster.ts → baseRoles) */
+  --vitereact-bg: #1e1e1e;
+  --vitereact-fg: #f8fafc;
+
+  /* Cluster palette slots (default-cluster.ts → paletteCssVarTemplate) */
+  --vitereact-palette-0: #1e1e1e;
+  --vitereact-palette-1: #2d6cdf;
+  --vitereact-palette-2: #3aa676;
+  --vitereact-palette-3: #d97706;
+  --vitereact-palette-4: #9b5de5;
+  --vitereact-palette-5: #e63946;
+  --vitereact-palette-6: #1d3557;
+  --vitereact-palette-7: #06b6d4;
+  --vitereact-palette-8: #475569;
+  --vitereact-palette-9: #94a3b8;
+  --vitereact-palette-10: #cbd5e1;
+  --vitereact-palette-11: #e2e8f0;
+  --vitereact-palette-12: #f1f5f9;
+  --vitereact-palette-13: #fef3c7;
+  --vitereact-palette-14: #bbf7d0;
+  --vitereact-palette-15: #f8fafc;
+
+  /* Cluster semantic names (default-cluster.ts → semanticCssNames) */
+  --vitereact-color-primary: var(--vitereact-palette-1);
+  --vitereact-color-accent: var(--vitereact-palette-3);
+  --vitereact-color-surface: var(--vitereact-palette-0);
+  --vitereact-color-muted: var(--vitereact-palette-8);
+  --vitereact-color-danger: var(--vitereact-palette-5);
+}
+
+body {
+  background: var(--vitereact-bg);
+  color: var(--vitereact-fg);
+  font-size: var(--vitereact-text-base);
+  padding: var(--vitereact-spacing-lg);
+}
+
+.vitereact-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--vitereact-spacing-lg);
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.vitereact-heading {
+  font-size: var(--vitereact-text-heading);
+  font-weight: 700;
+  margin: 0 0 var(--vitereact-spacing-md);
+  color: var(--vitereact-color-primary);
+}
+
+.vitereact-card {
+  background: var(--vitereact-color-surface);
+  color: var(--vitereact-fg);
+  padding: var(--vitereact-spacing-md);
+  border-radius: var(--vitereact-radius);
+  border: 1px solid var(--vitereact-color-muted);
+}
+
+.vitereact-card + .vitereact-card {
+  margin-top: var(--vitereact-spacing-md);
+}
+
+.vitereact-button {
+  display: inline-block;
+  padding: var(--vitereact-spacing-md);
+  border-radius: var(--vitereact-radius);
+  background: var(--vitereact-color-accent);
+  color: var(--vitereact-bg);
+  border: none;
+  cursor: pointer;
+}
+
+.vitereact-button:hover {
+  background: var(--vitereact-color-primary);
+}
+
+.vitereact-link {
+  color: var(--vitereact-color-accent);
+  text-decoration: underline;
+}
+
+.vitereact-swatch-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--vitereact-spacing-md);
+}
+
+.vitereact-swatch {
+  width: 4rem;
+  height: 4rem;
+  border-radius: var(--vitereact-radius);
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--vitereact-fg);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+  padding: 0.25rem;
+}
+
+.vitereact-meta {
+  font-size: 0.875rem;
+  color: var(--vitereact-color-muted);
+}
+
+.vitereact-rerender-counter {
+  font-variant-numeric: tabular-nums;
+  color: var(--vitereact-color-accent);
+  font-weight: 700;
+}

--- a/examples/vite-react/tests/e2e/apply-roundtrip.spec.ts
+++ b/examples/vite-react/tests/e2e/apply-roundtrip.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Apply-pipeline round-trip spec for the Vite + React example.
+ *
+ * Drives the panel UI to tweak a token, click Apply, and asserts the demo
+ * tokens CSS file on disk (`src/styles/tokens.css`) was rewritten by the
+ * bin sidecar. The full bin → file rewrite path is what the spec proves;
+ * the panel's in-memory `:root` override is exercised as a side effect.
+ *
+ * Prerequisites
+ * -------------
+ *  - Vite dev server on port 44325 (started by the Playwright `webServer`
+ *    config OR by an upstream `pnpm dev` invocation).
+ *  - Bin sidecar `design-token-panel-server` on port 24683, with
+ *    `--write-root .` and `--routing scaffold.routing.json` pointing at
+ *    this example's tree.
+ *
+ * Both are wired by `pnpm dev` (concurrently), so the local-run flow is:
+ *
+ *   pnpm --filter vite-react-example dev
+ *   # in another shell:
+ *   pnpm --filter vite-react-example exec playwright test
+ *
+ * Visibility seed
+ * ---------------
+ * Step 1 seeds `${storagePrefix}:visible = '1'` (the canonical truthy value
+ * the panel module writes; see `src/index.tsx` in the package). On reload,
+ * the React app's `useEffect` calls `mountPanel()`, which reads the flag
+ * and eagerly imports the panel module before first paint — same code path
+ * the Astro host adapter takes when the visible flag is set.
+ *
+ * Try/finally restores the original token value so re-running the spec is
+ * idempotent. The original value is captured at the start; if any assertion
+ * fails before restoration, the after-hook still rewrites the original
+ * value via the bin so the file on disk lands in a known-good state.
+ */
+
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, '..', '..', 'src', 'styles', 'tokens.css');
+const APPLY_URL = 'http://127.0.0.1:24683/apply';
+const ORIGIN = 'http://localhost:44325';
+
+const STORAGE_PREFIX = 'vite-react-example-tokens';
+const STORAGE_KEY_VISIBLE = `${STORAGE_PREFIX}:visible`;
+
+async function readTokenValue(cssVar: string): Promise<string> {
+  const css = await readFile(TOKENS_PATH, 'utf-8');
+  const escaped = cssVar.replace(/-/g, '\\-');
+  const re = new RegExp(`${escaped}:\\s*([^;]+);`);
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`Could not find ${cssVar} in ${TOKENS_PATH}`);
+  }
+  return m[1].trim();
+}
+
+async function postApply(cssVar: string, value: string): Promise<void> {
+  const response = await fetch(APPLY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify({ tokens: { [cssVar]: value } }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST /apply failed (${response.status}): ${text}`);
+  }
+}
+
+test.describe('Vite + React example — apply pipeline round-trip', () => {
+  const TARGET_VAR = '--vitereact-radius';
+  const TEST_VALUE = '1.25rem';
+  let originalValue = '';
+
+  test.beforeAll(async () => {
+    originalValue = await readTokenValue(TARGET_VAR);
+    if (originalValue === TEST_VALUE) {
+      throw new Error(
+        `Test value ${TEST_VALUE} matches original — pick a different test value.`,
+      );
+    }
+  });
+
+  test.afterAll(async () => {
+    // Restore the original token value via the bin so the test file lands
+    // in a known-good state regardless of how the test exited.
+    if (originalValue) {
+      try {
+        await postApply(TARGET_VAR, originalValue);
+      } catch {
+        // Best-effort restoration — the in-band assertion already failed if
+        // we get here; surfacing the secondary error would mask the primary.
+      }
+    }
+  });
+
+  test('panel-driven Apply rewrites the on-disk token value', async ({ page }) => {
+    // Step 1: seed visibility intent so the host adapter eagerly mounts the
+    // panel pre-paint (avoids needing a console-API call in the spec body).
+    // The canonical truthy value is '1' — see packages/.../src/index.tsx.
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate((visibleKey) => {
+      localStorage.setItem(visibleKey, '1');
+    }, STORAGE_KEY_VISIBLE);
+
+    // Step 2: hard-reload — adapter must mount the panel before paint.
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Step 3: open the Size tab and set the radius slider to TEST_VALUE.
+    // The panel ships role-tagged tabs; pick the Size tab and drive the
+    // first numeric input within it. The exact selector path depends on
+    // the panel's rendered DOM; the deferred verification step in the
+    // README covers the click-Apply phase manually.
+    const sizeTab = page.getByRole('tab', { name: /size/i });
+    await sizeTab.waitFor({ state: 'visible', timeout: 5000 });
+    await sizeTab.click();
+
+    const radiusInput = page.getByLabel(/border radius/i).first();
+    await radiusInput.waitFor({ state: 'visible', timeout: 5000 });
+    await radiusInput.fill('1.25');
+
+    // Step 4: click the Apply button in the panel chrome and confirm in
+    // the resulting modal.
+    const applyButton = page.getByRole('button', { name: /^apply$/i }).first();
+    await applyButton.waitFor({ state: 'visible', timeout: 5000 });
+    await applyButton.click();
+
+    const confirmButton = page.getByRole('button', { name: /confirm|apply now|write/i }).first();
+    await confirmButton.waitFor({ state: 'visible', timeout: 5000 });
+    await confirmButton.click();
+
+    // Step 5: poll the file on disk for the rewritten value. The bin
+    // writes atomically via a temp-file rename, so the new contents
+    // appear in a single fs operation; polling avoids a race with the
+    // server's HTTP response landing before the rename completes.
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await readTokenValue(TARGET_VAR);
+          } catch {
+            return '';
+          }
+        },
+        { timeout: 5000, intervals: [100, 250, 500] },
+      )
+      .toBe(TEST_VALUE);
+  });
+});

--- a/examples/vite-react/tsconfig.json
+++ b/examples/vite-react/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "moduleDetection": "force",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "vite.config.ts", "playwright.config.ts", "tests"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+/**
+ * Vite + React example for @takazudo/zudo-design-token-panel.
+ *
+ * Deliberately minimal: NO Tailwind, NO design-system integration, NO MDX,
+ * NO `react -> preact/compat` alias. The example proves the panel package
+ * works inside any Vite + React consumer that supplies just a `PanelConfig`
+ * and ships `preact` alongside React for the panel's own render tree.
+ *
+ * Apply-pipeline proxy
+ * --------------------
+ * `panelConfig.applyEndpoint` is set to the relative path `/api/dev/apply` so
+ * the panel POSTs to the same origin as the Vite dev server (no CORS
+ * preflight, no hardcoded port in the runtime config). Vite proxies that
+ * path to the bin sidecar on port 24683. This keeps the example app a
+ * vanilla static-output Vite build and avoids pulling in a Node server just
+ * to host one dev-only POST endpoint.
+ *
+ * IMPORTANT: do NOT alias `react` -> `preact/compat`. The example must use
+ * real React 18 — that is the entire point of the example. The panel renders
+ * via its own Preact runtime inside the panel root element, fully isolated
+ * from the host React tree.
+ */
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 44325,
+    proxy: {
+      '/api/dev/apply': {
+        target: 'http://127.0.0.1:24683',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/dev\/apply/, '/apply'),
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,46 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/vite-react:
+    dependencies:
+      '@takazudo/zudo-design-token-panel':
+        specifier: workspace:*
+        version: link:../../packages/zudo-design-token-panel
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
   packages/zudo-design-token-panel:
     devDependencies:
       '@types/node':
@@ -272,6 +312,18 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx@7.28.6':
     resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
     engines: {node: '>=6.9.0'}
@@ -370,16 +422,34 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -388,16 +458,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -406,10 +494,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -418,10 +518,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -430,10 +542,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -442,10 +566,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -454,10 +590,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.7':
@@ -466,16 +614,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.7':
@@ -484,10 +650,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -496,11 +674,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
@@ -508,16 +698,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -780,6 +988,9 @@ packages:
     peerDependencies:
       preact: ^10.4.0 || ^11.0.0-0
       vite: '>=2.0.0'
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -1064,6 +1275,18 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1193,6 +1416,17 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
@@ -1210,6 +1444,12 @@ packages:
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -1784,6 +2024,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -2223,6 +2468,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2619,6 +2868,19 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -2756,6 +3018,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -3074,6 +3339,46 @@ packages:
     resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
     peerDependencies:
       vite: 5.x || 6.x || 7.x || 8.x
+
+  vite@6.4.2:
+    resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -3602,6 +3907,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -3717,79 +4032,157 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -4026,6 +4419,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
@@ -4229,6 +4624,27 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4385,6 +4801,17 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
@@ -4402,6 +4829,18 @@ snapshots:
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -5094,6 +5533,35 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -5606,6 +6074,10 @@ snapshots:
   lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
 
@@ -6306,6 +6778,18 @@ snapshots:
 
   radix3@1.1.2: {}
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
@@ -6539,6 +7023,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   section-matter@1.0.0:
     dependencies:
@@ -6833,6 +7321,21 @@ snapshots:
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      yaml: 2.8.3
 
   vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/8
- parent PR
    - https://github.com/Takazudo/zudo-design-token-panel/pull/10

---

## Summary

Adds the Vite + React example app at `examples/vite-react/`, proving that
`@takazudo/zudo-design-token-panel` runs alongside a plain React 18 app
without any `react` → `preact/compat` alias. The panel mounts as a Preact
island from a `useEffect` in the React tree; the apply pipeline round-trips
through the bin sidecar via a Vite middleware proxy.

Closes #8 (epic). Stacks on top of super-epic root **#10** (`base/initial-port`).

## What's in this PR

### Scaffold (`pnpm create vite vite-react --template react-ts` then trimmed)

- React 18 + Vite 6 + TypeScript on dev port `44325`.
- `concurrently` runs Vite + the bin sidecar (`design-token-panel-server` on port `24683`).
- Vite `configureServer` proxies `/api/dev/apply` to the bin (no CORS preflight, no hardcoded port in `panelConfig`).
- **No** `react` → `preact/compat` alias — keeps React intact so this example proves the panel works alongside React, not as a React shim.
- `scaffold.routing.json` maps prefix `vitereact` → `src/styles/tokens.css`.

### Panel as a Preact island (the host-adapter port)

- `src/main.tsx` — entry; only stylesheets are statically imported (`reset.css`, `tokens.css`, `@takazudo/zudo-design-token-panel/styles`).
- `src/lib/mount-panel.ts` — local port of the package's Astro host adapter:
  - Installs `window.viteReactExample.{showDesignPanel, hideDesignPanel, toggleDesignPanel}`.
  - Lazy-loads the panel module via dynamic import; eagerly loads when `wasVisible()` is `1` or persisted overrides exist.
  - Calls `configurePanel(panelConfig)` on the freshly imported module **before** any panel API runs (singleton-safe; the package's main entry never reads `getPanelConfig()` at module-init).
  - StrictMode-safe via a per-`storagePrefix` bind flag and a memoised `modulePromise`.
- `src/App.tsx` — calls `mountPanel()` from a `useEffect`. Demo content (cards / buttons / palette swatches) reads `--vitereact-*` tokens; tweaks from the panel update the page in real time.

### Lazy-load fix (post-review)

A static `import { configurePanel }` in `main.tsx` was pulling the entire
panel module into the initial chunk and Vite folded the dynamic import in
`mount-panel.ts` back into the same chunk (Rollup warning:
"dynamic import will not move module into another chunk"). Moved the
`configurePanel` call into `loadPanelModule()`'s `.then()`. Result:

| | before | after |
|---|---|---|
| chunks | 1 | 2 (initial + lazy panel) |
| initial JS gzip | 73.23 KB | **24.23 KB** (-67%) |
| Rollup warning | yes | none |

Panel JS only loads when `wasVisible()` / persisted overrides are set
or when `window.viteReactExample.toggleDesignPanel()` is called.

### Apply pipeline + e2e

- `vite.config.ts` proxy: `/api/dev/apply` → `http://127.0.0.1:24683/apply`.
- `tests/e2e/apply-roundtrip.spec.ts` (Playwright) — port of the Astro spec; drives the panel UI to tweak `--vitereact-radius`, asserts `examples/vite-react/src/styles/tokens.css` was rewritten on disk, restores the original.
- `scripts/smoke-apply.mjs` — manual harness for the bin POST round-trip.
- `README.md` — run instructions, manual verification, Playwright invocation.

### Identifier family (per host-agnosticism contract)

| field | value |
|---|---|
| `storagePrefix` | `vite-react-example-tokens` |
| `consoleNamespace` | `viteReactExample` |
| `modalClassPrefix` | `vite-react-example-design-token-panel-modal` |
| `schemaId` | `vite-react-example-design-tokens/v1` |
| `exportFilenameBase` | `vite-react-example-design-tokens` |
| CSS-var family | `--vitereact-*` |
| routing prefix | `vitereact` |

## Verification

- `pnpm --filter vite-react-example typecheck` — passes
- `pnpm --filter vite-react-example build` — passes, no Rollup warning, two-chunk split
- `pnpm b4push` (build / test / typecheck / lint over the whole monorepo) — passes
- `/gcoc-review` (gpt-4.1) review of the diff — only HIGH finding was the lazy-load defeat, fixed in `9ca7cf9`. All other checks pass.
- Playwright e2e spec authored but not executed locally per the manager workflow rule (heavy/port-binding tests run on the merged base, not in child worktrees). CI on the epic-PR exercises the build/typecheck/test pipeline.

## Files

```
examples/vite-react/
├── README.md
├── index.html
├── package.json
├── playwright.config.ts
├── scaffold.routing.json
├── scripts/smoke-apply.mjs
├── src/
│   ├── App.tsx
│   ├── config/{panel-config,default-manifest,default-cluster}.ts
│   ├── lib/mount-panel.ts
│   ├── main.tsx
│   └── styles/{reset,tokens}.css
├── tests/e2e/apply-roundtrip.spec.ts
├── tsconfig.json
└── vite.config.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)