### PR TITLE
Prose Demo Pages: prose surfaces for all demos + new zfb-tailwind workspace

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build all workspaces (doc site + all 4 examples)
+      - name: Build all workspaces (doc site + all 5 examples)
         run: pnpm build
 
       - name: Stage deploy directory

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ The remaining work is split across Epics 2 through 7.
 ```
 zdtp/
 ├── packages/                       # workspace packages
-│   └── zudo-design-token-panel/    # (coming) panel + bin
+│   └── zudo-design-token-panel/    # panel + bin
 │                                   #   npm: @takazudo/zudo-design-token-panel
 ├── doc/                            # public doc site (zudo-doc framework)
-├── examples/                       # (coming) integration examples
+├── examples/                       # integration examples
 │   ├── astro/
 │   ├── vite-react/
-│   └── next/
+│   ├── next/
+│   ├── zfb/
+│   └── zfb-tailwind/
 └── LICENSE                         # MIT
 ```
 
@@ -88,12 +90,14 @@ Once the panel package and example apps land, `pnpm build`, `pnpm test`,
 Each deployable workspace is hosted under its own sub-path of
 `https://takazudomodular.com/pj/zudo-design-token-panel/`:
 
-| Workspace             | Deploy sub-path             | Build output             |
-| --------------------- | --------------------------- | ------------------------ |
-| `doc`                 | `/pj/zudo-design-token-panel/`                 | `doc/dist`               |
-| `examples/astro`      | `/pj/zudo-design-token-panel/astro/`           | `examples/astro/dist`    |
-| `examples/vite-react` | `/pj/zudo-design-token-panel/vite-react/`      | `examples/vite-react/dist` |
-| `examples/next`       | `/pj/zudo-design-token-panel/next/`            | `examples/next/out`      |
+| Workspace                | Deploy sub-path                                              | Build output                  |
+| ------------------------ | ------------------------------------------------------------ | ----------------------------- |
+| `doc`                    | `/pj/zudo-design-token-panel/`                               | `doc/dist`                    |
+| `examples/astro`         | `/pj/zudo-design-token-panel/examples/astro/`                | `examples/astro/dist`         |
+| `examples/vite-react`    | `/pj/zudo-design-token-panel/examples/vite-react/`           | `examples/vite-react/dist`    |
+| `examples/next`          | `/pj/zudo-design-token-panel/examples/next/`                 | `examples/next/out`           |
+| `examples/zfb`           | `/pj/zudo-design-token-panel/examples/zfb/`                  | `examples/zfb/dist`           |
+| `examples/zfb-tailwind`  | `/pj/zudo-design-token-panel/examples/zfb-tailwind/`         | `examples/zfb-tailwind/dist`  |
 
 To verify that no emitted asset, link, script, or inlined string reference
 escapes its workspace's sub-path, run:
@@ -102,7 +106,7 @@ escapes its workspace's sub-path, run:
 pnpm check:deploy-paths
 ```
 
-The script (`scripts/check-deploy-paths.sh`) builds all four workspaces (plus
+The script (`scripts/check-deploy-paths.sh`) builds all five workspaces (plus
 the `@takazudo/zudo-design-token-panel` package as a precondition) and then
 greps each bundle for:
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ those tweaks back into the source CSS files on disk.
 
 The panel is a Preact island that mounts inside a host web app. The bin is a
 small local server that watches edits from the panel and persists them. It is
-designed to plug into modern host frameworks: Astro, Vite + React, and
-Next.js — each integration ships as an example app under `examples/`.
+designed to plug into modern host frameworks: Astro, Vite + React, Next.js,
+zfb, and zfb + Tailwind v4 — each integration ships as an example app under
+`examples/`.
 
 ## Status
 

--- a/doc/.claude/prose-token-contract.md
+++ b/doc/.claude/prose-token-contract.md
@@ -1,0 +1,264 @@
+# Prose-Token Contract
+
+Internal design document for the **prose demo pages** epic.
+Every Wave-2 sub-issue (Astro, Next.js, Vite+React, zfb, zfb-tailwind) must
+satisfy this contract so the demo pages share a recognisable look that mirrors
+zudo-doc's reference appearance.
+
+---
+
+## Namespace convention
+
+Each demo defines its tokens inside its own `--{prefix}example-*` namespace.
+`{prefix}` is the per-demo identifier (e.g. `astro`, `next`, `vite`, `zfb`,
+`zfb-tailwind`). The prose tokens below are **in addition to** the base
+example tokens already established for each demo.
+
+---
+
+## Required token set
+
+### Vertical spacing scale (flow-space rhythm)
+
+These tokens control the `--flow-space` values assigned to block elements
+inside the prose container. All vertical spacing derives from the baseline
+rhythm unit so the page never contains arbitrary gap values.
+
+| Token | Purpose |
+|---|---|
+| `--{prefix}example-vsp-2xs` | Minimum gap — consecutive headings, tight list items |
+| `--{prefix}example-vsp-xs` | Tighter paragraph spacing within a sub-section |
+| `--{prefix}example-vsp-sm` | Standard heading-to-first-content gap |
+| `--{prefix}example-vsp-md` | Default body-level flow gap (baseline rhythm unit) |
+| `--{prefix}example-vsp-lg` | Pre-h3 section separation |
+| `--{prefix}example-vsp-xl` | Pre-h2 section separation |
+| `--{prefix}example-vsp-2xl` | Top-of-page or pre-first-heading clearance |
+
+### Horizontal spacing scale
+
+Used for inline padding, blockquote indent, code block horizontal padding,
+and table cell padding.
+
+| Token | Purpose |
+|---|---|
+| `--{prefix}example-hsp-xs` | Inline code padding, small insets |
+| `--{prefix}example-hsp-sm` | Table cell padding, tag padding |
+| `--{prefix}example-hsp-md` | Blockquote left indent |
+| `--{prefix}example-hsp-lg` | Section-level horizontal gutter |
+| `--{prefix}example-hsp-xl` | Outer prose container horizontal padding |
+
+### Type scale (paired with line-heights)
+
+| Token | Purpose |
+|---|---|
+| `--{prefix}example-text-h2` | `font-size` for `<h2>` headings |
+| `--{prefix}example-text-h3` | `font-size` for `<h3>` headings |
+| `--{prefix}example-text-h4` | `font-size` for `<h4>` headings |
+| `--{prefix}example-text-body` | `font-size` for body paragraphs and list items |
+| `--{prefix}example-text-small` | `font-size` for captions, table cells, helper text |
+| `--{prefix}example-text-micro` | `font-size` for meta information, code labels |
+
+### Line-height tokens
+
+| Token | Purpose |
+|---|---|
+| `--{prefix}example-leading-tight` | Heading line-height (compressed) |
+| `--{prefix}example-leading-snug` | Sub-heading / list-item line-height |
+| `--{prefix}example-leading-relaxed` | Body paragraph line-height (generous) |
+
+### Code surface
+
+| Token | Purpose |
+|---|---|
+| `--{prefix}example-code-bg` | Background colour for `<pre>` / inline `<code>` |
+| `--{prefix}example-code-fg` | Text colour inside code blocks |
+| `--{prefix}example-font-mono` | Monospace font-family string (e.g. `ui-monospace, monospace`) |
+
+> `--{prefix}example-font-mono` is a **string token** (font-family value),
+> not a size or colour. Wire it directly to `font-family: var(--{prefix}example-font-mono)`.
+
+### Border / accent — reuse existing tokens
+
+Heading top-border gradients and blockquote left-borders intentionally
+**reuse** the shared colour tokens already present in each demo's base layer:
+
+- `--{prefix}example-color-fg` — heading gradient start colour (foreground)
+- `--color-muted` — blockquote border, muted text, gradient terminus
+- `--color-accent` — link colour, highlighted inline code border
+
+No new colour tokens are required for these decorative borders. This keeps
+the prose page consistent with the rest of the demo without duplicating the
+colour system.
+
+---
+
+## Default values (recommended starting point)
+
+Each demo **may** override these values to match its own design language.
+The values below produce a comfortable reading experience that mirrors
+zudo-doc's prose pages.
+
+```css
+:root {
+  /* Vertical spacing — derive from 1.6rem (≈ 25.6 px) rhythm unit */
+  --{prefix}example-vsp-2xs: 0.25rem;   /* ~4 px  */
+  --{prefix}example-vsp-xs:  0.5rem;    /* ~8 px  */
+  --{prefix}example-vsp-sm:  0.75rem;   /* ~12 px */
+  --{prefix}example-vsp-md:  1rem;      /* ~16 px — default flow gap */
+  --{prefix}example-vsp-lg:  1.75rem;   /* ~28 px */
+  --{prefix}example-vsp-xl:  2.5rem;    /* ~40 px */
+  --{prefix}example-vsp-2xl: 3.5rem;    /* ~56 px */
+
+  /* Horizontal spacing */
+  --{prefix}example-hsp-xs:  0.25rem;
+  --{prefix}example-hsp-sm:  0.5rem;
+  --{prefix}example-hsp-md:  1rem;
+  --{prefix}example-hsp-lg:  1.5rem;
+  --{prefix}example-hsp-xl:  2rem;
+
+  /* Type scale */
+  --{prefix}example-text-h2:    1.75rem;
+  --{prefix}example-text-h3:    1.35rem;
+  --{prefix}example-text-h4:    1.1rem;
+  --{prefix}example-text-body:  1rem;
+  --{prefix}example-text-small: 0.875rem;
+  --{prefix}example-text-micro: 0.75rem;
+
+  /* Line-heights */
+  --{prefix}example-leading-tight:   1.2;
+  --{prefix}example-leading-snug:    1.45;
+  --{prefix}example-leading-relaxed: 1.75;
+
+  /* Code surface */
+  --{prefix}example-code-bg:   hsl(220 13% 11%);
+  --{prefix}example-code-fg:   hsl(220 14% 86%);
+  --{prefix}example-font-mono: ui-monospace, "Cascadia Code", "Source Code Pro",
+                                Menlo, Consolas, monospace;
+}
+```
+
+---
+
+## Flow-spacing CSS pattern
+
+Wire the tokens into the prose container with the flow utility pattern
+(Strategy 1 from prose-heading-spacing.mdx):
+
+```css
+/* Prose container */
+.{prefix}-example-prose > * + * {
+  margin-block-start: var(--flow-space, var(--{prefix}example-vsp-md));
+}
+
+/* Section separation before headings */
+.{prefix}-example-prose :where(h2) { --flow-space: var(--{prefix}example-vsp-xl); }
+.{prefix}-example-prose :where(h3) { --flow-space: var(--{prefix}example-vsp-lg); }
+.{prefix}-example-prose :where(h4) { --flow-space: var(--{prefix}example-vsp-md); }
+
+/* Heading-to-first-content: tight coupling */
+.{prefix}-example-prose :where(h2, h3, h4) + :where(p, ul, ol, table, pre, blockquote) {
+  --flow-space: var(--{prefix}example-vsp-sm);
+}
+
+/* Consecutive headings: tighten */
+.{prefix}-example-prose :where(h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6) {
+  --flow-space: var(--{prefix}example-vsp-2xs);
+}
+
+/* Trim edges */
+.{prefix}-example-prose > :first-child { margin-block-start: 0; }
+.{prefix}-example-prose > :last-child  { margin-block-end: 0; }
+```
+
+This pattern is flex/grid-safe because it uses only `margin-block-start`
+(one direction). No margin collapse dependency.
+See: typography/text-control/prose-heading-spacing.mdx — Strategy 1.
+
+---
+
+## Rationale
+
+### Why the flow-space pattern?
+
+Markdown-to-HTML produces flat element sequences. If each element owns both
+`margin-top` and `margin-bottom`, margin collapse in block flow and its
+**absence** in flex/grid containers produce different gaps from identical CSS.
+The flow utility assigns spacing to a single direction (`margin-block-start`)
+via a CSS custom property (`--flow-space`). Each block element sets its own
+`--flow-space` value; the container reads it. This makes spacing predictable
+in any layout context and eliminates the consecutive-heading accumulation
+problem with one override rule.
+
+Reference: `typography/text-control/prose-heading-spacing.mdx`
+Reference: `typography/text-control/vertical-rhythm.mdx`
+
+### Why `:where()` for zero specificity?
+
+The flow-space overrides use `:where(h2)`, `:where(h3, h4)`, etc. Because
+`:where()` contributes zero specificity to the selector, later rules (pair
+overrides, component-inline styles) can override `--flow-space` without
+specificity escalation. Declaration order controls which rule wins, which
+makes the system predictable and extensible.
+
+Reference: `interactive/selectors/is-where-selectors.mdx` (see also
+prose-heading-spacing.mdx "Fine-Tuning Specific Heading Pairs").
+
+### Why MDX component overrides instead of container-scoped CSS?
+
+In Tailwind v4, `@import "tailwindcss/utilities"` places utility classes
+inside a `@layer`. Unlayered CSS (a container rule such as
+`.prose :where(h3) { font-size: ... }`) always beats layered utilities
+regardless of specificity or source order. This creates an unsolvable cascade
+conflict whenever an `<h3>` inside the prose container is also used in an
+interactive component (forms, panels).
+
+The component-override pattern replaces container element selectors with
+explicit components (`ContentH2`, `ContentH3`, etc.) that carry their own
+styles. This eliminates the layering conflict: each context controls its own
+heading appearance via the component it chooses to render, not via a CSS rule
+that fights all other rules.
+
+For demos that do **not** use MDX or a framework with component-override
+support (plain Vite+React without `remark`/`rehype`, zfb), container-scoped
+CSS with `:where()` is acceptable because the cascade conflict arises only
+when the same HTML elements appear in non-content contexts on the same page.
+
+Reference: `methodology/architecture/mdx-component-architecture.mdx`
+
+### Why per-demo namespace isolation?
+
+Each demo lives in a different tech stack with different CSS scoping
+semantics. A shared `--example-*` namespace would let token definitions leak
+across demos when bundled together (e.g. in a multi-demo preview page).
+Per-demo namespaces (`--astro-example-*`, `--next-example-*`, etc.) keep
+each token set self-contained. Shared values (brand colours, font families)
+live in a common layer that all namespaces can reference.
+
+Reference: `methodology/design-systems/multi-namespace-token-strategy.mdx`
+
+---
+
+## /css-wisdom articles every Wave-2 sub-issue must cite
+
+| Article path | When to cite |
+|---|---|
+| `methodology/architecture/mdx-component-architecture.mdx` | When wiring MDX component-override maps in Astro/Next demos |
+| `typography/text-control/prose-heading-spacing.mdx` | When implementing the flow-space container CSS |
+| `typography/text-control/vertical-rhythm.mdx` | When choosing default token values (spacing scale rationale) |
+| `methodology/design-systems/multi-namespace-token-strategy.mdx` | When declaring the per-demo `--{prefix}example-*` tokens |
+
+---
+
+## zudo-doc reference paths (do NOT copy prose verbatim)
+
+These paths are provided for structural reference only. Examine the shapes
+and patterns; write your own implementation.
+
+- `src/styles/global.css` lines ~200–400 — pattern for wiring prose tokens
+  into a container; mirror using the demo's own `{prefix}`.
+- `src/components/content/heading-h2.tsx`, `heading-h3.tsx`, `heading-h4.tsx`
+  — gradient-bordered heading component shape.
+- `src/components/content/content-link.tsx`, `content-paragraph.tsx`,
+  `content-strong.tsx`, `content-blockquote.tsx`, `content-table.tsx`,
+  `content-code.tsx`, `content-ol.tsx`, `content-ul.tsx`
+  — component-override shape for demos that wire MDX override maps.

--- a/doc/content/prose-demo-source.md
+++ b/doc/content/prose-demo-source.md
@@ -1,0 +1,183 @@
+# Prose Demo
+
+This page demonstrates the full range of markdown-generated HTML elements
+styled through the `--{prefix}example-*` token namespace.
+Each section exercises a distinct element type so you can verify spacing,
+typography, and colour tokens at a glance.
+
+---
+
+## Headings
+
+Use the hierarchy below to check that vertical spacing and type-scale tokens
+produce clear section boundaries without excessive gaps.
+
+### Second-level sub-section
+
+The h3 heading above should sit closer to the h2 above it than to the
+content that follows — the heading visually "belongs" to the content below.
+
+#### Third-level detail heading
+
+The h4 above is the smallest heading level in the prose demo. It shares
+`leading-tight` line-height with h2 and h3 but uses a smaller `text-h4`
+font size.
+
+---
+
+## Text Formatting
+
+Prose pages rely on inline formatting to convey emphasis and editorial
+meaning without extra structure.
+
+A sentence can contain **bold text** to stress an important term, _italic
+text_ to indicate titles or introduce vocabulary, and ~~strikethrough text~~
+to mark deprecated or removed content.
+Combinations are valid: **_bold italic_** or ~~**bold strikethrough**~~.
+The styles should not break line-height or disrupt the baseline rhythm.
+
+---
+
+## Inline Code
+
+Inline code appears inside sentences to name identifiers, file paths, or
+short expressions.
+
+Pass the `--flow-space` custom property on an element to override the
+container's default vertical gap for that element only.
+The file lives at `src/styles/prose.css` and is imported by the page layout.
+
+---
+
+## Code Blocks
+
+Fenced code blocks render inside `<pre><code>` elements. The demo requires
+no syntax highlighting; raw colouring from `code-bg` and `code-fg` tokens
+is sufficient.
+
+```typescript
+// Wiring the prose token namespace for the {prefix} demo
+const proseTokens = {
+  vspMd:        `var(--{prefix}example-vsp-md)`,
+  textBody:     `var(--{prefix}example-text-body)`,
+  leadingRelaxed: `var(--{prefix}example-leading-relaxed)`,
+  codeBg:       `var(--{prefix}example-code-bg)`,
+  codeFg:       `var(--{prefix}example-code-fg)`,
+  fontMono:     `var(--{prefix}example-font-mono)`,
+} as const;
+
+export default proseTokens;
+```
+
+The block above should display with consistent horizontal padding derived
+from `hsp-sm`, a background from `code-bg`, and text coloured by `code-fg`.
+
+---
+
+## Unordered List
+
+Lists check that `vsp-xs` (item-to-item) and `vsp-md` (list-to-surrounding
+content) tokens produce balanced rhythm.
+
+- Token categories in the prose namespace
+  - Vertical spacing: `vsp-2xs` through `vsp-2xl`
+  - Horizontal spacing: `hsp-xs` through `hsp-xl`
+  - Type scale: `text-h2` through `text-micro`
+- Line-height tokens
+  - `leading-tight` — headings
+  - `leading-snug` — sub-headings and list items
+  - `leading-relaxed` — body paragraphs
+- Code surface tokens
+  - `code-bg`, `code-fg`, `font-mono`
+
+---
+
+## Ordered List
+
+Ordered lists share spacing tokens with unordered lists; the marker style
+differs but the rhythm should be identical.
+
+1. Define the token set in `--{prefix}example-*` namespace.
+2. Wire the flow utility into the prose container:
+   1. Apply `margin-block-start: var(--flow-space, ...)` to all children.
+   2. Set per-element `--flow-space` overrides using `:where()` selectors.
+   3. Tighten consecutive headings with a heading + heading adjacent rule.
+3. Map the type-scale and line-height tokens to each heading and paragraph.
+4. Apply code-surface tokens to `<pre>` and inline `<code>` elements.
+
+---
+
+## Blockquote
+
+A blockquote uses a left border coloured by `--color-accent` or
+`--color-muted`, with horizontal padding from `hsp-md`.
+
+> The flow utility assigns spacing to one margin direction only.
+> This makes spacing predictable in block flow, flex, and grid containers
+> without relying on margin collapse.
+
+A multi-paragraph blockquote checks that internal spacing between paragraphs
+is governed by the same `--flow-space` mechanism rather than ad-hoc margins.
+
+> First paragraph of a multi-paragraph quote.
+> It introduces the main idea and ends here.
+>
+> Second paragraph continues the thought.
+> Both paragraphs should have consistent internal rhythm.
+
+---
+
+## Tables
+
+A comparison table exercises `text-small`, `hsp-sm` cell padding, and border
+tokens.
+
+| Demo | Framework | MDX component overrides |
+|---|---|---|
+| astro | Astro + Preact | Yes — `components` prop on `<Content />` |
+| next | Next.js App Router | Yes — `useMDXComponents` / `MDXRemote` |
+| vite | Vite + React | Optional — depends on `remark`/`rehype` setup |
+| zfb | Zudo Framework Base | Container CSS with `:where()` selectors |
+| zfb-tailwind | Zudo Framework Base + Tailwind | Container CSS inside `@layer components` |
+
+---
+
+## Horizontal Rule
+
+A `<hr>` element marks a thematic break. It should have visible contrast
+against the page background and carry top and bottom spacing derived from
+`vsp-lg`.
+
+---
+
+## Links
+
+Links check `--color-accent` and underline treatment.
+
+Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
+to browse the source for all demo pages.
+Return to [{HOME_HREF}]({HOME_HREF}) to see the component gallery.
+
+The home link above uses the `{HOME_HREF}` placeholder.
+Each Wave-2 sub-task substitutes the correct value:
+
+- **Astro** — `import.meta.env.BASE_URL`
+- **Next.js** — `/` (or the configured `basePath`)
+- **Vite + React** — relative `index.html` or `import.meta.env.BASE_URL`
+- **zfb / zfb-tailwind** — full base-prefixed path from the build config
+
+---
+
+## Token reference
+
+The visual appearance of this page is driven entirely by the
+`--{prefix}example-*` token namespace.
+Vertical rhythm comes from `vsp-2xs` through `vsp-2xl`.
+Horizontal padding and indent come from `hsp-xs` through `hsp-xl`.
+Type sizes are set by `text-h2`, `text-h3`, `text-h4`, `text-body`,
+`text-small`, and `text-micro`.
+Line-heights use `leading-tight`, `leading-snug`, and `leading-relaxed`.
+Code blocks are styled with `code-bg`, `code-fg`, and `font-mono`.
+Heading borders and blockquote accents reuse the shared `--{prefix}example-color-fg`,
+`--color-muted`, and `--color-accent` tokens — no additional colour tokens
+are required.

--- a/doc/public/_redirects
+++ b/doc/public/_redirects
@@ -3,6 +3,8 @@
 # via the takazudomodular site). The *.pages.dev origin only serves the
 # subpath; redirect bare root to the base path so direct visits work.
 /  /pj/zudo-design-token-panel/  302
-# three-frameworks was renamed to four-frameworks
-/pj/zudo-design-token-panel/docs/getting-started/three-frameworks  /pj/zudo-design-token-panel/docs/getting-started/four-frameworks  301
-/pj/zudo-design-token-panel/docs/getting-started/three-frameworks/  /pj/zudo-design-token-panel/docs/getting-started/four-frameworks/  301
+# three-frameworks was renamed to four-frameworks, then to frameworks-comparison
+/pj/zudo-design-token-panel/docs/getting-started/three-frameworks  /pj/zudo-design-token-panel/docs/getting-started/frameworks-comparison  301
+/pj/zudo-design-token-panel/docs/getting-started/three-frameworks/  /pj/zudo-design-token-panel/docs/getting-started/frameworks-comparison/  301
+/pj/zudo-design-token-panel/docs/getting-started/four-frameworks  /pj/zudo-design-token-panel/docs/getting-started/frameworks-comparison  301
+/pj/zudo-design-token-panel/docs/getting-started/four-frameworks/  /pj/zudo-design-token-panel/docs/getting-started/frameworks-comparison/  301

--- a/doc/src/content/docs/getting-started/examples.mdx
+++ b/doc/src/content/docs/getting-started/examples.mdx
@@ -3,10 +3,12 @@ title: Examples
 sidebar_position: 90
 ---
 
-Reference integrations for `zudo-design-token-panel` across four popular
+Reference integrations for `zudo-design-token-panel` across five popular
 stacks. Each example wires the panel against a host-supplied
 `TokenManifest` and `ColorClusterConfig`, plus the companion bin server for
-applying tweaks back to source.
+applying tweaks back to source. Every example ships a `/prose` page that
+exercises the full range of markdown-generated HTML elements against the
+demo's token namespace.
 
 ## Try it
 
@@ -15,16 +17,22 @@ applying tweaks back to source.
   · [GitHub source](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/astro)
   — Drop the panel into an Astro site. Demonstrates host-config wiring with
   an Astro dev server and the bin apply pipeline.
+  [Prose page](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/astro/prose/)
+  exercises all prose elements against the `--astroexample-*` token namespace.
 - **Vite + React** —
   [Live demo](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/vite-react/)
   · [GitHub source](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/vite-react)
   — Use the panel from a Vite + React app. Shows how the Preact runtime
   coexists with React via the compat shim.
+  [Prose page](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/vite-react/prose.html)
+  exercises all prose elements against the `--vitereact-*` token namespace.
 - **Next.js** —
   [Live demo](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/next/)
   · [GitHub source](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/next)
   — Wire the panel into a Next.js app router project, including the bin
   server side-by-side with the Next dev server.
+  [Prose page](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/next/prose/)
+  exercises all prose elements against the `--nextexample-*` token namespace.
 - **zfb** —
   [Live demo](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/zfb/)
   · [GitHub source](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/zfb)
@@ -33,3 +41,15 @@ applying tweaks back to source.
   built-in proxy mechanism). The apply-endpoint URL is fully base-prefixed — see
   [`examples/zfb/PROBE-REPORT.md`](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/zfb/PROBE-REPORT.md)
   for context.
+  [Prose page](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/zfb/prose/)
+  exercises all prose elements against the `--zfbexample-*` token namespace.
+- **zfb + Tailwind v4** —
+  [Live demo](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/zfb-tailwind/)
+  · [GitHub source](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/zfb-tailwind)
+  — Extends the zfb example with Tailwind v4. Tokens are registered via an
+  `@theme` block into Tailwind's design-system namespaces so utility classes
+  like `text-body` and `p-hsp-md` resolve to the panel's custom properties
+  at build time.
+  [Prose page](https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples/zfb-tailwind/prose/)
+  exercises all prose elements against the `--zfbtailwindexample-*` token namespace,
+  with utility classes applied via `@layer components`.

--- a/doc/src/content/docs/getting-started/frameworks-comparison.mdx
+++ b/doc/src/content/docs/getting-started/frameworks-comparison.mdx
@@ -1,6 +1,6 @@
 ---
-title: Four Frameworks
-description: Side-by-side wiring for Astro, Vite + React, Next.js, and zfb — what changes, what stays the same.
+title: Frameworks Comparison
+description: Side-by-side wiring for Astro, Vite + React, Next.js, zfb, and zfb + Tailwind v4 — what changes, what stays the same.
 sidebar_position: 4
 ---
 
@@ -10,17 +10,18 @@ This page is the side-by-side overview. For full code, run any of the example ap
 
 ## Comparison
 
-| Step | Astro | Vite + React | Next.js (App Router) | zfb |
-| --- | --- | --- | --- | --- |
-| Install package | `pnpm add @takazudo/zudo-design-token-panel preact` | same | same | same |
-| Define `PanelConfig` | one TS file, host-side | same | same | same |
-| Mount the host | `<DesignTokenPanelHost>` in layout | call `configurePanel(...)` from entry | call `configurePanel(...)` from a `'use client'` module | call `configurePanel(...)` from a `"use client"` island |
-| Side-effect script | `void import('.../astro/host-adapter')` next to the host | not required | not required | `void import('.../astro/host-adapter')` in a `"use client"` island |
-| Styles import | once on the static graph | once on the static graph | once on the static graph | once on the static graph |
-| View-transition lifecycle | wired automatically by the host adapter when `<ClientRouter />` is present | n/a | n/a | n/a |
-| Apply proxy (dev) | Vite dev server proxy config | Vite dev server proxy config | Next.js `rewrites` | zfb plugin's `devMiddleware` hook |
-| Apply-endpoint URL | bare relative path (`api/dev/apply`) | bare relative path | bare relative path | full base-prefixed path |
-| Apply-pipeline bin | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script |
+| Step | Astro | Vite + React | Next.js (App Router) | zfb | zfb + Tailwind v4 |
+| --- | --- | --- | --- | --- | --- |
+| Install package | `pnpm add @takazudo/zudo-design-token-panel preact` | same | same | same | same + `tailwindcss` |
+| Define `PanelConfig` | one TS file, host-side | same | same | same | same |
+| Mount the host | `<DesignTokenPanelHost>` in layout | call `configurePanel(...)` from entry | call `configurePanel(...)` from a `'use client'` module | call `configurePanel(...)` from a `"use client"` island | same as zfb |
+| Side-effect script | `void import('.../astro/host-adapter')` next to the host | not required | not required | `void import('.../astro/host-adapter')` in a `"use client"` island | same as zfb |
+| Styles import | once on the static graph | once on the static graph | once on the static graph | once on the static graph | once on the static graph; tokens also registered via `@theme` block |
+| Tailwind integration | n/a | n/a | n/a | n/a | tokens registered into Tailwind namespaces via `@theme`; utility classes like `text-body` and `p-hsp-md` resolve to panel custom properties |
+| View-transition lifecycle | wired automatically by the host adapter when `<ClientRouter />` is present | n/a | n/a | n/a | n/a |
+| Apply proxy (dev) | Vite dev server proxy config | Vite dev server proxy config | Next.js `rewrites` | zfb plugin's `devMiddleware` hook | same as zfb |
+| Apply-endpoint URL | bare relative path (`api/dev/apply`) | bare relative path | bare relative path | full base-prefixed path | full base-prefixed path |
+| Apply-pipeline bin | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script | spawn via `concurrently` in dev script |
 
 What stays the same:
 
@@ -31,10 +32,11 @@ What stays the same:
 
 What differs:
 
-- Whether **you** call `configurePanel(...)` (Vite, Next.js, zfb) or the **host adapter** calls it for you (Astro).
+- Whether **you** call `configurePanel(...)` (Vite, Next.js, zfb, zfb-tailwind) or the **host adapter** calls it for you (Astro).
 - Whether the page goes through Astro's `<ClientRouter />` view-transition lifecycle (only Astro).
-- How the apply proxy is registered: Vite/Next use built-in proxy or rewrite config; zfb uses a plugin's `devMiddleware` hook.
-- Whether the `applyEndpoint` URL is bare (`api/dev/apply`) or base-prefixed (zfb only — see the zfb section below).
+- How the apply proxy is registered: Vite/Next use built-in proxy or rewrite config; zfb and zfb-tailwind use a plugin's `devMiddleware` hook.
+- Whether the `applyEndpoint` URL is bare (`api/dev/apply`) or base-prefixed (zfb and zfb-tailwind — see the zfb section below).
+- Whether tokens are also registered into Tailwind v4's design-system namespaces via an `@theme` block (zfb-tailwind only).
 
 ## Astro
 
@@ -176,6 +178,29 @@ export default {
 After zfb fix [#229](https://github.com/Takazudo/zudo-front-builder/issues/229), `devMiddleware`-registered paths are scoped under `base`, so the bare path resolves to 405. This is a configuration requirement for this deployment, not a zfb bug. See [`examples/zfb/PROBE-REPORT.md`](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/zfb/PROBE-REPORT.md) for the full rationale.
 
 Worked example: [`examples/zfb`](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/zfb).
+
+## zfb + Tailwind v4
+
+The zfb + Tailwind v4 example extends the zfb integration with Tailwind CSS v4. It shares the same panel wiring and `devMiddleware`-based apply proxy as the plain zfb example. The distinguishing feature is that design tokens are also registered into Tailwind's design-system namespaces via an `@theme` block, so utility classes like `text-body`, `p-hsp-md`, and `rounded-radius-sm` resolve to the panel's CSS custom properties at build time.
+
+```css
+/* styles/tokens.css */
+@theme {
+  --font-size-body: var(--zfbtailwindexample-text-body);
+  --spacing-hsp-md: var(--zfbtailwindexample-hsp-md);
+  --color-primary: var(--zfbtailwindexample-color-primary);
+}
+```
+
+With that `@theme` block in place, Tailwind utility classes and panel tokens stay in sync automatically: tweaking `--zfbtailwindexample-text-body` in the panel updates every element using `text-body`.
+
+The apply-endpoint URL follows the same base-prefixed pattern as the plain zfb example:
+
+```
+/pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply
+```
+
+Worked example: [`examples/zfb-tailwind`](https://github.com/Takazudo/zudo-design-token-panel/tree/main/examples/zfb-tailwind).
 
 ## Where to go next
 

--- a/doc/src/pages/index.astro
+++ b/doc/src/pages/index.astro
@@ -14,12 +14,14 @@ const astroExampleUrl = `${examplesBaseUrl}/astro`;
 const viteReactExampleUrl = `${examplesBaseUrl}/vite-react`;
 const nextExampleUrl = `${examplesBaseUrl}/next`;
 const zfbExampleUrl = `${examplesBaseUrl}/zfb`;
+const zfbTailwindExampleUrl = `${examplesBaseUrl}/zfb-tailwind`;
 const liveExamplesBaseUrl =
   "https://zudo-design-token-panel.pages.dev/pj/zudo-design-token-panel/examples";
 const astroLiveUrl = `${liveExamplesBaseUrl}/astro/`;
 const viteReactLiveUrl = `${liveExamplesBaseUrl}/vite-react/`;
 const nextLiveUrl = `${liveExamplesBaseUrl}/next/`;
 const zfbLiveUrl = `${liveExamplesBaseUrl}/zfb/`;
+const zfbTailwindLiveUrl = `${liveExamplesBaseUrl}/zfb-tailwind/`;
 ---
 
 <DocLayout title={settings.siteName} lang={defaultLocale} hideSidebar hideToc>
@@ -129,7 +131,7 @@ const zfbLiveUrl = `${liveExamplesBaseUrl}/zfb/`;
         tokens against your local dev server.
       </FeatureCard>
       <FeatureCard title="Example Apps" href="#example-apps">
-        Reference integrations across Astro, Vite + React, Next.js, and zfb.
+        Reference integrations across Astro, Vite + React, Next.js, zfb, and zfb + Tailwind v4.
         The example apps live alongside the panel package on GitHub, with live
         demos deployed.
       </FeatureCard>
@@ -145,10 +147,10 @@ const zfbLiveUrl = `${liveExamplesBaseUrl}/zfb/`;
       Example Apps
     </h2>
     <p class="text-muted text-small mb-vsp-md text-center max-w-[40rem] mx-auto">
-      Reference integrations across four popular stacks. Each card links to the
+      Reference integrations across five popular stacks. Each card links to the
       live demo; source code lives in the <code>examples/</code> directory on GitHub.
     </p>
-    <div class="grid gap-hsp-lg sm:grid-cols-2 lg:grid-cols-4">
+    <div class="grid gap-hsp-lg sm:grid-cols-2 lg:grid-cols-3">
       <FeatureCard title="Astro" href={astroLiveUrl} external>
         Drop the panel into an Astro site. Demonstrates host-config wiring
         with an Astro dev server and the bin apply pipeline.
@@ -173,6 +175,13 @@ const zfbLiveUrl = `${liveExamplesBaseUrl}/zfb/`;
         base-prefixed apply-endpoint URL.
         <br />
         <a href={zfbExampleUrl} target="_blank" rel="noopener noreferrer" class="text-xs underline">GitHub source</a>
+      </FeatureCard>
+      <FeatureCard title="zfb + Tailwind v4" href={zfbTailwindLiveUrl} external>
+        Extends the zfb example with Tailwind v4. Tokens are registered via
+        an <code>@theme</code> block so utility classes resolve to panel
+        custom properties at build time.
+        <br />
+        <a href={zfbTailwindExampleUrl} target="_blank" rel="noopener noreferrer" class="text-xs underline">GitHub source</a>
       </FeatureCard>
     </div>
   </section>

--- a/examples/astro/astro.config.ts
+++ b/examples/astro/astro.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import mdx from '@astrojs/mdx';
 import preact from '@astrojs/preact';
 
 /**
@@ -34,7 +35,7 @@ export default defineConfig({
   output: 'static',
   base: '/pj/zudo-design-token-panel/examples/astro/',
   devToolbar: { enabled: false },
-  integrations: [preact()],
+  integrations: [mdx(), preact()],
   server: {
     port: 44324,
   },

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -15,6 +15,7 @@
     "test:apply-smoke": "node scripts/smoke-apply.mjs"
   },
   "dependencies": {
+    "@astrojs/mdx": "^5.0.4",
     "@astrojs/preact": "^5.1.1",
     "@takazudo/zudo-design-token-panel": "workspace:*",
     "astro": "^6.1.5",

--- a/examples/astro/src/content.config.ts
+++ b/examples/astro/src/content.config.ts
@@ -1,0 +1,12 @@
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+/**
+ * Content Collections config for the Astro example (Astro 6 format).
+ * The "prose" collection holds the prose demo page MDX content.
+ */
+export const collections = {
+  prose: defineCollection({
+    loader: glob({ pattern: '**/*.mdx', base: './src/content/prose' }),
+  }),
+};

--- a/examples/astro/src/content/prose/index.mdx
+++ b/examples/astro/src/content/prose/index.mdx
@@ -1,0 +1,177 @@
+---
+title: Prose Demo
+---
+
+This page demonstrates the full range of markdown-generated HTML elements
+styled through the `--astroexample-*` token namespace.
+Each section exercises a distinct element type so you can verify spacing,
+typography, and colour tokens at a glance.
+
+---
+
+## Headings
+
+Use the hierarchy below to check that vertical spacing and type-scale tokens
+produce clear section boundaries without excessive gaps.
+
+### Second-level sub-section
+
+The h3 heading above should sit closer to the h2 above it than to the
+content that follows — the heading visually "belongs" to the content below.
+
+#### Third-level detail heading
+
+The h4 above is the smallest heading level in the prose demo. It shares
+`leading-tight` line-height with h2 and h3 but uses a smaller `text-h4`
+font size.
+
+---
+
+## Text Formatting
+
+Prose pages rely on inline formatting to convey emphasis and editorial
+meaning without extra structure.
+
+A sentence can contain **bold text** to stress an important term, _italic
+text_ to indicate titles or introduce vocabulary, and ~~strikethrough text~~
+to mark deprecated or removed content.
+Combinations are valid: **_bold italic_** or ~~**bold strikethrough**~~.
+The styles should not break line-height or disrupt the baseline rhythm.
+
+---
+
+## Inline Code
+
+Inline code appears inside sentences to name identifiers, file paths, or
+short expressions.
+
+Pass the `--flow-space` custom property on an element to override the
+container's default vertical gap for that element only.
+The file lives at `src/styles/tokens.css` and is imported by the page layout.
+
+---
+
+## Code Blocks
+
+Fenced code blocks render inside `<pre><code>` elements. The demo requires
+no syntax highlighting; raw colouring from `code-bg` and `code-fg` tokens
+is sufficient.
+
+```typescript
+// Wiring the prose token namespace for the astroexample demo
+const proseTokens = {
+  vspMd:          `var(--astroexample-vsp-md)`,
+  textBody:       `var(--astroexample-text-body)`,
+  leadingRelaxed: `var(--astroexample-leading-relaxed)`,
+  codeBg:         `var(--astroexample-code-bg)`,
+  codeFg:         `var(--astroexample-code-fg)`,
+  fontMono:       `var(--astroexample-font-mono)`,
+} as const;
+
+export default proseTokens;
+```
+
+The block above should display with consistent horizontal padding derived
+from `hsp-sm`, a background from `code-bg`, and text coloured by `code-fg`.
+
+---
+
+## Unordered List
+
+Lists check that `vsp-xs` (item-to-item) and `vsp-md` (list-to-surrounding
+content) tokens produce balanced rhythm.
+
+- Token categories in the prose namespace
+  - Vertical spacing: `vsp-2xs` through `vsp-2xl`
+  - Horizontal spacing: `hsp-xs` through `hsp-xl`
+  - Type scale: `text-h2` through `text-micro`
+- Line-height tokens
+  - `leading-tight` — headings
+  - `leading-snug` — sub-headings and list items
+  - `leading-relaxed` — body paragraphs
+- Code surface tokens
+  - `code-bg`, `code-fg`, `font-mono`
+
+---
+
+## Ordered List
+
+Ordered lists share spacing tokens with unordered lists; the marker style
+differs but the rhythm should be identical.
+
+1. Define the token set in `--astroexample-*` namespace.
+2. Wire the flow utility into the prose container:
+   1. Apply `margin-block-start: var(--flow-space, ...)` to all children.
+   2. Set per-element `--flow-space` overrides using `:where()` selectors.
+   3. Tighten consecutive headings with a heading + heading adjacent rule.
+3. Map the type-scale and line-height tokens to each heading and paragraph.
+4. Apply code-surface tokens to `<pre>` and inline `<code>` elements.
+
+---
+
+## Blockquote
+
+A blockquote uses a left border coloured by `--astroexample-color-muted`,
+with horizontal padding from `hsp-md`.
+
+> The flow utility assigns spacing to one margin direction only.
+> This makes spacing predictable in block flow, flex, and grid containers
+> without relying on margin collapse.
+
+A multi-paragraph blockquote checks that internal spacing between paragraphs
+is governed by the same `--flow-space` mechanism rather than ad-hoc margins.
+
+> First paragraph of a multi-paragraph quote.
+> It introduces the main idea and ends here.
+>
+> Second paragraph continues the thought.
+> Both paragraphs should have consistent internal rhythm.
+
+---
+
+## Tables
+
+A comparison table exercises `text-small`, `hsp-sm` cell padding, and border
+tokens.
+
+| Demo | Framework | MDX component overrides |
+|---|---|---|
+| astro | Astro + Preact | Yes — `components` prop on `<Content />` |
+| next | Next.js App Router | Yes — `useMDXComponents` / `MDXRemote` |
+| vite | Vite + React | Optional — depends on `remark`/`rehype` setup |
+| zfb | Zudo Framework Base | Container CSS with `:where()` selectors |
+| zfb-tailwind | Zudo Framework Base + Tailwind | Container CSS inside `@layer components` |
+
+---
+
+## Horizontal Rule
+
+A `<hr>` element marks a thematic break. It should have visible contrast
+against the page background and carry top and bottom spacing derived from
+`vsp-lg`.
+
+---
+
+## Links
+
+Links check `--astroexample-color-accent` and underline treatment.
+
+Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
+to browse the source for all demo pages.
+Return to <a href={import.meta.env.BASE_URL}>home</a> to see the component gallery.
+
+---
+
+## Token reference
+
+The visual appearance of this page is driven entirely by the
+`--astroexample-*` token namespace.
+Vertical rhythm comes from `vsp-2xs` through `vsp-2xl`.
+Horizontal padding and indent come from `hsp-xs` through `hsp-xl`.
+Type sizes are set by `text-h2`, `text-h3`, `text-h4`, `text-body`,
+`text-small`, and `text-micro`.
+Line-heights use `leading-tight`, `leading-snug`, and `leading-relaxed`.
+Code blocks are styled with `code-bg`, `code-fg`, and `font-mono`.
+Heading borders and blockquote accents reuse the shared `--astroexample-color-fg`,
+`--astroexample-color-muted`, and `--astroexample-color-accent` tokens — no
+additional colour tokens are required.

--- a/examples/astro/src/pages/about.astro
+++ b/examples/astro/src/pages/about.astro
@@ -10,6 +10,7 @@ import Layout from '../layouts/Layout.astro';
 
 const paletteIndices = Array.from({ length: 16 }, (_, i) => i);
 const homeHref = import.meta.env.BASE_URL;
+const proseHref = `${import.meta.env.BASE_URL}prose`;
 ---
 
 <Layout title="Astro Example — About">
@@ -43,6 +44,7 @@ const homeHref = import.meta.env.BASE_URL;
         then navigate <a class="astroexample-link" href={homeHref}>back to home</a>. The new value should
         still apply — proving the host adapter's <code>astro:page-load</code> reapply path works
         end-to-end.
+        Also try the <a class="astroexample-link" href={proseHref}>prose demo</a> to see typography tokens in action.
       </div>
     </section>
 

--- a/examples/astro/src/pages/index.astro
+++ b/examples/astro/src/pages/index.astro
@@ -9,6 +9,7 @@ import Layout from '../layouts/Layout.astro';
 
 const paletteIndices = Array.from({ length: 16 }, (_, i) => i);
 const aboutHref = `${import.meta.env.BASE_URL}about`;
+const proseHref = `${import.meta.env.BASE_URL}prose`;
 ---
 
 <Layout title="Astro Example — Design Token Panel">
@@ -46,6 +47,7 @@ const aboutHref = `${import.meta.env.BASE_URL}about`;
       <p>
         Try the <a class="astroexample-link" href={aboutHref}>about page</a> to confirm token tweaks
         persist across an Astro view-transition.
+        Visit the <a class="astroexample-link" href={proseHref}>prose demo</a> to see typography and spacing tokens in action.
       </p>
     </section>
 

--- a/examples/astro/src/pages/prose.astro
+++ b/examples/astro/src/pages/prose.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * Prose demo page. Renders the Wave-1 canonical MDX content inside
+ * .astroexample-prose so all --astroexample-* prose tokens are visible
+ * and respond to live panel tweaks.
+ *
+ * The MDX is loaded from src/content/prose/index.mdx via the Astro
+ * Content Collections API.
+ */
+
+import { getEntry, render } from 'astro:content';
+import Layout from '../layouts/Layout.astro';
+
+const entry = await getEntry('prose', 'index');
+if (!entry) {
+  throw new Error('prose/index.mdx not found');
+}
+const { Content } = await render(entry);
+
+const homeHref = import.meta.env.BASE_URL;
+const aboutHref = `${import.meta.env.BASE_URL}about`;
+---
+
+<Layout title="Astro Example — Prose Demo">
+  <div class="astroexample-stack">
+    <nav>
+      <a class="astroexample-link" href={homeHref}>← Home</a>
+      {' · '}
+      <a class="astroexample-link" href={aboutHref}>About</a>
+    </nav>
+
+    <main class="astroexample-prose">
+      <Content />
+    </main>
+  </div>
+</Layout>

--- a/examples/astro/src/styles/tokens.css
+++ b/examples/astro/src/styles/tokens.css
@@ -58,6 +58,40 @@
   --astroexample-color-surface: var(--astroexample-palette-0);
   --astroexample-color-muted: var(--astroexample-palette-8);
   --astroexample-color-danger: var(--astroexample-palette-5);
+
+  /* Prose tokens — vertical spacing scale (flow-space rhythm) */
+  --astroexample-vsp-2xs: 0.25rem;   /* ~4 px  — consecutive headings, tight items */
+  --astroexample-vsp-xs:  0.5rem;    /* ~8 px  — tighter intra-section spacing */
+  --astroexample-vsp-sm:  0.75rem;   /* ~12 px — heading-to-first-content gap */
+  --astroexample-vsp-md:  1rem;      /* ~16 px — default body flow gap */
+  --astroexample-vsp-lg:  1.75rem;   /* ~28 px — pre-h3 section separation */
+  --astroexample-vsp-xl:  2.5rem;    /* ~40 px — pre-h2 section separation */
+  --astroexample-vsp-2xl: 3.5rem;    /* ~56 px — top-of-page clearance */
+
+  /* Prose tokens — horizontal spacing scale */
+  --astroexample-hsp-xs:  0.25rem;   /* inline code padding, small insets */
+  --astroexample-hsp-sm:  0.5rem;    /* table cell padding, tag padding */
+  --astroexample-hsp-md:  1rem;      /* blockquote left indent */
+  --astroexample-hsp-lg:  1.5rem;    /* section-level horizontal gutter */
+  --astroexample-hsp-xl:  2rem;      /* outer prose container horizontal padding */
+
+  /* Prose tokens — type scale */
+  --astroexample-text-h2:    1.75rem;
+  --astroexample-text-h3:    1.35rem;
+  --astroexample-text-h4:    1.1rem;
+  --astroexample-text-body:  1rem;
+  --astroexample-text-small: 0.875rem;
+  --astroexample-text-micro: 0.75rem;
+
+  /* Prose tokens — line-heights */
+  --astroexample-leading-tight:   1.2;
+  --astroexample-leading-snug:    1.45;
+  --astroexample-leading-relaxed: 1.75;
+
+  /* Prose tokens — code surface */
+  --astroexample-code-bg:   hsl(220 13% 11%);
+  --astroexample-code-fg:   hsl(220 14% 86%);
+  --astroexample-font-mono: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
 }
 
 body {
@@ -135,4 +169,173 @@ body {
 .astroexample-meta {
   font-size: 0.875rem;
   color: var(--astroexample-color-muted);
+}
+
+/* ==========================================================================
+   Prose container — flow-space pattern (Strategy 1 per prose-heading-spacing.mdx)
+   Uses :where() selectors (zero specificity) so consumer rules win by order.
+   ========================================================================== */
+
+.astroexample-prose {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: var(--astroexample-vsp-2xl) var(--astroexample-hsp-xl);
+  font-size: var(--astroexample-text-body);
+  line-height: var(--astroexample-leading-relaxed);
+  color: var(--astroexample-fg);
+}
+
+/* Flow utility — all siblings get margin-block-start from --flow-space */
+.astroexample-prose > * + * {
+  margin-block-start: var(--flow-space, var(--astroexample-vsp-md));
+}
+
+/* Section separation before headings */
+.astroexample-prose :where(h2) { --flow-space: var(--astroexample-vsp-xl); }
+.astroexample-prose :where(h3) { --flow-space: var(--astroexample-vsp-lg); }
+.astroexample-prose :where(h4) { --flow-space: var(--astroexample-vsp-md); }
+
+/* Heading-to-first-content: tight coupling */
+.astroexample-prose :where(h2, h3, h4) + :where(p, ul, ol, table, pre, blockquote) {
+  --flow-space: var(--astroexample-vsp-sm);
+}
+
+/* Consecutive headings: tighten */
+.astroexample-prose :where(h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6) {
+  --flow-space: var(--astroexample-vsp-2xs);
+}
+
+/* Trim edges */
+.astroexample-prose > :first-child { margin-block-start: 0; }
+.astroexample-prose > :last-child  { margin-block-end: 0; }
+
+/* Headings — type scale + gradient top-border */
+.astroexample-prose :where(h2) {
+  font-size: var(--astroexample-text-h2);
+  font-weight: 700;
+  line-height: var(--astroexample-leading-tight);
+  padding-block-start: var(--astroexample-vsp-sm);
+  border-top: 3px solid transparent;
+  /* Gradient top-border: fg → muted, mirroring zudo-doc heading-h2.tsx pattern */
+  border-image: linear-gradient(
+    to right,
+    var(--astroexample-fg),
+    var(--astroexample-color-muted)
+  ) 1;
+}
+
+.astroexample-prose :where(h3) {
+  font-size: var(--astroexample-text-h3);
+  font-weight: 600;
+  line-height: var(--astroexample-leading-tight);
+  padding-block-start: var(--astroexample-vsp-xs);
+  border-top: 2px solid transparent;
+  border-image: linear-gradient(
+    to right,
+    var(--astroexample-fg),
+    var(--astroexample-color-muted)
+  ) 1;
+}
+
+.astroexample-prose :where(h4) {
+  font-size: var(--astroexample-text-h4);
+  font-weight: 600;
+  line-height: var(--astroexample-leading-tight);
+}
+
+/* Body text */
+.astroexample-prose :where(p) {
+  font-size: var(--astroexample-text-body);
+  line-height: var(--astroexample-leading-relaxed);
+}
+
+/* Lists */
+.astroexample-prose :where(ul, ol) {
+  padding-inline-start: var(--astroexample-hsp-lg);
+  line-height: var(--astroexample-leading-snug);
+}
+
+.astroexample-prose :where(li + li) {
+  margin-block-start: var(--astroexample-vsp-xs);
+}
+
+/* Blockquote */
+.astroexample-prose :where(blockquote) {
+  border-inline-start: 3px solid var(--astroexample-color-muted);
+  padding-inline-start: var(--astroexample-hsp-md);
+  color: var(--astroexample-color-muted);
+  font-style: italic;
+}
+
+/* Horizontal rule */
+.astroexample-prose :where(hr) {
+  border: none;
+  border-top: 1px solid var(--astroexample-color-muted);
+  margin-block: var(--astroexample-vsp-lg);
+}
+
+/* Inline code */
+.astroexample-prose :where(:not(pre) > code) {
+  font-family: var(--astroexample-font-mono);
+  font-size: var(--astroexample-text-micro);
+  background: var(--astroexample-code-bg);
+  color: var(--astroexample-code-fg);
+  padding: var(--astroexample-hsp-xs) var(--astroexample-hsp-sm);
+  border-radius: 0.25rem;
+}
+
+/* Code blocks */
+.astroexample-prose :where(pre) {
+  font-family: var(--astroexample-font-mono);
+  font-size: var(--astroexample-text-small);
+  background: var(--astroexample-code-bg);
+  color: var(--astroexample-code-fg);
+  padding: var(--astroexample-vsp-md) var(--astroexample-hsp-sm);
+  border-radius: var(--astroexample-radius, 0.25rem);
+  overflow-x: auto;
+}
+
+.astroexample-prose :where(pre > code) {
+  font-family: inherit;
+  font-size: inherit;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+/* Tables */
+.astroexample-prose :where(table) {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--astroexample-text-small);
+}
+
+.astroexample-prose :where(th, td) {
+  padding: var(--astroexample-hsp-xs) var(--astroexample-hsp-sm);
+  border: 1px solid var(--astroexample-color-muted);
+  text-align: left;
+}
+
+.astroexample-prose :where(th) {
+  font-weight: 600;
+  background: var(--astroexample-color-surface);
+}
+
+/* Links */
+.astroexample-prose :where(a) {
+  color: var(--astroexample-color-accent);
+  text-decoration: underline;
+}
+
+.astroexample-prose :where(a:hover) {
+  color: var(--astroexample-color-primary);
+}
+
+/* Strong / em */
+.astroexample-prose :where(strong) {
+  font-weight: 700;
+}
+
+.astroexample-prose :where(em) {
+  font-style: italic;
 }

--- a/examples/next/app/about/page.tsx
+++ b/examples/next/app/about/page.tsx
@@ -65,6 +65,13 @@ export default function AboutPage() {
           . The new value should still apply — proving the host adapter
           survives Next.js soft navigation end-to-end.
         </div>
+        <p>
+          See the{' '}
+          <Link className="nextexample-link" href="/prose">
+            prose demo page
+          </Link>{' '}
+          for typography tokens in action.
+        </p>
       </section>
 
       <section>

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -49,6 +49,13 @@ export default function HomePage() {
           </Link>{' '}
           to verify panel state survives Next's client-routed navigation.
         </p>
+        <p>
+          See the{' '}
+          <Link className="nextexample-link" href="/prose">
+            prose demo page
+          </Link>{' '}
+          for typography tokens in action.
+        </p>
       </header>
 
       <section>

--- a/examples/next/app/prose/page.mdx
+++ b/examples/next/app/prose/page.mdx
@@ -156,13 +156,13 @@ Links check `--color-accent` and underline treatment.
 
 Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
 to browse the source for all demo pages.
-Return to [/](/) to see the component gallery.
+Return to [home](/pj/zudo-design-token-panel/examples/next/) to see the component gallery.
 
-The home link above uses `/` as the base path for this Next.js demo.
+The home link above uses the configured `basePath` for this Next.js demo.
 Each Wave-2 sub-task substitutes the correct value:
 
 - **Astro** — `import.meta.env.BASE_URL`
-- **Next.js** — `/` (or the configured `basePath`)
+- **Next.js** — `/pj/zudo-design-token-panel/examples/next/` (the configured `basePath`)
 - **Vite + React** — relative `index.html` or `import.meta.env.BASE_URL`
 - **zfb / zfb-tailwind** — full base-prefixed path from the build config
 

--- a/examples/next/app/prose/page.mdx
+++ b/examples/next/app/prose/page.mdx
@@ -1,0 +1,183 @@
+# Prose Demo
+
+This page demonstrates the full range of markdown-generated HTML elements
+styled through the `--nextexample-*` token namespace.
+Each section exercises a distinct element type so you can verify spacing,
+typography, and colour tokens at a glance.
+
+---
+
+## Headings
+
+Use the hierarchy below to check that vertical spacing and type-scale tokens
+produce clear section boundaries without excessive gaps.
+
+### Second-level sub-section
+
+The h3 heading above should sit closer to the h2 above it than to the
+content that follows — the heading visually "belongs" to the content below.
+
+#### Third-level detail heading
+
+The h4 above is the smallest heading level in the prose demo. It shares
+`leading-tight` line-height with h2 and h3 but uses a smaller `text-h4`
+font size.
+
+---
+
+## Text Formatting
+
+Prose pages rely on inline formatting to convey emphasis and editorial
+meaning without extra structure.
+
+A sentence can contain **bold text** to stress an important term, _italic
+text_ to indicate titles or introduce vocabulary, and ~~strikethrough text~~
+to mark deprecated or removed content.
+Combinations are valid: **_bold italic_** or ~~**bold strikethrough**~~.
+The styles should not break line-height or disrupt the baseline rhythm.
+
+---
+
+## Inline Code
+
+Inline code appears inside sentences to name identifiers, file paths, or
+short expressions.
+
+Pass the `--flow-space` custom property on an element to override the
+container's default vertical gap for that element only.
+The file lives at `src/styles/prose.css` and is imported by the page layout.
+
+---
+
+## Code Blocks
+
+Fenced code blocks render inside `<pre><code>` elements. The demo requires
+no syntax highlighting; raw colouring from `code-bg` and `code-fg` tokens
+is sufficient.
+
+```typescript
+// Wiring the prose token namespace for the nextexample demo
+const proseTokens = {
+  vspMd:        `var(--nextexample-vsp-md)`,
+  textBody:     `var(--nextexample-text-body)`,
+  leadingRelaxed: `var(--nextexample-leading-relaxed)`,
+  codeBg:       `var(--nextexample-code-bg)`,
+  codeFg:       `var(--nextexample-code-fg)`,
+  fontMono:     `var(--nextexample-font-mono)`,
+} as const;
+
+export default proseTokens;
+```
+
+The block above should display with consistent horizontal padding derived
+from `hsp-sm`, a background from `code-bg`, and text coloured by `code-fg`.
+
+---
+
+## Unordered List
+
+Lists check that `vsp-xs` (item-to-item) and `vsp-md` (list-to-surrounding
+content) tokens produce balanced rhythm.
+
+- Token categories in the prose namespace
+  - Vertical spacing: `vsp-2xs` through `vsp-2xl`
+  - Horizontal spacing: `hsp-xs` through `hsp-xl`
+  - Type scale: `text-h2` through `text-micro`
+- Line-height tokens
+  - `leading-tight` — headings
+  - `leading-snug` — sub-headings and list items
+  - `leading-relaxed` — body paragraphs
+- Code surface tokens
+  - `code-bg`, `code-fg`, `font-mono`
+
+---
+
+## Ordered List
+
+Ordered lists share spacing tokens with unordered lists; the marker style
+differs but the rhythm should be identical.
+
+1. Define the token set in `--nextexample-*` namespace.
+2. Wire the flow utility into the prose container:
+   1. Apply `margin-block-start: var(--flow-space, ...)` to all children.
+   2. Set per-element `--flow-space` overrides using `:where()` selectors.
+   3. Tighten consecutive headings with a heading + heading adjacent rule.
+3. Map the type-scale and line-height tokens to each heading and paragraph.
+4. Apply code-surface tokens to `<pre>` and inline `<code>` elements.
+
+---
+
+## Blockquote
+
+A blockquote uses a left border coloured by `--color-accent` or
+`--color-muted`, with horizontal padding from `hsp-md`.
+
+> The flow utility assigns spacing to one margin direction only.
+> This makes spacing predictable in block flow, flex, and grid containers
+> without relying on margin collapse.
+
+A multi-paragraph blockquote checks that internal spacing between paragraphs
+is governed by the same `--flow-space` mechanism rather than ad-hoc margins.
+
+> First paragraph of a multi-paragraph quote.
+> It introduces the main idea and ends here.
+>
+> Second paragraph continues the thought.
+> Both paragraphs should have consistent internal rhythm.
+
+---
+
+## Tables
+
+A comparison table exercises `text-small`, `hsp-sm` cell padding, and border
+tokens.
+
+| Demo | Framework | MDX component overrides |
+|---|---|---|
+| astro | Astro + Preact | Yes — `components` prop on `<Content />` |
+| next | Next.js App Router | Yes — `useMDXComponents` / `MDXRemote` |
+| vite | Vite + React | Optional — depends on `remark`/`rehype` setup |
+| zfb | Zudo Framework Base | Container CSS with `:where()` selectors |
+| zfb-tailwind | Zudo Framework Base + Tailwind | Container CSS inside `@layer components` |
+
+---
+
+## Horizontal Rule
+
+A `<hr>` element marks a thematic break. It should have visible contrast
+against the page background and carry top and bottom spacing derived from
+`vsp-lg`.
+
+---
+
+## Links
+
+Links check `--color-accent` and underline treatment.
+
+Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
+to browse the source for all demo pages.
+Return to [/](/) to see the component gallery.
+
+The home link above uses `/` as the base path for this Next.js demo.
+Each Wave-2 sub-task substitutes the correct value:
+
+- **Astro** — `import.meta.env.BASE_URL`
+- **Next.js** — `/` (or the configured `basePath`)
+- **Vite + React** — relative `index.html` or `import.meta.env.BASE_URL`
+- **zfb / zfb-tailwind** — full base-prefixed path from the build config
+
+---
+
+## Token reference
+
+The visual appearance of this page is driven entirely by the
+`--nextexample-*` token namespace.
+Vertical rhythm comes from `vsp-2xs` through `vsp-2xl`.
+Horizontal padding and indent come from `hsp-xs` through `hsp-xl`.
+Type sizes are set by `text-h2`, `text-h3`, `text-h4`, `text-body`,
+`text-small`, and `text-micro`.
+Line-heights use `leading-tight`, `leading-snug`, and `leading-relaxed`.
+Code blocks are styled with `code-bg`, `code-fg`, and `font-mono`.
+Heading borders and blockquote accents reuse the shared `--nextexample-color-primary`,
+`--nextexample-color-muted`, and `--nextexample-color-accent` tokens — no additional colour tokens
+are required.

--- a/examples/next/mdx-components.tsx
+++ b/examples/next/mdx-components.tsx
@@ -1,0 +1,29 @@
+/*
+ * App Router MDX component override hook.
+ *
+ * STATIC-EXPORT RULE: this file MUST be pure-JSX — no 'use client', no
+ * useEffect, no hooks, no stateful behavior. Any client-only code here
+ * would break `output: 'export'` because the exporter rejects dynamic /
+ * runtime-mutable content in the MDX rendering path.
+ *
+ * The overrides below wire --nextexample-* prose tokens to MDX-generated
+ * elements by assigning the .nextexample-prose container class on the
+ * wrapper and relying on the CSS :where() rules in tokens.css for all
+ * child element styling. This follows the MDX component-architecture
+ * pattern (prose-token-contract.md: "Why MDX component overrides instead
+ * of container-scoped CSS?").
+ *
+ * Reference: prose-token-contract.md, methodology/architecture/mdx-component-architecture.mdx
+ */
+import type { MDXComponents } from 'mdx/types';
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    ...components,
+    // Wrap MDX page output in the prose container so tokens.css
+    // .nextexample-prose :where(...) rules apply to all MDX elements.
+    wrapper: ({ children }) => (
+      <div className="nextexample-prose">{children}</div>
+    ),
+  };
+}

--- a/examples/next/next.config.ts
+++ b/examples/next/next.config.ts
@@ -1,11 +1,12 @@
 import type { NextConfig } from 'next';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
+import createMDX from '@next/mdx';
 
 /*
  * Next.js config for the Next + React 19 example app.
  *
- * Deliberately minimal: NO bundler aliases, NO MDX, NO Tailwind, NO design
+ * Deliberately minimal: NO bundler aliases, NO Tailwind, NO design
  * system. The example proves @takazudo/zudo-design-token-panel works inside a
  * vanilla Next 15 App Router consumer that ships:
  *
@@ -64,8 +65,20 @@ const nextConfig: NextConfig = {
   // proxy) is picked up alongside the regular `route.ts` filenames. In
   // export mode, fall back to the Next defaults so the dev-only file is
   // invisible to the static exporter and `out/` never carries it.
-  pageExtensions: isExportBuild ? ['ts', 'tsx'] : ['ts', 'tsx', 'dev.ts', 'dev.tsx'],
+  // 'mdx' is included in both modes so page.mdx files are recognised as
+  // App Router pages regardless of build target.
+  pageExtensions: isExportBuild
+    ? ['ts', 'tsx', 'mdx']
+    : ['ts', 'tsx', 'dev.ts', 'dev.tsx', 'mdx'],
   ...(isExportBuild ? { output: 'export' as const } : {}),
 };
 
-export default nextConfig;
+/*
+ * Wrap the config with @next/mdx so .mdx files are processed as JSX pages.
+ * No remark/rehype plugins are needed for the prose demo — raw GFM is
+ * sufficient. Static export (output: 'export') is preserved because MDX
+ * pages emit only static JSX; no server-only APIs are used.
+ */
+const withMDX = createMDX({});
+
+export default withMDX(nextConfig);

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -15,6 +15,9 @@
     "test:apply-smoke": "node scripts/smoke-apply.mjs"
   },
   "dependencies": {
+    "@mdx-js/loader": "^3.1.1",
+    "@mdx-js/react": "^3.1.1",
+    "@next/mdx": "^16.2.6",
     "@takazudo/zudo-design-token-panel": "workspace:*",
     "next": "^15.5.15",
     "preact": "^10.29.1",
@@ -23,6 +26,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@types/mdx": "^2.0.13",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/examples/next/src/styles/tokens.css
+++ b/examples/next/src/styles/tokens.css
@@ -59,6 +59,42 @@
   --nextexample-color-surface: var(--nextexample-palette-0);
   --nextexample-color-muted: var(--nextexample-palette-8);
   --nextexample-color-danger: var(--nextexample-palette-5);
+
+  /* Prose tokens — vertical spacing scale (flow-space rhythm) */
+  /* prose-token-contract.md: vsp-* — baseline rhythm unit ≈ 1.6rem */
+  --nextexample-vsp-2xs: 0.25rem;   /* ~4 px  — consecutive headings, tight list items */
+  --nextexample-vsp-xs:  0.5rem;    /* ~8 px  — tighter paragraph spacing */
+  --nextexample-vsp-sm:  0.75rem;   /* ~12 px — heading-to-first-content gap */
+  --nextexample-vsp-md:  1rem;      /* ~16 px — default body-level flow gap */
+  --nextexample-vsp-lg:  1.75rem;   /* ~28 px — pre-h3 section separation */
+  --nextexample-vsp-xl:  2.5rem;    /* ~40 px — pre-h2 section separation */
+  --nextexample-vsp-2xl: 3.5rem;    /* ~56 px — top-of-page or pre-first-heading clearance */
+
+  /* Prose tokens — horizontal spacing scale */
+  --nextexample-hsp-xs:  0.25rem;   /* inline code padding, small insets */
+  --nextexample-hsp-sm:  0.5rem;    /* table cell padding, tag padding */
+  --nextexample-hsp-md:  1rem;      /* blockquote left indent */
+  --nextexample-hsp-lg:  1.5rem;    /* section-level horizontal gutter */
+  --nextexample-hsp-xl:  2rem;      /* outer prose container horizontal padding */
+
+  /* Prose tokens — type scale */
+  --nextexample-text-h2:    1.75rem;
+  --nextexample-text-h3:    1.35rem;
+  --nextexample-text-h4:    1.1rem;
+  --nextexample-text-body:  1rem;
+  --nextexample-text-small: 0.875rem;
+  --nextexample-text-micro: 0.75rem;
+
+  /* Prose tokens — line-height scale */
+  --nextexample-leading-tight:   1.2;
+  --nextexample-leading-snug:    1.45;
+  --nextexample-leading-relaxed: 1.75;
+
+  /* Prose tokens — code surface */
+  --nextexample-code-bg:   hsl(220 13% 11%);
+  --nextexample-code-fg:   hsl(220 14% 86%);
+  /* ui-monospace first per CSS Fonts spec; Cascadia Code / Source Code Pro as named fallbacks */
+  --nextexample-font-mono: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
 }
 
 body {
@@ -125,7 +161,7 @@ body {
   height: 4rem;
   border-radius: var(--nextexample-radius);
   display: flex;
-  align-items: end;
+  align-items: flex-end;
   justify-content: center;
   font-size: 0.75rem;
   color: var(--nextexample-fg);
@@ -142,4 +178,156 @@ body {
   font-variant-numeric: tabular-nums;
   color: var(--nextexample-color-accent);
   font-weight: 700;
+}
+
+/*
+ * Prose container — flow-space rhythm pattern
+ * (prose-token-contract.md: Flow-spacing CSS pattern / Strategy 1)
+ * :where() contributes zero specificity so later rules can override
+ * --flow-space without specificity escalation.
+ */
+.nextexample-prose {
+  max-width: 56rem;
+  margin: 0 auto;
+  padding: var(--nextexample-vsp-2xl) var(--nextexample-hsp-xl);
+  font-size: var(--nextexample-text-body);
+  line-height: var(--nextexample-leading-relaxed);
+  color: var(--nextexample-fg);
+}
+
+/* Flow-space: all direct children share the default gap */
+.nextexample-prose > * + * {
+  margin-block-start: var(--flow-space, var(--nextexample-vsp-md));
+}
+
+/* Section separation before headings */
+.nextexample-prose :where(h2) { --flow-space: var(--nextexample-vsp-xl); }
+.nextexample-prose :where(h3) { --flow-space: var(--nextexample-vsp-lg); }
+.nextexample-prose :where(h4) { --flow-space: var(--nextexample-vsp-md); }
+
+/* Heading-to-first-content: tight coupling */
+.nextexample-prose :where(h2, h3, h4) + :where(p, ul, ol, table, pre, blockquote) {
+  --flow-space: var(--nextexample-vsp-sm);
+}
+
+/* Consecutive headings: tighten */
+.nextexample-prose :where(h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6) {
+  --flow-space: var(--nextexample-vsp-2xs);
+}
+
+/* Trim block edges */
+.nextexample-prose > :first-child { margin-block-start: 0; }
+.nextexample-prose > :last-child  { margin-block-end: 0; }
+
+/* Heading type scale and line-height */
+.nextexample-prose :where(h2) {
+  font-size: var(--nextexample-text-h2);
+  line-height: var(--nextexample-leading-tight);
+  font-weight: 700;
+  padding-block-start: var(--nextexample-vsp-xs);
+  border-block-start: 2px solid var(--nextexample-color-primary);
+}
+
+.nextexample-prose :where(h3) {
+  font-size: var(--nextexample-text-h3);
+  line-height: var(--nextexample-leading-tight);
+  font-weight: 600;
+}
+
+.nextexample-prose :where(h4) {
+  font-size: var(--nextexample-text-h4);
+  line-height: var(--nextexample-leading-tight);
+  font-weight: 600;
+}
+
+/* Inline code */
+.nextexample-prose :where(code:not(pre code)) {
+  font-family: var(--nextexample-font-mono);
+  font-size: var(--nextexample-text-small);
+  background: var(--nextexample-code-bg);
+  color: var(--nextexample-code-fg);
+  padding: 0.1em var(--nextexample-hsp-xs);
+  border-radius: 3px;
+  border: 1px solid var(--nextexample-color-accent);
+}
+
+/* Code blocks */
+.nextexample-prose :where(pre) {
+  font-family: var(--nextexample-font-mono);
+  font-size: var(--nextexample-text-small);
+  background: var(--nextexample-code-bg);
+  color: var(--nextexample-code-fg);
+  padding: var(--nextexample-vsp-sm) var(--nextexample-hsp-sm);
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.nextexample-prose :where(pre code) {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Blockquote */
+.nextexample-prose :where(blockquote) {
+  border-inline-start: 3px solid var(--nextexample-color-muted);
+  padding-inline-start: var(--nextexample-hsp-md);
+  color: var(--nextexample-color-muted);
+}
+
+/* Lists */
+.nextexample-prose :where(ul) {
+  padding-inline-start: var(--nextexample-hsp-lg);
+  list-style-type: disc;
+}
+
+.nextexample-prose :where(ol) {
+  padding-inline-start: var(--nextexample-hsp-lg);
+  list-style-type: decimal;
+}
+
+.nextexample-prose :where(li + li) {
+  margin-block-start: var(--nextexample-vsp-xs);
+}
+
+/* Tables */
+.nextexample-prose :where(table) {
+  border-collapse: collapse;
+  font-size: var(--nextexample-text-small);
+  width: 100%;
+}
+
+.nextexample-prose :where(th, td) {
+  padding: var(--nextexample-hsp-xs) var(--nextexample-hsp-sm);
+  border: 1px solid var(--nextexample-color-muted);
+  text-align: left;
+}
+
+.nextexample-prose :where(th) {
+  font-weight: 600;
+  background: var(--nextexample-code-bg);
+}
+
+/* Horizontal rule */
+.nextexample-prose :where(hr) {
+  border: none;
+  border-block-start: 1px solid var(--nextexample-color-muted);
+  margin-block: var(--nextexample-vsp-lg);
+}
+
+/* Links */
+.nextexample-prose :where(a) {
+  color: var(--nextexample-color-accent);
+  text-decoration: underline;
+}
+
+/* Strong / em */
+.nextexample-prose :where(strong) {
+  font-weight: 700;
+}
+
+.nextexample-prose :where(em) {
+  font-style: italic;
 }

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -15,6 +15,8 @@
     "test:apply-smoke": "node scripts/smoke-apply.mjs"
   },
   "dependencies": {
+    "@mdx-js/react": "^3.1.1",
+    "@mdx-js/rollup": "^3.1.1",
     "@takazudo/zudo-design-token-panel": "workspace:*",
     "preact": "^10.29.1",
     "react": "^18.3.1",
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
+    "@types/mdx": "^2.0.13",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/examples/vite-react/prose.html
+++ b/examples/vite-react/prose.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Prose Demo — Vite + React Example — Design Token Panel</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/prose-main.tsx"></script>
+  </body>
+</html>

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -53,6 +53,14 @@ export function App() {
           Console API: <code>window.viteReactExample.toggleDesignPanel()</code>.
           Storage prefix: <code>vite-react-example-tokens</code>.
         </p>
+        <p>
+          <a
+            className="vitereact-link"
+            href={`${import.meta.env.BASE_URL}prose.html`}
+          >
+            Prose Demo →
+          </a>
+        </p>
       </header>
 
       <section>

--- a/examples/vite-react/src/components/ProseDemo.tsx
+++ b/examples/vite-react/src/components/ProseDemo.tsx
@@ -1,0 +1,31 @@
+/**
+ * ProseDemo — renders the canonical prose-demo MDX content inside a
+ * `.vitereact-prose` container so all prose tokens from tokens.css apply.
+ *
+ * The MDX module is imported statically (not lazily) because prose.html is
+ * a dedicated Vite entry — it ships its own chunk and there is nothing left
+ * to defer.
+ */
+
+import { useEffect } from 'react';
+import ProseDemoContent from '../content/prose-demo.mdx';
+import { mountPanel } from '../lib/mount-panel';
+
+export function ProseDemo() {
+  useEffect(() => {
+    mountPanel();
+    // No cleanup: panel adapter installs window-level singletons that must
+    // persist for the page lifetime (same rationale as App.tsx).
+  }, []);
+
+  return (
+    <>
+      <nav className="vitereact-prose-nav">
+        <a href={`${import.meta.env.BASE_URL}index.html`}>← Back to component gallery</a>
+      </nav>
+      <main className="vitereact-prose">
+        <ProseDemoContent />
+      </main>
+    </>
+  );
+}

--- a/examples/vite-react/src/content/prose-demo.mdx
+++ b/examples/vite-react/src/content/prose-demo.mdx
@@ -1,0 +1,175 @@
+# Prose Demo
+
+This page demonstrates the full range of markdown-generated HTML elements
+styled through the `--vitereact*` token namespace.
+Each section exercises a distinct element type so you can verify spacing,
+typography, and colour tokens at a glance.
+
+---
+
+## Headings
+
+Use the hierarchy below to check that vertical spacing and type-scale tokens
+produce clear section boundaries without excessive gaps.
+
+### Second-level sub-section
+
+The h3 heading above should sit closer to the h2 above it than to the
+content that follows — the heading visually "belongs" to the content below.
+
+#### Third-level detail heading
+
+The h4 above is the smallest heading level in the prose demo. It shares
+`leading-tight` line-height with h2 and h3 but uses a smaller `text-h4`
+font size.
+
+---
+
+## Text Formatting
+
+Prose pages rely on inline formatting to convey emphasis and editorial
+meaning without extra structure.
+
+A sentence can contain **bold text** to stress an important term, _italic
+text_ to indicate titles or introduce vocabulary, and ~~strikethrough text~~
+to mark deprecated or removed content.
+Combinations are valid: **_bold italic_** or ~~**bold strikethrough**~~.
+The styles should not break line-height or disrupt the baseline rhythm.
+
+---
+
+## Inline Code
+
+Inline code appears inside sentences to name identifiers, file paths, or
+short expressions.
+
+Pass the `--flow-space` custom property on an element to override the
+container's default vertical gap for that element only.
+The file lives at `src/styles/prose.css` and is imported by the page layout.
+
+---
+
+## Code Blocks
+
+Fenced code blocks render inside `<pre><code>` elements. The demo requires
+no syntax highlighting; raw colouring from `code-bg` and `code-fg` tokens
+is sufficient.
+
+```typescript
+// Wiring the prose token namespace for the vitereact demo
+const proseTokens = {
+  vspMd:          `var(--vitereact-vsp-md)`,
+  textBody:       `var(--vitereact-text-body)`,
+  leadingRelaxed: `var(--vitereact-leading-relaxed)`,
+  codeBg:         `var(--vitereact-code-bg)`,
+  codeFg:         `var(--vitereact-code-fg)`,
+  fontMono:       `var(--vitereact-font-mono)`,
+} as const;
+
+export default proseTokens;
+```
+
+The block above should display with consistent horizontal padding derived
+from `hsp-sm`, a background from `code-bg`, and text coloured by `code-fg`.
+
+---
+
+## Unordered List
+
+Lists check that `vsp-xs` (item-to-item) and `vsp-md` (list-to-surrounding
+content) tokens produce balanced rhythm.
+
+- Token categories in the prose namespace
+  - Vertical spacing: `vsp-2xs` through `vsp-2xl`
+  - Horizontal spacing: `hsp-xs` through `hsp-xl`
+  - Type scale: `text-h2` through `text-micro`
+- Line-height tokens
+  - `leading-tight` — headings
+  - `leading-snug` — sub-headings and list items
+  - `leading-relaxed` — body paragraphs
+- Code surface tokens
+  - `code-bg`, `code-fg`, `font-mono`
+
+---
+
+## Ordered List
+
+Ordered lists share spacing tokens with unordered lists; the marker style
+differs but the rhythm should be identical.
+
+1. Define the token set in `--vitereact-*` namespace.
+2. Wire the flow utility into the prose container:
+   1. Apply `margin-block-start: var(--flow-space, ...)` to all children.
+   2. Set per-element `--flow-space` overrides using `:where()` selectors.
+   3. Tighten consecutive headings with a heading + heading adjacent rule.
+3. Map the type-scale and line-height tokens to each heading and paragraph.
+4. Apply code-surface tokens to `<pre>` and inline `<code>` elements.
+
+---
+
+## Blockquote
+
+A blockquote uses a left border coloured by `--color-accent` or
+`--color-muted`, with horizontal padding from `hsp-md`.
+
+> The flow utility assigns spacing to one margin direction only.
+> This makes spacing predictable in block flow, flex, and grid containers
+> without relying on margin collapse.
+
+A multi-paragraph blockquote checks that internal spacing between paragraphs
+is governed by the same `--flow-space` mechanism rather than ad-hoc margins.
+
+> First paragraph of a multi-paragraph quote.
+> It introduces the main idea and ends here.
+>
+> Second paragraph continues the thought.
+> Both paragraphs should have consistent internal rhythm.
+
+---
+
+## Tables
+
+A comparison table exercises `text-small`, `hsp-sm` cell padding, and border
+tokens.
+
+| Demo | Framework | MDX component overrides |
+|---|---|---|
+| astro | Astro + Preact | Yes — `components` prop on `<Content />` |
+| next | Next.js App Router | Yes — `useMDXComponents` / `MDXRemote` |
+| vite | Vite + React | Optional — depends on `remark`/`rehype` setup |
+| zfb | Zudo Framework Base | Container CSS with `:where()` selectors |
+| zfb-tailwind | Zudo Framework Base + Tailwind | Container CSS inside `@layer components` |
+
+---
+
+## Horizontal Rule
+
+A `<hr>` element marks a thematic break. It should have visible contrast
+against the page background and carry top and bottom spacing derived from
+`vsp-lg`.
+
+---
+
+## Links
+
+Links check `--color-accent` and underline treatment.
+
+Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
+to browse the source for all demo pages.
+Return to [home](/) to see the component gallery.
+
+---
+
+## Token reference
+
+The visual appearance of this page is driven entirely by the
+`--vitereact-*` token namespace.
+Vertical rhythm comes from `vsp-2xs` through `vsp-2xl`.
+Horizontal padding and indent come from `hsp-xs` through `hsp-xl`.
+Type sizes are set by `text-h2`, `text-h3`, `text-h4`, `text-body`,
+`text-small`, and `text-micro`.
+Line-heights use `leading-tight`, `leading-snug`, and `leading-relaxed`.
+Code blocks are styled with `code-bg`, `code-fg`, and `font-mono`.
+Heading borders and blockquote accents reuse the shared `--vitereact-color-fg`,
+`--color-muted`, and `--color-accent` tokens — no additional colour tokens
+are required.

--- a/examples/vite-react/src/prose-main.tsx
+++ b/examples/vite-react/src/prose-main.tsx
@@ -1,0 +1,28 @@
+/**
+ * Entry script for prose.html.
+ *
+ * Mirrors main.tsx: imports the same reset + token CSS and the panel styles,
+ * then mounts the <ProseDemo> component into #root. The panel adapter is
+ * bootstrapped inside ProseDemo's useEffect (same pattern as App.tsx) so
+ * panel-driven token tweaks update the prose page live.
+ */
+
+import { StrictMode } from 'react';
+import ReactDOM from 'react-dom/client';
+
+import './styles/reset.css';
+import './styles/tokens.css';
+import '@takazudo/zudo-design-token-panel/styles';
+
+import { ProseDemo } from './components/ProseDemo';
+
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Vite + React prose entry: #root element missing in prose.html');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <StrictMode>
+    <ProseDemo />
+  </StrictMode>,
+);

--- a/examples/vite-react/src/styles/tokens.css
+++ b/examples/vite-react/src/styles/tokens.css
@@ -59,6 +59,40 @@
   --vitereact-color-surface: var(--vitereact-palette-0);
   --vitereact-color-muted: var(--vitereact-palette-8);
   --vitereact-color-danger: var(--vitereact-palette-5);
+
+  /* Prose vertical spacing — flow-space rhythm (vsp-2xs … vsp-2xl) */
+  --vitereact-vsp-2xs: 0.25rem;
+  --vitereact-vsp-xs:  0.5rem;
+  --vitereact-vsp-sm:  0.75rem;
+  --vitereact-vsp-md:  1rem;
+  --vitereact-vsp-lg:  1.75rem;
+  --vitereact-vsp-xl:  2.5rem;
+  --vitereact-vsp-2xl: 3.5rem;
+
+  /* Prose horizontal spacing (hsp-xs … hsp-xl) */
+  --vitereact-hsp-xs:  0.25rem;
+  --vitereact-hsp-sm:  0.5rem;
+  --vitereact-hsp-md:  1rem;
+  --vitereact-hsp-lg:  1.5rem;
+  --vitereact-hsp-xl:  2rem;
+
+  /* Prose type scale */
+  --vitereact-text-h2:    1.75rem;
+  --vitereact-text-h3:    1.35rem;
+  --vitereact-text-h4:    1.1rem;
+  --vitereact-text-body:  1rem;
+  --vitereact-text-small: 0.875rem;
+  --vitereact-text-micro: 0.75rem;
+
+  /* Prose line-heights */
+  --vitereact-leading-tight:   1.2;
+  --vitereact-leading-snug:    1.45;
+  --vitereact-leading-relaxed: 1.75;
+
+  /* Prose code surface */
+  --vitereact-code-bg:   hsl(220 13% 11%);
+  --vitereact-code-fg:   hsl(220 14% 86%);
+  --vitereact-font-mono: ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, monospace;
 }
 
 body {
@@ -142,4 +176,149 @@ body {
   font-variant-numeric: tabular-nums;
   color: var(--vitereact-color-accent);
   font-weight: 700;
+}
+
+/* ---------------------------------------------------------------------------
+ * Prose container — flow-space rhythm
+ * Strategy 1 from prose-heading-spacing.mdx: single margin-block-start
+ * direction, overridden per element via --flow-space custom property.
+ * :where() keeps specificity at zero so later rules or inline styles win
+ * without escalation.
+ * --------------------------------------------------------------------------- */
+.vitereact-prose {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: var(--vitereact-vsp-2xl) var(--vitereact-hsp-xl);
+  font-size: var(--vitereact-text-body);
+  line-height: var(--vitereact-leading-relaxed);
+  color: var(--vitereact-fg);
+}
+
+/* Default flow gap for all block children */
+.vitereact-prose > * + * {
+  margin-block-start: var(--flow-space, var(--vitereact-vsp-md));
+}
+
+/* Section separation before headings */
+.vitereact-prose :where(h2) { --flow-space: var(--vitereact-vsp-xl); }
+.vitereact-prose :where(h3) { --flow-space: var(--vitereact-vsp-lg); }
+.vitereact-prose :where(h4) { --flow-space: var(--vitereact-vsp-md); }
+
+/* Heading-to-first-content: tight coupling */
+.vitereact-prose :where(h2, h3, h4) + :where(p, ul, ol, table, pre, blockquote) {
+  --flow-space: var(--vitereact-vsp-sm);
+}
+
+/* Consecutive headings: tighten */
+.vitereact-prose :where(h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6) {
+  --flow-space: var(--vitereact-vsp-2xs);
+}
+
+/* Trim edges */
+.vitereact-prose > :first-child { margin-block-start: 0; }
+.vitereact-prose > :last-child  { margin-block-end: 0; }
+
+/* Type scale */
+.vitereact-prose h2 {
+  font-size: var(--vitereact-text-h2);
+  line-height: var(--vitereact-leading-tight);
+  font-weight: 700;
+  color: var(--vitereact-color-primary);
+}
+.vitereact-prose h3 {
+  font-size: var(--vitereact-text-h3);
+  line-height: var(--vitereact-leading-tight);
+  font-weight: 600;
+  color: var(--vitereact-color-primary);
+}
+.vitereact-prose h4 {
+  font-size: var(--vitereact-text-h4);
+  line-height: var(--vitereact-leading-snug);
+  font-weight: 600;
+}
+
+/* Inline code */
+.vitereact-prose :where(code):not(pre code) {
+  font-family: var(--vitereact-font-mono);
+  font-size: var(--vitereact-text-small);
+  background: var(--vitereact-code-bg);
+  color: var(--vitereact-code-fg);
+  padding: 0.1em var(--vitereact-hsp-xs);
+  border-radius: 3px;
+  border: 1px solid var(--vitereact-color-accent);
+}
+
+/* Code blocks */
+.vitereact-prose pre {
+  font-family: var(--vitereact-font-mono);
+  font-size: var(--vitereact-text-small);
+  background: var(--vitereact-code-bg);
+  color: var(--vitereact-code-fg);
+  padding: var(--vitereact-vsp-sm) var(--vitereact-hsp-sm);
+  border-radius: var(--vitereact-radius, 0.5rem);
+  overflow-x: auto;
+}
+.vitereact-prose pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+}
+
+/* Blockquote */
+.vitereact-prose blockquote {
+  border-left: 4px solid var(--vitereact-color-muted);
+  padding-left: var(--vitereact-hsp-md);
+  color: var(--vitereact-color-muted);
+  font-style: italic;
+}
+
+/* Horizontal rule */
+.vitereact-prose hr {
+  border: none;
+  border-top: 1px solid var(--vitereact-color-muted);
+  margin-block: var(--vitereact-vsp-lg);
+}
+
+/* Lists */
+.vitereact-prose ul,
+.vitereact-prose ol {
+  padding-inline-start: var(--vitereact-hsp-lg);
+}
+.vitereact-prose li + li {
+  margin-block-start: var(--vitereact-vsp-xs);
+}
+
+/* Links */
+.vitereact-prose a {
+  color: var(--vitereact-color-accent);
+  text-decoration: underline;
+}
+
+/* Tables */
+.vitereact-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--vitereact-text-small);
+}
+.vitereact-prose th,
+.vitereact-prose td {
+  border: 1px solid var(--vitereact-color-muted);
+  padding: var(--vitereact-hsp-xs) var(--vitereact-hsp-sm);
+  text-align: left;
+}
+.vitereact-prose th {
+  background: var(--vitereact-color-surface);
+  font-weight: 600;
+}
+
+/* Back-nav link at top of prose page */
+.vitereact-prose-nav {
+  margin-block-end: var(--vitereact-vsp-xl);
+}
+.vitereact-prose-nav a {
+  color: var(--vitereact-color-accent);
+  text-decoration: underline;
+  font-size: var(--vitereact-text-small);
 }

--- a/examples/vite-react/tsconfig.json
+++ b/examples/vite-react/tsconfig.json
@@ -18,7 +18,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "types": ["vite/client", "node"]
+    "types": ["vite/client", "node", "mdx"]
   },
   "include": ["src", "vite.config.ts", "playwright.config.ts", "tests"],
   "exclude": ["dist", "node_modules"]

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import mdx from '@mdx-js/rollup';
 
 /**
  * Vite + React example for @takazudo/zudo-design-token-panel.
@@ -36,7 +37,22 @@ import react from '@vitejs/plugin-react';
  */
 export default defineConfig({
   base: '/pj/zudo-design-token-panel/examples/vite-react/',
-  plugins: [react()],
+  plugins: [
+    // mdx must come before react() — it transforms .mdx to JSX that react()
+    // then processes via the automatic JSX runtime.
+    { enforce: 'pre', ...mdx({ jsxImportSource: 'react', providerImportSource: '@mdx-js/react' }) },
+    react(),
+  ],
+  build: {
+    rollupOptions: {
+      // Multi-page: emit dist/index.html and dist/prose.html as self-contained
+      // HTML entries so both pages work as static deploys.
+      input: {
+        main: 'index.html',
+        prose: 'prose.html',
+      },
+    },
+  },
   server: {
     port: 44325,
     proxy: {

--- a/examples/zfb-tailwind/.gitignore
+++ b/examples/zfb-tailwind/.gitignore
@@ -1,0 +1,5 @@
+# zfb build output
+dist/
+.zfb/
+.zfb-build/
+node_modules/

--- a/examples/zfb-tailwind/README.md
+++ b/examples/zfb-tailwind/README.md
@@ -1,0 +1,164 @@
+# zfb + Tailwind v4 example — @takazudo/zudo-design-token-panel
+
+Demonstrates `@takazudo/zudo-design-token-panel` inside a [zfb (zudo-front-builder)](https://github.com/Takazudo/zudo-front-builder) project with **Tailwind v4 enabled** via `tailwind: { enabled: true }`. Design tokens are registered via Tailwind v4's `@theme` block so utility classes like `bg-primary`, `p-vsp-md`, and `text-h2` resolve back to the panel's `--zfbtailwindexample-*` CSS custom properties.
+
+The workspace ships two pages:
+- **Showcase** (`/`) — Cards, buttons, palette swatches, and typography scale, all styled with Tailwind utilities.
+- **Prose** (`/prose`) — A full markdown document exercising all prose token categories (vertical/horizontal spacing, type scale, code surface) via the `.zfbtailwindexample-prose` container and the flow-space CSS pattern.
+
+## Prerequisites
+
+zfb is a Rust-based build tool. Install it before running this example:
+
+```sh
+cargo install --git https://github.com/Takazudo/zudo-front-builder zfb
+```
+
+Or, if you have a local checkout:
+
+```sh
+# From the zudo-front-builder repo root
+cargo install --path crates/zfb
+```
+
+Verify the install:
+
+```sh
+zfb --version
+```
+
+## Development
+
+```sh
+pnpm --filter zfb-tailwind-example dev
+```
+
+This starts two processes in parallel via `concurrently`:
+
+- `zfb dev` — the zfb dev server at `http://localhost:44328`
+- `design-token-panel-server` — the bin sidecar at port `24686`
+
+The panel is accessible from the browser console:
+
+```js
+window.zfbTailwindExample.toggleDesignPanel()
+```
+
+## Build
+
+```sh
+pnpm --filter zfb-tailwind-example build
+```
+
+Output lands in `examples/zfb-tailwind/dist/`. All asset URLs begin with `/pj/zudo-design-token-panel/examples/zfb-tailwind/` (the configured `base`).
+
+## Preview (after build)
+
+```sh
+pnpm --filter zfb-tailwind-example preview
+```
+
+## Typecheck
+
+```sh
+pnpm --filter zfb-tailwind-example typecheck
+```
+
+---
+
+## Island choice
+
+zfb's `<Island>` component marks a `"use client"` subtree for browser-side hydration. `pages/index.tsx` wraps `<PanelMount>` in `<Island when="visible" ssrFallback={null}>`:
+
+```tsx
+<Island when="visible" ssrFallback={null}>
+  <PanelMount />
+</Island>
+```
+
+`PanelMount` (`components/panel-mount.tsx`) returns `null` — it only runs a `useEffect` to bootstrap the panel adapter.
+
+**Why `ssrFallback={null}` (the zfb `client:only` equivalent)?**
+
+zfb's default `<Island>` SSR-renders the child and then hydrates it on the client. `PanelMount` uses `useEffect` from `preact/hooks`, which during SSR would fail with a Preact internal hooks error (`__H` undefined) because zfb's SSR renderer and the project's `preact` package are different instances — the Preact hooks options are only wired up in the SSR renderer's instance. Passing `ssrFallback` (even `null`) switches the island to skip-SSR mode, preventing the hooks from running during the server-side render pass. The component is then mounted client-side by the hydration runtime.
+
+The `when="visible"` strategy defers hydration until the element is in the viewport. Because `<PanelMount>` sits at the end of `<body>`, the IntersectionObserver fires shortly after first paint — effectively an idle-ish load strategy that does not block the critical-path chunk.
+
+---
+
+## Dev-middleware plugin pattern
+
+Unlike the other three examples (astro, vite-react, next) — which proxy `/api/dev/apply` through Vite's built-in `server.proxy` mechanism — zfb exposes the `devMiddleware` plugin hook instead.
+
+The plugin at `plugins/dev-apply-proxy.mjs` registers a handler via `ctx.register(path, handler)` and forwards the POST body to the bin sidecar at `http://127.0.0.1:24686/apply`:
+
+```js
+// plugins/dev-apply-proxy.mjs
+ctx.register(APPLY_ROUTE, async (req) => {
+  const upstream = await fetch("http://127.0.0.1:24686/apply", {
+    method: "POST",
+    body: req.body,
+  });
+  // ...
+});
+```
+
+The plugin is listed in `zfb.config.ts`:
+
+```ts
+plugins: [{ name: "./plugins/dev-apply-proxy.mjs" }]
+```
+
+---
+
+## Apply-endpoint difference vs. the other three examples
+
+**This is the most important difference to understand before modifying this demo.**
+
+The astro, vite-react, and next examples all set `applyEndpoint` to the bare relative path `/api/dev/apply`. Their respective proxy mechanisms intercept this path **without a base prefix** — Vite's `server.proxy` and Next's API route both operate at the root.
+
+**The zfb-tailwind example uses the FULL base-prefixed URL:**
+
+```ts
+// config/panel-config.ts
+applyEndpoint: '/pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply',
+```
+
+Per zfb issue [#229](https://github.com/Takazudo/zudo-front-builder/issues/229) (fix commit `b1049ef`), zfb's dev server mounts `devMiddleware`-registered paths **under the project `base`**. A bare `/api/dev/apply` is never reached by the handler. The panel's POST must use the full prefixed path.
+
+The plugin handler (`plugins/dev-apply-proxy.mjs`) registers at this same full path:
+
+```js
+const APPLY_ROUTE = "/pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply";
+ctx.register(APPLY_ROUTE, async (req) => { /* ... */ });
+```
+
+Do **not** try to "normalize" the `applyEndpoint` to a bare path — it will break the dev apply pipeline. This is a configuration requirement for this project, not a bug in zfb.
+
+For full context, see [examples/zfb/PROBE-REPORT.md](../zfb/PROBE-REPORT.md) and [zfb #229](https://github.com/Takazudo/zudo-front-builder/issues/229).
+
+---
+
+## Local-only build path (CI fallback)
+
+If CI cargo-install proves flaky (see Sub #36's note), the fallback is a local build:
+
+1. Build zfb locally from the repo:
+   ```sh
+   # From the zudo-front-builder repo root
+   cargo install --path crates/zfb
+   ```
+
+2. Build this example:
+   ```sh
+   pnpm --filter zfb-tailwind-example build
+   ```
+
+3. Deploy manually via wrangler:
+   ```sh
+   wrangler pages deploy examples/zfb-tailwind/dist \
+     --project-name zudo-design-token-panel \
+     --branch main
+   ```
+
+The CI pipeline (Sub #36) handles this automatically when the environment is configured correctly.

--- a/examples/zfb-tailwind/components/panel-mount.tsx
+++ b/examples/zfb-tailwind/components/panel-mount.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * PanelMount — the `"use client"` island that bootstraps the design-token
+ * panel adapter inside the zfb hydration pipeline.
+ *
+ * zfb renders pages as server components by default. This file marks the
+ * boundary between server-rendered HTML and the Preact island that runs in
+ * the browser. Wrapping this component in `<Island when="visible">` in
+ * `pages/index.tsx` defers hydration until the element scrolls into view,
+ * keeping the panel adapter out of the initial critical-path JS chunk.
+ *
+ * Panel adapter bootstrap
+ * -----------------------
+ * The responsibilities mirror the Vite + React example's `src/lib/mount-panel.ts`:
+ *
+ *   1. `configurePanel(panelConfig)` — supplies the host's config object to
+ *      the panel package's singleton BEFORE any other panel API runs. Called
+ *      once per storagePrefix, gated by the `bound` flag on
+ *      `window.__zudoDesignTokenPanelAdapter`.
+ *   2. Console API on `window[cfg.consoleNamespace]` — exposes
+ *      `showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel`.
+ *   3. Lazy-load gate — eagerly load the panel module when the user had it
+ *      open last session (`wasVisible()`) OR has persisted token overrides
+ *      (`hasPersistedOverrides()`). Either signal means the panel must boot
+ *      before first paint to avoid an FOUT.
+ *   4. `reapplyPersistedOverrides()` — called immediately after
+ *      `configurePanel` so persisted overrides land before the first paint.
+ *
+ * Storage-key formatters
+ * ----------------------
+ * `storageKey_visible` and `storageKey_stateV2` are replicated here
+ * (rather than imported from the package) because they live in an internal
+ * module not on the public surface. The formatters are trivial 1-line string
+ * concatenations. The canonical definitions in the package source MUST match:
+ *
+ *   storageKey_visible(cfg) -> `${cfg.storagePrefix}:visible`   (literal `:`)
+ *   storageKey_stateV2(cfg) -> `${cfg.storagePrefix}-state-v2`  (literal `-`)
+ *
+ * Note the asymmetry: the visible-key uses `:` while every other derived key
+ * uses `-`. It is a historical artifact preserved for storage-key continuity —
+ * see the comment on `storageKey_visible` in the package.
+ *
+ * Returns `null` — the panel adapter appends its own DOM root outside the
+ * Preact tree; this component owns no DOM of its own.
+ */
+
+import { useEffect } from 'preact/hooks';
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+import { panelConfig } from '../config/panel-config';
+
+// Mirrors the panel module's main entry shape we lazy-import below.
+type DesignTokenPanelModule = typeof import('@takazudo/zudo-design-token-panel');
+
+interface DesignTokenPanelAdapterState {
+  /** Per-`storagePrefix` bind flag — re-runs are no-ops. */
+  bound: boolean;
+  /** Memoised module promise so steady-state toggle/show/hide share one load. */
+  modulePromise: Promise<DesignTokenPanelModule> | null;
+}
+
+interface ConsoleApiSurface {
+  showDesignPanel?: () => Promise<void>;
+  hideDesignPanel?: () => Promise<void>;
+  toggleDesignPanel?: () => Promise<void>;
+  [extra: string]: unknown;
+}
+
+type AdapterStateMap = Record<string, DesignTokenPanelAdapterState>;
+
+interface AdapterWindow extends Window {
+  __zudoDesignTokenPanelAdapter?: AdapterStateMap;
+  [namespace: string]: unknown;
+}
+
+function storageKey_visible(cfg: PanelConfig): string {
+  // Mirrors packages/zudo-design-token-panel/src/config/panel-config.ts —
+  // the literal `:` separator (NOT `-`) is intentional and historical.
+  return `${cfg.storagePrefix}:visible`;
+}
+
+function storageKey_stateV2(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-state-v2`;
+}
+
+function getAdapterStateMap(win: AdapterWindow): AdapterStateMap {
+  if (!win.__zudoDesignTokenPanelAdapter) {
+    win.__zudoDesignTokenPanelAdapter = {};
+  }
+  return win.__zudoDesignTokenPanelAdapter;
+}
+
+function getAdapterState(win: AdapterWindow, key: string): DesignTokenPanelAdapterState {
+  const map = getAdapterStateMap(win);
+  let state = map[key];
+  if (!state) {
+    state = { bound: false, modulePromise: null };
+    map[key] = state;
+  }
+  return state;
+}
+
+function wasVisible(visibleKey: string): boolean {
+  try {
+    return window.localStorage.getItem(visibleKey) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function hasPersistedOverrides(stateV2Key: string): boolean {
+  try {
+    return window.localStorage.getItem(stateV2Key) !== null;
+  } catch {
+    return false;
+  }
+}
+
+async function loadPanelModule(state: DesignTokenPanelAdapterState) {
+  if (state.modulePromise === null) {
+    state.modulePromise = import('@takazudo/zudo-design-token-panel').then((mod) => {
+      // Configure FIRST — every other panel API reads getPanelConfig() and
+      // must observe the host's intended values, not the package sentinel.
+      mod.configurePanel(panelConfig);
+      try {
+        mod.reapplyPersistedOverrides();
+      } catch (err) {
+        // Defensive: never let a bad persist-state read kill the panel surface.
+        console.warn(
+          '[design-token-panel] reapplyPersistedOverrides() threw: ' + (err as Error).message,
+        );
+      }
+      return mod;
+    });
+  }
+  return state.modulePromise;
+}
+
+function installConsoleApi(
+  win: AdapterWindow,
+  namespace: string,
+  state: DesignTokenPanelAdapterState,
+): void {
+  const existing = (win[namespace] as ConsoleApiSurface | undefined) ?? {};
+  existing.showDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.showDesignTokenPanel();
+  };
+  existing.hideDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.hideDesignTokenPanel();
+  };
+  existing.toggleDesignPanel = async () => {
+    const panel = await loadPanelModule(state);
+    panel.toggleDesignPanel();
+  };
+  win[namespace] = existing;
+}
+
+function mountPanel(): void {
+  if (typeof window === 'undefined') return;
+
+  const cfg = panelConfig;
+  const win = window as unknown as AdapterWindow;
+  const state = getAdapterState(win, cfg.storagePrefix);
+
+  // Install console API every time — `bound` only gates the lazy-load
+  // probes, since the console handlers are idempotent.
+  installConsoleApi(win, cfg.consoleNamespace, state);
+
+  if (state.bound) return;
+  state.bound = true;
+
+  const visibleKey = storageKey_visible(cfg);
+  const stateV2Key = storageKey_stateV2(cfg);
+  if (wasVisible(visibleKey) || hasPersistedOverrides(stateV2Key)) {
+    void loadPanelModule(state);
+  }
+}
+
+export default function PanelMount() {
+  useEffect(() => {
+    mountPanel();
+    // No cleanup: the panel adapter installs window-level state that lives
+    // for the page lifetime. A teardown on unmount would be wrong.
+  }, []);
+  return null;
+}

--- a/examples/zfb-tailwind/config/default-cluster.ts
+++ b/examples/zfb-tailwind/config/default-cluster.ts
@@ -1,0 +1,78 @@
+/**
+ * Demo color cluster for the zfb-tailwind example.
+ *
+ * The cluster's CSS-var family is `--zfbtailwindexample-*` (palette + base
+ * roles + semantic names), declared on `:root` by `styles/tokens.css`. Tweaks
+ * in the panel write through these names; the apply pipeline (when wired
+ * through the bin sidecar) rewrites the same names on disk.
+ *
+ * `paletteCssVarTemplate` is the only knob that decides the per-slot var name.
+ * The cluster is JSON-serializable end-to-end so it round-trips through the
+ * Preact island JSON boundary.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+
+type ColorClusterDataConfig = PanelConfig['colorCluster'];
+
+export const defaultCluster: ColorClusterDataConfig = {
+  id: 'zfbtailwindexample-cluster',
+  label: 'zfb Tailwind Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--zfbtailwindexample-bg',
+    foreground: '--zfbtailwindexample-fg',
+  },
+  paletteCssVarTemplate: '--zfbtailwindexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--zfbtailwindexample-color-primary',
+    accent: '--zfbtailwindexample-color-accent',
+    surface: '--zfbtailwindexample-color-surface',
+    muted: '--zfbtailwindexample-color-muted',
+    danger: '--zfbtailwindexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};

--- a/examples/zfb-tailwind/config/default-manifest.ts
+++ b/examples/zfb-tailwind/config/default-manifest.ts
@@ -1,0 +1,85 @@
+/**
+ * Demo token manifest for the zfb example.
+ *
+ * Every `cssVar` is a `--zfbtailwindexample-*` name. These line up byte-for-byte
+ * with the declarations in `styles/tokens.css` so the panel can rewrite
+ * the same names live and the apply pipeline can rewrite them on disk.
+ *
+ * `TokenManifest` is reachable via the indexed-access lookup
+ * `PanelConfig['tokens']` — the package's `/astro` entry re-exports
+ * `PanelConfig`, so this avoids a deep import into `dist/tokens/manifest`.
+ *
+ * `spacingGroupOrder` is set to `['vsp', 'hsp']` (vertical above horizontal),
+ * proving the host-supplied ordering field overrides the package default.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+
+type TokenManifest = PanelConfig['tokens'];
+
+export const defaultManifest: TokenManifest = {
+  spacing: [
+    {
+      id: 'zfbtailwindexample-spacing-md',
+      cssVar: '--zfbtailwindexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'zfbtailwindexample-spacing-lg',
+      cssVar: '--zfbtailwindexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'zfbtailwindexample-text-base',
+      cssVar: '--zfbtailwindexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'zfbtailwindexample-text-heading',
+      cssVar: '--zfbtailwindexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'zfbtailwindexample-radius',
+      cssVar: '--zfbtailwindexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  // Color tab is driven by the cluster — leave per-token rows empty.
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};

--- a/examples/zfb-tailwind/config/panel-config.ts
+++ b/examples/zfb-tailwind/config/panel-config.ts
@@ -1,0 +1,66 @@
+/**
+ * Assembles the `PanelConfig` consumed by the zfb-tailwind example.
+ *
+ * The five identifier fields (`storagePrefix`, `consoleNamespace`,
+ * `modalClassPrefix`, `schemaId`, `exportFilenameBase`) all share a
+ * `zfb-tailwind-example*` namespace so localStorage entries, exported JSON, and
+ * modal classnames cannot collide with any other host's panel deployment.
+ *
+ * `applyEndpoint` — CRITICAL DIFFERENCE vs. astro / vite-react / next
+ * -----------------------------------------------------------------------
+ * The other three examples set `applyEndpoint` to the bare relative path
+ * `/api/dev/apply`, which their respective proxy mechanisms (Vite's
+ * `server.proxy`, Next's API route) intercept WITHOUT a base prefix.
+ *
+ * zfb's `devMiddleware` hook, per issue #229 (fix commit `b1049ef`), mounts
+ * registered paths under the project `base`. A bare `/api/dev/apply` is
+ * never reached by the zfb dev server; only the FULL base-prefixed URL:
+ *
+ *   /pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply
+ *
+ * is routed to the `dev-apply-proxy` plugin. The panel's POST must therefore
+ * use this full path. See `zfb.config.ts`, `plugins/dev-apply-proxy.mjs`,
+ * and README.md for the full rationale.
+ *
+ * This is a configuration requirement for this project, NOT a zfb bug.
+ *
+ * `applyRouting` shares the SAME JSON file the bin sidecar reads at startup
+ * (`scaffold.routing.json`). The host UI and the apply server therefore
+ * agree byte-for-byte on which CSS-var prefix maps to which file.
+ */
+
+import type { PanelConfig } from '@takazudo/zudo-design-token-panel/astro';
+import { defaultManifest } from './default-manifest';
+import { defaultCluster } from './default-cluster';
+
+// Inlined from scaffold.routing.json — mirrors the same routing object the
+// bin sidecar reads at startup. Kept in sync byte-for-byte with
+// `scaffold.routing.json` so the host UI and the apply server agree on
+// which CSS-var prefix maps to which file.
+//
+// Note: not imported as JSON because zfb's esbuild bundler pass currently
+// resolves relative JSON imports from the temp entry dir, not the source
+// file's directory. Inlining avoids the resolution issue without losing
+// the semantic link to the routing contract.
+const scaffoldRouting: Record<string, string> = {
+  zfbtailwindexample: 'styles/tokens.css',
+};
+
+export const panelConfig: PanelConfig = {
+  storagePrefix: 'zfb-tailwind-example-tokens',
+  consoleNamespace: 'zfbTailwindExample',
+  modalClassPrefix: 'zfb-tailwind-example-design-token-panel-modal',
+  schemaId: 'zfb-tailwind-example-design-tokens/v1',
+  exportFilenameBase: 'zfb-tailwind-example-design-tokens',
+  tokens: defaultManifest,
+  colorCluster: defaultCluster,
+  // Full base-prefixed URL — NOT the bare `/api/dev/apply` the other examples
+  // use. Required because zfb's devMiddleware mounts handlers under `base`.
+  // See the block comment above and README.md for the full rationale.
+  applyEndpoint: '/pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply',
+  applyRouting: scaffoldRouting,
+  // Explicit opt-out for the secondary color cluster — the demo ships a
+  // single primary palette only. `null` (NOT `undefined`) is the documented
+  // signal that the host has no secondary cluster.
+  secondaryColorCluster: null,
+};

--- a/examples/zfb-tailwind/content/prose/index.md
+++ b/examples/zfb-tailwind/content/prose/index.md
@@ -1,0 +1,177 @@
+---
+title: Prose Demo
+---
+
+This page demonstrates the full range of markdown-generated HTML elements
+styled through the `--zfbtailwindexample-*` token namespace.
+Each section exercises a distinct element type so you can verify spacing,
+typography, and colour tokens at a glance.
+
+---
+
+## Headings
+
+Use the hierarchy below to check that vertical spacing and type-scale tokens
+produce clear section boundaries without excessive gaps.
+
+### Second-level sub-section
+
+The h3 heading above should sit closer to the h2 above it than to the
+content that follows — the heading visually "belongs" to the content below.
+
+#### Third-level detail heading
+
+The h4 above is the smallest heading level in the prose demo. It shares
+`leading-tight` line-height with h2 and h3 but uses a smaller `text-h4`
+font size.
+
+---
+
+## Text Formatting
+
+Prose pages rely on inline formatting to convey emphasis and editorial
+meaning without extra structure.
+
+A sentence can contain **bold text** to stress an important term, _italic
+text_ to indicate titles or introduce vocabulary, and ~~strikethrough text~~
+to mark deprecated or removed content.
+Combinations are valid: **_bold italic_** or ~~**bold strikethrough**~~.
+The styles should not break line-height or disrupt the baseline rhythm.
+
+---
+
+## Inline Code
+
+Inline code appears inside sentences to name identifiers, file paths, or
+short expressions.
+
+Pass the `--flow-space` custom property on an element to override the
+container's default vertical gap for that element only.
+The file lives at `src/styles/prose.css` and is imported by the page layout.
+
+---
+
+## Code Blocks
+
+Fenced code blocks render inside `<pre><code>` elements. The demo requires
+no syntax highlighting; raw colouring from `code-bg` and `code-fg` tokens
+is sufficient.
+
+```typescript
+// Wiring the prose token namespace for the zfbtailwindexample demo
+const proseTokens = {
+  vspMd:          `var(--zfbtailwindexample-vsp-md)`,
+  textBody:       `var(--zfbtailwindexample-text-body)`,
+  leadingRelaxed: `var(--zfbtailwindexample-leading-relaxed)`,
+  codeBg:         `var(--zfbtailwindexample-code-bg)`,
+  codeFg:         `var(--zfbtailwindexample-code-fg)`,
+  fontMono:       `var(--zfbtailwindexample-font-mono)`,
+} as const;
+
+export default proseTokens;
+```
+
+The block above should display with consistent horizontal padding derived
+from `hsp-sm`, a background from `code-bg`, and text coloured by `code-fg`.
+
+---
+
+## Unordered List
+
+Lists check that `vsp-xs` (item-to-item) and `vsp-md` (list-to-surrounding
+content) tokens produce balanced rhythm.
+
+- Token categories in the prose namespace
+  - Vertical spacing: `vsp-2xs` through `vsp-2xl`
+  - Horizontal spacing: `hsp-xs` through `hsp-xl`
+  - Type scale: `text-h2` through `text-micro`
+- Line-height tokens
+  - `leading-tight` — headings
+  - `leading-snug` — sub-headings and list items
+  - `leading-relaxed` — body paragraphs
+- Code surface tokens
+  - `code-bg`, `code-fg`, `font-mono`
+
+---
+
+## Ordered List
+
+Ordered lists share spacing tokens with unordered lists; the marker style
+differs but the rhythm should be identical.
+
+1. Define the token set in `--zfbtailwindexample-*` namespace.
+2. Wire the flow utility into the prose container:
+   1. Apply `margin-block-start: var(--flow-space, ...)` to all children.
+   2. Set per-element `--flow-space` overrides using `:where()` selectors.
+   3. Tighten consecutive headings with a heading + heading adjacent rule.
+3. Map the type-scale and line-height tokens to each heading and paragraph.
+4. Apply code-surface tokens to `<pre>` and inline `<code>` elements.
+
+---
+
+## Blockquote
+
+A blockquote uses a left border coloured by `--color-accent` or
+`--color-muted`, with horizontal padding from `hsp-md`.
+
+> The flow utility assigns spacing to one margin direction only.
+> This makes spacing predictable in block flow, flex, and grid containers
+> without relying on margin collapse.
+
+A multi-paragraph blockquote checks that internal spacing between paragraphs
+is governed by the same `--flow-space` mechanism rather than ad-hoc margins.
+
+> First paragraph of a multi-paragraph quote.
+> It introduces the main idea and ends here.
+>
+> Second paragraph continues the thought.
+> Both paragraphs should have consistent internal rhythm.
+
+---
+
+## Tables
+
+A comparison table exercises `text-small`, `hsp-sm` cell padding, and border
+tokens.
+
+| Demo | Framework | MDX component overrides |
+|---|---|---|
+| astro | Astro + Preact | Yes — `components` prop on `<Content />` |
+| next | Next.js App Router | Yes — `useMDXComponents` / `MDXRemote` |
+| vite | Vite + React | Optional — depends on `remark`/`rehype` setup |
+| zfb | Zudo Framework Base | Container CSS with `:where()` selectors |
+| zfb-tailwind | Zudo Framework Base + Tailwind | Container CSS inside `@layer components` |
+
+---
+
+## Horizontal Rule
+
+A `<hr>` element marks a thematic break. It should have visible contrast
+against the page background and carry top and bottom spacing derived from
+`vsp-lg`.
+
+---
+
+## Links
+
+Links check `--color-accent` and underline treatment.
+
+Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
+to browse the source for all demo pages.
+Return to [/pj/zudo-design-token-panel/examples/zfb-tailwind/](/pj/zudo-design-token-panel/examples/zfb-tailwind/) to see the component gallery.
+
+---
+
+## Token reference
+
+The visual appearance of this page is driven entirely by the
+`--zfbtailwindexample-*` token namespace.
+Vertical rhythm comes from `vsp-2xs` through `vsp-2xl`.
+Horizontal padding and indent come from `hsp-xs` through `hsp-xl`.
+Type sizes are set by `text-h2`, `text-h3`, `text-h4`, `text-body`,
+`text-small`, and `text-micro`.
+Line-heights use `leading-tight`, `leading-snug`, and `leading-relaxed`.
+Code blocks are styled with `code-bg`, `code-fg`, and `font-mono`.
+Heading borders and blockquote accents reuse the shared `--zfbtailwindexample-color-fg`,
+`--color-muted`, and `--color-accent` tokens — no additional colour tokens
+are required.

--- a/examples/zfb-tailwind/package.json
+++ b/examples/zfb-tailwind/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "zfb-tailwind-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "zfb (zudo-front-builder) + Tailwind v4 example demonstrating @takazudo/zudo-design-token-panel — tokens registered via @theme block into Tailwind v4's design-system namespaces, showcase and prose pages styled with utility classes.",
+  "scripts": {
+    "dev": "lsof -ti:44328 | xargs kill -9 2>/dev/null || true; lsof -ti:24686 | xargs kill -9 2>/dev/null || true; concurrently -k -n zfb,tokens-bin -c blue,green \"pnpm run _dev:zfb\" \"pnpm run _dev:tokens-bin\"",
+    "_dev:zfb": "zfb dev",
+    "_dev:tokens-bin": "design-token-panel-server --write-root . --routing scaffold.routing.json --port 24686 --allow-origin http://localhost:44328",
+    "build": "zfb build",
+    "preview": "zfb preview",
+    "typecheck": "zfb check"
+  },
+  "dependencies": {
+    "@takazudo/zfb": "link:../../../zfb/packages/zfb",
+    "@takazudo/zfb-runtime": "link:../../../zfb/packages/zfb-runtime",
+    "@takazudo/zudo-design-token-panel": "workspace:*",
+    "preact": "^10.29.1",
+    "preact-render-to-string": "^6.5.0",
+    "tailwindcss": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "concurrently": "^9.2.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -1,0 +1,181 @@
+/**
+ * Home page of the zfb-tailwind example. Renders cards / buttons / palette
+ * swatches driven entirely by `--zfbtailwindexample-*` tokens via Tailwind v4
+ * utility classes, so opening the panel and tweaking any token rewrites the
+ * page in real time.
+ *
+ * Tailwind utility strategy
+ * -------------------------
+ * All visual styling uses utility classes that resolve back to the
+ * --zfbtailwindexample-* tokens via the @theme block in styles/tokens.css:
+ *
+ *   bg-surface  → background-color: var(--color-surface)
+ *               → var(--zfbtailwindexample-color-surface)
+ *
+ *   p-spacing-md → padding: var(--spacing-spacing-md)
+ *                → var(--zfbtailwindexample-spacing-md)
+ *
+ *   rounded-md  → border-radius: var(--radius-md)
+ *               → var(--zfbtailwindexample-radius)
+ *
+ * Panel mount
+ * -----------
+ * `<PanelMount>` is a `"use client"` component that bootstraps the panel
+ * adapter from a `useEffect`. It returns `null` — the adapter appends its own
+ * DOM root outside the Preact tree.
+ *
+ * `ssrFallback={null}` switches the Island to skip-SSR mode (the zfb
+ * equivalent of Astro's `client:only`). This is required because `PanelMount`
+ * uses `preact/hooks`, and during SSR the hooks fail with a Preact
+ * `__H`-undefined error caused by a dual-preact-instance boundary between the
+ * project's `preact` and zfb's SSR renderer's preact. Passing any
+ * `ssrFallback` (even `null`) prevents the child from being evaluated at SSR
+ * time; the hydration runtime mounts it client-side when `when="visible"` fires.
+ *
+ * Apply-endpoint note
+ * -------------------
+ * `panelConfig.applyEndpoint` is set to the FULL base-prefixed URL (see
+ * `config/panel-config.ts`). This differs from the other three examples.
+ * See README.md for the rationale.
+ */
+
+import { Island, type IslandProps } from '@takazudo/zfb';
+import PanelMount from '../components/panel-mount';
+import '../styles/tokens.css';
+
+const PALETTE_INDICES = Array.from({ length: 16 }, (_, i) => i);
+
+export default function HomePage() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>zfb + Tailwind v4 Example — Design Token Panel</title>
+      </head>
+      <body class="p-spacing-lg">
+        <main class="flex flex-col gap-spacing-lg max-w-[56rem] mx-auto">
+          <header>
+            <h1 class="text-heading font-bold mb-spacing-md text-primary">
+              Live token tweaking, in zfb + Tailwind v4
+            </h1>
+            <p>
+              Every visible element on this page is driven by a{' '}
+              <code>--zfbtailwindexample-*</code> CSS custom property, consumed via
+              Tailwind v4 utility classes. Open the panel from the browser console
+              and drag any slider — the change applies before the next paint.
+            </p>
+            <p class="text-small text-muted mt-spacing-md">
+              Console API:{' '}
+              <code>window.zfbTailwindExample.toggleDesignPanel()</code>. Storage
+              prefix: <code>zfb-tailwind-example-tokens</code>.
+            </p>
+            <nav class="mt-spacing-md">
+              <a
+                href="/pj/zudo-design-token-panel/examples/zfb-tailwind/prose/"
+                class="text-accent underline"
+              >
+                View prose page
+              </a>
+            </nav>
+          </header>
+
+          <section>
+            <h2 class="text-heading font-bold mb-spacing-md text-primary">
+              Cards (spacing + radius + surface)
+            </h2>
+            <div class="flex flex-col gap-spacing-md">
+              <div class="bg-surface text-fg p-spacing-md rounded-md border border-muted">
+                <strong>Card A.</strong> Padding driven by{' '}
+                <code>p-spacing-md</code> (→ <code>--zfbtailwindexample-spacing-md</code>),
+                corners by <code>rounded-md</code> (→ <code>--zfbtailwindexample-radius</code>),
+                background by <code>bg-surface</code>.
+              </div>
+              <div class="bg-surface text-fg p-spacing-md rounded-md border border-muted">
+                <strong>Card B.</strong> Stack gap driven by{' '}
+                <code>gap-spacing-lg</code>; outline by{' '}
+                <code>border-muted</code>.
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 class="text-heading font-bold mb-spacing-md text-primary">
+              Buttons (accent / primary)
+            </h2>
+            <p>
+              <button
+                class="inline-block p-spacing-md rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary"
+                type="button"
+              >
+                Action button
+              </button>
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-heading font-bold mb-spacing-md text-primary">
+              Palette swatches
+            </h2>
+            <div class="flex flex-wrap gap-spacing-md">
+              {PALETTE_INDICES.map((i) => (
+                <div
+                  key={i}
+                  class="w-16 h-16 rounded-md flex items-end justify-center text-micro text-fg"
+                  style={`background: var(--zfbtailwindexample-palette-${i}); text-shadow: 0 1px 2px rgba(0,0,0,0.7); padding: 0.25rem;`}
+                >
+                  {i}
+                </div>
+              ))}
+            </div>
+            <p class="text-small text-muted mt-spacing-md">
+              Each swatch reads{' '}
+              <code>--zfbtailwindexample-palette-{'{n}'}</code>. The cluster's{' '}
+              <code>paletteCssVarTemplate</code> is the only thing that decides
+              this name — change it in <code>config/default-cluster.ts</code>{' '}
+              and the apply pipeline writes a different variable on the next
+              palette tweak.
+            </p>
+          </section>
+
+          <section>
+            <h2 class="text-heading font-bold mb-spacing-md text-primary">
+              Typography scale
+            </h2>
+            <div class="flex flex-col gap-vsp-sm bg-surface p-spacing-md rounded-md border border-muted">
+              <p class="text-h2 leading-tight font-bold text-fg">Heading H2 — text-h2</p>
+              <p class="text-h3 leading-tight font-semibold text-fg">Heading H3 — text-h3</p>
+              <p class="text-h4 leading-snug font-semibold text-fg">Heading H4 — text-h4</p>
+              <p class="text-body leading-relaxed text-fg">Body text — text-body leading-relaxed</p>
+              <p class="text-small text-muted">Small text — text-small text-muted</p>
+              <p class="text-micro text-muted">Micro text — text-micro text-muted</p>
+            </div>
+          </section>
+        </main>
+
+        {/*
+          PanelMount is the `"use client"` island that bootstraps the panel adapter.
+          Uses `ssrFallback={null}` (the zfb equivalent of Astro's `client:only`)
+          so the island's internals are NOT evaluated at SSR time. PanelMount
+          returns null and only runs a useEffect — it has no meaningful SSR output —
+          and the hooks it uses (preact/hooks) would fail during SSR due to the
+          dual-preact-instance boundary between the project's preact and the
+          zfb SSR renderer's preact. Skipping SSR is the correct solution.
+          `when="visible"` defers hydration until the element enters the viewport;
+          since the island is at the bottom of <body>, this fires shortly after
+          first paint.
+        */}
+        <Island when="visible" ssrFallback={null}>
+          {/*
+            Cast bridges a structural-vs-nominal type mismatch between Preact's
+            VNode (type: string | ComponentType<any>) and zfb's framework-agnostic
+            structural VNode (type: string | ((...args: unknown[]) => unknown)).
+            They are runtime-compatible — the Island only walks props.children at
+            hydration time and never invokes `type` itself in this position.
+          */}
+          {(<PanelMount />) as unknown as IslandProps['children']}
+        </Island>
+      </body>
+    </html>
+  );
+}

--- a/examples/zfb-tailwind/pages/prose.tsx
+++ b/examples/zfb-tailwind/pages/prose.tsx
@@ -1,0 +1,86 @@
+/**
+ * Prose page for the zfb-tailwind example. Renders the "prose" content
+ * collection entry inside a `.zfbtailwindexample-prose` container that
+ * applies the flow-space pattern and element styles defined in
+ * `styles/tokens.css`.
+ *
+ * Content collection wiring
+ * -------------------------
+ * `getCollection("prose")` reads from `content/prose/` (declared in
+ * `zfb.config.ts` as `collections: [{ name: "prose", path: "content/prose" }]`).
+ * The first entry is rendered via `entry.Content`. The `components` prop
+ * passes element overrides — we extend `defaultComponents` with a custom
+ * `h2` override that adds the heading separator style while keeping all
+ * other elements as passthroughs.
+ *
+ * Prose container strategy
+ * ------------------------
+ * Per `doc/.claude/prose-token-contract.md`:
+ * For zfb demos that do not use framework-level MDX component overrides,
+ * container-scoped CSS with `:where()` is acceptable. The `styles/tokens.css`
+ * file defines the `.zfbtailwindexample-prose` container rules inside
+ * `@layer components`, which keeps them correctly positioned below Tailwind
+ * utility classes in the cascade.
+ *
+ * Panel mount
+ * -----------
+ * Same `<Island when="visible" ssrFallback={null}>` pattern as index.tsx.
+ * The panel adapter is shared via the `panelConfig` import from
+ * `../config/panel-config`.
+ */
+
+import { Island, type IslandProps } from '@takazudo/zfb';
+import { getCollection } from '@takazudo/zfb/content';
+import PanelMount from '../components/panel-mount';
+import '../styles/tokens.css';
+
+const BASE_PATH = '/pj/zudo-design-token-panel/examples/zfb-tailwind/';
+
+export default function ProsePage() {
+  const entries = getCollection("prose");
+  const entry = entries[0];
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Prose Demo — zfb + Tailwind v4 — Design Token Panel</title>
+      </head>
+      <body class="p-spacing-lg">
+        <nav class="mb-vsp-lg">
+          <a href={BASE_PATH} class="text-accent underline text-small">
+            Back to showcase
+          </a>
+        </nav>
+
+        <main class="max-w-[48rem] mx-auto">
+          <h1 class="text-heading font-bold mb-vsp-xl text-primary leading-tight">
+            Prose Demo
+          </h1>
+          <p class="text-small text-muted mb-vsp-xl">
+            All typography and spacing tokens are from the{' '}
+            <code>--zfbtailwindexample-*</code> namespace.
+            Open the panel (<code>window.zfbTailwindExample.toggleDesignPanel()</code>){' '}
+            to tweak them live.
+          </p>
+
+          {entry ? (
+            <article class="zfbtailwindexample-prose">
+              <entry.Content />
+            </article>
+          ) : (
+            <p class="text-danger">
+              No prose content found. Expected a file at{' '}
+              <code>content/prose/index.md</code>.
+            </p>
+          )}
+        </main>
+
+        <Island when="visible" ssrFallback={null}>
+          {(<PanelMount />) as unknown as IslandProps['children']}
+        </Island>
+      </body>
+    </html>
+  );
+}

--- a/examples/zfb-tailwind/plugins/dev-apply-proxy.mjs
+++ b/examples/zfb-tailwind/plugins/dev-apply-proxy.mjs
@@ -1,0 +1,89 @@
+// zfb plugin: dev-apply-proxy
+//
+// Intercepts POST /pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply
+// (the full base-prefixed path — see `zfb.config.ts` and README.md for why
+// this differs from the bare `/api/dev/apply` the other three examples use)
+// and forwards the request body verbatim to the bin sidecar running on
+// http://127.0.0.1:24686/apply.
+//
+// Per zfb issue #229 (fixed in commit b1049ef), devMiddleware handlers are
+// mounted under the project `base`. Registration at the full prefixed path
+// is therefore required — a bare `/api/dev/apply` would never be reached.
+//
+// The plugin is dev-only. During `zfb build` the `devMiddleware` hook is
+// not invoked, so the production static output has no dependency on this
+// module or on the sidecar port.
+//
+// No npm dependencies: global `fetch` (available in Node 18+) is used to
+// forward the request. The response status and body are piped back verbatim
+// so the panel's apply-pipeline sees the same error codes the sidecar emits.
+
+const BIN_SIDECAR_APPLY_URL = "http://127.0.0.1:24686/apply";
+
+// Cap dev-mode apply requests so a stuck sidecar doesn't hang the panel UI
+// indefinitely. 15s comfortably covers a slow scaffold rewrite.
+const SIDECAR_TIMEOUT_MS = 15_000;
+
+// The base prefix as a string constant — must match `zfb.config.ts`'s `base`
+// field exactly (minus the trailing slash). Registered as a path prefix so
+// zfb routes only POST /pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply
+// through this handler.
+const APPLY_ROUTE = "/pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply";
+
+/** @type {import("@takazudo/zfb/plugins").ZfbPlugin} */
+export default {
+  name: "dev-apply-proxy",
+
+  devMiddleware(ctx) {
+    ctx.register(APPLY_ROUTE, async (req) => {
+      if (req.method !== "POST") {
+        // Only POST is valid for the apply endpoint; let other methods 405.
+        return {
+          status: 405,
+          headers: { "content-type": "text/plain" },
+          body: "Method Not Allowed",
+        };
+      }
+
+      let upstreamResponse;
+      try {
+        upstreamResponse = await fetch(BIN_SIDECAR_APPLY_URL, {
+          method: "POST",
+          headers: {
+            "content-type": req.headers["content-type"] ?? "application/json",
+          },
+          // `req.body` is the raw request body string forwarded by zfb's
+          // plugin host. Forward it verbatim — the bin sidecar expects JSON.
+          body: req.body ?? "",
+          signal: AbortSignal.timeout(SIDECAR_TIMEOUT_MS),
+        });
+      } catch (err) {
+        // Sidecar unreachable (not started yet, crashed, wrong port, …) or
+        // request exceeded SIDECAR_TIMEOUT_MS (TimeoutError from AbortSignal).
+        const isTimeout = err instanceof Error && err.name === "TimeoutError";
+        ctx.logger.error(
+          `[dev-apply-proxy] fetch to ${BIN_SIDECAR_APPLY_URL} ${
+            isTimeout ? `timed out after ${SIDECAR_TIMEOUT_MS}ms` : `failed: ${String(err)}`
+          }`,
+        );
+        return {
+          status: isTimeout ? 504 : 502,
+          headers: { "content-type": "text/plain" },
+          body: isTimeout
+            ? `Gateway Timeout: bin sidecar did not respond within ${SIDECAR_TIMEOUT_MS}ms`
+            : `Bad Gateway: bin sidecar unreachable at ${BIN_SIDECAR_APPLY_URL}`,
+        };
+      }
+
+      const responseBody = await upstreamResponse.text();
+      return {
+        status: upstreamResponse.status,
+        headers: {
+          "content-type":
+            upstreamResponse.headers.get("content-type") ?? "application/json",
+        },
+        body: responseBody,
+      };
+    });
+  },
+};

--- a/examples/zfb-tailwind/scaffold.routing.json
+++ b/examples/zfb-tailwind/scaffold.routing.json
@@ -1,0 +1,3 @@
+{
+  "zfbtailwindexample": "styles/tokens.css"
+}

--- a/examples/zfb-tailwind/styles/tokens.css
+++ b/examples/zfb-tailwind/styles/tokens.css
@@ -1,0 +1,421 @@
+/*
+ * `--zfbtailwindexample-*` tokens + Tailwind v4 theme registration.
+ *
+ * File roles
+ * ----------
+ * 1. Source of truth for the demo's CSS-var values. The panel rewrites these
+ *    names live (in-memory :root overrides) when the user tweaks a slider.
+ *    The Apply pipeline rewrites THIS FILE on disk (see scaffold.routing.json —
+ *    prefix `zfbtailwindexample` → this path).
+ *
+ * 2. Tailwind v4 @theme registration. The @theme block below maps each
+ *    --zfbtailwindexample-* raw var onto Tailwind's built-in design-system
+ *    namespaces so that utility classes like `bg-primary`, `p-vsp-md`, and
+ *    `text-h2` work end-to-end.
+ *
+ * Tailwind v4 namespace prefix rules (critical — easy to get wrong)
+ * ------------------------------------------------------------------
+ * Only vars declared under the EXACT namespace prefixes below generate
+ * utility classes. A var named --vsp-md generates NO utility; it must be
+ * --spacing-vsp-md to generate p-vsp-md / m-vsp-md / gap-vsp-md / etc.
+ *
+ *   --color-*       → bg-*, text-*, border-*, fill-*, stroke-*, …
+ *   --spacing-*     → p-*, m-*, gap-*, w-*, h-*, inset-*, …
+ *   --text-*        → text-* (font-size); pair --text-*--line-height for lh
+ *   --font-*        → font-* (font-family)
+ *   --leading-*     → leading-* (line-height)
+ *   --radius-*      → rounded-*
+ *
+ * Reference: Tailwind CSS v4 "Theme Variables" docs.
+ */
+
+/* ── Token declarations ──────────────────────────────────────────────────── */
+:root {
+  /* Spacing tokens (manifest: spacing tab) */
+  --zfbtailwindexample-spacing-md: 1rem;
+  --zfbtailwindexample-spacing-lg: 2rem;
+
+  /* Typography tokens (manifest: typography tab) */
+  --zfbtailwindexample-text-base: 1rem;
+  --zfbtailwindexample-text-heading: 1.75rem;
+
+  /* Size tokens (manifest: size tab) */
+  --zfbtailwindexample-radius: 0.5rem;
+
+  /* Cluster base roles */
+  --zfbtailwindexample-bg: #1e1e1e;
+  --zfbtailwindexample-fg: #f8fafc;
+
+  /* Cluster palette slots */
+  --zfbtailwindexample-palette-0: #1e1e1e;
+  --zfbtailwindexample-palette-1: #2d6cdf;
+  --zfbtailwindexample-palette-2: #3aa676;
+  --zfbtailwindexample-palette-3: #d97706;
+  --zfbtailwindexample-palette-4: #9b5de5;
+  --zfbtailwindexample-palette-5: #e63946;
+  --zfbtailwindexample-palette-6: #1d3557;
+  --zfbtailwindexample-palette-7: #06b6d4;
+  --zfbtailwindexample-palette-8: #475569;
+  --zfbtailwindexample-palette-9: #94a3b8;
+  --zfbtailwindexample-palette-10: #cbd5e1;
+  --zfbtailwindexample-palette-11: #e2e8f0;
+  --zfbtailwindexample-palette-12: #f1f5f9;
+  --zfbtailwindexample-palette-13: #fef3c7;
+  --zfbtailwindexample-palette-14: #bbf7d0;
+  --zfbtailwindexample-palette-15: #f8fafc;
+
+  /* Cluster semantic names */
+  --zfbtailwindexample-color-primary: var(--zfbtailwindexample-palette-1);
+  --zfbtailwindexample-color-accent: var(--zfbtailwindexample-palette-3);
+  --zfbtailwindexample-color-surface: var(--zfbtailwindexample-palette-0);
+  --zfbtailwindexample-color-muted: var(--zfbtailwindexample-palette-8);
+  --zfbtailwindexample-color-danger: var(--zfbtailwindexample-palette-5);
+
+  /* ── Prose tokens (contract: doc/.claude/prose-token-contract.md) ─── */
+
+  /* Vertical spacing scale — 1.6rem (≈25.6px) baseline rhythm unit */
+  --zfbtailwindexample-vsp-2xs: 0.25rem;   /* ~4 px  — consecutive headings */
+  --zfbtailwindexample-vsp-xs:  0.5rem;    /* ~8 px  — tight paragraph spacing */
+  --zfbtailwindexample-vsp-sm:  0.75rem;   /* ~12 px — heading-to-first-content */
+  --zfbtailwindexample-vsp-md:  1rem;      /* ~16 px — default flow gap */
+  --zfbtailwindexample-vsp-lg:  1.75rem;   /* ~28 px — pre-h3 section separation */
+  --zfbtailwindexample-vsp-xl:  2.5rem;    /* ~40 px — pre-h2 section separation */
+  --zfbtailwindexample-vsp-2xl: 3.5rem;    /* ~56 px — top-of-page clearance */
+
+  /* Horizontal spacing scale */
+  --zfbtailwindexample-hsp-xs:  0.25rem;   /* inline code padding, small insets */
+  --zfbtailwindexample-hsp-sm:  0.5rem;    /* table cell padding */
+  --zfbtailwindexample-hsp-md:  1rem;      /* blockquote left indent */
+  --zfbtailwindexample-hsp-lg:  1.5rem;    /* section-level horizontal gutter */
+  --zfbtailwindexample-hsp-xl:  2rem;      /* outer prose container horizontal padding */
+
+  /* Type scale */
+  --zfbtailwindexample-text-h2:    1.75rem;
+  --zfbtailwindexample-text-h3:    1.35rem;
+  --zfbtailwindexample-text-h4:    1.1rem;
+  --zfbtailwindexample-text-body:  1rem;
+  --zfbtailwindexample-text-small: 0.875rem;
+  --zfbtailwindexample-text-micro: 0.75rem;
+
+  /* Line-height tokens */
+  --zfbtailwindexample-leading-tight:   1.2;
+  --zfbtailwindexample-leading-snug:    1.45;
+  --zfbtailwindexample-leading-relaxed: 1.75;
+
+  /* Code surface tokens */
+  --zfbtailwindexample-code-bg:   hsl(220 13% 11%);
+  --zfbtailwindexample-code-fg:   hsl(220 14% 86%);
+  /* font-family string — wire directly to font-family, not a size/colour */
+  --zfbtailwindexample-font-mono: ui-monospace, "Cascadia Code", "Source Code Pro",
+                                  Menlo, Consolas, monospace;
+}
+
+/* ── Design token panel chrome ───────────────────────────────────────────── */
+/* Vite library mode strips the source CSS import from the emitted JS, so
+   consumers must re-pull it explicitly via this CSS import. */
+@import '@takazudo/zudo-design-token-panel/styles.css';
+
+/* ── Tailwind v4 ─────────────────────────────────────────────────────────── */
+@import "tailwindcss";
+
+/*
+ * @theme block — maps --zfbtailwindexample-* raw vars onto Tailwind v4's
+ * design-system namespace prefixes so that utility classes generate correctly.
+ *
+ * Namespace rules applied here:
+ *   --color-*     → bg-*, text-*, border-*, …
+ *   --spacing-*   → p-*, m-*, gap-*, w-*, h-*, …  (vsp tokens map here)
+ *   --text-*      → text-* font-size utilities
+ *   --leading-*   → leading-* line-height utilities
+ *   --font-*      → font-* font-family utilities
+ *   --radius-*    → rounded-* utilities
+ *
+ * Example utility chain: p-vsp-md
+ *   CSS var:   --spacing-vsp-md: var(--zfbtailwindexample-vsp-md)
+ *   Token:     --zfbtailwindexample-vsp-md: 1rem
+ *   Resolves:  padding: 1rem
+ */
+@theme {
+  /* Colour utilities: bg-primary, bg-surface, text-primary, border-muted, … */
+  --color-primary: var(--zfbtailwindexample-color-primary);
+  --color-accent:  var(--zfbtailwindexample-color-accent);
+  --color-surface: var(--zfbtailwindexample-color-surface);
+  --color-muted:   var(--zfbtailwindexample-color-muted);
+  --color-danger:  var(--zfbtailwindexample-color-danger);
+  --color-bg:      var(--zfbtailwindexample-bg);
+  --color-fg:      var(--zfbtailwindexample-fg);
+
+  /* Spacing utilities for manifest spacing tokens: p-spacing-md, gap-spacing-lg */
+  --spacing-spacing-md: var(--zfbtailwindexample-spacing-md);
+  --spacing-spacing-lg: var(--zfbtailwindexample-spacing-lg);
+
+  /* Vertical spacing utilities: p-vsp-md, m-vsp-xl, gap-vsp-lg, … */
+  --spacing-vsp-2xs: var(--zfbtailwindexample-vsp-2xs);
+  --spacing-vsp-xs:  var(--zfbtailwindexample-vsp-xs);
+  --spacing-vsp-sm:  var(--zfbtailwindexample-vsp-sm);
+  --spacing-vsp-md:  var(--zfbtailwindexample-vsp-md);
+  --spacing-vsp-lg:  var(--zfbtailwindexample-vsp-lg);
+  --spacing-vsp-xl:  var(--zfbtailwindexample-vsp-xl);
+  --spacing-vsp-2xl: var(--zfbtailwindexample-vsp-2xl);
+
+  /* Horizontal spacing utilities: px-hsp-md, pl-hsp-lg, … */
+  --spacing-hsp-xs:  var(--zfbtailwindexample-hsp-xs);
+  --spacing-hsp-sm:  var(--zfbtailwindexample-hsp-sm);
+  --spacing-hsp-md:  var(--zfbtailwindexample-hsp-md);
+  --spacing-hsp-lg:  var(--zfbtailwindexample-hsp-lg);
+  --spacing-hsp-xl:  var(--zfbtailwindexample-hsp-xl);
+
+  /* Font-size utilities: text-h2, text-h3, text-body, text-small, … */
+  --text-heading: var(--zfbtailwindexample-text-heading);
+  --text-base:    var(--zfbtailwindexample-text-base);
+  --text-h2:      var(--zfbtailwindexample-text-h2);
+  --text-h3:      var(--zfbtailwindexample-text-h3);
+  --text-h4:      var(--zfbtailwindexample-text-h4);
+  --text-body:    var(--zfbtailwindexample-text-body);
+  --text-small:   var(--zfbtailwindexample-text-small);
+  --text-micro:   var(--zfbtailwindexample-text-micro);
+
+  /* Line-height utilities: leading-tight, leading-snug, leading-relaxed */
+  --leading-tight:   var(--zfbtailwindexample-leading-tight);
+  --leading-snug:    var(--zfbtailwindexample-leading-snug);
+  --leading-relaxed: var(--zfbtailwindexample-leading-relaxed);
+
+  /* Border-radius utilities: rounded-md (maps manifest radius token) */
+  --radius-md: var(--zfbtailwindexample-radius);
+
+  /* Font-family utilities: font-mono */
+  --font-mono: var(--zfbtailwindexample-font-mono);
+}
+
+/* ── Base styles ─────────────────────────────────────────────────────────── */
+/* Applied via @layer base to stay in Tailwind's layer cascade. */
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html {
+    -webkit-text-size-adjust: 100%;
+    color-scheme: light dark;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+    font-family:
+      system-ui,
+      -apple-system,
+      'Segoe UI',
+      sans-serif;
+    line-height: 1.5;
+    background: var(--zfbtailwindexample-bg);
+    color: var(--zfbtailwindexample-fg);
+    font-size: var(--zfbtailwindexample-text-base);
+  }
+
+  img,
+  svg {
+    display: block;
+    max-width: 100%;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+    color: inherit;
+  }
+}
+
+/* ── Prose container — flow-space pattern ────────────────────────────────── */
+/*
+ * Container-scoped CSS with :where() (zero-specificity selectors).
+ * Per prose-token-contract.md: for zfb demos that do not use framework-level
+ * MDX component overrides, container-scoped CSS with :where() is acceptable.
+ *
+ * The cascade conflict with Tailwind utilities arises only when the same HTML
+ * elements appear in non-content contexts on the same page — this demo keeps
+ * the prose container isolated so the conflict does not occur in practice.
+ *
+ * Flow-space pattern: assigns spacing to margin-block-start only (one
+ * direction) via a CSS custom property cascade. This is predictable in any
+ * layout context (block, flex, grid) because it does not rely on margin
+ * collapse. See prose-token-contract.md "Flow-spacing CSS pattern".
+ */
+@layer components {
+  /* Default flow gap for all direct children */
+  .zfbtailwindexample-prose > * + * {
+    margin-block-start: var(--flow-space, var(--zfbtailwindexample-vsp-md));
+  }
+
+  /* Section separation before headings */
+  .zfbtailwindexample-prose :where(h2) { --flow-space: var(--zfbtailwindexample-vsp-xl); }
+  .zfbtailwindexample-prose :where(h3) { --flow-space: var(--zfbtailwindexample-vsp-lg); }
+  .zfbtailwindexample-prose :where(h4) { --flow-space: var(--zfbtailwindexample-vsp-md); }
+
+  /* Heading-to-first-content: tight coupling */
+  .zfbtailwindexample-prose :where(h2, h3, h4) + :where(p, ul, ol, table, pre, blockquote) {
+    --flow-space: var(--zfbtailwindexample-vsp-sm);
+  }
+
+  /* Consecutive headings: tighten */
+  .zfbtailwindexample-prose :where(h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6) {
+    --flow-space: var(--zfbtailwindexample-vsp-2xs);
+  }
+
+  /* Trim edges */
+  .zfbtailwindexample-prose > :first-child { margin-block-start: 0; }
+  .zfbtailwindexample-prose > :last-child  { margin-block-end: 0; }
+
+  /* Heading styles */
+  .zfbtailwindexample-prose :where(h2) {
+    font-size: var(--zfbtailwindexample-text-h2);
+    line-height: var(--zfbtailwindexample-leading-tight);
+    font-weight: 700;
+    color: var(--zfbtailwindexample-color-primary);
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--zfbtailwindexample-color-muted);
+  }
+
+  .zfbtailwindexample-prose :where(h3) {
+    font-size: var(--zfbtailwindexample-text-h3);
+    line-height: var(--zfbtailwindexample-leading-tight);
+    font-weight: 600;
+    color: var(--zfbtailwindexample-fg);
+  }
+
+  .zfbtailwindexample-prose :where(h4) {
+    font-size: var(--zfbtailwindexample-text-h4);
+    line-height: var(--zfbtailwindexample-leading-snug);
+    font-weight: 600;
+    color: var(--zfbtailwindexample-fg);
+  }
+
+  /* Body text */
+  .zfbtailwindexample-prose :where(p) {
+    font-size: var(--zfbtailwindexample-text-body);
+    line-height: var(--zfbtailwindexample-leading-relaxed);
+  }
+
+  /* Inline code */
+  .zfbtailwindexample-prose :where(code):not(pre code) {
+    font-family: var(--zfbtailwindexample-font-mono);
+    font-size: var(--zfbtailwindexample-text-small);
+    background: var(--zfbtailwindexample-code-bg);
+    color: var(--zfbtailwindexample-code-fg);
+    padding: var(--zfbtailwindexample-hsp-xs) calc(var(--zfbtailwindexample-hsp-xs) * 2);
+    border-radius: 0.25rem;
+    border: 1px solid var(--zfbtailwindexample-color-accent);
+  }
+
+  /* Code blocks */
+  .zfbtailwindexample-prose :where(pre) {
+    font-family: var(--zfbtailwindexample-font-mono);
+    font-size: var(--zfbtailwindexample-text-small);
+    background: var(--zfbtailwindexample-code-bg);
+    color: var(--zfbtailwindexample-code-fg);
+    padding: var(--zfbtailwindexample-vsp-md) var(--zfbtailwindexample-hsp-sm);
+    border-radius: var(--zfbtailwindexample-radius);
+    overflow-x: auto;
+  }
+
+  .zfbtailwindexample-prose :where(pre code) {
+    font-family: inherit;
+    font-size: inherit;
+    background: none;
+    color: inherit;
+    padding: 0;
+    border-radius: 0;
+    border: none;
+  }
+
+  /* Blockquote */
+  .zfbtailwindexample-prose :where(blockquote) {
+    border-left: 4px solid var(--zfbtailwindexample-color-accent);
+    padding-left: var(--zfbtailwindexample-hsp-md);
+    color: var(--zfbtailwindexample-color-muted);
+    font-style: italic;
+  }
+
+  /* Lists */
+  .zfbtailwindexample-prose :where(ul) {
+    padding-left: var(--zfbtailwindexample-hsp-lg);
+    list-style-type: disc;
+  }
+
+  .zfbtailwindexample-prose :where(ol) {
+    padding-left: var(--zfbtailwindexample-hsp-lg);
+    list-style-type: decimal;
+  }
+
+  .zfbtailwindexample-prose :where(li) {
+    font-size: var(--zfbtailwindexample-text-body);
+    line-height: var(--zfbtailwindexample-leading-snug);
+    margin-block-start: var(--zfbtailwindexample-vsp-xs);
+  }
+
+  .zfbtailwindexample-prose :where(li:first-child) {
+    margin-block-start: 0;
+  }
+
+  /* Nested lists */
+  .zfbtailwindexample-prose :where(li > ul, li > ol) {
+    margin-block-start: var(--zfbtailwindexample-vsp-xs);
+  }
+
+  /* Tables */
+  .zfbtailwindexample-prose :where(table) {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--zfbtailwindexample-text-small);
+  }
+
+  .zfbtailwindexample-prose :where(th) {
+    text-align: left;
+    font-weight: 600;
+    padding: var(--zfbtailwindexample-hsp-sm) var(--zfbtailwindexample-hsp-sm);
+    border-bottom: 2px solid var(--zfbtailwindexample-color-muted);
+    color: var(--zfbtailwindexample-fg);
+  }
+
+  .zfbtailwindexample-prose :where(td) {
+    padding: var(--zfbtailwindexample-hsp-sm) var(--zfbtailwindexample-hsp-sm);
+    border-bottom: 1px solid var(--zfbtailwindexample-color-muted);
+    color: var(--zfbtailwindexample-fg);
+  }
+
+  /* Links */
+  .zfbtailwindexample-prose :where(a) {
+    color: var(--zfbtailwindexample-color-accent);
+    text-decoration: underline;
+  }
+
+  .zfbtailwindexample-prose :where(a:hover) {
+    color: var(--zfbtailwindexample-color-primary);
+  }
+
+  /* Horizontal rule */
+  .zfbtailwindexample-prose :where(hr) {
+    border: none;
+    border-top: 1px solid var(--zfbtailwindexample-color-muted);
+    margin-block: var(--zfbtailwindexample-vsp-lg);
+  }
+
+  /* Strong / em */
+  .zfbtailwindexample-prose :where(strong) {
+    font-weight: 700;
+    color: var(--zfbtailwindexample-fg);
+  }
+
+  .zfbtailwindexample-prose :where(em) {
+    font-style: italic;
+  }
+
+  .zfbtailwindexample-prose :where(del) {
+    text-decoration: line-through;
+    color: var(--zfbtailwindexample-color-muted);
+  }
+}

--- a/examples/zfb-tailwind/tsconfig.json
+++ b/examples/zfb-tailwind/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": false,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "pages/**/*",
+    "components/**/*",
+    "config/**/*",
+    "styles/**/*",
+    "plugins/**/*",
+    "zfb.config.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/zfb-tailwind/zfb.config.ts
+++ b/examples/zfb-tailwind/zfb.config.ts
@@ -1,0 +1,51 @@
+import { defineConfig } from "@takazudo/zfb/config";
+
+/**
+ * zfb + Tailwind v4 example for @takazudo/zudo-design-token-panel.
+ *
+ * Mirrors examples/zfb/ but with Tailwind v4 enabled via
+ * `tailwind: { enabled: true }`. This flag instructs zfb to integrate
+ * @tailwindcss/vite into the build pipeline so that `@import "tailwindcss"`
+ * and `@theme { ... }` blocks in CSS files are processed correctly.
+ *
+ * Content collections
+ * -------------------
+ * The `collections` entry declares a "prose" collection (mapped to
+ * `content/prose/`). zfb's collection mechanism enables the `getCollection`
+ * helper in page components, mirroring how Sub 5 (#45) wires MDX in the
+ * plain zfb example.
+ *
+ * Apply-pipeline (dev only)
+ * -------------------------
+ * Same pattern as examples/zfb/ — the `dev-apply-proxy` plugin intercepts
+ * POST requests at the full base-prefixed path:
+ *
+ *   /pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply
+ *
+ * Per zfb issue #229 (fixed in commit `b1049ef`), `devMiddleware`-registered
+ * paths are scoped under the project `base`. The bare path `/api/dev/apply`
+ * resolves to 405; the FULL base-prefixed path is what reaches the handler.
+ * See README.md for the full rationale.
+ *
+ * Port 24686 (tokens-bin) and 44328 (zfb dev) are offset by +1 from the
+ * plain zfb demo to avoid collision when both run simultaneously.
+ *
+ * Deploy `base`
+ * -------------
+ * `base: '/pj/zudo-design-token-panel/examples/zfb-tailwind/'` mirrors the
+ * production deploy path under the monorepo's docs site (see issue #18). zfb
+ * applies this prefix to every emitted asset URL and to the dev server's
+ * served paths, so the example deploys cleanly under the shared Cloudflare
+ * Pages project.
+ */
+export default defineConfig({
+  framework: "preact",
+  base: "/pj/zudo-design-token-panel/examples/zfb-tailwind/",
+  tailwind: { enabled: true },
+  collections: [{ name: "prose", path: "content/prose" }],
+  plugins: [
+    {
+      name: "./plugins/dev-apply-proxy.mjs",
+    },
+  ],
+});

--- a/examples/zfb/content/prose/index.mdx
+++ b/examples/zfb/content/prose/index.mdx
@@ -1,0 +1,181 @@
+---
+title: Prose Demo
+---
+
+# Prose Demo
+
+This page demonstrates the full range of markdown-generated HTML elements
+styled through the `--zfbexample-*` token namespace.
+Each section exercises a distinct element type so you can verify spacing,
+typography, and colour tokens at a glance.
+
+---
+
+## Headings
+
+Use the hierarchy below to check that vertical spacing and type-scale tokens
+produce clear section boundaries without excessive gaps.
+
+### Second-level sub-section
+
+The h3 heading above should sit closer to the h2 above it than to the
+content that follows — the heading visually "belongs" to the content below.
+
+#### Third-level detail heading
+
+The h4 above is the smallest heading level in the prose demo. It shares
+`leading-tight` line-height with h2 and h3 but uses a smaller `text-h4`
+font size.
+
+---
+
+## Text Formatting
+
+Prose pages rely on inline formatting to convey emphasis and editorial
+meaning without extra structure.
+
+A sentence can contain **bold text** to stress an important term, _italic
+text_ to indicate titles or introduce vocabulary, and ~~strikethrough text~~
+to mark deprecated or removed content.
+Combinations are valid: **_bold italic_** or ~~**bold strikethrough**~~.
+The styles should not break line-height or disrupt the baseline rhythm.
+
+---
+
+## Inline Code
+
+Inline code appears inside sentences to name identifiers, file paths, or
+short expressions.
+
+Pass the `--flow-space` custom property on an element to override the
+container's default vertical gap for that element only.
+The file lives at `src/styles/prose.css` and is imported by the page layout.
+
+---
+
+## Code Blocks
+
+Fenced code blocks render inside `<pre><code>` elements. The demo requires
+no syntax highlighting; raw colouring from `code-bg` and `code-fg` tokens
+is sufficient.
+
+```typescript
+// Wiring the prose token namespace for the zfb demo
+const proseTokens = {
+  vspMd:        `var(--zfbexample-vsp-md)`,
+  textBody:     `var(--zfbexample-text-body)`,
+  leadingRelaxed: `var(--zfbexample-leading-relaxed)`,
+  codeBg:       `var(--zfbexample-code-bg)`,
+  codeFg:       `var(--zfbexample-code-fg)`,
+  fontMono:     `var(--zfbexample-font-mono)`,
+} as const;
+
+export default proseTokens;
+```
+
+The block above should display with consistent horizontal padding derived
+from `hsp-sm`, a background from `code-bg`, and text coloured by `code-fg`.
+
+---
+
+## Unordered List
+
+Lists check that `vsp-xs` (item-to-item) and `vsp-md` (list-to-surrounding
+content) tokens produce balanced rhythm.
+
+- Token categories in the prose namespace
+  - Vertical spacing: `vsp-2xs` through `vsp-2xl`
+  - Horizontal spacing: `hsp-xs` through `hsp-xl`
+  - Type scale: `text-h2` through `text-micro`
+- Line-height tokens
+  - `leading-tight` — headings
+  - `leading-snug` — sub-headings and list items
+  - `leading-relaxed` — body paragraphs
+- Code surface tokens
+  - `code-bg`, `code-fg`, `font-mono`
+
+---
+
+## Ordered List
+
+Ordered lists share spacing tokens with unordered lists; the marker style
+differs but the rhythm should be identical.
+
+1. Define the token set in `--zfbexample-*` namespace.
+2. Wire the flow utility into the prose container:
+   1. Apply `margin-block-start: var(--flow-space, ...)` to all children.
+   2. Set per-element `--flow-space` overrides using `:where()` selectors.
+   3. Tighten consecutive headings with a heading + heading adjacent rule.
+3. Map the type-scale and line-height tokens to each heading and paragraph.
+4. Apply code-surface tokens to `<pre>` and inline `<code>` elements.
+
+---
+
+## Blockquote
+
+A blockquote uses a left border coloured by `--color-accent` or
+`--color-muted`, with horizontal padding from `hsp-md`.
+
+> The flow utility assigns spacing to one margin direction only.
+> This makes spacing predictable in block flow, flex, and grid containers
+> without relying on margin collapse.
+
+A multi-paragraph blockquote checks that internal spacing between paragraphs
+is governed by the same `--flow-space` mechanism rather than ad-hoc margins.
+
+> First paragraph of a multi-paragraph quote.
+> It introduces the main idea and ends here.
+>
+> Second paragraph continues the thought.
+> Both paragraphs should have consistent internal rhythm.
+
+---
+
+## Tables
+
+A comparison table exercises `text-small`, `hsp-sm` cell padding, and border
+tokens.
+
+| Demo | Framework | MDX component overrides |
+|---|---|---|
+| astro | Astro + Preact | Yes — `components` prop on `<Content />` |
+| next | Next.js App Router | Yes — `useMDXComponents` / `MDXRemote` |
+| vite | Vite + React | Optional — depends on `remark`/`rehype` setup |
+| zfb | Zudo Framework Base | Container CSS with `:where()` selectors |
+| zfb-tailwind | Zudo Framework Base + Tailwind | Container CSS inside `@layer components` |
+
+---
+
+## Horizontal Rule
+
+A `<hr>` element marks a thematic break. It should have visible contrast
+against the page background and carry top and bottom spacing derived from
+`vsp-lg`.
+
+---
+
+## Links
+
+Links check `--color-accent` and underline treatment.
+
+Visit the [project repository on GitHub](https://github.com/Takazudo/zudo-design-token-panel)
+to browse the source for all demo pages.
+Return to [/pj/zudo-design-token-panel/examples/zfb/](/pj/zudo-design-token-panel/examples/zfb/) to see the component gallery.
+
+The home link above uses the base-prefixed path for this zfb example.
+
+---
+
+## Token reference
+
+The visual appearance of this page is driven entirely by the
+`--zfbexample-*` token namespace.
+Vertical rhythm comes from `vsp-2xs` through `vsp-2xl`.
+Horizontal padding and indent come from `hsp-xs` through `hsp-xl`.
+Type sizes are set by `text-h2`, `text-h3`, `text-h4`, `text-body`,
+`text-small`, and `text-micro`.
+Line-heights use `leading-tight`, `leading-snug`, and `leading-relaxed`.
+Code blocks are styled with `code-bg`, `code-fg`, and `font-mono`.
+Heading borders and blockquote accents reuse the shared `--zfbexample-color-fg`,
+`--color-muted`, and `--color-accent` tokens — no additional colour tokens
+are required.

--- a/examples/zfb/pages/index.tsx
+++ b/examples/zfb/pages/index.tsx
@@ -56,6 +56,11 @@ export default function HomePage() {
               Console API: <code>window.zfbExample.toggleDesignPanel()</code>. Storage prefix:{' '}
               <code>zfb-example-tokens</code>.
             </p>
+            <p>
+              <a href="/pj/zudo-design-token-panel/examples/zfb/prose" class="zfbexample-link">
+                View Prose Demo →
+              </a>
+            </p>
           </header>
 
           <section>

--- a/examples/zfb/pages/prose.tsx
+++ b/examples/zfb/pages/prose.tsx
@@ -1,0 +1,64 @@
+/**
+ * Prose demo page — /prose
+ *
+ * Renders the single "prose" content-collection entry (content/prose/index.mdx)
+ * inside a `.zfbexample-prose` container so that the --zfbexample-* prose tokens
+ * (vsp-*, hsp-*, text-*, leading-*, code-*) and the :where() flow-space rules
+ * in styles/global.css apply to all markdown-generated HTML.
+ *
+ * `getCollection` is synchronous per zfb ADR-004. The prose collection
+ * contains one static entry so we grab index 0; a missing entry renders
+ * nothing rather than crashing.
+ *
+ * Panel mount
+ * -----------
+ * Re-uses the same <Island> / <PanelMount> pattern as index.tsx so the panel
+ * is available on this page too — token tweaks on the panel immediately reach
+ * the prose subtree via the :root CSS-var overrides.
+ */
+
+import { defaultComponents, getCollection, type CollectionEntry } from '@takazudo/zfb/content';
+import { Island, type IslandProps } from '@takazudo/zfb';
+import PanelMount from '../components/panel-mount';
+import '../styles/global.css';
+
+type ProseFrontmatter = {
+  title?: string;
+};
+
+export default function ProsePage() {
+  const entries = getCollection<ProseFrontmatter>('prose');
+  const post = entries[0] as CollectionEntry<ProseFrontmatter> | undefined;
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Prose Demo — zfb Example</title>
+      </head>
+      <body>
+        <nav style="padding: 1rem 2rem; border-bottom: 1px solid var(--zfbexample-color-muted);">
+          <a
+            href="/pj/zudo-design-token-panel/examples/zfb/"
+            class="zfbexample-link"
+          >
+            ← Back to home
+          </a>
+        </nav>
+
+        <main class="zfbexample-prose">
+          {post ? (
+            <post.Content components={{ ...defaultComponents }} />
+          ) : (
+            <p>No prose content found.</p>
+          )}
+        </main>
+
+        <Island when="visible" ssrFallback={null}>
+          {(<PanelMount />) as unknown as IslandProps['children']}
+        </Island>
+      </body>
+    </html>
+  );
+}

--- a/examples/zfb/styles/global.css
+++ b/examples/zfb/styles/global.css
@@ -185,3 +185,185 @@ body {
   font-size: 0.875rem;
   color: var(--zfbexample-color-muted);
 }
+
+/* ─── Prose tokens ───────────────────────────────────────────────────────── */
+:root {
+  /* Vertical spacing — derive from 1.6rem (≈ 25.6 px) rhythm unit */
+  --zfbexample-vsp-2xs: 0.25rem;   /* ~4 px  */
+  --zfbexample-vsp-xs:  0.5rem;    /* ~8 px  */
+  --zfbexample-vsp-sm:  0.75rem;   /* ~12 px */
+  --zfbexample-vsp-md:  1rem;      /* ~16 px — default flow gap */
+  --zfbexample-vsp-lg:  1.75rem;   /* ~28 px */
+  --zfbexample-vsp-xl:  2.5rem;    /* ~40 px */
+  --zfbexample-vsp-2xl: 3.5rem;    /* ~56 px */
+
+  /* Horizontal spacing */
+  --zfbexample-hsp-xs:  0.25rem;
+  --zfbexample-hsp-sm:  0.5rem;
+  --zfbexample-hsp-md:  1rem;
+  --zfbexample-hsp-lg:  1.5rem;
+  --zfbexample-hsp-xl:  2rem;
+
+  /* Type scale */
+  --zfbexample-text-h2:    1.75rem;
+  --zfbexample-text-h3:    1.35rem;
+  --zfbexample-text-h4:    1.1rem;
+  --zfbexample-text-body:  1rem;
+  --zfbexample-text-small: 0.875rem;
+  --zfbexample-text-micro: 0.75rem;
+
+  /* Line-heights */
+  --zfbexample-leading-tight:   1.2;
+  --zfbexample-leading-snug:    1.45;
+  --zfbexample-leading-relaxed: 1.75;
+
+  /* Code surface */
+  --zfbexample-code-bg:   hsl(220 13% 11%);
+  --zfbexample-code-fg:   hsl(220 14% 86%);
+  --zfbexample-font-mono: ui-monospace, "Cascadia Code", "Source Code Pro",
+                          Menlo, Consolas, monospace;
+}
+
+/* ─── Prose container — flow-space rhythm ────────────────────────────────── */
+/* Strategy 1 from prose-heading-spacing.mdx: one-direction margin-block-start
+   via --flow-space cascade variable. Predictable in block / flex / grid.
+   :where() contributes zero specificity so component-inline overrides win. */
+.zfbexample-prose {
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: var(--zfbexample-vsp-2xl) var(--zfbexample-hsp-xl);
+  font-size: var(--zfbexample-text-body);
+  line-height: var(--zfbexample-leading-relaxed);
+  color: var(--zfbexample-fg);
+}
+
+.zfbexample-prose > * + * {
+  margin-block-start: var(--flow-space, var(--zfbexample-vsp-md));
+}
+
+/* Section separation before headings */
+.zfbexample-prose :where(h2) { --flow-space: var(--zfbexample-vsp-xl); }
+.zfbexample-prose :where(h3) { --flow-space: var(--zfbexample-vsp-lg); }
+.zfbexample-prose :where(h4) { --flow-space: var(--zfbexample-vsp-md); }
+
+/* Heading-to-first-content: tight coupling */
+.zfbexample-prose :where(h2, h3, h4) + :where(p, ul, ol, table, pre, blockquote) {
+  --flow-space: var(--zfbexample-vsp-sm);
+}
+
+/* Consecutive headings: tighten */
+.zfbexample-prose :where(h2, h3, h4, h5, h6) + :where(h2, h3, h4, h5, h6) {
+  --flow-space: var(--zfbexample-vsp-2xs);
+}
+
+/* Trim edges */
+.zfbexample-prose > :first-child { margin-block-start: 0; }
+.zfbexample-prose > :last-child  { margin-block-end: 0; }
+
+/* Type scale + line-heights */
+.zfbexample-prose :where(h2) {
+  font-size: var(--zfbexample-text-h2);
+  line-height: var(--zfbexample-leading-tight);
+  font-weight: 700;
+}
+
+.zfbexample-prose :where(h3) {
+  font-size: var(--zfbexample-text-h3);
+  line-height: var(--zfbexample-leading-tight);
+  font-weight: 600;
+}
+
+.zfbexample-prose :where(h4) {
+  font-size: var(--zfbexample-text-h4);
+  line-height: var(--zfbexample-leading-tight);
+  font-weight: 600;
+}
+
+.zfbexample-prose :where(p, li) {
+  font-size: var(--zfbexample-text-body);
+  line-height: var(--zfbexample-leading-relaxed);
+}
+
+/* Code surface */
+.zfbexample-prose :where(pre) {
+  background: var(--zfbexample-code-bg);
+  color: var(--zfbexample-code-fg);
+  font-family: var(--zfbexample-font-mono);
+  font-size: var(--zfbexample-text-small);
+  padding: var(--zfbexample-vsp-sm) var(--zfbexample-hsp-sm);
+  border-radius: 0.25rem;
+  overflow-x: auto;
+}
+
+.zfbexample-prose :where(code) {
+  font-family: var(--zfbexample-font-mono);
+  font-size: var(--zfbexample-text-small);
+}
+
+/* Inline code (not inside pre) */
+.zfbexample-prose :where(p code, li code, td code) {
+  background: var(--zfbexample-code-bg);
+  color: var(--zfbexample-code-fg);
+  padding: 0.1em var(--zfbexample-hsp-xs);
+  border-radius: 0.2rem;
+  border: 1px solid var(--zfbexample-color-accent);
+}
+
+/* Blockquote */
+.zfbexample-prose :where(blockquote) {
+  border-left: 3px solid var(--zfbexample-color-accent);
+  padding-left: var(--zfbexample-hsp-md);
+  color: var(--zfbexample-color-muted);
+}
+
+/* Lists */
+.zfbexample-prose :where(ul) {
+  padding-left: var(--zfbexample-hsp-lg);
+  list-style: disc;
+}
+
+.zfbexample-prose :where(ol) {
+  padding-left: var(--zfbexample-hsp-lg);
+  list-style: decimal;
+}
+
+/* Tables */
+.zfbexample-prose :where(table) {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--zfbexample-text-small);
+}
+
+.zfbexample-prose :where(th, td) {
+  padding: var(--zfbexample-hsp-xs) var(--zfbexample-hsp-sm);
+  border: 1px solid var(--zfbexample-color-muted);
+  text-align: left;
+}
+
+.zfbexample-prose :where(th) {
+  font-weight: 600;
+}
+
+/* Horizontal rule */
+.zfbexample-prose :where(hr) {
+  border: none;
+  border-top: 1px solid var(--zfbexample-color-muted);
+  margin-block: var(--zfbexample-vsp-lg);
+}
+
+/* Links */
+.zfbexample-prose :where(a) {
+  color: var(--zfbexample-color-accent);
+  text-decoration: underline;
+}
+
+/* Heading top-border gradient — reuses fg + muted colour tokens */
+.zfbexample-prose :where(h2) {
+  padding-top: var(--zfbexample-vsp-xs);
+  border-top: 2px solid transparent;
+  border-image: linear-gradient(
+    to right,
+    var(--zfbexample-fg),
+    var(--zfbexample-color-muted)
+  ) 1;
+}

--- a/examples/zfb/zfb.config.ts
+++ b/examples/zfb/zfb.config.ts
@@ -36,6 +36,12 @@ import { defineConfig } from "@takazudo/zfb/config";
 export default defineConfig({
   framework: "preact",
   base: "/pj/zudo-design-token-panel/examples/zfb/",
+  collections: [
+    {
+      name: "prose",
+      path: "content/prose",
+    },
+  ],
   plugins: [
     {
       name: "./plugins/dev-apply-proxy.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,37 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  examples/zfb-tailwind:
+    dependencies:
+      '@takazudo/zfb':
+        specifier: link:../../../zfb/packages/zfb
+        version: link:../../../zfb/packages/zfb
+      '@takazudo/zfb-runtime':
+        specifier: link:../../../zfb/packages/zfb-runtime
+        version: link:../../../zfb/packages/zfb-runtime
+      '@takazudo/zudo-design-token-panel':
+        specifier: workspace:*
+        version: link:../../packages/zudo-design-token-panel
+      preact:
+        specifier: ^10.29.1
+        version: 10.29.1
+      preact-render-to-string:
+        specifier: ^6.5.0
+        version: 6.6.7(preact@10.29.1)
+      tailwindcss:
+        specifier: ^4.1.0
+        version: 4.2.4
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      concurrently:
+        specifier: ^9.2.1
+        version: 9.2.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/zudo-design-token-panel:
     devDependencies:
       '@types/node':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   examples/astro:
     dependencies:
+      '@astrojs/mdx':
+        specifier: ^5.0.4
+        version: 5.0.4(astro@6.1.9(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/preact':
         specifier: ^5.1.1
         version: 5.1.2(@babel/core@7.29.0)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(preact@10.29.1)(rollup@4.60.2)(yaml@2.8.3)
@@ -121,6 +124,15 @@ importers:
 
   examples/next:
     dependencies:
+      '@mdx-js/loader':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@next/mdx':
+        specifier: ^16.2.6
+        version: 16.2.6(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))
       '@takazudo/zudo-design-token-panel':
         specifier: workspace:*
         version: link:../../packages/zudo-design-token-panel
@@ -140,6 +152,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@types/mdx':
+        specifier: ^2.0.13
+        version: 2.0.13
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -1224,6 +1239,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@mdx-js/loader@3.1.1':
+    resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
+    peerDependencies:
+      webpack: '>=5'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -1243,6 +1266,17 @@ packages:
 
   '@next/env@15.5.15':
     resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+
+  '@next/mdx@16.2.6':
+    resolution: {integrity: sha512-0hdoSkzRbyud1dNRRDiyqD9FrxR2wwdiW+ffhYx+n+fXrFOJ7Nwpi8o7nUz2LiiM44BB9M0eIO1Evy3BBrS50A==}
+    peerDependencies:
+      '@mdx-js/loader': '>=0.15.0'
+      '@mdx-js/react': '>=0.15.0'
+    peerDependenciesMeta:
+      '@mdx-js/loader':
+        optional: true
+      '@mdx-js/react':
+        optional: true
 
   '@next/swc-darwin-arm64@15.5.15':
     resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
@@ -4942,6 +4976,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mdx-js/loader@3.1.1':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.8
@@ -4978,6 +5019,12 @@ snapshots:
       '@types/react': 18.3.28
       react: 18.3.1
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.5
+
   '@mdx-js/rollup@3.1.1(rollup@4.60.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
@@ -4993,6 +5040,13 @@ snapshots:
       langium: 4.2.2
 
   '@next/env@15.5.15': {}
+
+  '@next/mdx@16.2.6(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))':
+    dependencies:
+      source-map: 0.7.6
+    optionalDependencies:
+      '@mdx-js/loader': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
 
   '@next/swc-darwin-arm64@15.5.15':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,12 @@ importers:
 
   examples/vite-react:
     dependencies:
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@mdx-js/rollup':
+        specifier: ^3.1.1
+        version: 3.1.1(rollup@4.60.2)
       '@takazudo/zudo-design-token-panel':
         specifier: workspace:*
         version: link:../../packages/zudo-design-token-panel
@@ -174,6 +180,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@types/mdx':
+        specifier: ^2.0.13
+        version: 2.0.13
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -1186,6 +1195,17 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
+  '@mdx-js/rollup@3.1.1':
+    resolution: {integrity: sha512-v8satFmBB+DqDzYohnm1u2JOvxx6Hl3pUvqzJvfs2Zk/ngZ1aRUhsWpXvwPkNeGN9c2NCm/38H29ZqXQUjf8dw==}
+    peerDependencies:
+      rollup: '>=2'
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
@@ -4917,6 +4937,22 @@ snapshots:
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
       unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 18.3.28
+      react: 18.3.1
+
+  '@mdx-js/rollup@3.1.1(rollup@4.60.2)':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      rollup: 4.60.2
+      source-map: 0.7.6
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,15 @@ importers:
 
   examples/next:
     dependencies:
+      '@mdx-js/loader':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@next/mdx':
+        specifier: ^16.2.6
+        version: 16.2.6(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))
       '@takazudo/zudo-design-token-panel':
         specifier: workspace:*
         version: link:../../packages/zudo-design-token-panel
@@ -140,6 +149,9 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
+      '@types/mdx':
+        specifier: ^2.0.13
+        version: 2.0.13
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -1184,14 +1196,39 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@mdx-js/loader@3.1.1':
+    resolution: {integrity: sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==}
+    peerDependencies:
+      webpack: '>=5'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
 
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
   '@next/env@15.5.15':
     resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
+
+  '@next/mdx@16.2.6':
+    resolution: {integrity: sha512-0hdoSkzRbyud1dNRRDiyqD9FrxR2wwdiW+ffhYx+n+fXrFOJ7Nwpi8o7nUz2LiiM44BB9M0eIO1Evy3BBrS50A==}
+    peerDependencies:
+      '@mdx-js/loader': '>=0.15.0'
+      '@mdx-js/react': '>=0.15.0'
+    peerDependenciesMeta:
+      '@mdx-js/loader':
+        optional: true
+      '@mdx-js/react':
+        optional: true
 
   '@next/swc-darwin-arm64@15.5.15':
     resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
@@ -4891,6 +4928,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mdx-js/loader@3.1.1':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.8
@@ -4921,11 +4965,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.5
+
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.2
 
   '@next/env@15.5.15': {}
+
+  '@next/mdx@16.2.6(@mdx-js/loader@3.1.1)(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))':
+    dependencies:
+      source-map: 0.7.6
+    optionalDependencies:
+      '@mdx-js/loader': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
 
   '@next/swc-darwin-arm64@15.5.15':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   examples/astro:
     dependencies:
+      '@astrojs/mdx':
+        specifier: ^5.0.4
+        version: 5.0.4(astro@6.1.9(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/preact':
         specifier: ^5.1.1
         version: 5.1.2(@babel/core@7.29.0)(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(preact@10.29.1)(rollup@4.60.2)(yaml@2.8.3)

--- a/scripts/check-deploy-paths.sh
+++ b/scripts/check-deploy-paths.sh
@@ -23,10 +23,11 @@
 #      "/pj/zudo-design-token-panel/foo" and "/pj/zudo-design-token-panel/foo/" pointing at the same resource).
 #
 # Per-workspace sub-paths (Sub #34 / epic #29 — examples moved under /examples/):
-#   doc/dist                 → /pj/zudo-design-token-panel/
-#   examples/astro/dist      → /pj/zudo-design-token-panel/examples/astro/
-#   examples/vite-react/dist → /pj/zudo-design-token-panel/examples/vite-react/
-#   examples/next/out        → /pj/zudo-design-token-panel/examples/next/
+#   doc/dist                      → /pj/zudo-design-token-panel/
+#   examples/astro/dist           → /pj/zudo-design-token-panel/examples/astro/
+#   examples/vite-react/dist      → /pj/zudo-design-token-panel/examples/vite-react/
+#   examples/next/out             → /pj/zudo-design-token-panel/examples/next/
+#   examples/zfb-tailwind/dist    → /pj/zudo-design-token-panel/examples/zfb-tailwind/
 #
 # Exits non-zero on any escape so it can gate CI / pre-push.
 
@@ -77,7 +78,7 @@ cd "$ROOT_DIR"
 START=$(date +%s)
 
 # Workspaces in print order.
-WORKSPACES=("doc" "astro" "vite-react" "next")
+WORKSPACES=("doc" "astro" "vite-react" "next" "zfb-tailwind")
 
 # Per-workspace pass/fail tracker.
 declare -A WS_FAILS=()
@@ -319,7 +320,7 @@ audit_workspace() {
 }
 
 # ── Build phase ──────────────────────────────────
-section "Step 1/2: Build (panel package + 4 workspaces)"
+section "Step 1/2: Build (panel package + 5 workspaces)"
 
 # The next-example imports @takazudo/zudo-design-token-panel through the
 # package's `exports` map → ./dist/*. That dist is gitignored, so the panel
@@ -330,14 +331,16 @@ build_one "doc"               "doc"
 build_one "astro-example"     "astro-example"
 build_one "vite-react-example" "vite-react-example"
 build_one "next-example"      "next-example"
+build_one "zfb-tailwind-example" "zfb-tailwind-example"
 
 # ── Audit phase ──────────────────────────────────
 section "Step 2/2: Audit each emitted bundle"
 
-audit_workspace "doc"        "doc/dist"                 "/pj/zudo-design-token-panel/"
-audit_workspace "astro"      "examples/astro/dist"      "/pj/zudo-design-token-panel/examples/astro/"
-audit_workspace "vite-react" "examples/vite-react/dist" "/pj/zudo-design-token-panel/examples/vite-react/"
-audit_workspace "next"       "examples/next/out"        "/pj/zudo-design-token-panel/examples/next/"
+audit_workspace "doc"          "doc/dist"                      "/pj/zudo-design-token-panel/"
+audit_workspace "astro"        "examples/astro/dist"           "/pj/zudo-design-token-panel/examples/astro/"
+audit_workspace "vite-react"   "examples/vite-react/dist"      "/pj/zudo-design-token-panel/examples/vite-react/"
+audit_workspace "next"         "examples/next/out"             "/pj/zudo-design-token-panel/examples/next/"
+audit_workspace "zfb-tailwind" "examples/zfb-tailwind/dist"   "/pj/zudo-design-token-panel/examples/zfb-tailwind/"
 
 # ── Summary ──────────────────────────────────────
 END=$(date +%s)

--- a/scripts/stage-deploy.sh
+++ b/scripts/stage-deploy.sh
@@ -82,4 +82,14 @@ else
   echo "stage-deploy: skipping examples/zfb (dist not found — workspace not yet built)"
 fi
 
+# zfb-tailwind example (Sub #46): Tailwind v4 variant of the zfb demo.
+# Guard with an existence check so the script degrades gracefully when
+# the workspace hasn't been built yet.
+ZFB_TAILWIND_DIST="${ROOT_DIR}/examples/zfb-tailwind/dist"
+if [ -d "${ZFB_TAILWIND_DIST}" ]; then
+  copy_example "zfb-tailwind-example" "${ZFB_TAILWIND_DIST}" "examples/zfb-tailwind"
+else
+  echo "stage-deploy: skipping examples/zfb-tailwind (dist not found — workspace not yet built)"
+fi
+
 echo "stage-deploy: done. Deploy tree: ${DEST_DIR}/"


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/40

---

## Summary

Epic root PR for [#40](https://github.com/Takazudo/zudo-design-token-panel/issues/40) — Prose Demo Pages.

Adds a token-driven prose / markdown content surface to every existing demo (astro, next, vite-react, zfb) and scaffolds a new `examples/zfb-tailwind/` workspace with both showcase and prose pages. Each demo's prose surface is styled exclusively from its own `--{prefix}example-*` token namespace, so opening the panel and tweaking a token reaches the prose page end-to-end.

Also retires the "four demos / four frameworks" framing across the doc site now that there are five.

## Topic PRs (sub-issues)

| Sub | Wave | Title | Closes |
| --- | --- | --- | --- |
| 1 | 1 | Design prose-token contract + canonical content | #41 |
| 2 | 2 | Astro demo: prose page | #42 |
| 3 | 2 | Next.js demo: prose page | #43 |
| 4 | 2 | Vite + React demo: prose page | #44 |
| 5 | 2 | zfb demo: prose page | #45 |
| 6 | 2 | New `examples/zfb-tailwind/` demo: scaffold + showcase + prose | #46 |
| 7 | 3 | Cross-demo prose integration confirm + doc-site rename | #47 |

## Wave 1 — foundation

- `doc/.claude/prose-token-contract.md` — token vocabulary every demo extends (`vsp-*`, `hsp-*`, `text-*`, `leading-*`, `code-*`, `font-mono`), default values, flow-space CSS pattern, and `/css-wisdom` rationale.
- `doc/content/prose-demo-source.md` — canonical markdown content rendered by every Wave 2 demo. `{HOME_HREF}` and `{prefix}` placeholders are substituted per-demo.

## Wave 2 — five demos

- **astro** — `@astrojs/mdx`, Astro 6 content collection at `src/content/prose/`, `src/pages/prose.astro`, `.astroexample-prose` flow-space CSS.
- **next** — `@next/mdx` + `@mdx-js/loader` + `@mdx-js/react`, App Router `app/prose/page.mdx`, **pure-JSX** `mdx-components.tsx` (no `'use client'`, no hooks) so static `output: "export"` keeps producing `out/prose/index.html`.
- **vite-react** — `@mdx-js/rollup@^3` paired with `@mdx-js/react@^3` (avoids the v2/v3 `useMDXComponents` drift), Vite multi-page entry via `build.rollupOptions.input` (`prose.html` alongside `index.html`), `src/components/ProseDemo.tsx` rendering the MDX inside `<main className="vitereact-prose">`.
- **zfb** — native MDX via `getCollection("prose")` from `@takazudo/zfb/content`, `pages/prose.tsx`, `.zfbexample-prose` flow-space CSS.
- **zfb-tailwind** (NEW workspace) — mirrors zfb but with `tailwind: { enabled: true }`. Tokens registered via Tailwind v4 `@theme` block mapping `--zfbtailwindexample-*` raw vars onto `--color-*`, `--spacing-*`, `--text-*`, `--leading-*`, `--font-*`, `--radius-*` namespaces so utilities like `p-vsp-md` and `bg-primary` resolve back to panel tokens. Includes both showcase + prose pages, dev port 44328, tokens-bin port 24686. Deploy infra (`scripts/stage-deploy.sh`, `scripts/check-deploy-paths.sh`, `.github/workflows/main-deploy.yml`, root `README.md`) extended for the 5th workspace.

## Wave 3 — confirm + rename

- All 5 builds green; `stage-deploy.sh` produces all 5 example trees with prose surfaces; `check-deploy-paths.sh` passes.
- Token isolation grep clean — no sibling-prefix leaks between demos.
- Heading-sequence drift check passes for every demo's prose copy against the canonical source.
- `doc/src/content/docs/getting-started/four-frameworks.mdx` renamed → `frameworks-comparison.mdx` with title and comparison table updated to 5 frameworks; `doc/public/_redirects` keeps the old slug working.
- `doc/src/pages/index.astro` Example Apps grid extended from 4 to 5 cards (`lg:grid-cols-3` for two-row balance) and "four popular stacks" prose updated.
- `doc/src/content/docs/getting-started/examples.mdx` lists all 5 demos with prose-page links.
- Root `README.md` updated to mention all 5 demos.
- Inline fix: `examples/next/app/prose/page.mdx` home link changed from `/` to the deploy-prefixed path so static export resolves correctly under `/pj/zudo-design-token-panel/examples/next/`.

## Test plan

- [x] `pnpm install` clean.
- [x] `pnpm -r --if-present typecheck` — green across panel + doc + 5 demos.
- [x] `pnpm build` — green across all workspaces.
- [x] `bash scripts/stage-deploy.sh` produces all 5 example dirs with a prose surface.
- [x] `bash scripts/check-deploy-paths.sh` passes for the 5 workspaces.
- [x] CI green on this PR (Build, test, typecheck, lint + Build doc site and examples).
- [ ] Visual parity check on each prose page (h2 gradient border, blockquote left border, code block surface) — deferred; reviewer can spot-check the deployed Pages preview.
- [ ] Token-tweak smoke test — open the panel on any demo and confirm tweaking `vsp-md` visibly retunes the prose flow gap.

## Notes

- Reviewer: `/gcoc-review` (GitHub Copilot CLI cheap mode) — categorical-checklist output; concrete deterministic checks (token leakage, broken nav, doc-site rename leftovers, hardcoded creds) all clean.
- Wave 1 + Wave 2 + Wave 3 implemented as one-shot subagents per the `Execution mode: subagents` annotations on every sub-issue.
🤖 Orchestrated by /x-wt-teams (subagents path, sonnet children, -gcoc reviewer, -a auto-complete on)