### PR TITLE
[Abstract Token Tiers][W1-S2] Cross-tier reference resolver + apply emission

### DIFF
--- a/packages/zudo-design-token-panel/src/apply/__tests__/tier-resolver.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/tier-resolver.test.ts
@@ -419,3 +419,55 @@ describe('resolveTierItemValue — ref with no overrides', () => {
     expect(result).toEqual({ kind: 'ref', targetCssVar: '--zfb-easing-ease-in' });
   });
 });
+
+// ---------------------------------------------------------------------------
+// 11. Empty referenced tier → error
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — empty referenced tier', () => {
+  it('throws TierResolverError when the referenced tier has zero items', () => {
+    const tabWithEmptyRefTier: TabConfig = {
+      id: 'test',
+      label: 'Test',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Raw',
+          items: [],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'raw',
+          items: [rawItem('my-token', '--test-my-token', 'fallback')],
+        },
+      ],
+    };
+    expect(() =>
+      resolveTierItemValue(tabWithEmptyRefTier, 'semantic', 'my-token', EMPTY_OVERRIDES),
+    ).toThrowError(TierResolverError);
+  });
+
+  it('error message identifies the empty referenced tier', () => {
+    const tabWithEmptyRefTier: TabConfig = {
+      id: 'test',
+      label: 'Test',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Raw',
+          items: [],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'raw',
+          items: [rawItem('my-token', '--test-my-token', 'fallback')],
+        },
+      ],
+    };
+    expect(() =>
+      resolveTierItemValue(tabWithEmptyRefTier, 'semantic', 'my-token', EMPTY_OVERRIDES),
+    ).toThrow(/raw/);
+  });
+});

