### PR TITLE
fix(panel): 2-click bug after SPA nav (zudolab/zudo-doc#1633)

### DIFF
--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -443,7 +443,12 @@ function reapplyFromStorage(): void {
  */
 function handleExternalToggleEvent(): void {
   const isFreshMount = !findRoot();
-  const willBeOpen = !isPanelCurrentlyOpen();
+  // When the panel root is absent (fresh mount, or SPA-nav zombie state where
+  // `unmountForSwap` removed the root but left `OPEN_KEY='1'` behind), the
+  // user's intent on this toggle event is unambiguously "open" — deriving
+  // direction from a possibly-stale `OPEN_KEY` would mount the panel CLOSED
+  // and require a second click. See zudolab/zudo-doc#1633 / #1640 / #1631.
+  const willBeOpen = isFreshMount ? true : !isPanelCurrentlyOpen();
   seedOpenStateBeforeMount(willBeOpen);
   ensureMounted();
   // Fresh mount: the seed has already driven the mount-effect to the desired


### PR DESCRIPTION
## Summary

- Fix the "2-click after SPA nav" regression reported by downstream consumer zudolab/zudo-doc#1633 (epic) / #1640 (this fix) / #1631 (same root cause, different symptom).
- In `handleExternalToggleEvent`, when the panel root is absent from the DOM (`isFreshMount === true`), force `willBeOpen = true` instead of deriving it from a possibly-stale `OPEN_KEY`.

## Root cause (one-paragraph)

The previous code computed `willBeOpen = !isPanelCurrentlyOpen()` even on fresh mounts. `isPanelCurrentlyOpen` reads `localStorage[OPEN_KEY]`. After the SPA-nav lifecycle ran `unmountForSwap()` — which removes `#zudo-doc-tweak-root` but does NOT clear `OPEN_KEY` — a previously-open panel left behind `OPEN_KEY='1'`. The next toggle then computed `willBeOpen=false`, mounted the panel CLOSED, and returned early because `isFreshMount` short-circuited the sync event. User saw "nothing happened" on the first click; clicking again with `OPEN_KEY=null` worked. Full causal-proof record: [zudolab/zudo-doc #1640 R1b report](https://github.com/zudolab/zudo-doc/issues/1640).

## Why this one-line fix is the right shape

The user's intent on a toggle event when the root is absent is unambiguously "open" — the only reason to dispatch a toggle without a mounted panel is to open it. Deriving direction from a stale storage key is wrong by construction in that case. Steady-state toggles (root present) still flip via `!isPanelCurrentlyOpen()` so the close path is unchanged.

The alternative — clearing `OPEN_KEY` inside `unmountForSwap()` — would also work and is mentioned in the R1b report as Option B, but it changes the persistence semantics on SPA nav. The fresh-mount-forces-open fix has the smallest blast radius and only touches the one function that owns the buggy decision.

## Test plan

- [x] Reduced spec from R1b (`r1b-reduced-failure-local.spec.cjs`) passes 10/10 against local `pnpm preview` of the downstream consumer with the new bundle. Pre-fix: failed 10/10 against deployed PR-669.
- [x] `pnpm build` on the package succeeds with the change in place.
- [ ] Downstream `pnpm check && pnpm build` (zudo-doc f1-fix worktree) — running after pin bump.

## Files touched

- `packages/zudo-design-token-panel/src/index.tsx` — one-line behavior change + 4-line WHY comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)