### PR TITLE
open-issues: handle #49, #50, #51 (export TweakState, lifecycle adapter, configurable rename map)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,24 @@ Dates and versions may be absent for unreleased entries.
 ### Changed
 
 - Make typography-id rename map configurable via
-  `PanelConfig.legacyIdRenameMap`; default empty (BREAKING for hosts that
-  relied on the implicit built-in rename — zdtp's own callers can continue
-  to opt in by passing the re-exported `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP`
-  constant). The map shape is `Record<string, string | null>` — a `null`
-  value preserves the historical "drop this id" semantic for callers
-  whose original behavior dropped certain ids without replacement.
+  `PanelConfig.legacyIdRenameMap`; default empty so hosts whose manifest
+  ids are stable (e.g. zudo-doc) are not corrupted. The historical
+  zdtp-internal map is exported as `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP`,
+  and the bundled astro host adapter wires it in automatically so
+  existing zdtp deployments keep their behaviour without code changes.
+  Map shape is `Record<string, string | null>` — a `null` value
+  preserves the historical "drop this id" semantic for callers whose
+  original behavior dropped certain ids without replacement.
   ([#51](https://github.com/Takazudo/zudo-design-token-panel/issues/51))
+- After the typography migration runs (rename or null-drop),
+  `loadPersistedState` now rewrites the normalized envelope back to
+  `localStorage` so legacy ids and dropped entries don't survive on
+  disk indefinitely as dead data.
+- `LifecycleAdapter` partial adapters (one that registers only
+  `onBeforeSwap` or only `onPageLoad`) keep the astro fallback for the
+  unregistered channel and emit a `console.warn` so authors notice the
+  silent gap. Previously, the missing channel was silently dropped,
+  leaking the Preact tree on body-swapping routers (e.g. zfb).
 
 ## [0.1.0] — 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to `zudo-design-token-panel` are recorded in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Dates and versions may be absent for unreleased entries.
 
+## [Unreleased]
+
+### Added
+
+- Export `TweakState` (type) and `emptyOverrides` from main entry
+  ([#49](https://github.com/Takazudo/zudo-design-token-panel/issues/49))
+  — external SerDe layers (e.g. zudo-doc's `design-token-serde.ts`)
+  can now construct a fully-populated `TweakState` without reaching into
+  the test-only `./testing` sub-export.
+
 ## [0.1.0] — 2026-04-27
 
 Initial OSS port of the design-token panel + bin server from `zmodular`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `zudo-design-token-panel` are recorded in this file.
 The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Dates and versions may be absent for unreleased entries.
 
+## [Unreleased]
+
+### Changed
+
+- Make typography-id rename map configurable via
+  `PanelConfig.legacyIdRenameMap`; default empty (BREAKING for hosts that
+  relied on the implicit built-in rename — zdtp's own callers can continue
+  to opt in by passing the re-exported `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP`
+  constant).
+  ([#51](https://github.com/Takazudo/zudo-design-token-panel/issues/51))
+
 ## [0.1.0] — 2026-04-27
 
 Initial OSS port of the design-token panel + bin server from `zmodular`

--- a/packages/zudo-design-token-panel/CHANGELOG.md
+++ b/packages/zudo-design-token-panel/CHANGELOG.md
@@ -2,4 +2,12 @@
 
 ## Unreleased
 
-- Add framework-agnostic `setLifecycleAdapter` API for non-Astro hosts (#50). The astro `astro:before-swap` / `astro:page-load` fallback is preserved when no adapter is registered, and is actively unbound when a host installs an adapter so the internal handlers do not double-fire.
+### Added
+
+- Export `TweakState` (type) and `emptyOverrides` from main entry (#49) — external SerDe layers (e.g. zudo-doc's `design-token-serde.ts`) can now construct a fully-populated `TweakState` without reaching into the test-only `./testing` sub-export.
+- Framework-agnostic `setLifecycleAdapter(adapter)` API for non-Astro hosts (zfb, vite, etc.) (#50). The astro `astro:before-swap` / `astro:page-load` fallback is preserved when no adapter is registered, and is actively unbound when a host installs an adapter so the internal handlers do not double-fire. A partial adapter (one that registers only `onBeforeSwap` or only `onPageLoad`) keeps the astro fallback for the unregistered channel and emits a `console.warn` so authors notice the silent gap.
+
+### Changed
+
+- Make typography-id rename map configurable via `PanelConfig.legacyIdRenameMap` (#51). The default is an empty map (no renaming) so hosts whose manifest ids are stable (e.g. zudo-doc) are not corrupted. The historical zdtp-internal map is exported as `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` for opt-in callers; the bundled astro host adapter wires it in automatically so existing zdtp deployments keep their behaviour. Map shape is `Record<string, string | null>` — a `null` value preserves the historical "drop this id" semantic for callers whose original behaviour dropped certain ids without replacement.
+- After the typography migration runs (rename or null-drop), `loadPersistedState` rewrites the normalized envelope back to `localStorage` so legacy ids and dropped entries do not survive on disk indefinitely as dead data, and a host that later removes the opt-in rename map does not regress every user back to non-applying overrides.

--- a/packages/zudo-design-token-panel/CHANGELOG.md
+++ b/packages/zudo-design-token-panel/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Add framework-agnostic `setLifecycleAdapter` API for non-Astro hosts (#50). The astro `astro:before-swap` / `astro:page-load` fallback is preserved when no adapter is registered, and is actively unbound when a host installs an adapter so the internal handlers do not double-fire.

--- a/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
+++ b/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
@@ -934,9 +934,15 @@ After the rewrite, the v1 key is deleted.
 
 The typography-id rename applied during `loadPersistedState` migration is
 configurable via the optional `legacyIdRenameMap` field on `PanelConfig`
-(`Record<string, string>`). Keys are old ids found in persisted state;
-values are the new canonical ids. If both the old and new id are present
-in the payload, the new id wins (post-migration tweak preserved).
+(`Record<string, string | null>`). Keys are old ids found in persisted
+state; values are either the new canonical id (`string`) or `null` to drop
+the legacy id entirely. If both the old and new id are present in the
+payload, the new id wins (post-migration tweak preserved).
+
+`null` (drop) is the only safe way to retire an obsolete legacy id:
+`applyTokenOverrides` silently ignores ids missing from the active
+manifest, but every save round-trips the dead key back to disk, so a
+stray legacy override would otherwise persist indefinitely.
 
 **The default is an empty map** — i.e. no renaming happens unless the host
 opts in. Hosts whose canonical manifest ids happen to match what an
@@ -949,9 +955,10 @@ dropped overrides on stable ids.)
 For callers who depended on the historical zdtp-internal rename
 (`text-caption` → `text-xs`, `text-small` → `text-sm`, `text-body` →
 `text-base`, `text-subheading` → `text-lg`, `text-heading` → `text-3xl`,
-`text-display` → `text-5xl`), the package re-exports the same map as
-`ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` from the package root. Pass it via
-`legacyIdRenameMap` on `configurePanel` to keep the old behaviour.
+`text-display` → `text-5xl`, `text-micro` → drop), the package re-exports
+the same map as `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` from the package root.
+Pass it via `legacyIdRenameMap` on `configurePanel` to keep the old
+behaviour.
 
 ---
 

--- a/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
+++ b/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
@@ -932,11 +932,26 @@ After the rewrite, the v1 key is deleted.
 
 ### 8.4 Typography-id rename map
 
-A hard-coded typography-id rename map (`text-caption` → `text-xs`, etc.,
-plus a small set of dropped legacy ids) lives inside `loadPersistedState`.
-It applies regardless of `storagePrefix`. Hosts whose token manifest does
-not use those legacy ids see no behaviour change — the map only triggers
-when matching keys appear in the persisted payload.
+The typography-id rename applied during `loadPersistedState` migration is
+configurable via the optional `legacyIdRenameMap` field on `PanelConfig`
+(`Record<string, string>`). Keys are old ids found in persisted state;
+values are the new canonical ids. If both the old and new id are present
+in the payload, the new id wins (post-migration tweak preserved).
+
+**The default is an empty map** — i.e. no renaming happens unless the host
+opts in. Hosts whose canonical manifest ids happen to match what an
+implementation might consider "old" labels (e.g. `text-caption` is a
+stable id in some manifests) are therefore not corrupted by an opinionated
+built-in rename. (Pre-issue-#51 the rename was hard-coded inside
+`loadPersistedState` and applied unconditionally; that path silently
+dropped overrides on stable ids.)
+
+For callers who depended on the historical zdtp-internal rename
+(`text-caption` → `text-xs`, `text-small` → `text-sm`, `text-body` →
+`text-base`, `text-subheading` → `text-lg`, `text-heading` → `text-3xl`,
+`text-display` → `text-5xl`), the package re-exports the same map as
+`ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` from the package root. Pass it via
+`legacyIdRenameMap` on `configurePanel` to keep the old behaviour.
 
 ---
 

--- a/packages/zudo-design-token-panel/README.md
+++ b/packages/zudo-design-token-panel/README.md
@@ -829,6 +829,41 @@ The conventional placement is **at the end of `<body>`** in your shared layout. 
 
 The `./astro` sub-export is the only place that imports anything Astro-flavoured. The package's main entry (`@takazudo/zudo-design-token-panel`) is framework-agnostic: call `configurePanel(...)` yourself, then `import('@takazudo/zudo-design-token-panel')` to materialise the panel. The `astro:before-swap` / `astro:page-load` listeners no-op outside an Astro context but the storage / mount / apply paths work identically.
 
+#### Soft-nav lifecycle for non-Astro hosts (`setLifecycleAdapter`)
+
+For hosts that own a client-side router (zfb, custom SPA, etc.), persisted overrides need to re-apply after every soft navigation. Register a `LifecycleAdapter` so the panel's internal handlers route through your router's hooks instead of Astro's document events:
+
+```ts
+import {
+  setLifecycleAdapter,
+  type LifecycleAdapter,
+} from '@takazudo/zudo-design-token-panel';
+
+// Example: a zfb-style host that emits 'zfb:before-swap' / 'zfb:page-load'
+// CustomEvents on the document.
+const adapter: LifecycleAdapter = {
+  onBeforeSwap(callback) {
+    document.addEventListener('zfb:before-swap', callback);
+    return () => document.removeEventListener('zfb:before-swap', callback);
+  },
+  onPageLoad(callback) {
+    document.addEventListener('zfb:page-load', callback);
+    return () => document.removeEventListener('zfb:page-load', callback);
+  },
+};
+
+setLifecycleAdapter(adapter);
+```
+
+Each installer must return a cleanup fn that unbinds the listener — the panel calls it on re-registration and on `setLifecycleAdapter(null)`.
+
+Behaviour notes:
+
+- When NO adapter is registered (initial state, or after `setLifecycleAdapter(null)`), the panel falls back to its built-in `astro:before-swap` / `astro:page-load` document listeners. Backwards-compatible — existing Astro consumers see zero behaviour change.
+- When an adapter IS registered, the astro fallback is **actively unbound** so the internal handlers never double-fire on hosts that emit both event sets.
+- `setLifecycleAdapter(null)` re-installs the astro fallback. Useful for tests and re-init scenarios.
+- Re-registration (calling `setLifecycleAdapter` twice with different adapters) drains the previous adapter's cleanup fns before binding the new one — no listener leaks.
+
 ---
 
 ## 9. Storage-key derivation

--- a/packages/zudo-design-token-panel/src/__tests__/lifecycle-adapter.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/lifecycle-adapter.test.ts
@@ -229,4 +229,83 @@ describe('design-token-panel lifecycle adapter (#50)', () => {
     await waitForEffectFlush();
     expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
   });
+
+  /**
+   * Partial-adapter behaviour — codex side-by-side review (P2) and codex
+   * adversarial review (medium) flagged that registering only one of
+   * `{onBeforeSwap, onPageLoad}` would silently drop the other channel
+   * and leak the Preact tree on body-swapping routers (zfb, custom SSGs).
+   * The fix retains the astro fallback for the unregistered channel and
+   * emits a `console.warn` so authors notice the silent gap.
+   */
+  describe('partial adapter (only one hook provided)', () => {
+    it('keeps the astro fallback for onPageLoad when the adapter only registers onBeforeSwap', async () => {
+      localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const beforeSwapCleanup = vi.fn<CleanupFn>();
+      const onBeforeSwap = vi.fn<Installer>(() => beforeSwapCleanup);
+      setLifecycleAdapter({ onBeforeSwap });
+
+      // The astro:page-load fallback was retained — dispatching it mounts
+      // the panel as if no adapter had been registered.
+      dispatchAstroPageLoad();
+      await waitForEffectFlush();
+      expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
+
+      expect(onBeforeSwap).toHaveBeenCalledTimes(1);
+      const onPageLoadWarn = warn.mock.calls.find((c) =>
+        typeof c[0] === 'string' && c[0].includes('onPageLoad'),
+      );
+      expect(onPageLoadWarn).toBeDefined();
+
+      warn.mockRestore();
+    });
+
+    it('keeps the astro fallback for onBeforeSwap when the adapter only registers onPageLoad', async () => {
+      localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      // Capture the adapter's onPageLoad callback so we can drive it
+      // directly — astro:page-load is now inert (adapter owns that channel).
+      let capturedPageLoad: () => void = () => {};
+      const pageLoadCleanup = vi.fn<CleanupFn>();
+      const onPageLoad = vi.fn<Installer>((cb: () => void) => {
+        capturedPageLoad = cb;
+        return pageLoadCleanup;
+      });
+      setLifecycleAdapter({ onPageLoad });
+
+      // Mount via the adapter's captured callback.
+      capturedPageLoad();
+      await waitForEffectFlush();
+      expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
+
+      // Now exercise the MISSING channel: astro:before-swap should still
+      // unmount because the fallback was retained for the gap.
+      document.dispatchEvent(new CustomEvent('astro:before-swap'));
+      await waitForEffectFlush();
+      expect(document.getElementById(PANEL_ROOT_ID)).toBeNull();
+
+      const onBeforeSwapWarn = warn.mock.calls.find((c) =>
+        typeof c[0] === 'string' && c[0].includes('onBeforeSwap'),
+      );
+      expect(onBeforeSwapWarn).toBeDefined();
+
+      warn.mockRestore();
+    });
+
+    it('does NOT emit the partial-adapter warning for a complete adapter (both hooks provided)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const mock = createAdapterMock();
+      setLifecycleAdapter(mock.adapter);
+      // Filter on the partial-adapter warning specifically — other warns
+      // (singleton check, etc.) may fire on bootstrap and are unrelated.
+      const partialWarn = warn.mock.calls.find((c) =>
+        typeof c[0] === 'string' && c[0].includes('LifecycleAdapter is missing'),
+      );
+      expect(partialWarn).toBeUndefined();
+      warn.mockRestore();
+    });
+  });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/lifecycle-adapter.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/lifecycle-adapter.test.ts
@@ -53,7 +53,14 @@ import {
   panelRootId,
   storageKey_visible,
 } from '../config/panel-config';
-import { setLifecycleAdapter } from '../index';
+import { setLifecycleAdapter, type LifecycleAdapter } from '../index';
+
+/** Cleanup-fn callable signature returned by an adapter installer. */
+type CleanupFn = () => void;
+/** Adapter installer signature: receives the panel's internal handler, returns a cleanup fn. */
+type Installer = (callback: () => void) => CleanupFn;
+/** A vi.fn() typed as an `Installer` so it satisfies the strict `LifecycleAdapter` callback signature. */
+type InstallerMock = ReturnType<typeof vi.fn<Installer>>;
 
 const STORAGE_KEY_VISIBLE = storageKey_visible(getPanelConfig());
 const PANEL_ROOT_ID = panelRootId(getPanelConfig());
@@ -80,32 +87,39 @@ function dispatchAstroPageLoad(): void {
 }
 
 interface AdapterMock {
-  adapter: {
-    onBeforeSwap: ReturnType<typeof vi.fn>;
-    onPageLoad: ReturnType<typeof vi.fn>;
-  };
-  beforeSwapCleanup: ReturnType<typeof vi.fn>;
-  pageLoadCleanup: ReturnType<typeof vi.fn>;
+  /** Typed as `LifecycleAdapter` so it passes `setLifecycleAdapter`'s strict signature. */
+  adapter: LifecycleAdapter;
+  /** Same installer fns kept under their concrete `InstallerMock` type so tests can assert call counts. */
+  onBeforeSwap: InstallerMock;
+  onPageLoad: InstallerMock;
+  beforeSwapCleanup: ReturnType<typeof vi.fn<CleanupFn>>;
+  pageLoadCleanup: ReturnType<typeof vi.fn<CleanupFn>>;
   /** Most recent installer callback captured per hook. */
   capturedBeforeSwap: () => void;
   capturedPageLoad: () => void;
 }
 
 function createAdapterMock(): AdapterMock {
+  const beforeSwapCleanup = vi.fn<CleanupFn>();
+  const pageLoadCleanup = vi.fn<CleanupFn>();
+  const onBeforeSwap = vi.fn<Installer>();
+  const onPageLoad = vi.fn<Installer>();
   const ref: AdapterMock = {
-    adapter: { onBeforeSwap: vi.fn(), onPageLoad: vi.fn() },
-    beforeSwapCleanup: vi.fn(),
-    pageLoadCleanup: vi.fn(),
+    adapter: { onBeforeSwap, onPageLoad },
+    onBeforeSwap,
+    onPageLoad,
+    beforeSwapCleanup,
+    pageLoadCleanup,
     capturedBeforeSwap: () => {},
     capturedPageLoad: () => {},
   };
-  ref.adapter.onBeforeSwap.mockImplementation((cb: () => void) => {
+  onBeforeSwap.mockImplementation((cb: () => void) => {
     ref.capturedBeforeSwap = cb;
-    return ref.beforeSwapCleanup;
+    return beforeSwapCleanup;
   });
-  ref.adapter.onPageLoad.mockImplementation((cb: () => void) => {
+  onPageLoad.mockImplementation((cb: () => void) => {
     ref.capturedPageLoad = cb;
-    return ref.pageLoadCleanup;
+    return pageLoadCleanup;
   });
   return ref;
 }
@@ -153,8 +167,8 @@ describe('design-token-panel lifecycle adapter (#50)', () => {
     const mock = createAdapterMock();
     setLifecycleAdapter(mock.adapter);
 
-    expect(mock.adapter.onBeforeSwap).toHaveBeenCalledTimes(1);
-    expect(mock.adapter.onPageLoad).toHaveBeenCalledTimes(1);
+    expect(mock.onBeforeSwap).toHaveBeenCalledTimes(1);
+    expect(mock.onPageLoad).toHaveBeenCalledTimes(1);
 
     // Astro fallback removed: dispatching the document event must NOT mount.
     dispatchAstroPageLoad();
@@ -185,8 +199,8 @@ describe('design-token-panel lifecycle adapter (#50)', () => {
     expect(adapterA.pageLoadCleanup).toHaveBeenCalledTimes(1);
 
     // B's installers ran once each.
-    expect(adapterB.adapter.onBeforeSwap).toHaveBeenCalledTimes(1);
-    expect(adapterB.adapter.onPageLoad).toHaveBeenCalledTimes(1);
+    expect(adapterB.onBeforeSwap).toHaveBeenCalledTimes(1);
+    expect(adapterB.onPageLoad).toHaveBeenCalledTimes(1);
 
     // Only B routes to the live handler; firing through B mounts the panel.
     adapterB.capturedPageLoad();

--- a/packages/zudo-design-token-panel/src/__tests__/lifecycle-adapter.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/lifecycle-adapter.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for the framework-agnostic lifecycle adapter introduced for #50.
+ *
+ * Background: the panel module historically hard-coded
+ * `astro:before-swap` / `astro:page-load` document listeners. That was
+ * fine for Astro consumers, dead code everywhere else (zfb, vite, custom
+ * SSGs). The adapter exposes `setLifecycleAdapter(...)` so non-Astro hosts
+ * can route the same internal handlers through their own client-side
+ * navigation lifecycle, while keeping the astro fallback for backwards
+ * compatibility.
+ *
+ * The contracts under test:
+ *
+ *   1. With NO adapter (astro fallback active): dispatching
+ *      `astro:before-swap` / `astro:page-load` on `document` runs the
+ *      internal handlers (visible side effect: when the visibility flag is
+ *      `'1'`, the panel root mounts).
+ *
+ *   2. With an adapter registered: the astro fallback is ACTIVELY UNBOUND.
+ *      The same astro events become inert — only the adapter's installer
+ *      callbacks route to the internal handlers.
+ *
+ *   3. Re-registration cleans up the previous adapter's cleanup fns
+ *      before binding the new one (no listener leaks).
+ *
+ *   4. `setLifecycleAdapter(null)` re-installs the astro fallback,
+ *      making the document listeners live again.
+ *
+ * Approach: rather than spy on the (private) internal handlers, we observe
+ * a public side effect that we know fires from `reapplyFromStorage`:
+ * when the panel's visibility flag is `'1'`, a page-load triggers a
+ * Preact mount and the panel root element appears in the DOM. We toggle
+ * visibility between phases and assert mount / no-mount behaviour. This
+ * keeps the test coupled to user-observable behaviour, not private symbols.
+ *
+ * Module-state caveat: the panel module installs document listeners at
+ * import time. If we used `vi.resetModules()` to get a fresh bootstrap per
+ * test, prior modules' listeners would linger on the document object
+ * (jsdom shares `document` across tests in a file) and a single dispatch
+ * would trigger every old `reapplyFromStorage` we've ever registered,
+ * defeating the unbind assertion. Instead we import the module ONCE for
+ * the whole file and reset state between tests via
+ * `setLifecycleAdapter(null)` (which drains current cleanup fns and
+ * re-binds the astro fallback) plus storage / DOM resets.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  getPanelConfig,
+  panelRootId,
+  storageKey_visible,
+} from '../config/panel-config';
+import { setLifecycleAdapter } from '../index';
+
+const STORAGE_KEY_VISIBLE = storageKey_visible(getPanelConfig());
+const PANEL_ROOT_ID = panelRootId(getPanelConfig());
+
+/**
+ * Wait for Preact's effect flush. Same recipe as
+ * `auto-mount-on-visibility.test.tsx` — see that file for the rAF /
+ * setTimeout timing rationale.
+ */
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+/**
+ * Trigger a synthetic astro page-load. Used as the probe for "is the astro
+ * fallback currently bound?" — when bound, this fires `reapplyFromStorage`,
+ * which mounts the panel iff `STORAGE_KEY_VISIBLE === '1'`.
+ */
+function dispatchAstroPageLoad(): void {
+  document.dispatchEvent(new CustomEvent('astro:page-load'));
+}
+
+interface AdapterMock {
+  adapter: {
+    onBeforeSwap: ReturnType<typeof vi.fn>;
+    onPageLoad: ReturnType<typeof vi.fn>;
+  };
+  beforeSwapCleanup: ReturnType<typeof vi.fn>;
+  pageLoadCleanup: ReturnType<typeof vi.fn>;
+  /** Most recent installer callback captured per hook. */
+  capturedBeforeSwap: () => void;
+  capturedPageLoad: () => void;
+}
+
+function createAdapterMock(): AdapterMock {
+  const ref: AdapterMock = {
+    adapter: { onBeforeSwap: vi.fn(), onPageLoad: vi.fn() },
+    beforeSwapCleanup: vi.fn(),
+    pageLoadCleanup: vi.fn(),
+    capturedBeforeSwap: () => {},
+    capturedPageLoad: () => {},
+  };
+  ref.adapter.onBeforeSwap.mockImplementation((cb: () => void) => {
+    ref.capturedBeforeSwap = cb;
+    return ref.beforeSwapCleanup;
+  });
+  ref.adapter.onPageLoad.mockImplementation((cb: () => void) => {
+    ref.capturedPageLoad = cb;
+    return ref.pageLoadCleanup;
+  });
+  return ref;
+}
+
+describe('design-token-panel lifecycle adapter (#50)', () => {
+  beforeAll(() => {
+    // Module-init bootstrap may have mounted the panel during import (the
+    // visibility flag could carry over from another test file in the same
+    // process). Drain the DOM once before the per-test setup takes over.
+    document.body.innerHTML = '';
+  });
+
+  beforeEach(() => {
+    // Restore the astro fallback bindings to a known clean state. This
+    // drains whatever cleanup fns the previous test left active and
+    // re-installs the astro fallback fresh — the document ends up with
+    // exactly one pair of `astro:before-swap` / `astro:page-load` listeners.
+    setLifecycleAdapter(null);
+    __resetPanelConfigForTests();
+    localStorage.clear();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    // Make sure no test leaves a custom adapter installed (which would
+    // unbind the astro fallback for whatever runs next).
+    setLifecycleAdapter(null);
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('astro fallback is active when no adapter is registered', async () => {
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+    expect(document.getElementById(PANEL_ROOT_ID)).toBeNull();
+
+    dispatchAstroPageLoad();
+    await waitForEffectFlush();
+
+    expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
+  });
+
+  it('registering an adapter unbinds the astro fallback', async () => {
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+
+    const mock = createAdapterMock();
+    setLifecycleAdapter(mock.adapter);
+
+    expect(mock.adapter.onBeforeSwap).toHaveBeenCalledTimes(1);
+    expect(mock.adapter.onPageLoad).toHaveBeenCalledTimes(1);
+
+    // Astro fallback removed: dispatching the document event must NOT mount.
+    dispatchAstroPageLoad();
+    await waitForEffectFlush();
+    expect(document.getElementById(PANEL_ROOT_ID)).toBeNull();
+
+    // Calling the adapter's captured page-load handler DOES mount —
+    // the same internal handler was rebound through the adapter.
+    mock.capturedPageLoad();
+    await waitForEffectFlush();
+    expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
+  });
+
+  it('re-registration cleans up the previous adapter before binding the new one', async () => {
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+
+    const adapterA = createAdapterMock();
+    const adapterB = createAdapterMock();
+
+    setLifecycleAdapter(adapterA.adapter);
+    expect(adapterA.beforeSwapCleanup).not.toHaveBeenCalled();
+    expect(adapterA.pageLoadCleanup).not.toHaveBeenCalled();
+
+    setLifecycleAdapter(adapterB.adapter);
+
+    // A's cleanups fired exactly once during the swap.
+    expect(adapterA.beforeSwapCleanup).toHaveBeenCalledTimes(1);
+    expect(adapterA.pageLoadCleanup).toHaveBeenCalledTimes(1);
+
+    // B's installers ran once each.
+    expect(adapterB.adapter.onBeforeSwap).toHaveBeenCalledTimes(1);
+    expect(adapterB.adapter.onPageLoad).toHaveBeenCalledTimes(1);
+
+    // Only B routes to the live handler; firing through B mounts the panel.
+    adapterB.capturedPageLoad();
+    await waitForEffectFlush();
+    expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
+  });
+
+  it('setLifecycleAdapter(null) restores the astro fallback', async () => {
+    localStorage.setItem(STORAGE_KEY_VISIBLE, '1');
+
+    const mock = createAdapterMock();
+    setLifecycleAdapter(mock.adapter);
+
+    // Sanity: astro is inert while the adapter owns the channel.
+    dispatchAstroPageLoad();
+    await waitForEffectFlush();
+    expect(document.getElementById(PANEL_ROOT_ID)).toBeNull();
+
+    setLifecycleAdapter(null);
+
+    expect(mock.beforeSwapCleanup).toHaveBeenCalledTimes(1);
+    expect(mock.pageLoadCleanup).toHaveBeenCalledTimes(1);
+
+    // Astro fallback is back: dispatching the document event mounts again.
+    dispatchAstroPageLoad();
+    await waitForEffectFlush();
+    expect(document.getElementById(PANEL_ROOT_ID)).not.toBeNull();
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/package-exports.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/package-exports.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 /**
  * Package-exports pin test.
@@ -94,5 +94,59 @@ describe('package.json exports — ./astro/host-adapter sub-export', () => {
         ).toBe(true);
       }
     }
+  });
+});
+
+describe('main entry — TweakState + emptyOverrides re-exports (#49)', () => {
+  /**
+   * The main entry must re-export `TweakState` (type) and `emptyOverrides`
+   * (runtime value) so external SerDe layers (e.g. zudo-doc's
+   * `design-token-serde.ts`) can construct a fully-populated `TweakState`
+   * without reaching into the package internals or the test-only
+   * `./testing` sub-export.
+   *
+   * Two layers of assertion:
+   *  (1) source-level — the index.tsx re-export line is present.
+   *  (2) dist-level runtime smoke — the built `dist/index.js` actually
+   *      surfaces `emptyOverrides` as a callable export. Skipped when
+   *      `dist/` has not been built yet (mirrors the existing pattern
+   *      used by the other dist-existence assertions in this file).
+   */
+
+  it('source: index.tsx re-exports TweakState (type) and emptyOverrides (value)', () => {
+    const indexSource = readFileSync(`${packageRoot}/src/index.tsx`, 'utf8');
+    expect(
+      indexSource,
+      'main entry must contain `export type { TweakState } ...` so consumers can import the type from the package root',
+    ).toMatch(/export\s+type\s*\{[^}]*\bTweakState\b[^}]*\}\s+from\s+['"]\.\/state\/tweak-state['"]/);
+    expect(
+      indexSource,
+      'main entry must contain `export { emptyOverrides } ...` so consumers can use the runtime factory from the package root',
+    ).toMatch(/export\s*\{[^}]*\bemptyOverrides\b[^}]*\}\s+from\s+['"]\.\/state\/tweak-state['"]/);
+  });
+
+  it('dist: built index.js exposes emptyOverrides as a callable export', async () => {
+    const distExists = existsSync(`${packageRoot}/dist`);
+    if (!distExists) {
+      // Mirror the skip-when-not-built behaviour of the other dist
+      // assertions in this file. CI runs the build before tests.
+      return;
+    }
+    const distIndex = `${packageRoot}/dist/index.js`;
+    expect(
+      existsSync(distIndex),
+      `${distIndex} must exist on disk — run pnpm --filter @takazudo/zudo-design-token-panel build first`,
+    ).toBe(true);
+    // Path-based dynamic import: avoids depending on whether the package
+    // is reachable by name from inside the package's own test context.
+    const mod = (await import(pathToFileURL(distIndex).href)) as Record<string, unknown>;
+    expect(
+      typeof mod.emptyOverrides,
+      'main entry must surface emptyOverrides as a runtime function',
+    ).toBe('function');
+    // Sanity: emptyOverrides() returns an empty plain object — the
+    // documented "default for new tabs" shape.
+    const result = (mod.emptyOverrides as () => Record<string, unknown>)();
+    expect(result).toEqual({});
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   DEFAULT_PANEL_CONFIG,
   __resetPanelConfigForTests,
+  assertValidPanelConfig,
   configurePanel,
   exportFilename,
   getPanelConfig,
@@ -188,5 +189,90 @@ describe('panel-config — configurePanel idempotency', () => {
     expect(() => configurePanel(CONFIG_B)).toThrow(/already called with different values/);
     // The first config is preserved — the second call did not silently overwrite.
     expect(getPanelConfig()).toEqual(CONFIG_A);
+  });
+});
+
+describe('panel-config — assertValidPanelConfig accepts and rejects legacyIdRenameMap shapes', () => {
+  /**
+   * The new optional `legacyIdRenameMap` is an opt-in for hosts who
+   * depended on the historical built-in typography rename. The validator
+   * gates the trust boundary on the inline JSON config, so it must accept
+   * an absent field, accept an empty / populated object whose values are
+   * all strings, and reject every other shape (null inside, array, value
+   * not a string).
+   */
+  function makeBaseConfig(extra: Partial<PanelConfig> = {}): PanelConfig {
+    return {
+      storagePrefix: 'p',
+      consoleNamespace: 'p',
+      modalClassPrefix: 'p-modal',
+      schemaId: 'p/v1',
+      exportFilenameBase: 'p',
+      tokens: EMPTY_MANIFEST,
+      colorCluster: EMPTY_CLUSTER,
+      ...extra,
+    };
+  }
+
+  it('accepts a config with no legacyIdRenameMap field (default)', () => {
+    expect(() => assertValidPanelConfig(makeBaseConfig())).not.toThrow();
+  });
+
+  it('accepts an empty legacyIdRenameMap', () => {
+    expect(() => assertValidPanelConfig(makeBaseConfig({ legacyIdRenameMap: {} }))).not.toThrow();
+  });
+
+  it('accepts a populated legacyIdRenameMap with string values', () => {
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          legacyIdRenameMap: { 'text-caption': 'text-xs', 'text-body': 'text-base' },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects legacyIdRenameMap with a non-string value', () => {
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          legacyIdRenameMap: { 'text-caption': 123 as any },
+        }),
+      ),
+    ).toThrow(/legacyIdRenameMap\["text-caption"\] must be a string/);
+  });
+
+  it('rejects legacyIdRenameMap when set to an array', () => {
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          legacyIdRenameMap: ['nope'] as any,
+        }),
+      ),
+    ).toThrow(/legacyIdRenameMap must be a plain object/);
+  });
+
+  it('rejects legacyIdRenameMap with a null value inside', () => {
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          legacyIdRenameMap: { 'text-caption': null as any },
+        }),
+      ),
+    ).toThrow(/legacyIdRenameMap\["text-caption"\] must be a string/);
+  });
+
+  it('rejects legacyIdRenameMap when set to null (not a plain object)', () => {
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          legacyIdRenameMap: null as any,
+        }),
+      ),
+    ).toThrow(/legacyIdRenameMap must be a plain object/);
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
@@ -232,7 +232,21 @@ describe('panel-config — assertValidPanelConfig accepts and rejects legacyIdRe
     ).not.toThrow();
   });
 
-  it('rejects legacyIdRenameMap with a non-string value', () => {
+  it('accepts legacyIdRenameMap with a null value (drop semantics)', () => {
+    // `null` signals "drop the legacy id entirely" — used for legacy ids
+    // that have no replacement in the current manifest. The validator
+    // must accept it because the historical zdtp-internal map relies on it
+    // (see ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP's text-micro entry).
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          legacyIdRenameMap: { 'text-micro': null, 'text-caption': 'text-xs' },
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rejects legacyIdRenameMap with a non-string non-null value', () => {
     expect(() =>
       assertValidPanelConfig(
         makeBaseConfig({
@@ -240,7 +254,7 @@ describe('panel-config — assertValidPanelConfig accepts and rejects legacyIdRe
           legacyIdRenameMap: { 'text-caption': 123 as any },
         }),
       ),
-    ).toThrow(/legacyIdRenameMap\["text-caption"\] must be a string/);
+    ).toThrow(/legacyIdRenameMap\["text-caption"\] must be a string or null/);
   });
 
   it('rejects legacyIdRenameMap when set to an array', () => {
@@ -254,18 +268,7 @@ describe('panel-config — assertValidPanelConfig accepts and rejects legacyIdRe
     ).toThrow(/legacyIdRenameMap must be a plain object/);
   });
 
-  it('rejects legacyIdRenameMap with a null value inside', () => {
-    expect(() =>
-      assertValidPanelConfig(
-        makeBaseConfig({
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          legacyIdRenameMap: { 'text-caption': null as any },
-        }),
-      ),
-    ).toThrow(/legacyIdRenameMap\["text-caption"\] must be a string/);
-  });
-
-  it('rejects legacyIdRenameMap when set to null (not a plain object)', () => {
+  it('rejects legacyIdRenameMap when the field itself is set to null', () => {
     expect(() =>
       assertValidPanelConfig(
         makeBaseConfig({
@@ -274,5 +277,16 @@ describe('panel-config — assertValidPanelConfig accepts and rejects legacyIdRe
         }),
       ),
     ).toThrow(/legacyIdRenameMap must be a plain object/);
+  });
+
+  it('rejects legacyIdRenameMap with an array value inside', () => {
+    expect(() =>
+      assertValidPanelConfig(
+        makeBaseConfig({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          legacyIdRenameMap: { 'text-caption': ['text-xs'] as any },
+        }),
+      ),
+    ).toThrow(/legacyIdRenameMap\["text-caption"\] must be a string or null/);
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
@@ -143,20 +143,17 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     // Payload written under the old id scheme (text-caption / text-body /
     // text-heading / text-display) should land on the new ids (text-xs /
     // text-base / text-3xl / text-5xl) when the host has opted in via
-    // PanelConfig.legacyIdRenameMap.
-    //
-    // Note: text-micro had no main-site equivalent in the historical
-    // hard-coded map, so it was dropped. The new Record<string, string>
-    // shape can only rename, not drop — a stray text-micro override now
-    // passes through verbatim and is silently ignored downstream by the
-    // apply pipeline (no token in the active manifest matches it).
+    // PanelConfig.legacyIdRenameMap. text-micro has no main-site
+    // equivalent so the historical map maps it to `null` (drop) — that
+    // semantic survives the move from a hard-coded internal map to the
+    // configurable opt-in map.
     installFixturePanelConfig({ legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } });
     STORAGE_KEY_V2 = getStorageKeyV2();
 
     const v2 = {
       color: makeColor(),
       typography: {
-        'text-micro': '0.8rem', // not in opt-in map — passes through
+        'text-micro': '0.8rem', // null in opt-in map → dropped
         'text-caption': '1rem',
         'text-small': '1.15rem',
         'text-body': '1.5rem',
@@ -170,7 +167,6 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     const result = loadPersistedState(storage, defaults);
 
     expect(result!.typography).toEqual({
-      'text-micro': '0.8rem',
       'text-xs': '1rem',
       'text-sm': '1.15rem',
       'text-base': '1.5rem',

--- a/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/spacing-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP,
   getStorageKeyV1,
   getStorageKeyV2,
   type ColorTweakState,
@@ -138,15 +139,24 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     expect(result!.spacing).toEqual({ 'hsp-sm': '0.75rem' });
   });
 
-  it('migrates legacy typography ids to the current main-site tiers', () => {
+  it('migrates legacy typography ids when the host opts into ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP', () => {
     // Payload written under the old id scheme (text-caption / text-body /
     // text-heading / text-display) should land on the new ids (text-xs /
-    // text-base / text-3xl / text-5xl). text-micro has no main-site
-    // equivalent and should be dropped silently.
+    // text-base / text-3xl / text-5xl) when the host has opted in via
+    // PanelConfig.legacyIdRenameMap.
+    //
+    // Note: text-micro had no main-site equivalent in the historical
+    // hard-coded map, so it was dropped. The new Record<string, string>
+    // shape can only rename, not drop — a stray text-micro override now
+    // passes through verbatim and is silently ignored downstream by the
+    // apply pipeline (no token in the active manifest matches it).
+    installFixturePanelConfig({ legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
     const v2 = {
       color: makeColor(),
       typography: {
-        'text-micro': '0.8rem', // dropped
+        'text-micro': '0.8rem', // not in opt-in map — passes through
         'text-caption': '1rem',
         'text-small': '1.15rem',
         'text-body': '1.5rem',
@@ -160,6 +170,7 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     const result = loadPersistedState(storage, defaults);
 
     expect(result!.typography).toEqual({
+      'text-micro': '0.8rem',
       'text-xs': '1rem',
       'text-sm': '1.15rem',
       'text-base': '1.5rem',
@@ -169,10 +180,13 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     });
   });
 
-  it('prefers the post-migration id when both legacy and current keys exist', () => {
+  it('prefers the post-migration id when both legacy and current keys exist (opt-in)', () => {
     // If the user already tweaked text-base after migration and we still
     // see an ancient text-body value lingering in storage, the fresh one
     // wins — we must not clobber the user's post-rename edit.
+    installFixturePanelConfig({ legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
     const v2 = {
       color: makeColor(),
       typography: {
@@ -185,5 +199,26 @@ describe('loadPersistedState — spacing / typography / size sections', () => {
     const result = loadPersistedState(storage, defaults);
 
     expect(result!.typography).toEqual({ 'text-base': '1.6rem' });
+  });
+
+  it('with default config (no legacyIdRenameMap): preserves typography ids verbatim (issue #51)', () => {
+    // Default fixture has no legacyIdRenameMap → the rename is a no-op.
+    // A stable id like text-caption that happens to match what the
+    // historical zdtp-internal map called "old" MUST survive verbatim.
+    const v2 = {
+      color: makeColor(),
+      typography: {
+        'text-caption': '1rem',
+        'text-body': '1.5rem',
+      },
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V2]: JSON.stringify(v2) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result!.typography).toEqual({
+      'text-caption': '1rem',
+      'text-body': '1.5rem',
+    });
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
@@ -337,7 +337,9 @@ describe('loadPersistedState — typography rename map (configurable)', () => {
   });
 
   it('exports ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP with the documented historical mappings', () => {
-    // Pin the constant's contents so the opt-in opt-in stays stable.
+    // Pin the constant's contents so the opt-in stays stable. text-micro
+    // maps to null (drop) — its historical "no main-site equivalent"
+    // semantic — so opt-in callers get the full original behaviour.
     expect(ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP).toEqual({
       'text-caption': 'text-xs',
       'text-small': 'text-sm',
@@ -345,6 +347,30 @@ describe('loadPersistedState — typography rename map (configurable)', () => {
       'text-subheading': 'text-lg',
       'text-heading': 'text-3xl',
       'text-display': 'text-5xl',
+      'text-micro': null,
     });
+  });
+
+  it('with legacyIdRenameMap value of null: drops the legacy id entirely (no dead persistence)', () => {
+    // Without drop semantics, a stray legacy id (e.g. text-micro) survives
+    // every save round-trip as dead localStorage data: applyTokenOverrides
+    // silently ignores ids missing from the active manifest, but every
+    // save writes the dead key back to disk. Mapping to `null` ensures the
+    // hydrate step purges it once and never persists it again.
+    installFixturePanelConfig({ legacyIdRenameMap: { 'text-micro': null } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({
+        'text-micro': '0.7rem',
+        'text-base': '1rem',
+      }),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.typography['text-micro']).toBeUndefined();
+    expect(result!.typography['text-base']).toBe('1rem');
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
+  ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP,
   getStorageKeyV1,
   getStorageKeyV2,
   type ColorTweakState,
@@ -240,5 +241,110 @@ describe('loadPersistedState — v1→v2 migration', () => {
     // migration ran successfully → v1 deleted, v2 overwritten
     expect(storage.entries[STORAGE_KEY_V1]).toBeUndefined();
     expect(storage.entries[STORAGE_KEY_V2]).toBeDefined();
+  });
+});
+
+/**
+ * Typography-id rename behaviour — driven by `PanelConfig.legacyIdRenameMap`.
+ *
+ * Pre-issue-#51 the migration map was hard-coded inside `loadPersistedState`,
+ * which silently corrupted hosts whose canonical manifest ids happened to
+ * match the "old" labels (e.g. `zudo-doc`'s `text-caption` was IS the
+ * stable id, not a legacy one). The map is now an opt-in config field;
+ * these tests pin both ends of that contract.
+ */
+describe('loadPersistedState — typography rename map (configurable)', () => {
+  /** Build a minimal v2 envelope with a single typography override. */
+  function makeV2WithTypography(typography: Record<string, string>): string {
+    return JSON.stringify({
+      color: makeV1(),
+      typography,
+    });
+  }
+
+  it('with NO legacyIdRenameMap configured: preserves stable ids verbatim (issue #51 regression)', () => {
+    // Default fixture config has no `legacyIdRenameMap` → empty rename map.
+    // A host whose canonical manifest id happens to be `text-caption` MUST
+    // see their override survive verbatim instead of being remapped to a
+    // non-existent id and silently dropped.
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({ 'text-caption': '0.9rem' }),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.typography).toEqual({ 'text-caption': '0.9rem' });
+  });
+
+  it('with legacyIdRenameMap = ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP: applies the historical rename', () => {
+    installFixturePanelConfig({ legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({
+        'text-caption': '0.9rem',
+        'text-body': '1.4rem',
+      }),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.typography['text-xs']).toBe('0.9rem');
+    expect(result!.typography['text-base']).toBe('1.4rem');
+    // Old ids are gone after the rename — only the new ids carry the value.
+    expect(result!.typography['text-caption']).toBeUndefined();
+    expect(result!.typography['text-body']).toBeUndefined();
+  });
+
+  it('with a custom partial map: only specified keys are renamed; others pass through', () => {
+    installFixturePanelConfig({
+      legacyIdRenameMap: { 'old-only-key': 'new-key' },
+    });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({
+        'old-only-key': '1rem',
+        'unrelated-key': '2rem',
+      }),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.typography['new-key']).toBe('1rem');
+    expect(result!.typography['unrelated-key']).toBe('2rem');
+    expect(result!.typography['old-only-key']).toBeUndefined();
+  });
+
+  it('when both old and new ids are present: new id wins (post-migration tweak preserved)', () => {
+    installFixturePanelConfig({ legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({
+        'text-caption': 'OLD',
+        'text-xs': 'NEW',
+      }),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.typography['text-xs']).toBe('NEW');
+  });
+
+  it('exports ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP with the documented historical mappings', () => {
+    // Pin the constant's contents so the opt-in opt-in stays stable.
+    expect(ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP).toEqual({
+      'text-caption': 'text-xs',
+      'text-small': 'text-sm',
+      'text-body': 'text-base',
+      'text-subheading': 'text-lg',
+      'text-heading': 'text-3xl',
+      'text-display': 'text-5xl',
+    });
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/tweak-state.test.ts
@@ -373,4 +373,67 @@ describe('loadPersistedState — typography rename map (configurable)', () => {
     expect(result!.typography['text-micro']).toBeUndefined();
     expect(result!.typography['text-base']).toBe('1rem');
   });
+
+  it('persists the renamed envelope back to storage so legacy ids do not survive (issue #51 codex finding)', () => {
+    // The migration must be DURABLE: rewriting in-memory only would leave
+    // legacy keys on disk indefinitely, and a host that later removes the
+    // opt-in rename map would regress every user back to non-applying
+    // overrides on the next reload.
+    installFixturePanelConfig({ legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({
+        'text-caption': '0.9rem',
+        'text-micro': '0.6rem',
+      }),
+    });
+
+    loadPersistedState(storage, defaults);
+
+    const rewritten = JSON.parse(storage.entries[STORAGE_KEY_V2]!) as {
+      typography: Record<string, string>;
+    };
+    expect(rewritten.typography['text-xs']).toBe('0.9rem');
+    expect(rewritten.typography['text-caption']).toBeUndefined();
+    expect(rewritten.typography['text-micro']).toBeUndefined();
+  });
+
+  it('does NOT rewrite storage when the typography slice is unchanged (no spurious writes)', () => {
+    // Guard against writeback churn for hosts whose payload already matches
+    // the canonical envelope — every reload would otherwise touch storage.
+    installFixturePanelConfig({ legacyIdRenameMap: {} });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const original = makeV2WithTypography({ 'text-caption': '0.9rem' });
+    const storage = makeStorage({ [STORAGE_KEY_V2]: original });
+
+    loadPersistedState(storage, defaults);
+
+    expect(storage.entries[STORAGE_KEY_V2]).toBe(original);
+  });
+
+  it('rejects prototype-chain payload keys as rename targets (Object.hasOwn guard)', () => {
+    // A payload key like `toString` / `constructor` / `hasOwnProperty`
+    // would match an inherited Object.prototype method under a `k in
+    // renameMap` check and corrupt the rename target. The Object.hasOwn
+    // guard ensures only own-property keys participate in the rename.
+    installFixturePanelConfig({ legacyIdRenameMap: { 'text-caption': 'text-xs' } });
+    STORAGE_KEY_V2 = getStorageKeyV2();
+
+    const storage = makeStorage({
+      [STORAGE_KEY_V2]: makeV2WithTypography({
+        toString: '1rem',
+        constructor: '2rem',
+        'text-caption': '0.9rem',
+      }),
+    });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.typography['toString']).toBe('1rem');
+    expect(result!.typography['constructor']).toBe('2rem');
+    expect(result!.typography['text-xs']).toBe('0.9rem');
+  });
 });

--- a/packages/zudo-design-token-panel/src/astro/host-adapter.ts
+++ b/packages/zudo-design-token-panel/src/astro/host-adapter.ts
@@ -56,6 +56,7 @@ import {
   storageKey_visible,
   type PanelConfig,
 } from '../config/panel-config';
+import { ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } from '../state/tweak-state';
 
 interface DesignTokenPanelAdapterState {
   /** Per-`storagePrefix` bind flag — re-runs of the script are no-ops. */
@@ -243,7 +244,17 @@ function installConsoleApi(
 (function bootstrap(): void {
   // 1. Parse and apply config FIRST so every subsequent reader (storage keys,
   //    console namespace, …) observes the host's intended values.
-  const config = readInlineConfig();
+  //
+  // The astro path is the historical zdtp-internal caller — its persisted
+  // payloads predate issue #51 and use the legacy typography ids
+  // (`text-caption`, `text-small`, …) that the host's manifest now publishes
+  // under their Tailwind-tier names. Inject the opt-in legacy rename map
+  // here unless the host already supplied one, so existing astro deployments
+  // don't lose user tweaks on the upgrade.
+  const inline = readInlineConfig();
+  const config: PanelConfig = inline.legacyIdRenameMap
+    ? inline
+    : { ...inline, legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } };
   configurePanel(config);
 
   // Re-read via `getPanelConfig()` so the storage/namespace derivations use

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -111,6 +111,22 @@ export interface PanelConfig {
    * routing map).
    */
   applyRouting?: ApplyRoutingMap;
+  /**
+   * Optional id rename map applied during `loadPersistedState` migration.
+   * Keys are old ids found in persisted state; values are new canonical ids.
+   *
+   * Defaults to an empty map (no renaming) so hosts whose manifest ids are
+   * already stable (e.g. `zudo-doc`, whose canonical typography ids are the
+   * same names that an earlier zdtp-internal port step treated as "old"
+   * labels) are not corrupted: an override on a stable id was being remapped
+   * to a non-existent id and silently dropped.
+   *
+   * zdtp's own astro wiring opts in by passing the legacy zdtp-internal map
+   * (`ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP`, exported from the package root)
+   * via this field, preserving the historical rename for callers that depend
+   * on it.
+   */
+  legacyIdRenameMap?: Record<string, string>;
 }
 
 /**
@@ -380,6 +396,22 @@ export function assertValidPanelConfig(value: unknown): asserts value is PanelCo
       if (typeof v !== 'string') {
         throw new Error(
           `[design-token-panel] PanelConfig.applyRouting[${JSON.stringify(k)}] must be a string`,
+        );
+      }
+    }
+  }
+  if (cfg.legacyIdRenameMap !== undefined) {
+    if (
+      cfg.legacyIdRenameMap === null ||
+      typeof cfg.legacyIdRenameMap !== 'object' ||
+      Array.isArray(cfg.legacyIdRenameMap)
+    ) {
+      throw new Error('[design-token-panel] PanelConfig.legacyIdRenameMap must be a plain object');
+    }
+    for (const [k, v] of Object.entries(cfg.legacyIdRenameMap as Record<string, unknown>)) {
+      if (typeof v !== 'string') {
+        throw new Error(
+          `[design-token-panel] PanelConfig.legacyIdRenameMap[${JSON.stringify(k)}] must be a string`,
         );
       }
     }

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -113,20 +113,28 @@ export interface PanelConfig {
   applyRouting?: ApplyRoutingMap;
   /**
    * Optional id rename map applied during `loadPersistedState` migration.
-   * Keys are old ids found in persisted state; values are new canonical ids.
+   * Keys are old ids found in persisted state; values are either:
    *
-   * Defaults to an empty map (no renaming) so hosts whose manifest ids are
-   * already stable (e.g. `zudo-doc`, whose canonical typography ids are the
-   * same names that an earlier zdtp-internal port step treated as "old"
-   * labels) are not corrupted: an override on a stable id was being remapped
-   * to a non-existent id and silently dropped.
+   *  - A `string` — new canonical id; the value moves to that key.
+   *  - `null` — drop the id entirely. Use this for legacy ids that have no
+   *    replacement in the current manifest (otherwise stray overrides
+   *    persist indefinitely as dead localStorage data: the apply pipeline
+   *    silently ignores ids missing from the active manifest, but every
+   *    save round-trips the dead key back to disk).
+   *
+   * Defaults to an empty map (no renaming, no drops) so hosts whose
+   * manifest ids are already stable (e.g. `zudo-doc`, whose canonical
+   * typography ids are the same names that an earlier zdtp-internal port
+   * step treated as "old" labels) are not corrupted: an override on a
+   * stable id was being remapped to a non-existent id and silently
+   * dropped.
    *
    * zdtp's own astro wiring opts in by passing the legacy zdtp-internal map
    * (`ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP`, exported from the package root)
-   * via this field, preserving the historical rename for callers that depend
-   * on it.
+   * via this field, preserving the historical rename + drop behaviour for
+   * callers that depend on it.
    */
-  legacyIdRenameMap?: Record<string, string>;
+  legacyIdRenameMap?: Record<string, string | null>;
 }
 
 /**
@@ -409,9 +417,9 @@ export function assertValidPanelConfig(value: unknown): asserts value is PanelCo
       throw new Error('[design-token-panel] PanelConfig.legacyIdRenameMap must be a plain object');
     }
     for (const [k, v] of Object.entries(cfg.legacyIdRenameMap as Record<string, unknown>)) {
-      if (typeof v !== 'string') {
+      if (v !== null && typeof v !== 'string') {
         throw new Error(
-          `[design-token-panel] PanelConfig.legacyIdRenameMap[${JSON.stringify(k)}] must be a string`,
+          `[design-token-panel] PanelConfig.legacyIdRenameMap[${JSON.stringify(k)}] must be a string or null (got ${typeof v})`,
         );
       }
     }

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -480,17 +480,49 @@ function bindAstroFallback(state: AdapterLifecycleState): void {
  * adapter. Each adapter installer returns a cleanup fn we capture so the
  * next `setLifecycleAdapter` call can drain it.
  *
- * Defensive: if the adapter omits a hook, we skip that hook silently — the
- * intent is "host owns this lifecycle channel, but only the channels it
- * implements". The other channel stays unbound (no astro fallback) because
- * mixing two channels would double-fire the handler on hosts that emit both.
+ * If the adapter omits a hook, the corresponding astro fallback listener is
+ * retained for that channel — otherwise a host registering only one of
+ * `{onBeforeSwap, onPageLoad}` would silently leak the other channel
+ * (no `unmountForSwap` → orphaned Preact tree on body-swapping routers, or
+ * no `reapplyFromStorage` → persisted overrides not re-applied after nav).
+ * The internal handlers are idempotent, so a host that emits both astro
+ * events AND its own custom event observes at most a no-op double-call.
+ *
+ * A `console.warn` fires for partial adapters so authors notice the
+ * fallback was retained — silent acceptance was the original design and
+ * caused a real leak in zfb-style hosts that only have a before-swap event.
  */
 function bindAdapter(state: AdapterLifecycleState, adapter: LifecycleAdapter): void {
+  if (typeof document === 'undefined') return;
   if (adapter.onBeforeSwap) {
     state.cleanups.push(adapter.onBeforeSwap(unmountForSwap));
+  } else {
+    document.addEventListener('astro:before-swap', unmountForSwap);
+    state.cleanups.push(() =>
+      document.removeEventListener('astro:before-swap', unmountForSwap),
+    );
   }
   if (adapter.onPageLoad) {
     state.cleanups.push(adapter.onPageLoad(reapplyFromStorage));
+  } else {
+    document.addEventListener('astro:page-load', reapplyFromStorage);
+    state.cleanups.push(() =>
+      document.removeEventListener('astro:page-load', reapplyFromStorage),
+    );
+  }
+  if (!adapter.onBeforeSwap || !adapter.onPageLoad) {
+    const missing = [
+      !adapter.onBeforeSwap ? 'onBeforeSwap' : null,
+      !adapter.onPageLoad ? 'onPageLoad' : null,
+    ]
+      .filter(Boolean)
+      .join(', ');
+    console.warn(
+      `[design-token-panel] LifecycleAdapter is missing ${missing}. ` +
+        'Astro fallback listener retained for the missing channel(s) so the ' +
+        'panel does not leak the Preact tree or skip override re-apply on ' +
+        'soft-nav. Provide the hook explicitly to silence this warning.',
+    );
   }
 }
 

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -366,8 +366,52 @@ function onMaybeMount(): void {
   ensureMounted();
 }
 
+// ---------------------------------------------------------------------------
+// Framework-agnostic lifecycle adapter (#50)
+//
+// Historically the module hard-coded `astro:before-swap` / `astro:page-load`
+// document listeners — fine for Astro hosts, dead code everywhere else
+// (zfb, vite, custom SSGs). To support soft-nav for non-Astro hosts without
+// breaking existing Astro consumers, the lifecycle hooks now route through
+// an internal "active bindings" registry:
+//
+//  - At import-time we install the astro fallback and capture its cleanup
+//    fns (the registry's initial entries).
+//  - `setLifecycleAdapter(adapter)` calls every captured cleanup fn (which
+//    actively unbinds the astro listeners or any previously-registered
+//    adapter), then re-binds the same internal handlers through the
+//    adapter's `onBeforeSwap` / `onPageLoad`, capturing their returned
+//    cleanup fns for the next swap.
+//  - `setLifecycleAdapter(null)` clears the current adapter and re-installs
+//    the astro fallback — useful for tests and re-init scenarios.
+//
+// The registered handlers are the existing `unmountForSwap` /
+// `reapplyFromStorage` functions — the adapter only changes WHO calls them.
+// ---------------------------------------------------------------------------
+
+/**
+ * Framework-agnostic lifecycle hook adapter. A host that owns its own
+ * client-side navigation lifecycle (zfb, custom router, etc.) implements
+ * this and calls `setLifecycleAdapter(...)` so persisted overrides re-apply
+ * after every soft navigation without depending on Astro events.
+ *
+ * Each callback installer must return a cleanup function that unbinds the
+ * listener — `setLifecycleAdapter` calls these on re-registration and on
+ * `setLifecycleAdapter(null)`.
+ */
+export interface LifecycleAdapter {
+  /** Install a handler that fires before a client-side navigation swaps the document. */
+  onBeforeSwap?: (callback: () => void) => () => void;
+  /** Install a handler that fires after a client-side navigation has loaded the new page. */
+  onPageLoad?: (callback: () => void) => () => void;
+}
+
 interface AdapterLifecycleState {
   bound: boolean;
+  /** Cleanup fns for whatever set of bindings is currently active (astro fallback or a registered adapter). */
+  cleanups: Array<() => void>;
+  /** The adapter currently in effect, or `null` when the astro fallback is active. */
+  adapter: LifecycleAdapter | null;
 }
 
 /**
@@ -384,9 +428,77 @@ type AdapterWindow = Window & {
 function getAdapterState(): AdapterLifecycleState {
   const w = window as AdapterWindow;
   if (w.__zudoDesignTokenPanelLifecycle) return w.__zudoDesignTokenPanelLifecycle;
-  const state: AdapterLifecycleState = { bound: false };
+  const state: AdapterLifecycleState = { bound: false, cleanups: [], adapter: null };
   w.__zudoDesignTokenPanelLifecycle = state;
   return state;
+}
+
+/** Active cleanup fns are tracked on the lifecycle state so re-bind paths can drain them in one call. */
+function runCleanups(state: AdapterLifecycleState): void {
+  const fns = state.cleanups;
+  state.cleanups = [];
+  for (const fn of fns) {
+    try {
+      fn();
+    } catch {
+      /* a listener-removal that throws should not abort the rebind */
+    }
+  }
+}
+
+/**
+ * Install the astro fallback document listeners and record their removers
+ * on the lifecycle state's cleanup list. SSR-guarded — outside a browser
+ * the listeners are a no-op and the cleanup list stays empty.
+ */
+function bindAstroFallback(state: AdapterLifecycleState): void {
+  if (typeof document === 'undefined') return;
+  document.addEventListener('astro:before-swap', unmountForSwap);
+  document.addEventListener('astro:page-load', reapplyFromStorage);
+  state.cleanups.push(
+    () => document.removeEventListener('astro:before-swap', unmountForSwap),
+    () => document.removeEventListener('astro:page-load', reapplyFromStorage),
+  );
+}
+
+/**
+ * Install the same internal handlers through a host-supplied lifecycle
+ * adapter. Each adapter installer returns a cleanup fn we capture so the
+ * next `setLifecycleAdapter` call can drain it.
+ *
+ * Defensive: if the adapter omits a hook, we skip that hook silently — the
+ * intent is "host owns this lifecycle channel, but only the channels it
+ * implements". The other channel stays unbound (no astro fallback) because
+ * mixing two channels would double-fire the handler on hosts that emit both.
+ */
+function bindAdapter(state: AdapterLifecycleState, adapter: LifecycleAdapter): void {
+  if (adapter.onBeforeSwap) {
+    state.cleanups.push(adapter.onBeforeSwap(unmountForSwap));
+  }
+  if (adapter.onPageLoad) {
+    state.cleanups.push(adapter.onPageLoad(reapplyFromStorage));
+  }
+}
+
+/**
+ * Register a framework-agnostic lifecycle adapter (or pass `null` to
+ * restore the astro fallback). Safe to call before or after the module's
+ * import-time bootstrap — late registration drains the astro fallback's
+ * cleanup fns first, so the original document listeners are actively
+ * unbound and never double-fire alongside the adapter.
+ *
+ * No-op outside a browser context (SSR-safe).
+ */
+export function setLifecycleAdapter(adapter: LifecycleAdapter | null): void {
+  if (typeof window === 'undefined') return;
+  const state = getAdapterState();
+  runCleanups(state);
+  state.adapter = adapter;
+  if (adapter) {
+    bindAdapter(state, adapter);
+  } else {
+    bindAstroFallback(state);
+  }
 }
 
 if (typeof window !== 'undefined') {
@@ -397,10 +509,9 @@ if (typeof window !== 'undefined') {
     window.addEventListener(TOGGLE_EVENT, onMaybeMount);
     window.addEventListener(TOGGLE_EVENT_ALIAS, onMaybeMount);
 
-    if (typeof document !== 'undefined') {
-      document.addEventListener('astro:before-swap', unmountForSwap);
-      document.addEventListener('astro:page-load', reapplyFromStorage);
-    }
+    // Initial bindings: astro fallback. `setLifecycleAdapter(...)` rewrites
+    // this set later if a host installs an adapter.
+    bindAstroFallback(state);
 
     // Apply persisted overrides to `:root` BEFORE any Preact render — kills
     // the hard-navigation FOUT. `reapplyFromStorage()` below then mounts the

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -232,6 +232,14 @@ export type { ColorScheme, ColorRef } from './config/color-schemes';
 // Re-export the `TokenManifest` shape so consumers can type their
 // host-supplied `panelConfig.tokens` field.
 export type { TokenManifest, TokenDef } from './tokens/manifest';
+// Re-export the unified `TweakState` envelope and the `emptyOverrides()`
+// factory so external SerDe / persistence layers (e.g. zudo-doc's
+// `design-token-serde.ts`) can construct and type a fully-populated
+// `TweakState` without reaching into the package's internals or the
+// test-only `./testing` sub-export. Type-only export of `TweakState`
+// avoids isolatedModules surprises; `emptyOverrides` is a runtime value.
+export type { TweakState } from './state/tweak-state';
+export { emptyOverrides } from './state/tweak-state';
 
 export function showDesignTokenPanel(): void {
   if (typeof window === 'undefined') return;

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -226,6 +226,12 @@ export function __panelConfigForTest(): PanelConfig {
 // `import type { ColorClusterConfig } from '@takazudo/zudo-design-token-panel'`
 // instead of digging into an internal sub-path.
 export type { ColorClusterConfig } from './state/tweak-state';
+// Opt-in legacy zdtp-internal typography rename map. Hosts that depended on
+// the historical built-in rename (text-caption → text-xs, …) can pass this
+// constant via `PanelConfig.legacyIdRenameMap` to keep the old behaviour;
+// the default `loadPersistedState` path now applies an empty rename map so
+// hosts whose manifest ids are stable are not corrupted (issue #51).
+export { ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } from './state/tweak-state';
 // Re-exported so hosts can type the entries of their optional
 // `PanelConfig.colorPresets` map without reaching for an internal sub-path.
 export type { ColorScheme, ColorRef } from './config/color-schemes';

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -867,10 +867,13 @@ function hydrateTypographyOverrides(
   const out: TokenOverrides = {};
   for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
     if (typeof v !== 'string') continue;
-    if (k in renameMap) {
+    // `Object.hasOwn` (not `k in renameMap`) so a payload key like
+    // `toString` / `constructor` cannot match an inherited Object.prototype
+    // method and corrupt the rename target.
+    if (Object.hasOwn(renameMap, k)) {
       const target = renameMap[k];
       if (target === null) continue; // dropped legacy id
-      if (!(target in out)) {
+      if (!Object.hasOwn(out, target)) {
         // Only take the legacy value if no post-migration value already set.
         out[target] = v;
       }
@@ -955,6 +958,21 @@ export function loadPersistedState(
             obj.secondary as Partial<ColorTweakState>,
             initSecondaryDefaults(secondaryCluster),
           );
+        }
+        // Renormalize storage when the typography migration actually changed
+        // the slice (rename or null-drop) OR the legacy `font` alias was
+        // used instead of `typography`. Without this, legacy ids and dropped
+        // entries survive on disk indefinitely as dead data, and a host
+        // that later removes the opt-in rename map regresses every user
+        // back to non-applying overrides.
+        const typographyChanged =
+          JSON.stringify(typographySlice ?? {}) !== JSON.stringify(next.typography);
+        if (typographyChanged || obj.typography === undefined) {
+          try {
+            storage.setItem(STORAGE_KEY_V2, JSON.stringify(next));
+          } catch {
+            /* storage full — return the in-memory state anyway */
+          }
         }
         return next;
       }

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -794,8 +794,10 @@ export interface StorageLike {
  * panel-internal labels (`text-caption`, `text-small`, `text-body`,
  * `text-subheading`, `text-heading`, `text-display`) to main-site Tailwind
  * tiers (`text-xs`, `text-sm`, `text-base`, `text-lg`, `text-3xl`,
- * `text-5xl`). This map preserves persisted user tweaks across that
- * one-time rename for callers that opt in.
+ * `text-5xl`), and dropped `text-micro` entirely (no main-site equivalent
+ * exists). This map preserves persisted user tweaks across that one-time
+ * rename — including the drop of `text-micro` (`null` value) — for callers
+ * that opt in.
  *
  * Critically, this map is NOT applied by default any more (see issue #51):
  * hosts whose canonical manifest ids share names with these "old" labels —
@@ -803,23 +805,23 @@ export interface StorageLike {
  * their valid overrides remapped to non-existent ids and silently dropped.
  * The default `loadPersistedState` path now applies an empty rename map.
  *
- * Note: the historical map also "dropped" `text-micro` (mapped it to null)
- * because no main-site equivalent existed. The new
- * `Record<string, string>` shape can express renames but not drops; a
- * stray `text-micro` override that survives migration is harmless because
- * `applyTokenOverrides` silently ignores ids that are not in the active
- * manifest.
+ * The `text-micro: null` entry exists because dropping is the only way to
+ * keep an obsolete legacy id from persisting indefinitely as dead
+ * localStorage data: `applyTokenOverrides` silently ignores unknown ids,
+ * but every save round-trips the dead key back to disk.
  *
  * Spacing + size manifest ids were NOT renamed (hsp-/vsp- ids kept their
  * labels), so this migration only applies to the typography slice.
  */
-export const ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP: Readonly<Record<string, string>> = {
+export const ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP: Readonly<Record<string, string | null>> = {
   'text-caption': 'text-xs',
   'text-small': 'text-sm',
   'text-body': 'text-base',
   'text-subheading': 'text-lg',
   'text-heading': 'text-3xl',
   'text-display': 'text-5xl',
+  // Dropped — no main-site equivalent. `null` signals "discard".
+  'text-micro': null,
 };
 
 /**
@@ -839,9 +841,16 @@ function hydrateOverrides(raw: unknown): TokenOverrides {
 
 /**
  * Same as `hydrateOverrides` but also rewrites typography-slice keys per a
- * caller-supplied rename map. If BOTH the old and new ids are present, the
- * new id wins (user actively tweaked it post-migration). Keys not mentioned
- * in the rename map pass through unchanged.
+ * caller-supplied rename map. Map values are interpreted as:
+ *
+ *  - A `string` — rename: the value moves to that key. If BOTH the old and
+ *    new ids are present in the payload, the new id wins (post-migration
+ *    user tweak preserved).
+ *  - `null` — drop the legacy id entirely (no replacement in the active
+ *    manifest). Without this, a stray legacy override survives every save
+ *    as dead localStorage data.
+ *
+ * Keys not mentioned in the rename map pass through unchanged.
  *
  * The rename map is sourced from `PanelConfig.legacyIdRenameMap` at call time
  * by `loadPersistedState`. The default is an empty map (no renaming) so
@@ -852,7 +861,7 @@ function hydrateOverrides(raw: unknown): TokenOverrides {
  */
 function hydrateTypographyOverrides(
   raw: unknown,
-  renameMap: Readonly<Record<string, string>> = {},
+  renameMap: Readonly<Record<string, string | null>> = {},
 ): TokenOverrides {
   if (!raw || typeof raw !== 'object') return {};
   const out: TokenOverrides = {};
@@ -860,6 +869,7 @@ function hydrateTypographyOverrides(
     if (typeof v !== 'string') continue;
     if (k in renameMap) {
       const target = renameMap[k];
+      if (target === null) continue; // dropped legacy id
       if (!(target in out)) {
         // Only take the legacy value if no post-migration value already set.
         out[target] = v;

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -787,32 +787,39 @@ export interface StorageLike {
 }
 
 /**
- * Legacy → current id mapping for the typography slice.
+ * Legacy zdtp-internal typography rename map — opt-in via
+ * `PanelConfig.legacyIdRenameMap`.
  *
- * An earlier port step renamed the font-size manifest ids from panel-internal
- * labels (`text-caption`, `text-small`, `text-body`, `text-subheading`,
- * `text-heading`, `text-display`) to main-site Tailwind tiers (`text-xs`,
- * `text-sm`, `text-base`, `text-lg`, `text-3xl`, `text-5xl`). The
- * `text-micro` id was dropped entirely (no `--zd-font-xxs` equivalent in the
- * design system).
+ * An earlier zdtp-internal port step renamed the font-size manifest ids from
+ * panel-internal labels (`text-caption`, `text-small`, `text-body`,
+ * `text-subheading`, `text-heading`, `text-display`) to main-site Tailwind
+ * tiers (`text-xs`, `text-sm`, `text-base`, `text-lg`, `text-3xl`,
+ * `text-5xl`). This map preserves persisted user tweaks across that
+ * one-time rename for callers that opt in.
  *
- * When a v2 payload comes in with the old ids we rewrite the keys here so
- * existing persisted tweaks survive the rename without the user losing
- * their work. Unknown / dropped ids (e.g. `text-micro`) are silently
- * discarded — they no longer route to anything.
+ * Critically, this map is NOT applied by default any more (see issue #51):
+ * hosts whose canonical manifest ids share names with these "old" labels —
+ * e.g. `zudo-doc`, where `text-caption` IS the stable id — were having
+ * their valid overrides remapped to non-existent ids and silently dropped.
+ * The default `loadPersistedState` path now applies an empty rename map.
  *
- * Note: spacing + size manifest ids were NOT renamed (hsp-/vsp- ids kept
- * their labels), so this migration only applies to the typography slice.
+ * Note: the historical map also "dropped" `text-micro` (mapped it to null)
+ * because no main-site equivalent existed. The new
+ * `Record<string, string>` shape can express renames but not drops; a
+ * stray `text-micro` override that survives migration is harmless because
+ * `applyTokenOverrides` silently ignores ids that are not in the active
+ * manifest.
+ *
+ * Spacing + size manifest ids were NOT renamed (hsp-/vsp- ids kept their
+ * labels), so this migration only applies to the typography slice.
  */
-const TYPOGRAPHY_ID_MIGRATIONS: Readonly<Record<string, string | null>> = {
+export const ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP: Readonly<Record<string, string>> = {
   'text-caption': 'text-xs',
   'text-small': 'text-sm',
   'text-body': 'text-base',
   'text-subheading': 'text-lg',
   'text-heading': 'text-3xl',
   'text-display': 'text-5xl',
-  // Dropped — no main-site equivalent. Null signals "discard".
-  'text-micro': null,
 };
 
 /**
@@ -831,19 +838,28 @@ function hydrateOverrides(raw: unknown): TokenOverrides {
 }
 
 /**
- * Same as `hydrateOverrides` but also rewrites legacy typography-slice keys
- * per `TYPOGRAPHY_ID_MIGRATIONS`. If BOTH the old and new ids are present,
- * the new id wins (user actively tweaked it post-migration). Keys mapped to
- * `null` are dropped.
+ * Same as `hydrateOverrides` but also rewrites typography-slice keys per a
+ * caller-supplied rename map. If BOTH the old and new ids are present, the
+ * new id wins (user actively tweaked it post-migration). Keys not mentioned
+ * in the rename map pass through unchanged.
+ *
+ * The rename map is sourced from `PanelConfig.legacyIdRenameMap` at call time
+ * by `loadPersistedState`. The default is an empty map (no renaming) so
+ * hosts whose manifest ids are stable are not corrupted by an opinionated
+ * built-in rename — see issue #51 and the doc on
+ * `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` for the historical zdtp-internal map
+ * that callers can opt into.
  */
-function hydrateTypographyOverrides(raw: unknown): TokenOverrides {
+function hydrateTypographyOverrides(
+  raw: unknown,
+  renameMap: Readonly<Record<string, string>> = {},
+): TokenOverrides {
   if (!raw || typeof raw !== 'object') return {};
   const out: TokenOverrides = {};
   for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
     if (typeof v !== 'string') continue;
-    if (k in TYPOGRAPHY_ID_MIGRATIONS) {
-      const target = TYPOGRAPHY_ID_MIGRATIONS[k];
-      if (target === null) continue; // dropped id
+    if (k in renameMap) {
+      const target = renameMap[k];
       if (!(target in out)) {
         // Only take the legacy value if no post-migration value already set.
         out[target] = v;
@@ -894,15 +910,21 @@ export function loadPersistedState(
       if (obj.color && isValidColorShape(obj.color, cluster.paletteSize)) {
         const defaults = colorDefaults ?? tryInitColorFromScheme(cluster);
         const typographySlice = obj.typography !== undefined ? obj.typography : obj.font;
+        // Rename map sourced from the active panel config. Defaults to an
+        // empty map (no renaming) so hosts whose manifest ids are stable are
+        // not corrupted — see issue #51 and the doc on
+        // `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` for the opt-in zdtp-internal
+        // map.
+        const renameMap = getPanelConfig().legacyIdRenameMap ?? {};
         const next: TweakState = {
           color: hydrateColorState(obj.color as Partial<ColorTweakState>, defaults),
           // New sections added after v1 migration — tolerate their absence so
           // older v2 payloads (Color-only) still load cleanly.
           spacing: hydrateOverrides(obj.spacing),
-          // Typography slice: run through the id-migration step so payloads
-          // persisted under the old ids (text-caption, text-body, …) survive
-          // the rename to main-site tiers (text-xs, text-base, …).
-          typography: hydrateTypographyOverrides(typographySlice),
+          // Typography slice: apply the host-configured rename map (if any)
+          // so payloads persisted under the host's "old" ids survive a
+          // host-driven id rename without losing the user's tweaks.
+          typography: hydrateTypographyOverrides(typographySlice, renameMap),
           size: hydrateOverrides(obj.size),
           panelPosition: hydratePanelPosition(obj.panelPosition),
         };


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/52
- closes
    - https://github.com/Takazudo/zudo-design-token-panel/issues/49
    - https://github.com/Takazudo/zudo-design-token-panel/issues/50
    - https://github.com/Takazudo/zudo-design-token-panel/issues/51

---

## Summary

Three independent library issues handled in parallel as one /x-wt-teams session against `@takazudo/zudo-design-token-panel`:

- **#49** — Export `TweakState` (type) and `emptyOverrides` from the package main entry.
- **#50** — Add framework-agnostic `setLifecycleAdapter` API for non-Astro hosts.
- **#51** — Make the typography-id rename map configurable via `PanelConfig.legacyIdRenameMap` (default empty).

A combined deep-review pass (codex side-by-side, codex adversarial, gpt-4.1 copilot, plus 3 Claude Opus reviewers in parallel) caught a handful of issues that have been fixed in the same PR — most notably a wire-up gap in the astro host-adapter that would have silently dropped the historical typography rename for zdtp's own users.

## Changes

### #49 — Main-entry exports for TweakState / emptyOverrides

- `src/index.tsx`: `export type { TweakState }` and `export { emptyOverrides }` from `./state/tweak-state`. The type-only export keeps the `isolatedModules` build honest.
- `src/__tests__/package-exports.test.ts`: extended with a runtime dist-level smoke that exercises the built output (not just the source-level export) — the existing test only pinned the exports map.

### #50 — Framework-agnostic lifecycle adapter

- New public API in `src/index.tsx`:
  ```ts
  export interface LifecycleAdapter {
    onBeforeSwap?: (cb: () => void) => () => void;
    onPageLoad?:   (cb: () => void) => () => void;
  }
  export function setLifecycleAdapter(adapter: LifecycleAdapter | null): void;
  ```
- When no adapter is registered, the package falls back to the existing `astro:before-swap` / `astro:page-load` document listeners (backwards-compatible).
- Registering an adapter actively unbinds the astro fallback and rebinds through the adapter; `setLifecycleAdapter(null)` restores the fallback. Re-registration drains the previous adapter's cleanup fns first.
- **Partial-adapter safety**: when a host registers only one of `{onBeforeSwap, onPageLoad}`, the astro fallback is retained for the missing channel and a `console.warn` fires so authors notice the silent gap (catches a leak in zfb-style soft-nav hosts that only have a before-swap event).
- `README.md` updated with a usage example for non-Astro hosts.

### #51 — Configurable typography-id rename map

- `src/config/panel-config.ts`: `PanelConfig` gains an optional `legacyIdRenameMap?: Record<string, string | null>` field, validated by `assertValidPanelConfig`. A `null` value preserves the historical "drop this id" semantic.
- `src/state/tweak-state.ts`: `loadPersistedState` now sources the rename map from `PanelConfig.legacyIdRenameMap` (default empty); the historical zdtp-internal map is exported as `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` for opt-in callers.
- `src/astro/host-adapter.ts`: bundled astro adapter automatically wires `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` into `configurePanel` so existing zdtp deployments keep their behaviour without code changes.
- `PORTABLE-CONTRACT.md` §8.4 updated.

### Deep-review fixes (rolled in)

- `hydrateTypographyOverrides` switched from `k in renameMap` to `Object.hasOwn(renameMap, k)` so a payload key like `toString` / `constructor` cannot match an inherited Object.prototype method and corrupt the rename target.
- `loadPersistedState` now rewrites the normalized v2 envelope back to `localStorage` when the typography migration changed the slice (rename or null-drop). Without the writeback, legacy keys would survive on disk indefinitely as dead data, and a host removing the opt-in rename map would regress every user back to non-applying overrides.
- The astro host-adapter wiring above (was documented but not actually implemented in the initial #51 commit).
- Partial-adapter fallback for #50 (above).

### CHANGELOG

- Root `CHANGELOG.md` and `packages/zudo-design-token-panel/CHANGELOG.md` synced; both list all three issues plus the review fixes.

## Test Plan

- [x] `pnpm --filter @takazudo/zudo-design-token-panel test` — 222 / 222 pass (24 test files; +6 regression tests covering writeback, prototype-chain guard, partial-adapter fallback, dist-level smoke, and the typography-id rename contract).
- [x] `pnpm --filter @takazudo/zudo-design-token-panel exec tsc --noEmit` — clean.
- [x] `pnpm --filter @takazudo/zudo-design-token-panel build` — succeeds (`dist/index.js` 69.97 kB / 16.80 kB gzipped).
- [ ] Manual: in a host project (zudo-doc), confirm `import { TweakState, emptyOverrides } from '@takazudo/zudo-design-token-panel'` type-checks and runs.
- [ ] Manual: in a zfb-style host, register a `setLifecycleAdapter({ onBeforeSwap, onPageLoad })` and confirm overrides re-apply across soft-nav.
- [ ] Manual: confirm an existing zdtp astro deployment still applies the historical `text-caption → text-xs` rename on first load after this lands (the host-adapter wires the legacy map automatically).