### PR TITLE
Enable GFM strikethrough (+ tables) in next / vite-react / zfb / zfb-tailwind prose demos

### DIFF
--- a/examples/next/next.config.ts
+++ b/examples/next/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import createMDX from '@next/mdx';
+import remarkGfm from 'remark-gfm';
 
 /*
  * Next.js config for the Next + React 19 example app.
@@ -75,10 +76,11 @@ const nextConfig: NextConfig = {
 
 /*
  * Wrap the config with @next/mdx so .mdx files are processed as JSX pages.
- * No remark/rehype plugins are needed for the prose demo — raw GFM is
- * sufficient. Static export (output: 'export') is preserved because MDX
- * pages emit only static JSX; no server-only APIs are used.
+ * `remark-gfm` is required for GFM constructs (~~strike~~, tables, autolinks,
+ * task lists). @next/mdx does not enable GFM by default. Static export
+ * (output: 'export') is preserved because MDX pages emit only static JSX;
+ * no server-only APIs are used.
  */
-const withMDX = createMDX({});
+const withMDX = createMDX({ options: { remarkPlugins: [remarkGfm] } });
 
 export default withMDX(nextConfig);

--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -22,7 +22,8 @@
     "next": "^15.5.15",
     "preact": "^10.29.1",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -20,7 +20,8 @@
     "@takazudo/zudo-design-token-panel": "workspace:*",
     "preact": "^10.29.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import mdx from '@mdx-js/rollup';
+import remarkGfm from 'remark-gfm';
 
 /**
  * Vite + React example for @takazudo/zudo-design-token-panel.
@@ -40,7 +41,7 @@ export default defineConfig({
   plugins: [
     // mdx must come before react() — it transforms .mdx to JSX that react()
     // then processes via the automatic JSX runtime.
-    { enforce: 'pre', ...mdx({ jsxImportSource: 'react', providerImportSource: '@mdx-js/react' }) },
+    { enforce: 'pre', ...mdx({ jsxImportSource: 'react', providerImportSource: '@mdx-js/react', remarkPlugins: [remarkGfm] }) },
     react(),
   ],
   build: {

--- a/examples/zfb-tailwind/zfb.config.ts
+++ b/examples/zfb-tailwind/zfb.config.ts
@@ -43,6 +43,9 @@ export default defineConfig({
   base: "/pj/zudo-design-token-panel/examples/zfb-tailwind/",
   tailwind: { enabled: true },
   collections: [{ name: "prose", path: "content/prose" }],
+  // Demo: opt into a curated subset via the per-construct form.
+  // See ../zfb/zfb.config.ts for the shorthand form.
+  markdown: { gfm: { strikethrough: true, table: true } },
   plugins: [
     {
       name: "./plugins/dev-apply-proxy.mjs",

--- a/examples/zfb/.gitignore
+++ b/examples/zfb/.gitignore
@@ -2,3 +2,5 @@
 dist/
 .zfb/
 .zfb-build/
+# Generated tailwind entry file (build artifact from zfb binary)
+zfb-tailwind-entry-*.css

--- a/examples/zfb/zfb.config.ts
+++ b/examples/zfb/zfb.config.ts
@@ -42,6 +42,9 @@ export default defineConfig({
       path: "content/prose",
     },
   ],
+  // Demo: opt into every GFM construct via the shorthand.
+  // See ../zfb-tailwind/zfb.config.ts for the per-construct form.
+  markdown: { gfm: true },
   plugins: [
     {
       name: "./plugins/dev-apply-proxy.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/60

---

## Summary

Enable GFM strikethrough rendering in all four prose demos that were rendering `~~text~~` as raw text. The astro demo was already correct (`@astrojs/mdx` enables GFM by default) and is verified unchanged.

- **examples/next**: pass `remark-gfm` to `@next/mdx` via `createMDX({ options: { remarkPlugins: [remarkGfm] } })`
- **examples/vite-react**: pass `remark-gfm` to `@mdx-js/rollup` via the plugin's `remarkPlugins` option
- **examples/zfb**: opt into the new upstream zfb `markdown.gfm: true` shorthand
- **examples/zfb-tailwind**: opt into the same feature via the per-construct partial form (`markdown: { gfm: { strikethrough: true, table: true } }`) so the two zfb demos together document both API shapes

The zfb-side fix to enable a flexible `markdown.gfm` config (covering strikethrough, table, autolinkLiteral, taskListItem, footnoteDefinition) was implemented and merged upstream in [zudo-front-builder#249](https://github.com/Takazudo/zudo-front-builder/pull/249) (merge SHA c4ace6d on zfb `main`). This PR consumes that release.

## Changes

- examples/next/next.config.ts — wire `remarkPlugins: [remarkGfm]`; replace misleading "no plugins needed" comment with a factual note
- examples/next/package.json — add `remark-gfm@^4.0.1` dep
- examples/vite-react/vite.config.ts — add `remarkPlugins: [remarkGfm]` to the `mdx()` call
- examples/vite-react/package.json — add `remark-gfm@^4.0.1` dep
- examples/zfb/zfb.config.ts — add `markdown: { gfm: true }` to `defineConfig`
- examples/zfb-tailwind/zfb.config.ts — add `markdown: { gfm: { strikethrough: true, table: true } }` to `defineConfig`
- examples/zfb/.gitignore — ignore transient `zfb-tailwind-entry-*.css` build artifact
- pnpm-lock.yaml — regenerated for new deps

## Verification (sub-issue #67)

Full-repo build + 5×3 matrix verified on `base/prose-strikethrough-fix`:

| Demo | Strikethrough | Table | Fallback marker |
|---|---|---|---|
| astro | PASS | PASS | n/a |
| next | PASS | PASS | n/a |
| vite-react | PASS (`_components.del` JSX; no raw `~~`) | PASS (`_components.table` JSX) | n/a |
| zfb | PASS | PASS | ABSENT (snapshot/bundler hash parity) |
| zfb-tailwind | PASS | PASS | ABSENT |

Astro non-regression: `examples/astro/dist/prose/index.html` is bitwise-equal to its `main` baseline (sha256 `250d47b8…`).

`pnpm b4push` green: install, build, 232 tests, typecheck, lint.

`/codex-review` and `/gcoc-review` (combined reviewer mode): no actionable findings.

## Sub-issues closed by this PR

- Closes #62 (examples/next)
- Closes #63 (examples/vite-react)
- Closes #65 (examples/zfb)
- Closes #66 (examples/zfb-tailwind)
- Closes #64 (zfb cargo rebuild + smoke test — confirm step; no zdtp commits)
- Closes #67 (full-repo verification — confirm step; one `.gitignore` touch only)
- Closes #61 (zfb upstream — merged separately on zfb main, c4ace6d)

The epic #60 auto-closes when all sub-issues close.

## Test plan

- [ ] CI green on this PR (already verified at merge time)
- [ ] Visual spot-check of any prose demo after merge if desired (e.g. `pnpm --filter zfb-example build` and open `examples/zfb/dist/prose/index.html`)