### PR TITLE
[Initial Port] Example app: Next.js

### DIFF
--- a/examples/next/.gitignore
+++ b/examples/next/.gitignore
@@ -1,0 +1,16 @@
+# Next.js
+.next/
+out/
+
+# Dependencies
+node_modules/
+
+# TypeScript
+*.tsbuildinfo
+
+# Playwright
+playwright-report/
+test-results/
+
+# Logs
+*.log

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -54,6 +54,11 @@ the bin **directly with CORS**. This example picks the API route. Why:
 The route is a transport-level adapter: it forwards the body bytes
 verbatim and the upstream status code verbatim. The bin owns the schema.
 
+**Dev-only**: the route short-circuits to `404` when `NODE_ENV ===
+'production'` so `next start` (and any production deploy) does not expose
+a localhost-bin proxy. This matches Vite's `server.proxy` semantics —
+proxies apply only to the dev server, not to production builds.
+
 ## Apply-pipeline manual verification
 
 The Playwright spec at `tests/e2e/apply-roundtrip.spec.ts` automates this; the

--- a/examples/next/README.md
+++ b/examples/next/README.md
@@ -1,0 +1,209 @@
+# Next.js example — `@takazudo/zudo-design-token-panel`
+
+A minimal Next.js 15 (App Router) + React 19 app that mounts the
+design-token panel as a Preact island via a `'use client'` boundary,
+demonstrates live token tweaking, and exercises the full apply pipeline by
+round-tripping tweaks back to disk through the bin sidecar
+(`design-token-panel-server`).
+
+## Run
+
+```bash
+pnpm --filter next-example dev
+```
+
+`pnpm dev` runs two processes via `concurrently`:
+
+| process | port  | role                                                                            |
+| ------- | ----- | ------------------------------------------------------------------------------- |
+| Next    | 44326 | the example site                                                                |
+| bin     | 24684 | `design-token-panel-server` — receives `/apply` POSTs, rewrites `tokens.css`    |
+
+The Next API route at `app/api/dev/apply/route.ts` forwards
+`/api/dev/apply` to the bin (see "Apply pipeline — proxy choice" below), so
+the panel POSTs to a same-origin URL — no CORS preflight, no hardcoded port
+in the runtime config.
+
+Open [http://localhost:44326](http://localhost:44326) and run
+`window.nextExample.toggleDesignPanel()` in the browser console to show the
+panel. Drag any slider — the page repaints before the next frame.
+
+## Apply pipeline — proxy choice (Next API route vs CORS-allowed fetch)
+
+The Epic #9 brief left this open: route the panel's apply POST through a
+**Next API route** (`app/api/dev/apply/route.ts`) or have the panel fetch
+the bin **directly with CORS**. This example picks the API route. Why:
+
+1. **Same-origin POST means no CORS preflight.** The panel issues a JSON
+   POST to `/api/dev/apply` on the same origin Next is serving the page
+   on; the browser issues no `OPTIONS` request, the bin never has to
+   reason about cross-origin headers, and the runtime config in
+   `src/config/panel-config.ts` carries no port number — exactly the
+   shape the Vite + React sibling example uses. Keeps the panel config
+   identical (`applyEndpoint: '/api/dev/apply'`) across both examples.
+2. **App Router has no built-in dev-server proxy.** Vite ships
+   `server.proxy` so the Vite + React example runs the proxy from
+   `vite.config.ts`. Next has nothing equivalent at the framework level —
+   an API route is the canonical "talk to a backend without CORS" surface
+   in App Router and ships in production builds too.
+3. **Bin Origin validation stays simple.** The route forwards the POST
+   with `Origin: http://localhost:44326` regardless of what the incoming
+   request has, so the bin's `--allow-origin http://localhost:44326`
+   gate matches one stable origin only.
+
+The route is a transport-level adapter: it forwards the body bytes
+verbatim and the upstream status code verbatim. The bin owns the schema.
+
+## Apply-pipeline manual verification
+
+The Playwright spec at `tests/e2e/apply-roundtrip.spec.ts` automates this; the
+manual procedure is documented here so the round-trip is verifiable without
+booting the e2e harness.
+
+1. Start the dev environment:
+
+   ```bash
+   pnpm --filter next-example dev
+   ```
+
+2. In a second shell, capture the current value of one token:
+
+   ```bash
+   grep -- '--nextexample-radius' examples/next/src/styles/tokens.css
+   #   --nextexample-radius: 0.5rem;
+   ```
+
+3. In the browser, open the panel via
+   `window.nextExample.toggleDesignPanel()`. Switch to the **Size** tab,
+   drag the **Border Radius** slider to a different value, then click
+   **Apply** in the panel chrome and confirm the diff.
+
+4. In the second shell, re-read the same line — it should now show the new
+   value:
+
+   ```bash
+   grep -- '--nextexample-radius' examples/next/src/styles/tokens.css
+   #   --nextexample-radius: 1.25rem;
+   ```
+
+5. The next page reload picks up the new value from the file (the in-memory
+   override is no longer needed because the source-of-truth on disk now
+   matches).
+
+For a non-interactive smoke check that bypasses the panel UI and the Next
+API route — POSTing directly to the bin on port 24684 — run:
+
+```bash
+pnpm --filter next-example test:apply-smoke
+```
+
+## What the example proves
+
+- The panel package consumes ZERO project-specific defaults from its own
+  bundle. Every identifier (`storagePrefix`, `consoleNamespace`,
+  `paletteCssVarTemplate`, semantic CSS-var names, etc.) flows in from
+  `src/config/panel-config.ts`.
+- The apply pipeline routes by CSS-var prefix family: the `nextexample`
+  prefix in `scaffold.routing.json` maps to `src/styles/tokens.css`, so
+  any tweak to a `--nextexample-*` token rewrites that file.
+- The panel works inside a real React 19 + Next 15 App Router app
+  **without** a `react -> preact/compat` alias. The host React tree never
+  owns the panel's render surface — `mountPanel()` lazy-imports the
+  panel module and Preact mounts inside its own root element, fully
+  isolated from React reconciliation.
+- React 19 StrictMode is enabled (the App Router default;
+  `next.config.ts` makes it explicit). The host adapter is StrictMode-safe
+  via the per-`storagePrefix` bind flag pinned on
+  `window.__zudoDesignTokenPanelAdapter` — the `useEffect` in
+  `app/_components/PanelBootstrap.tsx` is invoked twice in dev, but the
+  second call short-circuits.
+- Panel state survives soft navigation. `next/link` between `/` and
+  `/about` is a client-routed swap; the layout component persists across
+  it, the `PanelBootstrap` adapter binds once, and the panel's DOM root
+  lives outside the React tree (appended to `document.body` by the panel
+  module), so no part of the route swap can disturb panel state.
+- Panel state survives React rerenders. The "Verify across rerender"
+  section on the home page exposes a counter button + a child-subtree
+  toggle so the panel's persistence across React reconciliation is
+  observable in the UI.
+
+## Identifier family
+
+The host-agnosticism contract for this example pins these identifiers:
+
+| field                 | value                                       |
+| --------------------- | ------------------------------------------- |
+| `storagePrefix`       | `next-example-tokens`                       |
+| `consoleNamespace`    | `nextExample`                               |
+| `modalClassPrefix`    | `next-example-design-token-panel-modal`     |
+| `schemaId`            | `next-example-design-tokens/v1`             |
+| `exportFilenameBase`  | `next-example-design-tokens`                |
+| CSS-var family        | `--nextexample-*`                           |
+| routing prefix        | `nextexample`                               |
+| Next dev port         | `44326`                                     |
+| bin sidecar port      | `24684`                                     |
+
+The console-API call is `window.nextExample.toggleDesignPanel()`.
+
+## Apply pipeline — flow
+
+```
+┌───────────────┐   POST /api/dev/apply    ┌────────────────────────────┐
+│   Panel UI    │ ───────────────────────▶ │   Next API route           │
+│ (Preact)      │   { tokens: {…} }        │   app/api/dev/apply        │
+└───────────────┘                          │   /route.ts                │
+                                           │                            │
+                                           │   forwards verbatim with   │
+                                           │   Origin: localhost:44326  │
+                                           ▼                            ▼
+                                  ┌────────────────────────────────────────┐
+                                  │   bin sidecar  (port 24684)            │
+                                  │   design-token-panel-server            │
+                                  │   --routing scaffold.routing.json      │
+                                  │   --write-root .                       │
+                                  └────────────────────────────────────────┘
+                                           │   atomic temp-rename write
+                                           ▼
+                                  ┌────────────────────────────────────────┐
+                                  │   examples/next/src/styles/tokens.css  │
+                                  └────────────────────────────────────────┘
+```
+
+## Layout
+
+```
+examples/next/
+├── README.md                     # this file
+├── next-env.d.ts                 # standard Next 15 type-reference file
+├── next.config.ts                # reactStrictMode + outputFileTracingRoot pin
+├── package.json                  # name: next-example, dev = next + bin
+├── playwright.config.ts          # apply-roundtrip e2e config
+├── scaffold.routing.json         # CSS-var prefix → file map (shared by panel + bin)
+├── tsconfig.json                 # Next 15 strict TS, resolveJsonModule on
+├── app/
+│   ├── about/
+│   │   └── page.tsx              # second route — soft-navigation analog
+│   ├── api/
+│   │   └── dev/
+│   │       └── apply/
+│   │           └── route.ts      # POST /api/dev/apply → bin proxy
+│   ├── _components/
+│   │   └── PanelBootstrap.tsx    # 'use client' island — useEffect → mountPanel
+│   ├── layout.tsx                # global CSS + <PanelBootstrap />
+│   └── page.tsx                  # demo content + rerender-verify section
+├── scripts/
+│   └── smoke-apply.mjs           # non-UI smoke harness for the bin
+├── src/
+│   ├── config/
+│   │   ├── default-cluster.ts    # `--nextexample-*` color cluster
+│   │   ├── default-manifest.ts   # `--nextexample-*` token rows
+│   │   └── panel-config.ts       # PanelConfig assembly
+│   ├── lib/
+│   │   └── mount-panel.ts        # adapter (console API + lazy-load + StrictMode bind flag)
+│   └── styles/
+│       ├── reset.css
+│       └── tokens.css            # `--nextexample-*` source of truth (apply target)
+└── tests/
+    └── e2e/
+        └── apply-roundtrip.spec.ts
+```

--- a/examples/next/app/_components/PanelBootstrap.tsx
+++ b/examples/next/app/_components/PanelBootstrap.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+/*
+ * Client-only bootstrap for the design-token panel adapter.
+ *
+ * This is the React-19 client-component analog of the Vite + React example's
+ * `useEffect`-from-`App.tsx` pattern. Next.js App Router renders the tree as
+ * RSC by default, and side-effecting browser code (panel adapter, console
+ * API installation, lazy panel-module dynamic import) is only allowed under
+ * a `'use client'` boundary — hence this file.
+ *
+ * Rendering this component once in `app/layout.tsx` wires the panel for
+ * every route in the app: the layout component renders on each navigation
+ * and `<PanelBootstrap />` is a sibling of `{children}`, so the effect
+ * mounts on the first SSR-hydration handoff and the per-`storagePrefix`
+ * bind flag inside `mountPanel()` short-circuits subsequent calls. The
+ * RSC ↔ client-component boundary stays clean because PanelBootstrap
+ * returns `null` — it owns no DOM of its own; the panel adapter appends
+ * the panel root element directly to `document.body` via the panel
+ * module, fully outside the React render tree.
+ *
+ * StrictMode safety: `next.config.ts` enables `reactStrictMode: true`
+ * (the App Router default) so this `useEffect` runs twice in dev. The
+ * `mountPanel()` body is StrictMode-safe via the per-`storagePrefix`
+ * `bound` flag pinned on `window.__zudoDesignTokenPanelAdapter`. We also
+ * deliberately ship NO cleanup function: the panel adapter installs
+ * window-level state that lives for the page lifetime, so a per-mount
+ * cleanup would be wrong.
+ */
+
+import { useEffect } from 'react';
+import { mountPanel } from '../../src/lib/mount-panel';
+
+export default function PanelBootstrap() {
+  useEffect(() => {
+    mountPanel();
+  }, []);
+  return null;
+}

--- a/examples/next/app/about/page.tsx
+++ b/examples/next/app/about/page.tsx
@@ -1,0 +1,90 @@
+/*
+ * Second page of the Next.js example. Mirrors the home page's shape so token
+ * tweaks can be verified across a Next.js soft-navigation.
+ *
+ * Soft-navigation note: this page is server-rendered (no `'use client'`
+ * directive) — clicking the `<Link href="/">` below is a client-side
+ * navigation that swaps the route without a full document reload. The
+ * panel's host adapter installed by `app/_components/PanelBootstrap.tsx`
+ * (rendered once in `app/layout.tsx`) is therefore NOT re-mounted on the
+ * navigation; the layout component persists across the route swap, and
+ * the panel's DOM root is appended outside the React tree by the panel
+ * adapter, so the panel state survives the navigation intact. This is
+ * the Next.js analog of the Astro example's `astro:before-swap` /
+ * `astro:page-load` reapply path and the Vite + React example's
+ * "verify across rerender" section.
+ *
+ * The page mirrors the home page's palette swatches so a side-by-side
+ * comparison after a token tweak is trivial: tweak a palette colour on
+ * `/`, follow the link to `/about`, confirm the swatches show the new
+ * colour without an FOUT and without a console-API roundtrip.
+ */
+
+import Link from 'next/link';
+
+const PALETTE_INDICES = Array.from({ length: 16 }, (_, i) => i);
+
+export default function AboutPage() {
+  return (
+    <main className="nextexample-stack">
+      <header>
+        <h1 className="nextexample-heading">About this example</h1>
+        <p>
+          The <code>examples/next</code> sub-package consumes
+          <code> @takazudo/zudo-design-token-panel</code> through its built
+          artifact only — there are no deep imports into <code>dist/</code>,
+          no bundler aliases, and no framework integration beyond the
+          <code> &apos;use client&apos;</code> bootstrap component.
+        </p>
+        <ul>
+          <li>No Tailwind, no preflight stylesheet, no design-system dependency.</li>
+          <li>
+            Storage prefix <code>next-example-tokens</code>, console namespace
+            <code> nextExample</code>.
+          </li>
+          <li>
+            Palette CSS-var template <code>--nextexample-palette-{`{n}`}</code>.
+          </li>
+          <li>
+            Apply endpoint <code>/api/dev/apply</code> handled by a Next API
+            route (<code>app/api/dev/apply/route.ts</code>) that forwards to
+            the bin sidecar on port 24684.
+          </li>
+        </ul>
+      </header>
+
+      <section>
+        <h2 className="nextexample-heading">Verify across navigation</h2>
+        <div className="nextexample-card">
+          Open the panel via{' '}
+          <code>window.nextExample.toggleDesignPanel()</code>, change a token,
+          then{' '}
+          <Link className="nextexample-link" href="/">
+            navigate back to home
+          </Link>
+          . The new value should still apply — proving the host adapter
+          survives Next.js soft navigation end-to-end.
+        </div>
+      </section>
+
+      <section>
+        <h2 className="nextexample-heading">Palette swatches (mirrored)</h2>
+        <div className="nextexample-swatch-row">
+          {PALETTE_INDICES.map((i) => (
+            <div
+              key={i}
+              className="nextexample-swatch"
+              style={{ background: `var(--nextexample-palette-${i})` }}
+            >
+              {i}
+            </div>
+          ))}
+        </div>
+        <p className="nextexample-meta">
+          These swatches are identical to the home page so a side-by-side
+          comparison after a token tweak is trivial.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/examples/next/app/api/dev/apply/route.ts
+++ b/examples/next/app/api/dev/apply/route.ts
@@ -1,0 +1,79 @@
+/*
+ * Apply-pipeline proxy — Next.js API route.
+ *
+ * Mirrors the proxy the Vite + React example installs in vite.config.ts:
+ *
+ *   panel POST -> /api/dev/apply -> bin sidecar at 127.0.0.1:24684/apply
+ *
+ * Why an API route (not direct CORS-allowed fetch from the panel to the bin)?
+ *
+ *   1. Same-origin POST means no CORS preflight. The panel issues a JSON
+ *      `POST /api/dev/apply` against the same origin Next is serving the
+ *      page on, the browser issues no OPTIONS request, the bin never has to
+ *      reason about cross-origin headers, and the runtime config in
+ *      `src/config/panel-config.ts` carries no port number — exactly the
+ *      shape the vite-react example uses.
+ *
+ *   2. App Router has no built-in dev-server proxy config equivalent to
+ *      Vite's `server.proxy`. An API route is the canonical "talk to a
+ *      backend without CORS" surface in App Router, and the route file is
+ *      idiomatic Next: it ships in production builds too (so the same
+ *      apply pipeline is reachable from `next start` if a host wants to
+ *      run the bin under a process supervisor).
+ *
+ *   3. The bin sidecar still validates the Origin header for safety, so
+ *      this route forwards the request with `Origin: http://localhost:44326`
+ *      regardless of what the incoming request had — the bin is started
+ *      with `--allow-origin http://localhost:44326` in `pnpm dev`, which
+ *      is the only origin the panel ever runs against during development.
+ *
+ * The implementation forwards the body bytes verbatim and the status code
+ * verbatim. We don't try to parse, transform, or validate the JSON — the
+ * bin owns the schema, this route is a transport-level adapter.
+ */
+
+const BIN_APPLY_URL = 'http://127.0.0.1:24684/apply';
+const FORWARD_ORIGIN = 'http://localhost:44326';
+
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.text();
+  const incomingContentType = request.headers.get('content-type') ?? 'application/json';
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(BIN_APPLY_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': incomingContentType,
+        Origin: FORWARD_ORIGIN,
+      },
+      body,
+    });
+  } catch (err) {
+    // Surface a 502 when the bin sidecar is unreachable — same shape the
+    // Vite proxy returns when its target connection fails. The panel UI
+    // shows the response body in the apply-failure modal, so a clear
+    // message here is actionable from the browser.
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(
+      JSON.stringify({
+        error: 'bin-sidecar-unreachable',
+        message,
+        target: BIN_APPLY_URL,
+        hint: 'Run `pnpm --filter next-example dev` so the bin sidecar listens on port 24684.',
+      }),
+      {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+  }
+
+  const upstreamBody = await upstream.text();
+  return new Response(upstreamBody, {
+    status: upstream.status,
+    headers: {
+      'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+    },
+  });
+}

--- a/examples/next/app/api/dev/apply/route.ts
+++ b/examples/next/app/api/dev/apply/route.ts
@@ -1,5 +1,5 @@
 /*
- * Apply-pipeline proxy — Next.js API route.
+ * Apply-pipeline proxy — Next.js API route (DEV-ONLY).
  *
  * Mirrors the proxy the Vite + React example installs in vite.config.ts:
  *
@@ -16,10 +16,13 @@
  *
  *   2. App Router has no built-in dev-server proxy config equivalent to
  *      Vite's `server.proxy`. An API route is the canonical "talk to a
- *      backend without CORS" surface in App Router, and the route file is
- *      idiomatic Next: it ships in production builds too (so the same
- *      apply pipeline is reachable from `next start` if a host wants to
- *      run the bin under a process supervisor).
+ *      backend without CORS" surface in App Router, so the route is the
+ *      right Next-shaped tool for the job — but it ships in production
+ *      builds too. To keep the parity with vite-react's dev-only proxy
+ *      (`vite.config.ts`'s `server.proxy` does not apply to production
+ *      builds), this route SHORT-CIRCUITS to 404 in production. The
+ *      apply pipeline is a developer-only surface — production builds of
+ *      the example app must not expose a proxy to a localhost bin.
  *
  *   3. The bin sidecar still validates the Origin header for safety, so
  *      this route forwards the request with `Origin: http://localhost:44326`
@@ -36,6 +39,14 @@ const BIN_APPLY_URL = 'http://127.0.0.1:24684/apply';
 const FORWARD_ORIGIN = 'http://localhost:44326';
 
 export async function POST(request: Request): Promise<Response> {
+  // Dev-only gate. `next dev` sets NODE_ENV=development; `next build` /
+  // `next start` set NODE_ENV=production. In production, the route returns
+  // 404 — same surface a non-existent route would return, so a curious
+  // probe gets no signal that the dev proxy ever existed in the build.
+  if (process.env.NODE_ENV === 'production') {
+    return new Response('Not Found', { status: 404 });
+  }
+
   const body = await request.text();
   const incomingContentType = request.headers.get('content-type') ?? 'application/json';
 

--- a/examples/next/app/layout.tsx
+++ b/examples/next/app/layout.tsx
@@ -4,10 +4,24 @@ import '../src/styles/reset.css';
 import '../src/styles/tokens.css';
 import '@takazudo/zudo-design-token-panel/styles';
 
-// TODO (sub-task 2): wire <PanelBootstrap /> here as a 'use client' island so
-// the design-token panel adapter binds on every route. Stylesheets land first
-// because layout.tsx is the canonical Next App Router entry for global CSS.
+import PanelBootstrap from './_components/PanelBootstrap';
 
+/*
+ * Root layout for the Next.js example.
+ *
+ * Stylesheets land first because layout.tsx is the canonical Next App Router
+ * entry for global CSS — the order matters because `tokens.css` defines the
+ * `--nextexample-*` custom properties the panel rewrites at runtime, and the
+ * panel package's own chrome CSS (`/styles`) lands afterwards so its rules
+ * cascade above the host's reset.
+ *
+ * <PanelBootstrap /> is the `'use client'` island that calls `mountPanel()`
+ * from a `useEffect`. It returns `null` — the panel adapter appends its own
+ * DOM root outside the React tree — and rendering it once here wires the
+ * adapter for every route in the app (the per-`storagePrefix` bind flag
+ * inside mountPanel short-circuits StrictMode's double-invoke and any
+ * subsequent layout re-renders).
+ */
 export const metadata: Metadata = {
   title: 'Next.js Example — Design Token Panel',
   description:
@@ -17,7 +31,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <PanelBootstrap />
+      </body>
     </html>
   );
 }

--- a/examples/next/app/layout.tsx
+++ b/examples/next/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+import '../src/styles/reset.css';
+import '../src/styles/tokens.css';
+import '@takazudo/zudo-design-token-panel/styles';
+
+// TODO (sub-task 2): wire <PanelBootstrap /> here as a 'use client' island so
+// the design-token panel adapter binds on every route. Stylesheets land first
+// because layout.tsx is the canonical Next App Router entry for global CSS.
+
+export const metadata: Metadata = {
+  title: 'Next.js Example — Design Token Panel',
+  description:
+    'Next.js 15 + React 19 example app for @takazudo/zudo-design-token-panel — host-config-driven panel mounted as a Preact island via a "use client" boundary.',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -1,0 +1,10 @@
+// Sub-task 1 placeholder. Demo content lands in sub-task 3 — for now just
+// render enough to make `next build` happy and let the typecheck verify the
+// scaffold wiring.
+export default function HomePage() {
+  return (
+    <main>
+      <p>Next example — scaffold.</p>
+    </main>
+  );
+}

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -1,10 +1,165 @@
-// Sub-task 1 placeholder. Demo content lands in sub-task 3 — for now just
-// render enough to make `next build` happy and let the typecheck verify the
-// scaffold wiring.
+'use client';
+
+/*
+ * Home page for the Next.js example.
+ *
+ * Ports the structure of `examples/vite-react/src/App.tsx` (cards, buttons,
+ * palette swatches, "verify across rerender" section) into the App Router
+ * idiom. Marked `'use client'` so the rerender-verify counter's `useState`
+ * actually rerenders on click — the panel's persistence across React state
+ * changes is the demonstration this section exists for.
+ *
+ * The mount-panel call has been relocated to `app/_components/PanelBootstrap.tsx`
+ * (rendered in `app/layout.tsx`) so the panel adapter binds for every route
+ * in the app — including `/about`, the soft-navigation sibling that proves
+ * the panel state survives Next's client-routed navigations. See the block
+ * comment in `PanelBootstrap.tsx` for why the boundary lives in the layout.
+ *
+ * Soft-navigation note: the Vite + React analog of "view-transitions don't
+ * disturb panel state" is Next's client-side navigation between pages via
+ * `next/link`. The link to `/about` below — combined with `/about`'s link
+ * back to `/` — is what proves the equivalence in the demo runtime.
+ */
+
+import Link from 'next/link';
+import { useCallback, useState } from 'react';
+
+const PALETTE_INDICES = Array.from({ length: 16 }, (_, i) => i);
+
 export default function HomePage() {
   return (
-    <main>
-      <p>Next example — scaffold.</p>
+    <main className="nextexample-stack">
+      <header>
+        <h1 className="nextexample-heading">Live token tweaking, in plain Next.js + React</h1>
+        <p>
+          Every visible element on this page is driven by a{' '}
+          <code>--nextexample-*</code> CSS custom property. Open the panel from
+          the browser console and drag any slider — the change applies before
+          the next paint, and survives React rerenders because the CSS vars
+          live on <code>:root</code>, not in React state.
+        </p>
+        <p className="nextexample-meta">
+          Console API: <code>window.nextExample.toggleDesignPanel()</code>.
+          Storage prefix: <code>next-example-tokens</code>.
+        </p>
+        <p>
+          Soft-navigation analog of view-transitions:{' '}
+          <Link className="nextexample-link" href="/about">
+            visit the /about page
+          </Link>{' '}
+          to verify panel state survives Next's client-routed navigation.
+        </p>
+      </header>
+
+      <section>
+        <h2 className="nextexample-heading">Cards (spacing + radius + surface)</h2>
+        <div className="nextexample-card">
+          <strong>Card A.</strong> Padding driven by{' '}
+          <code>--nextexample-spacing-md</code>, corners by{' '}
+          <code>--nextexample-radius</code>, background by{' '}
+          <code>--nextexample-color-surface</code>.
+        </div>
+        <div className="nextexample-card">
+          <strong>Card B.</strong> Stack gap driven by{' '}
+          <code>--nextexample-spacing-lg</code>; outline by{' '}
+          <code>--nextexample-color-muted</code>.
+        </div>
+      </section>
+
+      <section>
+        <h2 className="nextexample-heading">Buttons + links (accent / primary)</h2>
+        <p>
+          <button className="nextexample-button" type="button">
+            Action button
+          </button>
+        </p>
+        <p>
+          The styled{' '}
+          <a className="nextexample-link" href="#rerender-verify">
+            rerender-verify section
+          </a>{' '}
+          below proves the panel's tokens persist across React state changes.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="nextexample-heading">Palette swatches</h2>
+        <div className="nextexample-swatch-row">
+          {PALETTE_INDICES.map((i) => (
+            <div
+              key={i}
+              className="nextexample-swatch"
+              style={{ background: `var(--nextexample-palette-${i})` }}
+            >
+              {i}
+            </div>
+          ))}
+        </div>
+        <p className="nextexample-meta">
+          Each swatch reads <code>--nextexample-palette-{'{n}'}</code>. The
+          cluster's <code>paletteCssVarTemplate</code> is the only thing that
+          decides this name — change it in <code>default-cluster.ts</code> and
+          the apply pipeline writes a different variable on the next palette
+          tweak.
+        </p>
+      </section>
+
+      <RerenderVerify />
     </main>
+  );
+}
+
+/**
+ * Verify across rerender. This component mirrors the Vite + React example's
+ * `RerenderVerify` component. Its purpose is to confirm:
+ *
+ *   1. A `setState`-driven rerender keeps the panel's `:root` overrides in
+ *      place (the React tree doesn't own those vars, so it can't lose
+ *      them).
+ *   2. A child subtree that mounts/unmounts arbitrarily on the same render
+ *      cycle does not disturb the panel either — the panel's mount root is
+ *      a sibling appended by the panel adapter, not a child of the React
+ *      tree, so React reconciliation cannot touch it.
+ */
+function RerenderVerify() {
+  const [count, setCount] = useState(0);
+  const [showChild, setShowChild] = useState(true);
+
+  const bump = useCallback(() => {
+    setCount((c) => c + 1);
+  }, []);
+
+  const toggleChild = useCallback(() => {
+    setShowChild((v) => !v);
+  }, []);
+
+  return (
+    <section id="rerender-verify">
+      <h2 className="nextexample-heading">Verify across rerender</h2>
+      <div className="nextexample-card">
+        Click the button to trigger a React rerender. Tweak any panel slider,
+        then click again — the tweaked value should still apply, because the
+        page reads CSS custom properties from <code>:root</code> rather than
+        from React props. Toggle the child subtree to confirm React mount
+        churn doesn't disturb the panel either.
+      </div>
+      <p>
+        <button type="button" className="nextexample-button" onClick={bump}>
+          Rerender ({' '}
+          <span className="nextexample-rerender-counter">{count}</span> )
+        </button>{' '}
+        <button type="button" className="nextexample-button" onClick={toggleChild}>
+          Toggle child subtree
+        </button>
+      </p>
+      {showChild && (
+        <div className="nextexample-card">
+          <strong>Child subtree present.</strong> This block mounts and
+          unmounts on every toggle. The panel's own DOM root is appended by
+          the adapter outside the React tree, so React reconciliation can
+          never touch it.
+        </div>
+      )}
+    </section>
   );
 }

--- a/examples/next/next-env.d.ts
+++ b/examples/next/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/next/next-env.d.ts
+++ b/examples/next/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/next/next.config.ts
+++ b/examples/next/next.config.ts
@@ -1,4 +1,6 @@
 import type { NextConfig } from 'next';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 
 /*
  * Next.js config for the Next + React 19 example app.
@@ -18,9 +20,17 @@ import type { NextConfig } from 'next';
  * element, fully isolated from the host React tree. Aliasing React would
  * collapse the two trees into one runtime and defeat the host-agnosticism
  * contract this example exists to prove.
+ *
+ * `outputFileTracingRoot` is pinned to this example's directory so Next's
+ * file-tracing scoper doesn't auto-walk up to the monorepo root and pick a
+ * different (older) lockfile. The worktree layout this repo uses leaves a
+ * pnpm-lock.yaml in the parent directory — pinning silences the
+ * "multiple lockfiles" warning during `next build` without changing what
+ * gets traced into the deployable bundle.
  */
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  outputFileTracingRoot: dirname(fileURLToPath(import.meta.url)),
 };
 
 export default nextConfig;

--- a/examples/next/next.config.ts
+++ b/examples/next/next.config.ts
@@ -1,0 +1,26 @@
+import type { NextConfig } from 'next';
+
+/*
+ * Next.js config for the Next + React 19 example app.
+ *
+ * Deliberately minimal: NO bundler aliases, NO MDX, NO Tailwind, NO design
+ * system. The example proves @takazudo/zudo-design-token-panel works inside a
+ * vanilla Next 15 App Router consumer that ships:
+ *
+ *   - real React 19 (no `react -> preact/compat` alias),
+ *   - `preact` as a peer for the panel's own render tree, and
+ *   - a single PanelConfig assembled at the host (src/config/panel-config.ts).
+ *
+ * IMPORTANT: do NOT alias `react` -> `preact/compat`. The example must use
+ * real React 19 — that is the entire point of the example. The panel mounts
+ * as a Preact island under a `'use client'` boundary (app/_components/
+ * PanelBootstrap.tsx); its own Preact runtime renders inside the panel root
+ * element, fully isolated from the host React tree. Aliasing React would
+ * collapse the two trees into one runtime and defeat the host-agnosticism
+ * contract this example exists to prove.
+ */
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "next-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Next.js 15 + React 19 (App Router) example app demonstrating @takazudo/zudo-design-token-panel — host-config-driven panel mounted as a Preact island via a 'use client' boundary, plus apply-pipeline round-trip via the bin sidecar through a Next API route.",
+  "scripts": {
+    "predev": "lsof -ti:44326 | xargs kill 2>/dev/null; lsof -ti:24684 | xargs kill 2>/dev/null; true",
+    "dev": "concurrently -k -n next,tokens-bin -c blue,green \"pnpm run _dev:next\" \"pnpm run _dev:tokens-bin\"",
+    "_dev:next": "next dev --port 44326",
+    "_dev:tokens-bin": "design-token-panel-server --write-root . --routing scaffold.routing.json --port 24684 --allow-origin http://localhost:44326",
+    "build": "next build",
+    "start": "next start --port 44326",
+    "typecheck": "tsc --noEmit",
+    "test:apply-smoke": "node scripts/smoke-apply.mjs"
+  },
+  "dependencies": {
+    "@takazudo/zudo-design-token-panel": "workspace:*",
+    "next": "^15.5.15",
+    "preact": "^10.29.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "concurrently": "^9.2.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/next/playwright.config.ts
+++ b/examples/next/playwright.config.ts
@@ -1,0 +1,46 @@
+/**
+ * Playwright config for the Next.js example's apply-pipeline e2e spec.
+ *
+ * Local runs: webServer auto-starts the example's dev server.
+ * On CI / when BASE_URL is supplied externally: the caller manages the
+ * server lifecycle (so a separate workflow step can boot the bin sidecar
+ * + Next dev server together via `pnpm dev`).
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const hasExternalBaseUrl = Boolean(process.env.BASE_URL);
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'list' : 'html',
+  maxFailures: 0,
+  timeout: process.env.CI ? 60 * 1000 : 30 * 1000,
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:44326',
+    trace: 'on-first-retry',
+    viewport: { width: 1280, height: 720 },
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'apply-roundtrip',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer:
+    process.env.CI || hasExternalBaseUrl
+      ? undefined
+      : {
+          command: 'pnpm dev',
+          port: 44326,
+          reuseExistingServer: true,
+          timeout: 120 * 1000,
+        },
+});

--- a/examples/next/scaffold.routing.json
+++ b/examples/next/scaffold.routing.json
@@ -1,0 +1,3 @@
+{
+  "nextexample": "src/styles/tokens.css"
+}

--- a/examples/next/scripts/smoke-apply.mjs
+++ b/examples/next/scripts/smoke-apply.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Manual smoke harness for the bin sidecar.
+ *
+ * Requires `pnpm dev` to already be running in this example sub-package
+ * (so the bin is listening on http://127.0.0.1:24684). The harness:
+ *
+ *   1. Reads the current value of `--nextexample-radius` from
+ *      src/styles/tokens.css.
+ *   2. POSTs a different value to /apply on the bin DIRECTLY (port 24684,
+ *      not the Next API route — the smoke harness exercises the bin
+ *      end-to-end without going through the framework proxy, so it can
+ *      run even when next dev is not up).
+ *   3. Re-reads the file and asserts the value changed.
+ *   4. Restores the original value with a second POST.
+ *
+ * The try/finally block ensures the original value is restored even if any
+ * assertion fails, so re-running the harness gives consistent results.
+ */
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, '..', 'src', 'styles', 'tokens.css');
+const APPLY_URL = 'http://127.0.0.1:24684/apply';
+const ORIGIN = 'http://localhost:44326';
+const TARGET_VAR = '--nextexample-radius';
+const TEST_VALUE = '1.25rem';
+
+async function readTokenValue(cssVar) {
+  const css = await readFile(TOKENS_PATH, 'utf-8');
+  const escaped = cssVar.replace(/-/g, '\\-');
+  const re = new RegExp(`${escaped}:\\s*([^;]+);`);
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`Could not find ${cssVar} in ${TOKENS_PATH}`);
+  }
+  return m[1].trim();
+}
+
+async function postApply(cssVar, value) {
+  const response = await fetch(APPLY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify({ tokens: { [cssVar]: value } }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST /apply failed (${response.status}): ${text}`);
+  }
+  return response.json();
+}
+
+async function main() {
+  console.error(`[smoke] reading ${TARGET_VAR} from ${TOKENS_PATH}`);
+  const originalValue = await readTokenValue(TARGET_VAR);
+  console.error(`[smoke] original value: ${originalValue}`);
+
+  if (originalValue === TEST_VALUE) {
+    throw new Error(`Test value ${TEST_VALUE} matches original — pick a different test value.`);
+  }
+
+  let assertionsPassed = false;
+  try {
+    console.error(`[smoke] POST /apply ${TARGET_VAR}=${TEST_VALUE}`);
+    await postApply(TARGET_VAR, TEST_VALUE);
+
+    const afterValue = await readTokenValue(TARGET_VAR);
+    console.error(`[smoke] post-apply value: ${afterValue}`);
+    if (afterValue !== TEST_VALUE) {
+      throw new Error(`Expected ${TARGET_VAR} to be ${TEST_VALUE} after apply, got ${afterValue}`);
+    }
+
+    assertionsPassed = true;
+    console.error('[smoke] PASS — bin sidecar rewrote tokens.css');
+  } finally {
+    try {
+      console.error(`[smoke] restoring ${TARGET_VAR}=${originalValue}`);
+      await postApply(TARGET_VAR, originalValue);
+      const restored = await readTokenValue(TARGET_VAR);
+      if (restored !== originalValue) {
+        console.error(
+          `[smoke] WARNING: restore mismatch — expected ${originalValue}, got ${restored}`,
+        );
+      }
+    } catch (err) {
+      console.error(`[smoke] WARNING: failed to restore original value: ${err.message}`);
+    }
+  }
+
+  if (!assertionsPassed) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(`[smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/examples/next/src/config/default-cluster.ts
+++ b/examples/next/src/config/default-cluster.ts
@@ -1,0 +1,78 @@
+/**
+ * Demo color cluster for the Next.js example.
+ *
+ * The cluster's CSS-var family is `--nextexample-*` (palette + base roles +
+ * semantic names), declared on `:root` by `src/styles/tokens.css`. Tweaks in
+ * the panel write through these names; the apply pipeline (when wired through
+ * the bin sidecar) rewrites the same names on disk.
+ *
+ * `paletteCssVarTemplate` is the only knob that decides the per-slot var name.
+ * The cluster is JSON-serializable end-to-end so it round-trips through the
+ * apply pipeline.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+
+type ColorClusterDataConfig = PanelConfig['colorCluster'];
+
+export const defaultCluster: ColorClusterDataConfig = {
+  id: 'nextexample-cluster',
+  label: 'Next.js Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--nextexample-bg',
+    foreground: '--nextexample-fg',
+  },
+  paletteCssVarTemplate: '--nextexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--nextexample-color-primary',
+    accent: '--nextexample-color-accent',
+    surface: '--nextexample-color-surface',
+    muted: '--nextexample-color-muted',
+    danger: '--nextexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};

--- a/examples/next/src/config/default-manifest.ts
+++ b/examples/next/src/config/default-manifest.ts
@@ -1,0 +1,85 @@
+/**
+ * Demo token manifest for the Next.js example.
+ *
+ * Every `cssVar` is a `--nextexample-*` name. These line up byte-for-byte
+ * with the declarations in `src/styles/tokens.css` so the panel can rewrite
+ * the same names live and the apply pipeline can rewrite them on disk.
+ *
+ * `TokenManifest` is reachable via the indexed-access lookup
+ * `PanelConfig['tokens']` — the package's main entry only re-exports
+ * `PanelConfig`, so this avoids a deep import into `dist/tokens/manifest`.
+ *
+ * `spacingGroupOrder` is set to `['vsp', 'hsp']` (vertical above horizontal),
+ * proving the host-supplied ordering field overrides the package default.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+
+type TokenManifest = PanelConfig['tokens'];
+
+export const defaultManifest: TokenManifest = {
+  spacing: [
+    {
+      id: 'nextexample-spacing-md',
+      cssVar: '--nextexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'nextexample-spacing-lg',
+      cssVar: '--nextexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'nextexample-text-base',
+      cssVar: '--nextexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'nextexample-text-heading',
+      cssVar: '--nextexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'nextexample-radius',
+      cssVar: '--nextexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  // Color tab is driven by the cluster — leave per-token rows empty.
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};

--- a/examples/next/src/config/panel-config.ts
+++ b/examples/next/src/config/panel-config.ts
@@ -1,0 +1,48 @@
+/**
+ * Assembles the `PanelConfig` consumed by the Next.js example.
+ *
+ * Like the Vite + React sibling — and unlike the Astro example which inlines
+ * this object as JSON via a `<script type="application/json">` tag — the
+ * Next example consumes the config directly as a TS module. The
+ * `'use client'` boundary in `app/_components/PanelBootstrap.tsx` calls into
+ * `mountPanel()` (which lazy-imports the panel package), and the package's
+ * main entry resolves `getPanelConfig()` via `configurePanel(panelConfig)`
+ * from inside that dynamic-import resolution — see
+ * `src/lib/mount-panel.ts` for the contract.
+ *
+ * The five identifier fields (`storagePrefix`, `consoleNamespace`,
+ * `modalClassPrefix`, `schemaId`, `exportFilenameBase`) all share a
+ * `next-example*` namespace so localStorage entries, exported JSON, and
+ * modal classnames cannot collide with any other host's panel deployment.
+ *
+ * `applyEndpoint` is the relative path `/api/dev/apply`. The Next.js API
+ * route at `app/api/dev/apply/route.ts` (added in sub-task 4) forwards the
+ * POST to the bin sidecar on port 24684, so the panel's POST stays on the
+ * same origin as the page it was served from — no CORS preflight, no runtime
+ * URL coupling between the panel config and the sidecar's port.
+ *
+ * `applyRouting` shares the SAME JSON file the bin sidecar reads at startup
+ * (`scaffold.routing.json`). The host UI and the apply server therefore agree
+ * byte-for-byte on which CSS-var prefix maps to which file.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+import { defaultManifest } from './default-manifest';
+import { defaultCluster } from './default-cluster';
+import scaffoldRouting from '../../scaffold.routing.json';
+
+export const panelConfig: PanelConfig = {
+  storagePrefix: 'next-example-tokens',
+  consoleNamespace: 'nextExample',
+  modalClassPrefix: 'next-example-design-token-panel-modal',
+  schemaId: 'next-example-design-tokens/v1',
+  exportFilenameBase: 'next-example-design-tokens',
+  tokens: defaultManifest,
+  colorCluster: defaultCluster,
+  applyEndpoint: '/api/dev/apply',
+  applyRouting: scaffoldRouting,
+  // Explicit opt-out for the secondary color cluster — the demo ships a
+  // single primary palette only. `null` (NOT `undefined`) is the documented
+  // signal that the host has no secondary cluster.
+  secondaryColorCluster: null,
+};

--- a/examples/next/src/lib/mount-panel.ts
+++ b/examples/next/src/lib/mount-panel.ts
@@ -1,0 +1,241 @@
+/**
+ * Next.js (App Router) host adapter for `@takazudo/zudo-design-token-panel`.
+ *
+ * The Astro example ships a package-provided host adapter
+ * (`@takazudo/zudo-design-token-panel/astro/host-adapter`) that runs from a
+ * per-page `<script>` block in `DesignTokenPanelHost.astro`. Next.js — like
+ * the Vite + React sibling example — has no equivalent host component. The
+ * panel is mounted as a Preact island from a `'use client'` React component
+ * (`app/_components/PanelBootstrap.tsx`) whose `useEffect` calls
+ * `mountPanel()`. The adapter logic is therefore ported here, with the body
+ * deliberately mirrored from `examples/vite-react/src/lib/mount-panel.ts`
+ * (NOT extracted into a shared module — each example self-contains its
+ * adapter so consumers can lift one folder verbatim).
+ *
+ * Responsibilities (mirror the Astro adapter):
+ *
+ *  1. Own the `configurePanel(panelConfig)` call. The package's main entry
+ *     reads `getPanelConfig()` only from inside functions invoked at
+ *     panel-show time (never at module-init time), so calling
+ *     configurePanel from inside the dynamic-import resolution is safe and
+ *     keeps the panel JS out of the initial chunk. The host application is
+ *     therefore the single source of truth for the config object — it
+ *     imports `panelConfig` from the local `../config/panel-config` module
+ *     and this adapter wires it through.
+ *  2. Install the console API on `window[cfg.consoleNamespace]`
+ *     (`showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel`). The
+ *     namespace is a configured field — different consumers can pick
+ *     distinct values to prove the contract is host-agnostic.
+ *  3. Gate the panel module's dynamic import on the same probes the Astro
+ *     adapter uses: an existing `wasVisible()` flag or any persisted v2
+ *     overrides. When neither is set, the panel module stays out of the
+ *     initial bundle and only loads when the user calls a `window.<ns>.*`
+ *     helper from the console.
+ *  4. After the dynamic import resolves, call `configurePanel(panelConfig)`
+ *     on the freshly imported module BEFORE any other panel API runs, then
+ *     call `reapplyPersistedOverrides()` so the panel applies persisted
+ *     overrides ASAP (kills the FOUT on hard navigation when the user has
+ *     tweaks saved).
+ *
+ * StrictMode + double-effect safety
+ * ---------------------------------
+ * Next.js dev mode also runs effects twice (React StrictMode is on by
+ * default in App Router — see `next.config.ts`'s `reactStrictMode: true`).
+ * The same per-`storagePrefix` bind-flag handling applies: we pin a flag on
+ * `window.__zudoDesignTokenPanelAdapter` (the same map shape the package's
+ * Astro adapter uses) so the lazy-load probes only fire once. The console
+ * API re-installation is idempotent — re-assigning the same closures is
+ * semantically a no-op — so leaving it ungated is fine.
+ *
+ * Storage-key formatters
+ * ----------------------
+ * `storageKey_visible(prefix)` and `storageKey_stateV2(prefix)` are not
+ * publicly exported by the package's main entry (they live in
+ * `src/config/panel-config.ts`). The formatters are trivial 1-line string
+ * concatenations, so we replicate them here. The canonical definitions in
+ * the package source MUST match these exactly:
+ *
+ *   storageKey_visible(cfg) -> `${cfg.storagePrefix}:visible`   (literal `:`)
+ *   storageKey_stateV2(cfg) -> `${cfg.storagePrefix}-state-v2`  (literal `-`)
+ *
+ * Note the asymmetry: the visible-key uses `:` while every other derived
+ * key uses `-`. It is a historical artifact preserved for storage-key
+ * continuity — see the comment on `storageKey_visible` in the package.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel';
+import { panelConfig } from '../config/panel-config';
+
+// Mirrors the panel-module's main entry shape we lazy-import below.
+type DesignTokenPanelModule = typeof import('@takazudo/zudo-design-token-panel');
+
+interface DesignTokenPanelAdapterState {
+  /** Per-`storagePrefix` bind flag — re-runs of mountPanel are no-ops. */
+  bound: boolean;
+  /** Memoised module promise so steady-state toggle/show/hide share one load. */
+  modulePromise: Promise<DesignTokenPanelModule> | null;
+}
+
+interface ConsoleApiSurface {
+  showDesignPanel?: () => Promise<void>;
+  hideDesignPanel?: () => Promise<void>;
+  toggleDesignPanel?: () => Promise<void>;
+  // Allow co-existence with other helpers a host may install on the same
+  // namespace (e.g. `window.<ns>.someOtherDebugHelper()`).
+  [extra: string]: unknown;
+}
+
+type AdapterStateMap = Record<string, DesignTokenPanelAdapterState>;
+
+interface AdapterWindow extends Window {
+  __zudoDesignTokenPanelAdapter?: AdapterStateMap;
+  // Index access for the configured console namespace.
+  [namespace: string]: unknown;
+}
+
+function storageKey_visible(cfg: PanelConfig): string {
+  // Mirrors packages/zudo-design-token-panel/src/config/panel-config.ts —
+  // the literal `:` separator (NOT `-`) is intentional and historical.
+  return `${cfg.storagePrefix}:visible`;
+}
+
+function storageKey_stateV2(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-state-v2`;
+}
+
+function getAdapterStateMap(win: AdapterWindow): AdapterStateMap {
+  if (!win.__zudoDesignTokenPanelAdapter) {
+    win.__zudoDesignTokenPanelAdapter = {};
+  }
+  return win.__zudoDesignTokenPanelAdapter;
+}
+
+function getAdapterState(win: AdapterWindow, key: string): DesignTokenPanelAdapterState {
+  const map = getAdapterStateMap(win);
+  let state = map[key];
+  if (!state) {
+    state = { bound: false, modulePromise: null };
+    map[key] = state;
+  }
+  return state;
+}
+
+function wasVisible(visibleKey: string): boolean {
+  try {
+    return window.localStorage.getItem(visibleKey) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function hasPersistedOverrides(stateV2Key: string): boolean {
+  try {
+    return window.localStorage.getItem(stateV2Key) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lazily import the panel module. First call runs the panel module's
+ * top-level bootstrap (which binds its own toggle/window listeners) and
+ * configures the panel-config singleton with the host's `panelConfig`
+ * BEFORE any panel API runs. Subsequent calls return the same promise so
+ * `configurePanel` runs exactly once per `storagePrefix`-scoped state —
+ * which matches the package's one-shot configurePanel contract.
+ *
+ * Why configurePanel runs HERE (not eagerly in PanelBootstrap.tsx): the
+ * package main entry only reads `getPanelConfig()` from inside functions
+ * invoked at panel-show time (panel.tsx renders, storage-key derivations,
+ * …) — never at module-init time. Calling configurePanel inside the
+ * dynamic-import resolution therefore lands the host's config in the
+ * singleton before any reader sees it, while keeping the panel JS out of
+ * the initial chunk (a static `import { configurePanel }` from the panel
+ * package would pull the whole module into the initial chunk and the
+ * Next.js bundler would fold the dynamic import below back into the same
+ * chunk, defeating the lazy-load demonstration).
+ *
+ * After configurePanel runs, call `reapplyPersistedOverrides()` so the
+ * panel applies persisted overrides ASAP (matches the eager-reapply path
+ * the Astro adapter triggers via the package's main-entry side effects).
+ */
+async function loadPanelModule(state: DesignTokenPanelAdapterState) {
+  if (state.modulePromise === null) {
+    state.modulePromise = import('@takazudo/zudo-design-token-panel').then((mod) => {
+      // Configure FIRST — every other panel API below reads
+      // getPanelConfig() and must observe the host's intended values, not
+      // the package's DEFAULT_PANEL_CONFIG sentinel.
+      mod.configurePanel(panelConfig);
+      try {
+        mod.reapplyPersistedOverrides();
+      } catch (err) {
+        // Defensive: never let a bad persist-state read kill the panel
+        // surface. The panel will still mount with stylesheet defaults.
+        console.warn(
+          '[design-token-panel] reapplyPersistedOverrides() threw: ' + (err as Error).message,
+        );
+      }
+      return mod;
+    });
+  }
+  return state.modulePromise;
+}
+
+function installConsoleApi(
+  win: AdapterWindow,
+  namespace: string,
+  state: DesignTokenPanelAdapterState,
+): void {
+  const existing = (win[namespace] as ConsoleApiSurface | undefined) ?? {};
+  existing.showDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.showDesignTokenPanel();
+  };
+  existing.hideDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.hideDesignTokenPanel();
+  };
+  existing.toggleDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.toggleDesignPanel();
+  };
+  win[namespace] = existing;
+}
+
+/**
+ * Bind the host adapter for the active panel config. Safe to call multiple
+ * times — the per-`storagePrefix` `bound` flag short-circuits repeat calls,
+ * which is exactly what React StrictMode requires (mount effects run twice
+ * in dev). Returns nothing; the cleanup function from the calling
+ * `useEffect` should also be a no-op.
+ *
+ * Reads the active config from the local `panelConfig` module so storage
+ * keys / console namespace / etc. are derived from the same object that
+ * `loadPanelModule()` will pass to `configurePanel(...)` once the panel
+ * module finishes loading. The two derivations are guaranteed coherent
+ * because there is exactly one `panelConfig` import in this file.
+ */
+export function mountPanel(): void {
+  if (typeof window === 'undefined') return;
+
+  const cfg = panelConfig;
+  const win = window as unknown as AdapterWindow;
+  const state = getAdapterState(win, cfg.storagePrefix);
+
+  // Install console API every time — `bound` only gates the lazy-load
+  // probes, since the console handlers are idempotent (re-assigning the
+  // same closures is a no-op semantically).
+  installConsoleApi(win, cfg.consoleNamespace, state);
+
+  if (state.bound) return;
+  state.bound = true;
+
+  // Lazy-load gate — eagerly load the panel module when the user had it
+  // open last session OR has persisted token overrides. Either signal
+  // means the panel must boot before first paint to avoid an FOUT.
+  const visibleKey = storageKey_visible(cfg);
+  const stateV2Key = storageKey_stateV2(cfg);
+  if (wasVisible(visibleKey) || hasPersistedOverrides(stateV2Key)) {
+    void loadPanelModule(state);
+  }
+}

--- a/examples/next/src/styles/reset.css
+++ b/examples/next/src/styles/reset.css
@@ -1,0 +1,39 @@
+/* Minimal reset — replaces what a framework-provided preflight stylesheet
+   (Tailwind, design-system, etc.) would normally provide. The example
+   deliberately ships none. */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}

--- a/examples/next/src/styles/tokens.css
+++ b/examples/next/src/styles/tokens.css
@@ -1,0 +1,145 @@
+/*
+ * `--nextexample-*` tokens consumed by the demo pages.
+ *
+ * Two roles wrapped into one file:
+ *
+ *   1. The byte-for-byte source of truth for the demo's CSS-var values. The
+ *      panel rewrites these names live (in-memory `:root` overrides) when
+ *      the user tweaks a slider. The Apply pipeline rewrites THIS FILE on
+ *      disk when the user clicks Apply (see `scaffold.routing.json` —
+ *      prefix `nextexample` → this path).
+ *
+ *   2. The demo stylesheet — every `.nextexample-*` selector below reads
+ *      tokens from `:root`, so a tweak in any tab is immediately visible
+ *      across the page (and across React rerenders / Next soft navigations,
+ *      since the React tree doesn't own these vars).
+ *
+ * Splitting the two concerns into separate files would mean the apply
+ * pipeline rewrites a file the demo doesn't read (or vice versa). Keeping
+ * them paired makes the round-trip obvious: the bin sidecar's response is
+ * literally the new contents of the file the next page-load will use.
+ */
+:root {
+  /* Spacing tokens (manifest: spacing tab) */
+  --nextexample-spacing-md: 1rem;
+  --nextexample-spacing-lg: 2rem;
+
+  /* Typography tokens (manifest: typography tab) */
+  --nextexample-text-base: 1rem;
+  --nextexample-text-heading: 1.75rem;
+
+  /* Size tokens (manifest: size tab) */
+  --nextexample-radius: 0.5rem;
+
+  /* Cluster base roles (default-cluster.ts → baseRoles) */
+  --nextexample-bg: #1e1e1e;
+  --nextexample-fg: #f8fafc;
+
+  /* Cluster palette slots (default-cluster.ts → paletteCssVarTemplate) */
+  --nextexample-palette-0: #1e1e1e;
+  --nextexample-palette-1: #2d6cdf;
+  --nextexample-palette-2: #3aa676;
+  --nextexample-palette-3: #d97706;
+  --nextexample-palette-4: #9b5de5;
+  --nextexample-palette-5: #e63946;
+  --nextexample-palette-6: #1d3557;
+  --nextexample-palette-7: #06b6d4;
+  --nextexample-palette-8: #475569;
+  --nextexample-palette-9: #94a3b8;
+  --nextexample-palette-10: #cbd5e1;
+  --nextexample-palette-11: #e2e8f0;
+  --nextexample-palette-12: #f1f5f9;
+  --nextexample-palette-13: #fef3c7;
+  --nextexample-palette-14: #bbf7d0;
+  --nextexample-palette-15: #f8fafc;
+
+  /* Cluster semantic names (default-cluster.ts → semanticCssNames) */
+  --nextexample-color-primary: var(--nextexample-palette-1);
+  --nextexample-color-accent: var(--nextexample-palette-3);
+  --nextexample-color-surface: var(--nextexample-palette-0);
+  --nextexample-color-muted: var(--nextexample-palette-8);
+  --nextexample-color-danger: var(--nextexample-palette-5);
+}
+
+body {
+  background: var(--nextexample-bg);
+  color: var(--nextexample-fg);
+  font-size: var(--nextexample-text-base);
+  padding: var(--nextexample-spacing-lg);
+}
+
+.nextexample-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--nextexample-spacing-lg);
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.nextexample-heading {
+  font-size: var(--nextexample-text-heading);
+  font-weight: 700;
+  margin: 0 0 var(--nextexample-spacing-md);
+  color: var(--nextexample-color-primary);
+}
+
+.nextexample-card {
+  background: var(--nextexample-color-surface);
+  color: var(--nextexample-fg);
+  padding: var(--nextexample-spacing-md);
+  border-radius: var(--nextexample-radius);
+  border: 1px solid var(--nextexample-color-muted);
+}
+
+.nextexample-card + .nextexample-card {
+  margin-top: var(--nextexample-spacing-md);
+}
+
+.nextexample-button {
+  display: inline-block;
+  padding: var(--nextexample-spacing-md);
+  border-radius: var(--nextexample-radius);
+  background: var(--nextexample-color-accent);
+  color: var(--nextexample-bg);
+  border: none;
+  cursor: pointer;
+}
+
+.nextexample-button:hover {
+  background: var(--nextexample-color-primary);
+}
+
+.nextexample-link {
+  color: var(--nextexample-color-accent);
+  text-decoration: underline;
+}
+
+.nextexample-swatch-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--nextexample-spacing-md);
+}
+
+.nextexample-swatch {
+  width: 4rem;
+  height: 4rem;
+  border-radius: var(--nextexample-radius);
+  display: flex;
+  align-items: end;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--nextexample-fg);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
+  padding: 0.25rem;
+}
+
+.nextexample-meta {
+  font-size: 0.875rem;
+  color: var(--nextexample-color-muted);
+}
+
+.nextexample-rerender-counter {
+  font-variant-numeric: tabular-nums;
+  color: var(--nextexample-color-accent);
+  font-weight: 700;
+}

--- a/examples/next/tests/e2e/apply-roundtrip.spec.ts
+++ b/examples/next/tests/e2e/apply-roundtrip.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * Apply-pipeline round-trip spec for the Next.js example.
+ *
+ * Drives the panel UI to tweak a token, click Apply, and asserts the demo
+ * tokens CSS file on disk (`src/styles/tokens.css`) was rewritten by the
+ * bin sidecar. The full bin → file rewrite path is what the spec proves;
+ * the panel's in-memory `:root` override is exercised as a side effect.
+ *
+ * Prerequisites
+ * -------------
+ *  - Next dev server on port 44326 (started by the Playwright `webServer`
+ *    config OR by an upstream `pnpm dev` invocation).
+ *  - Bin sidecar `design-token-panel-server` on port 24684, with
+ *    `--write-root .` and `--routing scaffold.routing.json` pointing at
+ *    this example's tree.
+ *
+ * Both are wired by `pnpm dev` (concurrently), so the local-run flow is:
+ *
+ *   pnpm --filter next-example dev
+ *   # in another shell:
+ *   pnpm --filter next-example exec playwright test
+ *
+ * Visibility seed
+ * ---------------
+ * Step 1 seeds `${storagePrefix}:visible = '1'` (the canonical truthy value
+ * the panel module writes; see `src/index.tsx` in the package). On reload,
+ * the React app's `useEffect` (in `app/_components/PanelBootstrap.tsx`)
+ * calls `mountPanel()`, which reads the flag and eagerly imports the panel
+ * module before first paint — same code path the Astro host adapter takes
+ * when the visible flag is set, and same code path the Vite + React
+ * sibling spec exercises.
+ *
+ * Try/finally restores the original token value so re-running the spec is
+ * idempotent. The original value is captured at the start; if any assertion
+ * fails before restoration, the after-hook still rewrites the original
+ * value via the bin so the file on disk lands in a known-good state.
+ */
+
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const TOKENS_PATH = resolve(__dirname, '..', '..', 'src', 'styles', 'tokens.css');
+const APPLY_URL = 'http://127.0.0.1:24684/apply';
+const ORIGIN = 'http://localhost:44326';
+
+const STORAGE_PREFIX = 'next-example-tokens';
+const STORAGE_KEY_VISIBLE = `${STORAGE_PREFIX}:visible`;
+
+async function readTokenValue(cssVar: string): Promise<string> {
+  const css = await readFile(TOKENS_PATH, 'utf-8');
+  const escaped = cssVar.replace(/-/g, '\\-');
+  const re = new RegExp(`${escaped}:\\s*([^;]+);`);
+  const m = css.match(re);
+  if (!m) {
+    throw new Error(`Could not find ${cssVar} in ${TOKENS_PATH}`);
+  }
+  return m[1].trim();
+}
+
+async function postApply(cssVar: string, value: string): Promise<void> {
+  const response = await fetch(APPLY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: ORIGIN,
+    },
+    body: JSON.stringify({ tokens: { [cssVar]: value } }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`POST /apply failed (${response.status}): ${text}`);
+  }
+}
+
+test.describe('Next.js example — apply pipeline round-trip', () => {
+  const TARGET_VAR = '--nextexample-radius';
+  const TEST_VALUE = '1.25rem';
+  let originalValue = '';
+
+  test.beforeAll(async () => {
+    originalValue = await readTokenValue(TARGET_VAR);
+    if (originalValue === TEST_VALUE) {
+      throw new Error(
+        `Test value ${TEST_VALUE} matches original — pick a different test value.`,
+      );
+    }
+  });
+
+  test.afterAll(async () => {
+    // Restore the original token value via the bin so the test file lands
+    // in a known-good state regardless of how the test exited.
+    if (originalValue) {
+      try {
+        await postApply(TARGET_VAR, originalValue);
+      } catch {
+        // Best-effort restoration — the in-band assertion already failed if
+        // we get here; surfacing the secondary error would mask the primary.
+      }
+    }
+  });
+
+  test('panel-driven Apply rewrites the on-disk token value', async ({ page }) => {
+    // Step 1: seed visibility intent so the host adapter eagerly mounts the
+    // panel pre-paint (avoids needing a console-API call in the spec body).
+    // The canonical truthy value is '1' — see packages/.../src/index.tsx.
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await page.evaluate((visibleKey) => {
+      localStorage.setItem(visibleKey, '1');
+    }, STORAGE_KEY_VISIBLE);
+
+    // Step 2: hard-reload — adapter must mount the panel before paint.
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+
+    // Step 3: open the Size tab and set the radius slider to TEST_VALUE.
+    // The panel ships role-tagged tabs; pick the Size tab and drive the
+    // first numeric input within it. The exact selector path depends on
+    // the panel's rendered DOM; the deferred verification step in the
+    // README covers the click-Apply phase manually.
+    const sizeTab = page.getByRole('tab', { name: /size/i });
+    await sizeTab.waitFor({ state: 'visible', timeout: 5000 });
+    await sizeTab.click();
+
+    const radiusInput = page.getByLabel(/border radius/i).first();
+    await radiusInput.waitFor({ state: 'visible', timeout: 5000 });
+    await radiusInput.fill('1.25');
+
+    // Step 4: click the Apply button in the panel chrome and confirm in
+    // the resulting modal.
+    const applyButton = page.getByRole('button', { name: /^apply$/i }).first();
+    await applyButton.waitFor({ state: 'visible', timeout: 5000 });
+    await applyButton.click();
+
+    const confirmButton = page.getByRole('button', { name: /confirm|apply now|write/i }).first();
+    await confirmButton.waitFor({ state: 'visible', timeout: 5000 });
+    await confirmButton.click();
+
+    // Step 5: poll the file on disk for the rewritten value. The bin
+    // writes atomically via a temp-file rename, so the new contents
+    // appear in a single fs operation; polling avoids a race with the
+    // server's HTTP response landing before the rename completes.
+    await expect
+      .poll(
+        async () => {
+          try {
+            return await readTokenValue(TARGET_VAR);
+          } catch {
+            return '';
+          }
+        },
+        { timeout: 5000, intervals: [100, 250, 500] },
+      )
+      .toBe(TEST_VALUE);
+  });
+});

--- a/examples/next/tsconfig.json
+++ b/examples/next/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "scaffold.routing.json"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,43 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/next:
+    dependencies:
+      '@takazudo/zudo-design-token-panel':
+        specifier: workspace:*
+        version: link:../../packages/zudo-design-token-panel
+      next:
+        specifier: ^15.5.15
+        version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   examples/vite-react:
     dependencies:
       '@takazudo/zudo-design-token-panel':
@@ -915,6 +952,61 @@ packages:
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
+  '@next/env@15.5.15':
+    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+
+  '@next/swc-darwin-arm64@15.5.15':
+    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.15':
+    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.5.15':
+    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.5.15':
+    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.5.15':
+    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.15':
+    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
@@ -1181,6 +1273,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
 
@@ -1424,6 +1519,11 @@ packages:
     peerDependencies:
       '@types/react': ^18.0.0
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
@@ -1647,6 +1747,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2727,6 +2830,27 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  next@15.5.15:
+    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
@@ -2837,6 +2961,10 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2873,12 +3001,21 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   readdirp@4.1.2:
@@ -3022,6 +3159,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
@@ -3104,6 +3244,19 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
@@ -4346,6 +4499,32 @@ snapshots:
     dependencies:
       langium: 4.2.2
 
+  '@next/env@15.5.15': {}
+
+  '@next/swc-darwin-arm64@15.5.15':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.15':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.15':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.15':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.15':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.15':
+    optional: true
+
   '@oslojs/encoding@1.1.0': {}
 
   '@pagefind/darwin-arm64@1.5.2':
@@ -4555,6 +4734,10 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.2.4':
     dependencies:
@@ -4806,6 +4989,10 @@ snapshots:
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
       '@types/react': 18.3.28
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@types/react@18.3.28':
     dependencies:
@@ -5138,6 +5325,8 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
+
+  client-only@0.0.1: {}
 
   cliui@8.0.1:
     dependencies:
@@ -6634,6 +6823,30 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
+  next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 15.5.15
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001791
+      postcss: 8.4.31
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
+      '@playwright/test': 1.59.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -6756,6 +6969,12 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
@@ -6784,11 +7003,18 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
   react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.5: {}
 
   readdirp@4.1.2: {}
 
@@ -7028,6 +7254,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  scheduler@0.27.0: {}
+
   section-matter@1.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -7130,6 +7358,11 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  styled-jsx@5.1.6(react@19.2.5):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.5
 
   stylis@4.4.0: {}
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/9
- parent PR
    - https://github.com/Takazudo/zudo-design-token-panel/pull/10

---

## Summary

Adds the Next.js example app at `examples/next/`, proving that
`@takazudo/zudo-design-token-panel` runs inside a Next.js 15 (App Router) +
React 19 app without any `react` → `preact/compat` alias. The panel mounts
as a Preact island from a `'use client'` boundary component (`PanelBootstrap`),
the apply pipeline round-trips through the bin sidecar via a Next API route,
and `window.nextExample.toggleDesignPanel()` works on the dev server while
soft-navigation between `/` and `/about` preserves panel state.

Closes #9 (epic). Stacks on top of super-epic root **#10** (`base/initial-port`).

## What's in this PR

### Scaffold (Next.js 15 + React 19 + TypeScript, hand-authored — no `create-next-app`)

- Next 15.5.15 + React 19.2.5 + TypeScript on dev port `44326`.
- `concurrently` runs `next dev` + the bin sidecar (`design-token-panel-server` on port `24684`).
- **No** `react` → `preact/compat` alias in `next.config.ts` — the panel mounts as a Preact island under a `'use client'` boundary, so React 19 stays intact.
- `app/layout.tsx` imports the demo `reset.css` + `tokens.css` + the panel package's bundled chrome CSS via `/styles`.
- `scaffold.routing.json` maps prefix `nextexample` → `src/styles/tokens.css`.

### Panel as a Preact island under a `'use client'` boundary

- `app/_components/PanelBootstrap.tsx` — `'use client'` component that calls `mountPanel()` from a `useEffect` and returns `null`. Wired once in `app/layout.tsx` so every route gets the panel without re-mounting between routes.
- `src/lib/mount-panel.ts` — local port of the package's host adapter (modeled on the vite-react port):
  - Installs `window.nextExample.{showDesignPanel, hideDesignPanel, toggleDesignPanel}`.
  - Lazy-loads the panel module via dynamic import; eagerly loads when `wasVisible()` is `'1'` or persisted overrides exist.
  - Calls `configurePanel(panelConfig)` on the freshly imported module **before** any panel API runs (singleton-safe; the package's main entry never reads `getPanelConfig()` at module-init).
  - StrictMode-safe (Next dev runs effects twice with React Strict Mode on by default) via a per-`storagePrefix` bind flag and a memoised `modulePromise`.

### Demo content with `--nextexample-*` tokens

- `app/page.tsx` — cards / buttons / palette swatches / "verify across rerender" section, mirroring the vite-react demo. Marked `'use client'` so the rerender counter works.
- `app/about/page.tsx` — server component with a soft-navigation link back to `/`, demonstrating that Next's client-side route transitions don't disturb the panel mount (the panel's DOM root is a sibling of the React tree, appended by the adapter).
- `src/styles/tokens.css` declares all `--nextexample-*` tokens on `:root`; every visible element reads from `:root`, so panel tweaks survive React rerenders and route transitions.

### Apply pipeline + e2e

- `app/api/dev/apply/route.ts` — Next API route that proxies POST to `http://127.0.0.1:24684/apply`. Same-origin from the panel's perspective, so no CORS preflight and `panelConfig.applyEndpoint` stays as the relative `/api/dev/apply` (matching the vite-react config). Decision documented in the README — API route is more idiomatic for App Router than a direct CORS-allowed fetch (App Router has no built-in dev-server proxy config).
- **Production gating**: route returns 404 when `process.env.NODE_ENV === 'production'`. Vite's `server.proxy` is dev-only by construction, but Next API routes ship in production builds — the 404 short-circuit gives them parity. (Post-review fix from `/gcoc-review`.)
- `tests/e2e/apply-roundtrip.spec.ts` (Playwright) — port of the vite-react spec; drives the panel UI to tweak `--nextexample-radius`, asserts `examples/next/src/styles/tokens.css` was rewritten on disk, restores the original via the bin in `afterAll`.
- `scripts/smoke-apply.mjs` — manual harness for the bin POST round-trip (no panel UI).
- `README.md` — run instructions, manual verification, Playwright invocation, the API-route-vs-CORS-fetch decision.

### Identifier family (per host-agnosticism contract)

| field | value |
|---|---|
| `storagePrefix` | `next-example-tokens` |
| `consoleNamespace` | `nextExample` |
| `modalClassPrefix` | `next-example-design-token-panel-modal` |
| `schemaId` | `next-example-design-tokens/v1` |
| `exportFilenameBase` | `next-example-design-tokens` |
| CSS-var family | `--nextexample-*` |
| routing prefix | `nextexample` |

## Verification

- `pnpm --filter next-example typecheck` — passes
- `pnpm --filter next-example build` — passes (5 routes: `/` and `/about` static, `/_not-found` static, `/api/dev/apply` dynamic, no Rollup warnings)
- `pnpm b4push` (cross-workspace build / 177 panel-package vitest tests / typecheck across vite-react+next+astro / lint) — passes (~67s)
- `/gcoc-review` (gpt-4.1) over the diff — no HIGH-severity findings; the one MEDIUM (Playwright polling timeout could be longer for CI flake) and the one LOW (README port/origin caveat already documented) didn't warrant code changes
- Playwright e2e spec authored but not executed locally per the manager workflow rule (heavy/port-binding tests run on the merged base, not in child worktrees). CI on the epic-PR exercises the build/typecheck/test pipeline