### PR TITLE
feat(tokens): W1-S1 define TabConfig / TierConfig / TierItem types + value-kind union

### DIFF
--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -277,6 +277,17 @@ export type { ColorScheme, ColorRef } from './config/color-schemes';
 // Re-export the `TokenManifest` shape so consumers can type their
 // host-supplied `panelConfig.tokens` field.
 export type { TokenManifest, TokenDef } from './tokens/manifest';
+// Re-export the abstract tier-model types so consumers can build host-supplied
+// TabConfig trees without reaching into the package internals.
+export type {
+  TierValueKind,
+  PillSpec,
+  TierItem,
+  TierConfig,
+  TabConfig,
+  ColorClusterExtras,
+} from './tokens/tier-model';
+export { isLengthKind, isNumberKind, isSelectKind, isTextKind, isColorKind } from './tokens/tier-model';
 // Re-export the unified `TweakState` envelope and the `emptyOverrides()`
 // factory so external SerDe / persistence layers (e.g. zudo-doc's
 // `design-token-serde.ts`) can construct and type a fully-populated

--- a/packages/zudo-design-token-panel/src/tokens/__tests__/tier-model.test.ts
+++ b/packages/zudo-design-token-panel/src/tokens/__tests__/tier-model.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isColorKind,
+  isLengthKind,
+  isNumberKind,
+  isSelectKind,
+  isTextKind,
+  type TierValueKind,
+} from '../tier-model';
+
+describe('isLengthKind', () => {
+  it('returns true for a length kind', () => {
+    const v: TierValueKind = { kind: 'length', min: 0, max: 10, step: 0.5, unit: 'rem' };
+    expect(isLengthKind(v)).toBe(true);
+  });
+
+  it('returns false for non-length kinds', () => {
+    const cases: TierValueKind[] = [
+      { kind: 'number', min: 0, max: 10, step: 1 },
+      { kind: 'select', options: ['a'] },
+      { kind: 'text' },
+      { kind: 'color' },
+    ];
+    for (const v of cases) {
+      expect(isLengthKind(v)).toBe(false);
+    }
+  });
+
+  it('narrows the type so unit is accessible without error', () => {
+    const v: TierValueKind = { kind: 'length', min: 0, max: 10, step: 0.5, unit: 'px' };
+    if (isLengthKind(v)) {
+      expect(v.unit).toBe('px');
+    }
+  });
+});
+
+describe('isNumberKind', () => {
+  it('returns true for a number kind', () => {
+    const v: TierValueKind = { kind: 'number', min: 1, max: 100, step: 1 };
+    expect(isNumberKind(v)).toBe(true);
+  });
+
+  it('returns false for non-number kinds', () => {
+    const cases: TierValueKind[] = [
+      { kind: 'length', min: 0, max: 10, step: 0.5, unit: 'rem' },
+      { kind: 'select', options: ['a'] },
+      { kind: 'text' },
+      { kind: 'color' },
+    ];
+    for (const v of cases) {
+      expect(isNumberKind(v)).toBe(false);
+    }
+  });
+
+  it('narrows the type so step is accessible without error', () => {
+    const v: TierValueKind = { kind: 'number', min: 0, max: 10, step: 2 };
+    if (isNumberKind(v)) {
+      expect(v.step).toBe(2);
+    }
+  });
+});
+
+describe('isSelectKind', () => {
+  it('returns true for a select kind', () => {
+    const v: TierValueKind = { kind: 'select', options: ['bold', 'normal'] };
+    expect(isSelectKind(v)).toBe(true);
+  });
+
+  it('returns false for non-select kinds', () => {
+    const cases: TierValueKind[] = [
+      { kind: 'length', min: 0, max: 10, step: 0.5, unit: 'rem' },
+      { kind: 'number', min: 0, max: 10, step: 1 },
+      { kind: 'text' },
+      { kind: 'color' },
+    ];
+    for (const v of cases) {
+      expect(isSelectKind(v)).toBe(false);
+    }
+  });
+
+  it('narrows the type so options is accessible without error', () => {
+    const v: TierValueKind = { kind: 'select', options: ['a', 'b'] };
+    if (isSelectKind(v)) {
+      expect(v.options).toEqual(['a', 'b']);
+    }
+  });
+});
+
+describe('isTextKind', () => {
+  it('returns true for a text kind', () => {
+    const v: TierValueKind = { kind: 'text' };
+    expect(isTextKind(v)).toBe(true);
+  });
+
+  it('returns false for non-text kinds', () => {
+    const cases: TierValueKind[] = [
+      { kind: 'length', min: 0, max: 10, step: 0.5, unit: 'rem' },
+      { kind: 'number', min: 0, max: 10, step: 1 },
+      { kind: 'select', options: ['a'] },
+      { kind: 'color' },
+    ];
+    for (const v of cases) {
+      expect(isTextKind(v)).toBe(false);
+    }
+  });
+});
+
+describe('isColorKind', () => {
+  it('returns true for a color kind', () => {
+    const v: TierValueKind = { kind: 'color' };
+    expect(isColorKind(v)).toBe(true);
+  });
+
+  it('returns false for non-color kinds', () => {
+    const cases: TierValueKind[] = [
+      { kind: 'length', min: 0, max: 10, step: 0.5, unit: 'rem' },
+      { kind: 'number', min: 0, max: 10, step: 1 },
+      { kind: 'select', options: ['a'] },
+      { kind: 'text' },
+    ];
+    for (const v of cases) {
+      expect(isColorKind(v)).toBe(false);
+    }
+  });
+});