--- a/packages/zudo-design-token-panel/src/apply/__tests__/tier-resolver.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/tier-resolver.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveTierItemValue,
+  emitTierItemCssValue,
+  TierResolverError,
+  type TabOverrides,
+} from '../tier-resolver';
+import type { TabConfig, TierItem } from '../../tokens/tier-model';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+const rawItem = (id: string, cssVar: string, defaultVal: string): TierItem => ({
+  id,
+  cssVar,
+  label: id,
+  default: defaultVal,
+  type: { kind: 'text' },
+});
+
+const lengthItem = (id: string, cssVar: string, defaultVal: string): TierItem => ({
+  id,
+  cssVar,
+  label: id,
+  default: defaultVal,
+  type: { kind: 'length', min: 0, max: 10, step: 0.25, unit: 'rem' },
+});
+
+const numberItem = (id: string, cssVar: string, defaultVal: string): TierItem => ({
+  id,
+  cssVar,
+  label: id,
+  default: defaultVal,
+  type: { kind: 'number', min: 0, max: 100, step: 1 },
+});
+
+const selectItem = (id: string, cssVar: string, defaultVal: string, options: string[]): TierItem => ({
+  id,
+  cssVar,
+  label: id,
+  default: defaultVal,
+  type: { kind: 'select', options },
+});
+
+const colorItem = (id: string, cssVar: string, defaultVal: string): TierItem => ({
+  id,
+  cssVar,
+  label: id,
+  default: defaultVal,
+  type: { kind: 'color' },
+});
+
+/** A two-tier easing tab: tier "raw" (literal) → tier "semantic" (refs raw). */
+const EASING_TAB: TabConfig = {
+  id: 'easing',
+  label: 'Easing',
+  tiers: [
+    {
+      id: 'raw',
+      label: 'Raw',
+      items: [
+        rawItem('ease-in', '--zfb-easing-ease-in', 'cubic-bezier(0.42,0,1,1)'),
+        rawItem('ease-out', '--zfb-easing-ease-out', 'cubic-bezier(0,0,0.58,1)'),
+        rawItem('ease-in-out', '--zfb-easing-ease-in-out', 'cubic-bezier(0.42,0,0.58,1)'),
+      ],
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'raw',
+      items: [
+        rawItem('tab-open', '--zfb-easing-tab-open', 'ease-in'),
+        rawItem('tab-close', '--zfb-easing-tab-close', 'ease-out'),
+      ],
+    },
+  ],
+};
+
+/** A single-tier spacing tab. */
+const SPACING_TAB: TabConfig = {
+  id: 'spacing',
+  label: 'Spacing',
+  tiers: [
+    {
+      id: 'raw',
+      label: 'Raw',
+      items: [
+        lengthItem('hsp-xs', '--zd-spacing-hgap-xs', '0.5rem'),
+        lengthItem('hsp-sm', '--zd-spacing-hgap-sm', '1rem'),
+      ],
+    },
+  ],
+};
+
+/** A size tab with a pill item (radius-full toggle). */
+const SIZE_TAB_WITH_PILL: TabConfig = {
+  id: 'size',
+  label: 'Size',
+  tiers: [
+    {
+      id: 'raw',
+      label: 'Raw',
+      items: [
+        {
+          id: 'radius-full',
+          cssVar: '--zd-radius-full',
+          label: 'Radius Full',
+          default: '0.5rem',
+          type: { kind: 'length', min: 0, max: 9999, step: 1, unit: 'px' },
+          pill: {
+            value: '9999px',
+            customDefault: '0.5rem',
+          },
+        },
+        lengthItem('radius-md', '--zd-radius-md', '0.375rem'),
+      ],
+    },
+  ],
+};
+
+const EMPTY_OVERRIDES: TabOverrides = {};
+
+// ---------------------------------------------------------------------------
+// 1. Literal tier — no override (uses item default)
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — literal, no override', () => {
+  it('returns default when no override is present', () => {
+    const result = resolveTierItemValue(SPACING_TAB, 'raw', 'hsp-xs', EMPTY_OVERRIDES);
+    expect(result).toEqual({ kind: 'literal', value: '0.5rem' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Literal tier — with override
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — literal, with override', () => {
+  it('returns the override value when present', () => {
+    const overrides: TabOverrides = { raw: { 'hsp-xs': '0.75rem' } };
+    const result = resolveTierItemValue(SPACING_TAB, 'raw', 'hsp-xs', overrides);
+    expect(result).toEqual({ kind: 'literal', value: '0.75rem' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Valid reference
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — valid ref', () => {
+  it('returns kind:ref with the target cssVar when the override id exists in the ref tier', () => {
+    const overrides: TabOverrides = { semantic: { 'tab-open': 'ease-out' } };
+    const result = resolveTierItemValue(EASING_TAB, 'semantic', 'tab-open', overrides);
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--zfb-easing-ease-out' });
+  });
+
+  it('returns kind:ref using the override id pointing at ease-in', () => {
+    const overrides: TabOverrides = { semantic: { 'tab-close': 'ease-in' } };
+    const result = resolveTierItemValue(EASING_TAB, 'semantic', 'tab-close', overrides);
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--zfb-easing-ease-in' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Missing ref id → fallback to item default in target tier
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — unknown ref id fallback', () => {
+  it('falls back to the target tier item matching the source itemId when ref id is unknown', () => {
+    // 'nonexistent' is not an id in the raw tier → fall back to item 'tab-open' in raw
+    // But 'tab-open' is not in the raw tier either → falls back to first item (ease-in)
+    const overrides: TabOverrides = { semantic: { 'tab-open': 'nonexistent-id' } };
+    const result = resolveTierItemValue(EASING_TAB, 'semantic', 'tab-open', overrides);
+    // tab-open doesn't exist in raw tier, so fallback to first item: ease-in
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--zfb-easing-ease-in' });
+  });
+
+  it('falls back to matching itemId in target tier when it exists', () => {
+    // 'ease-in' exists in raw tier, and tab has an item 'ease-in' in semantic
+    // Let's test with a tab where the fallback-by-id succeeds
+    const tabWithMatchingFallback: TabConfig = {
+      id: 'test',
+      label: 'Test',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Raw',
+          items: [
+            rawItem('ease-in', '--raw-ease-in', 'cubic-bezier(0.42,0,1,1)'),
+            rawItem('ease-out', '--raw-ease-out', 'cubic-bezier(0,0,0.58,1)'),
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'raw',
+          items: [
+            // id matches an existing raw item — so fallback-by-id picks it up
+            rawItem('ease-in', '--semantic-ease-in', 'ease-in'),
+          ],
+        },
+      ],
+    };
+    const overrides: TabOverrides = { semantic: { 'ease-in': 'totally-unknown' } };
+    const result = resolveTierItemValue(tabWithMatchingFallback, 'semantic', 'ease-in', overrides);
+    // 'totally-unknown' not in raw; fallback to matching id 'ease-in' in raw → --raw-ease-in
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--raw-ease-in' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Reference to unknown tier id → error
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — unknown tier id error', () => {
+  it('throws TierResolverError when the tierId does not exist in the tab', () => {
+    expect(() =>
+      resolveTierItemValue(EASING_TAB, 'does-not-exist', 'tab-open', EMPTY_OVERRIDES),
+    ).toThrowError(TierResolverError);
+  });
+
+  it('error message names the missing tier', () => {
+    expect(() =>
+      resolveTierItemValue(EASING_TAB, 'phantom-tier', 'tab-open', EMPTY_OVERRIDES),
+    ).toThrow(/phantom-tier/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Ref pointing at wrong tier (referencesTier mismatch) → error
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — broken referencesTier config', () => {
+  it('throws TierResolverError when referencesTier points at a tier that does not exist', () => {
+    const brokenTab: TabConfig = {
+      id: 'broken',
+      label: 'Broken',
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'nonexistent-raw-tier',
+          items: [rawItem('my-item', '--broken-my-item', 'fallback')],
+        },
+      ],
+    };
+    expect(() =>
+      resolveTierItemValue(brokenTab, 'semantic', 'my-item', EMPTY_OVERRIDES),
+    ).toThrowError(TierResolverError);
+  });
+
+  it('error message names the missing referencesTier id', () => {
+    const brokenTab: TabConfig = {
+      id: 'broken',
+      label: 'Broken',
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'missing-tier-xyz',
+          items: [rawItem('item-a', '--broken-a', 'default-a')],
+        },
+      ],
+    };
+    expect(() =>
+      resolveTierItemValue(brokenTab, 'semantic', 'item-a', EMPTY_OVERRIDES),
+    ).toThrow(/missing-tier-xyz/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Pill toggle emission
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — pill toggle', () => {
+  it('emits pill.value when the override equals pill.value (pill ON)', () => {
+    const overrides: TabOverrides = { raw: { 'radius-full': '9999px' } };
+    const result = resolveTierItemValue(SIZE_TAB_WITH_PILL, 'raw', 'radius-full', overrides);
+    expect(result).toEqual({ kind: 'literal', value: '9999px' });
+  });
+
+  it('emits the override as-is when it does NOT equal pill.value (custom slider value)', () => {
+    const overrides: TabOverrides = { raw: { 'radius-full': '1.5rem' } };
+    const result = resolveTierItemValue(SIZE_TAB_WITH_PILL, 'raw', 'radius-full', overrides);
+    expect(result).toEqual({ kind: 'literal', value: '1.5rem' });
+  });
+
+  it('emits pill.customDefault when there is no override (pill OFF, no prior value)', () => {
+    const result = resolveTierItemValue(SIZE_TAB_WITH_PILL, 'raw', 'radius-full', EMPTY_OVERRIDES);
+    expect(result).toEqual({ kind: 'literal', value: '0.5rem' });
+  });
+
+  it('emits item default for non-pill item with no override', () => {
+    const result = resolveTierItemValue(SIZE_TAB_WITH_PILL, 'raw', 'radius-md', EMPTY_OVERRIDES);
+    expect(result).toEqual({ kind: 'literal', value: '0.375rem' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. emitTierItemCssValue
+// ---------------------------------------------------------------------------
+
+describe('emitTierItemCssValue', () => {
+  it('returns the value string for a literal result', () => {
+    expect(emitTierItemCssValue({ kind: 'literal', value: '1.25rem' })).toBe('1.25rem');
+  });
+
+  it('wraps the cssVar in var() for a ref result', () => {
+    expect(emitTierItemCssValue({ kind: 'ref', targetCssVar: '--zfb-easing-ease-in' })).toBe(
+      'var(--zfb-easing-ease-in)',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Every TierValueKind snapshotted — resolve without error
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — every TierValueKind', () => {
+  it('resolves a length item (snapshot)', () => {
+    const result = resolveTierItemValue(SPACING_TAB, 'raw', 'hsp-sm', EMPTY_OVERRIDES);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "kind": "literal",
+        "value": "1rem",
+      }
+    `);
+  });
+
+  it('resolves a number item (snapshot)', () => {
+    const tab: TabConfig = {
+      id: 'test',
+      label: 'Test',
+      tiers: [{ id: 'raw', label: 'Raw', items: [numberItem('opacity-hover', '--zd-opacity-hover', '0.8')] }],
+    };
+    const result = resolveTierItemValue(tab, 'raw', 'opacity-hover', EMPTY_OVERRIDES);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "kind": "literal",
+        "value": "0.8",
+      }
+    `);
+  });
+
+  it('resolves a select item (snapshot)', () => {
+    const tab: TabConfig = {
+      id: 'test',
+      label: 'Test',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Raw',
+          items: [selectItem('fw-bold', '--zd-font-weight-bold', '700', ['400', '500', '700', '900'])],
+        },
+      ],
+    };
+    const result = resolveTierItemValue(tab, 'raw', 'fw-bold', EMPTY_OVERRIDES);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "kind": "literal",
+        "value": "700",
+      }
+    `);
+  });
+
+  it('resolves a text item (snapshot)', () => {
+    const result = resolveTierItemValue(EASING_TAB, 'raw', 'ease-in', EMPTY_OVERRIDES);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "kind": "literal",
+        "value": "cubic-bezier(0.42,0,1,1)",
+      }
+    `);
+  });
+
+  it('resolves a color item (snapshot)', () => {
+    const tab: TabConfig = {
+      id: 'test',
+      label: 'Test',
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [colorItem('primary', '--zd-color-primary', '#3b82f6')],
+        },
+      ],
+    };
+    const result = resolveTierItemValue(tab, 'palette', 'primary', EMPTY_OVERRIDES);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "kind": "literal",
+        "value": "#3b82f6",
+      }
+    `);
+  });
+
+  it('resolves a ref kind item (snapshot)', () => {
+    const result = resolveTierItemValue(EASING_TAB, 'semantic', 'tab-open', EMPTY_OVERRIDES);
+    // No override → uses itemId 'tab-open' as ref id → finds ease-in? No: tab-open is not in raw tier.
+    // Falls back to first item in raw tier (ease-in)
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "kind": "ref",
+        "targetCssVar": "--zfb-easing-ease-in",
+      }
+    `);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Ref tier with no overrides — item id not in target tier → first item
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — ref with no overrides', () => {
+  it('falls back to first raw item when the semantic item id does not exist in raw tier', () => {
+    // tab-open is not an id in the raw tier, so it falls to first item (ease-in)
+    const result = resolveTierItemValue(EASING_TAB, 'semantic', 'tab-open', EMPTY_OVERRIDES);
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--zfb-easing-ease-in' });
+  });
+});

--- a/packages/zudo-design-token-panel/src/apply/tier-resolver.ts
+++ b/packages/zudo-design-token-panel/src/apply/tier-resolver.ts
@@ -1,0 +1,181 @@
+/**
+ * Cross-tier reference resolver and CSS value emitter.
+ *
+ * Pure module — no DOM, no Preact, no IO. Safe to import in any environment.
+ *
+ * ## TabOverrides shape
+ *
+ * `TabOverrides` is a two-level nested map:
+ *
+ *   tierId → itemId → overrideValue (CSS string)
+ *
+ * Example:
+ *   {
+ *     raw:      { 'ease-in': 'cubic-bezier(0.42,0,1,1)' },
+ *     semantic: { 'tab-open': 'ease-in' },  // ref value — points at a raw item id
+ *   }
+ *
+ * For a literal tier (no referencesTier) the value is the CSS string to emit.
+ * For a reference tier (referencesTier is set) the value is the id of a target
+ * item in the named tier.
+ */
+
+import type { TabConfig, TierConfig, TierItem } from '../tokens/tier-model';
+
+export type TabOverrides = Readonly<Record<string, Readonly<Record<string, string>>>>;
+
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
+export class TierResolverError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TierResolverError';
+    Object.setPrototypeOf(this, TierResolverError.prototype);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution result
+// ---------------------------------------------------------------------------
+
+export type ResolvedLiteral = { kind: 'literal'; value: string };
+export type ResolvedRef = { kind: 'ref'; targetCssVar: string };
+export type ResolvedTierItem = ResolvedLiteral | ResolvedRef;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function findTier(tab: TabConfig, tierId: string): TierConfig | undefined {
+  return tab.tiers.find((t) => t.id === tierId);
+}
+
+function findItem(tier: TierConfig, itemId: string): TierItem | undefined {
+  return tier.items.find((i) => i.id === itemId);
+}
+
+// ---------------------------------------------------------------------------
+// Core resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the effective CSS value for a single tier item.
+ *
+ * For literal tiers (no `referencesTier`):
+ *   Returns { kind: 'literal', value } where value is the override string
+ *   or the item's `default`.
+ *
+ * For reference tiers (`referencesTier` is set):
+ *   The override value is interpreted as an item id in the referenced tier.
+ *   Returns { kind: 'ref', targetCssVar } pointing at the referenced item's
+ *   cssVar so callers can emit `var(--targetCssVar)`.
+ *
+ * Pill semantics:
+ *   When a literal-tier item has a `pill` spec and the override value equals
+ *   `pill.value`, the pill value is returned verbatim (the pill toggle is ON).
+ *   When the override is absent but the item has a pill, `pill.customDefault`
+ *   is used as the baseline (not the item's `default`). The item's `default`
+ *   is used only when neither an override nor a pill customDefault apply.
+ *
+ * Error cases (throw TierResolverError):
+ *   - tierId not found in tab.tiers
+ *   - referencesTier id not found in tab.tiers
+ *   - ref override points at a tier other than the one declared in referencesTier
+ *     (guarded by design: the resolver validates the target tier id)
+ *
+ * Fallback case (no error):
+ *   - ref override id not found in the target tier → falls back to the target
+ *     tier's item whose id matches itemId; if that also doesn't exist, falls
+ *     back to the first item's default.
+ */
+export function resolveTierItemValue(
+  tab: TabConfig,
+  tierId: string,
+  itemId: string,
+  overrides: TabOverrides,
+): ResolvedTierItem {
+  const tier = findTier(tab, tierId);
+  if (!tier) {
+    throw new TierResolverError(
+      `Tier "${tierId}" not found in tab "${tab.id}". ` +
+        `Available tiers: ${tab.tiers.map((t) => t.id).join(', ')}.`,
+    );
+  }
+
+  const item = findItem(tier, itemId);
+  if (!item) {
+    throw new TierResolverError(
+      `Item "${itemId}" not found in tier "${tierId}" of tab "${tab.id}".`,
+    );
+  }
+
+  const tierOverrides = overrides[tierId];
+  const overrideValue = tierOverrides?.[itemId];
+
+  // -------------------------------------------------------------------------
+  // Reference tier
+  // -------------------------------------------------------------------------
+  if (tier.referencesTier !== undefined) {
+    const refTierId = tier.referencesTier;
+    const refTier = findTier(tab, refTierId);
+    if (!refTier) {
+      throw new TierResolverError(
+        `Tier "${tierId}" declares referencesTier "${refTierId}" ` +
+          `but that tier does not exist in tab "${tab.id}".`,
+      );
+    }
+
+    const refItemId = overrideValue ?? itemId;
+    const refItem = findItem(refTier, refItemId);
+
+    if (!refItem) {
+      // Unknown ref id — fall back to the matching item by id in the ref tier,
+      // or the first item if nothing matches.
+      const fallbackItem = findItem(refTier, itemId) ?? refTier.items[0];
+      if (!fallbackItem) {
+        throw new TierResolverError(
+          `Referenced tier "${refTierId}" has no items; cannot resolve fallback ` +
+            `for item "${itemId}" in tier "${tierId}" of tab "${tab.id}".`,
+        );
+      }
+      return { kind: 'ref', targetCssVar: fallbackItem.cssVar };
+    }
+
+    return { kind: 'ref', targetCssVar: refItem.cssVar };
+  }
+
+  // -------------------------------------------------------------------------
+  // Literal tier
+  // -------------------------------------------------------------------------
+  if (overrideValue !== undefined) {
+    // Pill toggle: if the override equals pill.value, emit the pill value.
+    if (item.pill && overrideValue === item.pill.value) {
+      return { kind: 'literal', value: item.pill.value };
+    }
+    return { kind: 'literal', value: overrideValue };
+  }
+
+  // No override — use pill.customDefault if available, otherwise item.default.
+  if (item.pill) {
+    return { kind: 'literal', value: item.pill.customDefault };
+  }
+  return { kind: 'literal', value: item.default };
+}
+
+// ---------------------------------------------------------------------------
+// Emitter
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a resolved tier item into the final CSS value string to write into
+ * a CSS custom property.
+ *
+ * - Literal → returns the value as-is (e.g. `1.25rem`).
+ * - Ref     → returns `var(--targetCssVar)` (e.g. `var(--zfb-easing-ease-in)`).
+ */
+export function emitTierItemCssValue(resolved: ResolvedTierItem): string {
+  if (resolved.kind === 'literal') return resolved.value;
+  return `var(${resolved.targetCssVar})`;
+}

--- a/packages/zudo-design-token-panel/src/tokens/tier-model.ts
+++ b/packages/zudo-design-token-panel/src/tokens/tier-model.ts
@@ -1,0 +1,85 @@
+/**
+ * Abstract token tier model — TabConfig / TierConfig / TierItem types and
+ * value-kind union.
+ *
+ * This module declares the unified shape that the tier resolver and the rest
+ * of the abstract-token-tiers epic build on. It contains ONLY types and
+ * tiny narrowing helpers; no runtime logic, no DOM.
+ *
+ * NOTE (W1-S2): These types were authored in parallel with W1-S1. When both
+ * sub-issues land on base/abstract-token-tiers, the manager will retain
+ * whichever version landed first and delete any duplicate. No breaking API
+ * difference is expected — the shapes are identical across both worktrees.
+ */
+
+export type TierValueKind =
+  | { kind: 'length'; min: number; max: number; step: number; unit: string }
+  | { kind: 'number'; min: number; max: number; step: number }
+  | { kind: 'select'; options: readonly string[] }
+  | { kind: 'text' }
+  | { kind: 'color' };
+
+export type PillSpec = { value: string; customDefault: string };
+
+export interface TierItem {
+  id: string;
+  cssVar: string;
+  label: string;
+  group?: string;
+  default: string;
+  type: TierValueKind;
+  pill?: PillSpec;
+  readonly?: true;
+}
+
+export interface TierConfig {
+  id: string;
+  label: string;
+  items: readonly TierItem[];
+  /** When set, each item's override value is the id of an item in the tier
+   *  identified by this string. The resolver emits var(--that-item-cssVar). */
+  referencesTier?: string;
+}
+
+export interface TabConfig {
+  id: string;
+  label: string;
+  tiers: readonly TierConfig[];
+  advancedTiers?: readonly string[];
+  colorExtras?: ColorClusterExtras;
+}
+
+/**
+ * Captures the non-data fields of today's ColorClusterDataConfig that do not
+ * belong in the tier model itself. Wave 7 wires the consumers; defined here
+ * so TabConfig can carry it without a forward-reference.
+ */
+export interface ColorClusterExtras {
+  schemes?: readonly unknown[];
+  baseRoles?: readonly unknown[];
+  secondaryCluster?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Narrowing helpers
+// ---------------------------------------------------------------------------
+
+export function isLengthKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'length' }> {
+  return k.kind === 'length';
+}
+
+export function isNumberKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'number' }> {
+  return k.kind === 'number';
+}
+
+export function isSelectKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'select' }> {
+  return k.kind === 'select';
+}
+
+export function isTextKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'text' }> {
+  return k.kind === 'text';
+}
+
+export function isColorKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'color' }> {
+  return k.kind === 'color';
+}


### PR DESCRIPTION
## Summary

- Adds `packages/zudo-design-token-panel/src/tokens/tier-model.ts` with `TabConfig`, `TierConfig`, `TierItem`, `TierValueKind`, `PillSpec` types and five narrowing helpers (`isLengthKind`, `isColorKind`, etc.) — authored in parallel with W1-S1; manager resolves the duplicate on merge
- Adds `packages/zudo-design-token-panel/src/apply/tier-resolver.ts` with `resolveTierItemValue` and `emitTierItemCssValue` — pure module, no DOM/Preact/IO
- Adds 23 tests in `src/apply/__tests__/tier-resolver.test.ts` covering all acceptance criteria

## Resolver behavior

- **Literal tier** (no `referencesTier`): returns override or `item.default`; pill toggle emits `pill.value` when override matches, else returns override as-is; no-override pill items return `pill.customDefault`
- **Reference tier** (`referencesTier` set): override value is treated as a target item id; resolves to `{ kind: 'ref', targetCssVar }` for `emitTierItemCssValue` to wrap in `var(...)`; unknown ref id falls back to matching source item id in target tier, then to first item
- **Error cases**: unknown `tierId`, unknown `referencesTier` id — both throw `TierResolverError` with descriptive messages

## TabOverrides shape

`TabOverrides` is `Readonly<Record<tierId, Readonly<Record<itemId, cssValueOrRefId>>>>`. For literal tiers the value is a CSS string; for reference tiers it is a target item id.

## Type dependency on W1-S1

This branch declares its own `tier-model.ts` (identical shape to the W1-S1 sketch). When both branches land on `base/abstract-token-tiers`, the manager should delete the duplicate from whichever branch landed second and ensure the resolver imports from the single canonical file.

## Test plan

- [x] `pnpm -F zudo-design-token-panel typecheck` passes (package level)
- [x] 23 tier-resolver tests pass
- [x] `pnpm -F zudo-design-token-panel build` passes; `dist/apply/tier-resolver.d.ts` and `dist/tokens/tier-model.d.ts` generated

## Closes

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)