### PR TITLE
feat: expose host-config public API + /testing sub-export for storage-key continuity

### DIFF
--- a/packages/zudo-design-token-panel/package.json
+++ b/packages/zudo-design-token-panel/package.json
@@ -44,6 +44,10 @@
       "types": "./dist/server/index.d.ts",
       "import": "./dist/server/index.js"
     },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js"
+    },
     "./styles": "./dist/zudo-design-token-panel.css",
     "./styles.css": "./dist/zudo-design-token-panel.css"
   },

--- a/packages/zudo-design-token-panel/src/astro/index.ts
+++ b/packages/zudo-design-token-panel/src/astro/index.ts
@@ -28,3 +28,19 @@ export type { ColorScheme, ColorRef } from '../config/color-schemes';
 // config blob is parsed. See `setPanelColorPresets` jsdoc in
 // `panel-config.ts` for the rationale.
 export { setPanelColorPresets } from '../config/panel-config';
+
+// ---------------------------------------------------------------------------
+// From src/config/color-schemes — bundled scheme registry
+// ---------------------------------------------------------------------------
+export { colorSchemes } from '../config/color-schemes';
+
+// ---------------------------------------------------------------------------
+// From src/config/color-scheme-utils — panel settings and semantic mappings
+// ---------------------------------------------------------------------------
+export { panelSettings, SEMANTIC_CSS_NAMES, SEMANTIC_DEFAULTS_ZD } from '../config/color-scheme-utils';
+
+// ---------------------------------------------------------------------------
+// From src/tokens/manifest — group ordering, titles, and public token types
+// ---------------------------------------------------------------------------
+export { GROUP_ORDER, FONT_GROUP_ORDER, SIZE_GROUP_ORDER, GROUP_TITLES } from '../tokens/manifest';
+export type { TokenDef, TokenManifest } from '../tokens/manifest';

--- a/packages/zudo-design-token-panel/src/testing.ts
+++ b/packages/zudo-design-token-panel/src/testing.ts
@@ -1,0 +1,35 @@
+/**
+ * /testing sub-export — test-utility symbols for storage-key continuity tests.
+ *
+ * Re-exports symbols that consumers need to write storage-key continuity and
+ * manifest-ordering tests without reaching into the package's internal source
+ * paths. Intended for use in test files only — not for production code.
+ *
+ * Consumer usage:
+ *   import { configurePanel, storageKey_open, ... } from '@takazudo/zudo-design-token-panel/testing';
+ */
+
+// ---------------------------------------------------------------------------
+// From src/config/panel-config.ts
+// ---------------------------------------------------------------------------
+export {
+  configurePanel,
+  storageKey_open,
+  storageKey_position,
+  storageKey_stateV1,
+  storageKey_stateV2,
+  storageKey_visible,
+  __resetPanelConfigForTests,
+} from './config/panel-config';
+export type { PanelConfig } from './config/panel-config';
+
+// ---------------------------------------------------------------------------
+// From src/state/tweak-state.ts
+// ---------------------------------------------------------------------------
+export { getStorageKeyV1, getStorageKeyV2, loadPersistedState } from './state/tweak-state';
+export type { ColorTweakState, StorageLike } from './state/tweak-state';
+
+// ---------------------------------------------------------------------------
+// From src/tokens/manifest.ts
+// ---------------------------------------------------------------------------
+export { GROUP_ORDER, FONT_GROUP_ORDER, SIZE_GROUP_ORDER, GROUP_TITLES } from './tokens/manifest';

--- a/packages/zudo-design-token-panel/vite.config.ts
+++ b/packages/zudo-design-token-panel/vite.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
         // banner only on this chunk (see `output.banner` below) and
         // `chmod +x` in the package build script.
         'bin/server': 'src/bin/server.ts',
+        // Test-utility sub-export. Re-exports symbols consumers need for
+        // storage-key continuity tests (configurePanel, storageKey_*, etc.)
+        // without exposing the full internal source tree.
+        testing: 'src/testing.ts',
       },
       formats: ['es'],
     },


### PR DESCRIPTION
## Summary

Two commits on this branch expose stable public API paths that the consumer project (zmod, epic #1733 / https://github.com/Takazudo/zmodular/issues/1733) needs after relocating design-token-panel wiring files from a workspace package into the main site's source tree.

### Commit 1 — /testing sub-export

Adds a `./testing` sub-export to `@takazudo/zudo-design-token-panel` that re-exports test-utility symbols needed by consumers to write storage-key continuity tests.

**Why:** The consumer project relocated `storage-key-continuity.test.ts` and `zmod-default-manifest-ordering.test.ts` from the workspace package into the main site's test suite. Those tests import symbols like `configurePanel`, `storageKey_*`, `loadPersistedState`, `GROUP_ORDER`, etc. Previously they reached these via relative paths into the workspace package's `src/`. With the workspace package being replaced by this standalone npm package, consumers need a stable public path.

**Symbols exposed via `@takazudo/zudo-design-token-panel/testing`:**

- From `config/panel-config.ts`: `configurePanel`, `storageKey_open`, `storageKey_position`, `storageKey_stateV1`, `storageKey_stateV2`, `storageKey_visible`, `__resetPanelConfigForTests`, `PanelConfig` (type)
- From `state/tweak-state.ts`: `getStorageKeyV1`, `getStorageKeyV2`, `loadPersistedState`, `ColorTweakState` (type), `StorageLike` (type)
- From `tokens/manifest.ts`: `GROUP_ORDER`, `FONT_GROUP_ORDER`, `SIZE_GROUP_ORDER`, `GROUP_TITLES`

### Commit 2 — /astro public API symbols

Extends the `/astro` sub-export with host-config symbols needed by the relocated zmod production files (`zmod-default-manifest.ts` and `zmod-default-cluster.ts`) at runtime.

**Why:** These production files were previously importing via deep relative paths into the workspace package source tree. Sub 3 of epic #1733 will delete that workspace package, so these imports must be re-routed onto the stable public API before deletion.

**Symbols exposed via `@takazudo/zudo-design-token-panel/astro` (new additions):**

- From `config/color-schemes`: `colorSchemes` (data)
- From `config/color-scheme-utils`: `panelSettings` (data), `SEMANTIC_CSS_NAMES` (const), `SEMANTIC_DEFAULTS_ZD` (const)
- From `tokens/manifest`: `GROUP_ORDER`, `FONT_GROUP_ORDER`, `SIZE_GROUP_ORDER`, `GROUP_TITLES` (consts), `TokenDef` (type), `TokenManifest` (type)

Note: `GROUP_ORDER` / `FONT_GROUP_ORDER` / `SIZE_GROUP_ORDER` / `GROUP_TITLES` are also on `/testing` — deliberate dual-export so production code uses `/astro` and tests use `/testing`.

No new logic added — only re-exports.

## Test plan

- [x] `pnpm build` succeeds; `dist/astro/index.js` and `dist/astro/index.d.ts` contain all new symbols
- [x] `pnpm test` passes (23 test files, 195 tests)