--- a/packages/zudo-design-token-panel/src/tokens/tier-model.ts
+++ b/packages/zudo-design-token-panel/src/tokens/tier-model.ts
@@ -1,0 +1,107 @@
+import type { BaseRoleKey, ClusterPanelSettings } from '../config/cluster-config';
+import type { ColorScheme } from '../config/color-schemes';
+
+// ---------------------------------------------------------------------------
+// Value-kind discriminated union
+// ---------------------------------------------------------------------------
+
+export type TierValueKind =
+  | { kind: 'length'; min: number; max: number; step: number; unit: string }
+  | { kind: 'number'; min: number; max: number; step: number }
+  | { kind: 'select'; options: readonly string[] }
+  | { kind: 'text' }
+  | { kind: 'color' };
+
+// ---------------------------------------------------------------------------
+// Narrowing helpers
+// ---------------------------------------------------------------------------
+
+export function isLengthKind(v: TierValueKind): v is Extract<TierValueKind, { kind: 'length' }> {
+  return v.kind === 'length';
+}
+
+export function isNumberKind(v: TierValueKind): v is Extract<TierValueKind, { kind: 'number' }> {
+  return v.kind === 'number';
+}
+
+export function isSelectKind(v: TierValueKind): v is Extract<TierValueKind, { kind: 'select' }> {
+  return v.kind === 'select';
+}
+
+export function isTextKind(v: TierValueKind): v is Extract<TierValueKind, { kind: 'text' }> {
+  return v.kind === 'text';
+}
+
+export function isColorKind(v: TierValueKind): v is Extract<TierValueKind, { kind: 'color' }> {
+  return v.kind === 'color';
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-types
+// ---------------------------------------------------------------------------
+
+export interface PillSpec {
+  value: string;
+  customDefault: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tier item
+// ---------------------------------------------------------------------------
+
+export interface TierItem {
+  id: string;
+  cssVar: string;
+  label: string;
+  group?: string;
+  default: string;
+  type: TierValueKind;
+  pill?: PillSpec;
+  readonly?: true;
+}
+
+// ---------------------------------------------------------------------------
+// Tier config
+// ---------------------------------------------------------------------------
+
+export interface TierConfig {
+  id: string;
+  label: string;
+  items: readonly TierItem[];
+  /** When set, this tier's items hold references — each value is the id of
+   *  an item in the tier whose id matches referencesTier. The apply pipeline
+   *  emits var(--tier1-cssvar). */
+  referencesTier?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Color cluster extras
+//
+// Captures everything in ColorClusterDataConfig EXCEPT palette / semantic data
+// (paletteSize, paletteCssVarTemplate, semanticDefaults, semanticCssNames).
+// Those fields move into the tier model as TierItems. Wave 7 wires this type
+// into the color tab so ColorClusterExtras replaces the non-tier fields on
+// the existing config shape.
+// ---------------------------------------------------------------------------
+
+export interface ColorClusterExtras {
+  id: string;
+  label?: string;
+  baseRoles: Partial<Record<BaseRoleKey, string>>;
+  baseDefaults: Partial<Record<BaseRoleKey, number>>;
+  defaultShikiTheme: string;
+  colorSchemes: Record<string, ColorScheme>;
+  panelSettings: ClusterPanelSettings;
+}
+
+// ---------------------------------------------------------------------------
+// Tab config
+// ---------------------------------------------------------------------------
+
+export interface TabConfig {
+  id: string;
+  label: string;
+  tiers: readonly TierConfig[];
+  advancedTiers?: readonly string[];
+  colorExtras?: ColorClusterExtras;
+}


### PR DESCRIPTION
## Summary

- Adds new `packages/zudo-design-token-panel/src/tokens/tier-model.ts` module defining the abstract tier model types: `TierValueKind` discriminated union (length / number / select / text / color), `PillSpec`, `TierItem`, `TierConfig` (with optional `referencesTier`), `ColorClusterExtras`, and `TabConfig` (with optional `advancedTiers`, `colorExtras`).
- Adds five narrowing helpers (`isLengthKind`, `isNumberKind`, `isSelectKind`, `isTextKind`, `isColorKind`) with full type-predicate signatures.
- Adds `packages/zudo-design-token-panel/src/tokens/__tests__/tier-model.test.ts` with 13 tests covering every narrowing helper.
- Re-exports all new public types and helpers from the package root (`src/index.tsx`) so `import type { TabConfig, TierConfig, TierItem } from '@takazudo/zudo-design-token-panel'` works.

## ColorClusterExtras shape

`ColorClusterExtras` captures everything in `ColorClusterDataConfig` **except** the palette/semantic data fields (`paletteSize`, `paletteCssVarTemplate`, `semanticDefaults`, `semanticCssNames`). Those fields will move to the tier model as `TierItem`s when Wave 7 wires up the color tab. Wave 7 can confirm or adjust this split.

## Test plan

- [x] `pnpm -F zudo-design-token-panel typecheck` passes (package-level only — pre-existing example type errors unrelated to this change)
- [x] 13 tests pass: `vitest run src/tokens/__tests__/tier-model.test.ts`
- [x] `pnpm -F zudo-design-token-panel build` succeeds

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)