### PR TITLE
feat(config): W1-S3 back-compat shim — lift legacy tokens + colorCluster into TabConfig[]

### DIFF
--- a/packages/zudo-design-token-panel/src/config/__tests__/__snapshots__/lift-legacy-config.test.ts.snap
+++ b/packages/zudo-design-token-panel/src/config/__tests__/__snapshots__/lift-legacy-config.test.ts.snap
@@ -1,0 +1,1921 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`liftLegacyConfigToTabs — astro example > produces a stable snapshot 1`] = `
+[
+  {
+    "id": "spacing",
+    "label": "Spacing",
+    "spacingGroupOrder": [
+      "vsp",
+      "hsp",
+    ],
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--astroexample-spacing-md",
+            "default": "1rem",
+            "group": "hsp",
+            "id": "astroexample-spacing-md",
+            "label": "Spacing M",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--astroexample-spacing-lg",
+            "default": "2rem",
+            "group": "vsp",
+            "id": "astroexample-spacing-lg",
+            "label": "Spacing L",
+            "type": {
+              "kind": "length",
+              "max": 6,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Spacing",
+      },
+    ],
+  },
+  {
+    "id": "font",
+    "label": "Font",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--astroexample-text-base",
+            "default": "1rem",
+            "group": "font-size",
+            "id": "astroexample-text-base",
+            "label": "Body Text",
+            "type": {
+              "kind": "length",
+              "max": 1.5,
+              "min": 0.75,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--astroexample-text-heading",
+            "default": "1.75rem",
+            "group": "font-size",
+            "id": "astroexample-text-heading",
+            "label": "Heading Text",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 1,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Typography",
+      },
+    ],
+  },
+  {
+    "id": "size",
+    "label": "Size",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--astroexample-radius",
+            "default": "0.5rem",
+            "group": "radius",
+            "id": "astroexample-radius",
+            "label": "Border Radius",
+            "type": {
+              "kind": "length",
+              "max": 2,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Size",
+      },
+    ],
+  },
+  {
+    "colorExtras": {
+      "baseDefaults": {
+        "background": 0,
+        "foreground": 15,
+      },
+      "baseRoles": {
+        "background": "--astroexample-bg",
+        "foreground": "--astroexample-fg",
+      },
+      "colorSchemes": {
+        "Default": {
+          "background": 0,
+          "cursor": 4,
+          "foreground": 15,
+          "palette": [
+            "#1e1e1e",
+            "#2d6cdf",
+            "#3aa676",
+            "#d97706",
+            "#9b5de5",
+            "#e63946",
+            "#1d3557",
+            "#06b6d4",
+            "#475569",
+            "#94a3b8",
+            "#cbd5e1",
+            "#e2e8f0",
+            "#f1f5f9",
+            "#fef3c7",
+            "#bbf7d0",
+            "#f8fafc",
+          ],
+          "selectionBg": 1,
+          "selectionFg": 15,
+          "shikiTheme": "github-dark",
+        },
+      },
+      "defaultShikiTheme": "github-dark",
+      "id": "astroexample-cluster",
+      "label": "Astro Example",
+      "paletteCssVarTemplate": "--astroexample-palette-{n}",
+      "paletteSize": 16,
+      "panelSettings": {
+        "colorMode": false,
+        "colorScheme": "Default",
+      },
+      "semanticCssNames": {
+        "accent": "--astroexample-color-accent",
+        "danger": "--astroexample-color-danger",
+        "muted": "--astroexample-color-muted",
+        "primary": "--astroexample-color-primary",
+        "surface": "--astroexample-color-surface",
+      },
+      "semanticDefaults": {
+        "accent": 3,
+        "danger": 5,
+        "muted": 8,
+        "primary": 1,
+        "surface": 0,
+      },
+    },
+    "id": "color",
+    "label": "Color",
+    "tiers": [
+      {
+        "id": "palette",
+        "items": [
+          {
+            "cssVar": "--astroexample-palette-0",
+            "default": "",
+            "id": "palette-0",
+            "label": "Palette 0",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-1",
+            "default": "",
+            "id": "palette-1",
+            "label": "Palette 1",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-2",
+            "default": "",
+            "id": "palette-2",
+            "label": "Palette 2",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-3",
+            "default": "",
+            "id": "palette-3",
+            "label": "Palette 3",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-4",
+            "default": "",
+            "id": "palette-4",
+            "label": "Palette 4",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-5",
+            "default": "",
+            "id": "palette-5",
+            "label": "Palette 5",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-6",
+            "default": "",
+            "id": "palette-6",
+            "label": "Palette 6",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-7",
+            "default": "",
+            "id": "palette-7",
+            "label": "Palette 7",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-8",
+            "default": "",
+            "id": "palette-8",
+            "label": "Palette 8",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-9",
+            "default": "",
+            "id": "palette-9",
+            "label": "Palette 9",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-10",
+            "default": "",
+            "id": "palette-10",
+            "label": "Palette 10",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-11",
+            "default": "",
+            "id": "palette-11",
+            "label": "Palette 11",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-12",
+            "default": "",
+            "id": "palette-12",
+            "label": "Palette 12",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-13",
+            "default": "",
+            "id": "palette-13",
+            "label": "Palette 13",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-14",
+            "default": "",
+            "id": "palette-14",
+            "label": "Palette 14",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-palette-15",
+            "default": "",
+            "id": "palette-15",
+            "label": "Palette 15",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Palette",
+      },
+      {
+        "id": "semantic",
+        "items": [
+          {
+            "cssVar": "--astroexample-color-primary",
+            "default": "1",
+            "id": "semantic-primary",
+            "label": "primary",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-color-accent",
+            "default": "3",
+            "id": "semantic-accent",
+            "label": "accent",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-color-surface",
+            "default": "0",
+            "id": "semantic-surface",
+            "label": "surface",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-color-muted",
+            "default": "8",
+            "id": "semantic-muted",
+            "label": "muted",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--astroexample-color-danger",
+            "default": "5",
+            "id": "semantic-danger",
+            "label": "danger",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Semantic",
+        "referencesTier": "palette",
+      },
+    ],
+  },
+]
+`;
+
+exports[`liftLegacyConfigToTabs — next example > produces a stable snapshot 1`] = `
+[
+  {
+    "id": "spacing",
+    "label": "Spacing",
+    "spacingGroupOrder": [
+      "vsp",
+      "hsp",
+    ],
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--nextexample-spacing-md",
+            "default": "1rem",
+            "group": "hsp",
+            "id": "nextexample-spacing-md",
+            "label": "Spacing M",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--nextexample-spacing-lg",
+            "default": "2rem",
+            "group": "vsp",
+            "id": "nextexample-spacing-lg",
+            "label": "Spacing L",
+            "type": {
+              "kind": "length",
+              "max": 6,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Spacing",
+      },
+    ],
+  },
+  {
+    "id": "font",
+    "label": "Font",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--nextexample-text-base",
+            "default": "1rem",
+            "group": "font-size",
+            "id": "nextexample-text-base",
+            "label": "Body Text",
+            "type": {
+              "kind": "length",
+              "max": 1.5,
+              "min": 0.75,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--nextexample-text-heading",
+            "default": "1.75rem",
+            "group": "font-size",
+            "id": "nextexample-text-heading",
+            "label": "Heading Text",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 1,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Typography",
+      },
+    ],
+  },
+  {
+    "id": "size",
+    "label": "Size",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--nextexample-radius",
+            "default": "0.5rem",
+            "group": "radius",
+            "id": "nextexample-radius",
+            "label": "Border Radius",
+            "type": {
+              "kind": "length",
+              "max": 2,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Size",
+      },
+    ],
+  },
+  {
+    "colorExtras": {
+      "baseDefaults": {
+        "background": 0,
+        "foreground": 15,
+      },
+      "baseRoles": {
+        "background": "--nextexample-bg",
+        "foreground": "--nextexample-fg",
+      },
+      "colorSchemes": {
+        "Default": {
+          "background": 0,
+          "cursor": 4,
+          "foreground": 15,
+          "palette": [
+            "#1e1e1e",
+            "#2d6cdf",
+            "#3aa676",
+            "#d97706",
+            "#9b5de5",
+            "#e63946",
+            "#1d3557",
+            "#06b6d4",
+            "#475569",
+            "#94a3b8",
+            "#cbd5e1",
+            "#e2e8f0",
+            "#f1f5f9",
+            "#fef3c7",
+            "#bbf7d0",
+            "#f8fafc",
+          ],
+          "selectionBg": 1,
+          "selectionFg": 15,
+          "shikiTheme": "github-dark",
+        },
+      },
+      "defaultShikiTheme": "github-dark",
+      "id": "nextexample-cluster",
+      "label": "Next.js Example",
+      "paletteCssVarTemplate": "--nextexample-palette-{n}",
+      "paletteSize": 16,
+      "panelSettings": {
+        "colorMode": false,
+        "colorScheme": "Default",
+      },
+      "semanticCssNames": {
+        "accent": "--nextexample-color-accent",
+        "danger": "--nextexample-color-danger",
+        "muted": "--nextexample-color-muted",
+        "primary": "--nextexample-color-primary",
+        "surface": "--nextexample-color-surface",
+      },
+      "semanticDefaults": {
+        "accent": 3,
+        "danger": 5,
+        "muted": 8,
+        "primary": 1,
+        "surface": 0,
+      },
+    },
+    "id": "color",
+    "label": "Color",
+    "tiers": [
+      {
+        "id": "palette",
+        "items": [
+          {
+            "cssVar": "--nextexample-palette-0",
+            "default": "",
+            "id": "palette-0",
+            "label": "Palette 0",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-1",
+            "default": "",
+            "id": "palette-1",
+            "label": "Palette 1",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-2",
+            "default": "",
+            "id": "palette-2",
+            "label": "Palette 2",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-3",
+            "default": "",
+            "id": "palette-3",
+            "label": "Palette 3",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-4",
+            "default": "",
+            "id": "palette-4",
+            "label": "Palette 4",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-5",
+            "default": "",
+            "id": "palette-5",
+            "label": "Palette 5",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-6",
+            "default": "",
+            "id": "palette-6",
+            "label": "Palette 6",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-7",
+            "default": "",
+            "id": "palette-7",
+            "label": "Palette 7",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-8",
+            "default": "",
+            "id": "palette-8",
+            "label": "Palette 8",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-9",
+            "default": "",
+            "id": "palette-9",
+            "label": "Palette 9",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-10",
+            "default": "",
+            "id": "palette-10",
+            "label": "Palette 10",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-11",
+            "default": "",
+            "id": "palette-11",
+            "label": "Palette 11",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-12",
+            "default": "",
+            "id": "palette-12",
+            "label": "Palette 12",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-13",
+            "default": "",
+            "id": "palette-13",
+            "label": "Palette 13",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-14",
+            "default": "",
+            "id": "palette-14",
+            "label": "Palette 14",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-palette-15",
+            "default": "",
+            "id": "palette-15",
+            "label": "Palette 15",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Palette",
+      },
+      {
+        "id": "semantic",
+        "items": [
+          {
+            "cssVar": "--nextexample-color-primary",
+            "default": "1",
+            "id": "semantic-primary",
+            "label": "primary",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-color-accent",
+            "default": "3",
+            "id": "semantic-accent",
+            "label": "accent",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-color-surface",
+            "default": "0",
+            "id": "semantic-surface",
+            "label": "surface",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-color-muted",
+            "default": "8",
+            "id": "semantic-muted",
+            "label": "muted",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--nextexample-color-danger",
+            "default": "5",
+            "id": "semantic-danger",
+            "label": "danger",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Semantic",
+        "referencesTier": "palette",
+      },
+    ],
+  },
+]
+`;
+
+exports[`liftLegacyConfigToTabs — vite-react example > produces a stable snapshot 1`] = `
+[
+  {
+    "id": "spacing",
+    "label": "Spacing",
+    "spacingGroupOrder": [
+      "vsp",
+      "hsp",
+    ],
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--vitereact-spacing-md",
+            "default": "1rem",
+            "group": "hsp",
+            "id": "vitereact-spacing-md",
+            "label": "Spacing M",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--vitereact-spacing-lg",
+            "default": "2rem",
+            "group": "vsp",
+            "id": "vitereact-spacing-lg",
+            "label": "Spacing L",
+            "type": {
+              "kind": "length",
+              "max": 6,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Spacing",
+      },
+    ],
+  },
+  {
+    "id": "font",
+    "label": "Font",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--vitereact-text-base",
+            "default": "1rem",
+            "group": "font-size",
+            "id": "vitereact-text-base",
+            "label": "Body Text",
+            "type": {
+              "kind": "length",
+              "max": 1.5,
+              "min": 0.75,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--vitereact-text-heading",
+            "default": "1.75rem",
+            "group": "font-size",
+            "id": "vitereact-text-heading",
+            "label": "Heading Text",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 1,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Typography",
+      },
+    ],
+  },
+  {
+    "id": "size",
+    "label": "Size",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--vitereact-radius",
+            "default": "0.5rem",
+            "group": "radius",
+            "id": "vitereact-radius",
+            "label": "Border Radius",
+            "type": {
+              "kind": "length",
+              "max": 2,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Size",
+      },
+    ],
+  },
+  {
+    "colorExtras": {
+      "baseDefaults": {
+        "background": 0,
+        "foreground": 15,
+      },
+      "baseRoles": {
+        "background": "--vitereact-bg",
+        "foreground": "--vitereact-fg",
+      },
+      "colorSchemes": {
+        "Default": {
+          "background": 0,
+          "cursor": 4,
+          "foreground": 15,
+          "palette": [
+            "#1e1e1e",
+            "#2d6cdf",
+            "#3aa676",
+            "#d97706",
+            "#9b5de5",
+            "#e63946",
+            "#1d3557",
+            "#06b6d4",
+            "#475569",
+            "#94a3b8",
+            "#cbd5e1",
+            "#e2e8f0",
+            "#f1f5f9",
+            "#fef3c7",
+            "#bbf7d0",
+            "#f8fafc",
+          ],
+          "selectionBg": 1,
+          "selectionFg": 15,
+          "shikiTheme": "github-dark",
+        },
+      },
+      "defaultShikiTheme": "github-dark",
+      "id": "vitereact-cluster",
+      "label": "Vite + React Example",
+      "paletteCssVarTemplate": "--vitereact-palette-{n}",
+      "paletteSize": 16,
+      "panelSettings": {
+        "colorMode": false,
+        "colorScheme": "Default",
+      },
+      "semanticCssNames": {
+        "accent": "--vitereact-color-accent",
+        "danger": "--vitereact-color-danger",
+        "muted": "--vitereact-color-muted",
+        "primary": "--vitereact-color-primary",
+        "surface": "--vitereact-color-surface",
+      },
+      "semanticDefaults": {
+        "accent": 3,
+        "danger": 5,
+        "muted": 8,
+        "primary": 1,
+        "surface": 0,
+      },
+    },
+    "id": "color",
+    "label": "Color",
+    "tiers": [
+      {
+        "id": "palette",
+        "items": [
+          {
+            "cssVar": "--vitereact-palette-0",
+            "default": "",
+            "id": "palette-0",
+            "label": "Palette 0",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-1",
+            "default": "",
+            "id": "palette-1",
+            "label": "Palette 1",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-2",
+            "default": "",
+            "id": "palette-2",
+            "label": "Palette 2",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-3",
+            "default": "",
+            "id": "palette-3",
+            "label": "Palette 3",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-4",
+            "default": "",
+            "id": "palette-4",
+            "label": "Palette 4",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-5",
+            "default": "",
+            "id": "palette-5",
+            "label": "Palette 5",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-6",
+            "default": "",
+            "id": "palette-6",
+            "label": "Palette 6",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-7",
+            "default": "",
+            "id": "palette-7",
+            "label": "Palette 7",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-8",
+            "default": "",
+            "id": "palette-8",
+            "label": "Palette 8",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-9",
+            "default": "",
+            "id": "palette-9",
+            "label": "Palette 9",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-10",
+            "default": "",
+            "id": "palette-10",
+            "label": "Palette 10",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-11",
+            "default": "",
+            "id": "palette-11",
+            "label": "Palette 11",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-12",
+            "default": "",
+            "id": "palette-12",
+            "label": "Palette 12",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-13",
+            "default": "",
+            "id": "palette-13",
+            "label": "Palette 13",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-14",
+            "default": "",
+            "id": "palette-14",
+            "label": "Palette 14",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-palette-15",
+            "default": "",
+            "id": "palette-15",
+            "label": "Palette 15",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Palette",
+      },
+      {
+        "id": "semantic",
+        "items": [
+          {
+            "cssVar": "--vitereact-color-primary",
+            "default": "1",
+            "id": "semantic-primary",
+            "label": "primary",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-color-accent",
+            "default": "3",
+            "id": "semantic-accent",
+            "label": "accent",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-color-surface",
+            "default": "0",
+            "id": "semantic-surface",
+            "label": "surface",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-color-muted",
+            "default": "8",
+            "id": "semantic-muted",
+            "label": "muted",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--vitereact-color-danger",
+            "default": "5",
+            "id": "semantic-danger",
+            "label": "danger",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Semantic",
+        "referencesTier": "palette",
+      },
+    ],
+  },
+]
+`;
+
+exports[`liftLegacyConfigToTabs — zfb example > produces a stable snapshot 1`] = `
+[
+  {
+    "id": "spacing",
+    "label": "Spacing",
+    "spacingGroupOrder": [
+      "vsp",
+      "hsp",
+    ],
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--zfbexample-spacing-md",
+            "default": "1rem",
+            "group": "hsp",
+            "id": "zfbexample-spacing-md",
+            "label": "Spacing M",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-spacing-lg",
+            "default": "2rem",
+            "group": "vsp",
+            "id": "zfbexample-spacing-lg",
+            "label": "Spacing L",
+            "type": {
+              "kind": "length",
+              "max": 6,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Spacing",
+      },
+    ],
+  },
+  {
+    "id": "font",
+    "label": "Font",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--zfbexample-text-base",
+            "default": "1rem",
+            "group": "font-size",
+            "id": "zfbexample-text-base",
+            "label": "Body Text",
+            "type": {
+              "kind": "length",
+              "max": 1.5,
+              "min": 0.75,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-text-heading",
+            "default": "1.75rem",
+            "group": "font-size",
+            "id": "zfbexample-text-heading",
+            "label": "Heading Text",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 1,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Typography",
+      },
+    ],
+  },
+  {
+    "id": "size",
+    "label": "Size",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--zfbexample-radius",
+            "default": "0.5rem",
+            "group": "radius",
+            "id": "zfbexample-radius",
+            "label": "Border Radius",
+            "type": {
+              "kind": "length",
+              "max": 2,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Size",
+      },
+    ],
+  },
+  {
+    "colorExtras": {
+      "baseDefaults": {
+        "background": 0,
+        "foreground": 15,
+      },
+      "baseRoles": {
+        "background": "--zfbexample-bg",
+        "foreground": "--zfbexample-fg",
+      },
+      "colorSchemes": {
+        "Default": {
+          "background": 0,
+          "cursor": 4,
+          "foreground": 15,
+          "palette": [
+            "#1e1e1e",
+            "#2d6cdf",
+            "#3aa676",
+            "#d97706",
+            "#9b5de5",
+            "#e63946",
+            "#1d3557",
+            "#06b6d4",
+            "#475569",
+            "#94a3b8",
+            "#cbd5e1",
+            "#e2e8f0",
+            "#f1f5f9",
+            "#fef3c7",
+            "#bbf7d0",
+            "#f8fafc",
+          ],
+          "selectionBg": 1,
+          "selectionFg": 15,
+          "shikiTheme": "github-dark",
+        },
+      },
+      "defaultShikiTheme": "github-dark",
+      "id": "zfbexample-cluster",
+      "label": "zfb Example",
+      "paletteCssVarTemplate": "--zfbexample-palette-{n}",
+      "paletteSize": 16,
+      "panelSettings": {
+        "colorMode": false,
+        "colorScheme": "Default",
+      },
+      "semanticCssNames": {
+        "accent": "--zfbexample-color-accent",
+        "danger": "--zfbexample-color-danger",
+        "muted": "--zfbexample-color-muted",
+        "primary": "--zfbexample-color-primary",
+        "surface": "--zfbexample-color-surface",
+      },
+      "semanticDefaults": {
+        "accent": 3,
+        "danger": 5,
+        "muted": 8,
+        "primary": 1,
+        "surface": 0,
+      },
+    },
+    "id": "color",
+    "label": "Color",
+    "tiers": [
+      {
+        "id": "palette",
+        "items": [
+          {
+            "cssVar": "--zfbexample-palette-0",
+            "default": "",
+            "id": "palette-0",
+            "label": "Palette 0",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-1",
+            "default": "",
+            "id": "palette-1",
+            "label": "Palette 1",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-2",
+            "default": "",
+            "id": "palette-2",
+            "label": "Palette 2",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-3",
+            "default": "",
+            "id": "palette-3",
+            "label": "Palette 3",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-4",
+            "default": "",
+            "id": "palette-4",
+            "label": "Palette 4",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-5",
+            "default": "",
+            "id": "palette-5",
+            "label": "Palette 5",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-6",
+            "default": "",
+            "id": "palette-6",
+            "label": "Palette 6",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-7",
+            "default": "",
+            "id": "palette-7",
+            "label": "Palette 7",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-8",
+            "default": "",
+            "id": "palette-8",
+            "label": "Palette 8",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-9",
+            "default": "",
+            "id": "palette-9",
+            "label": "Palette 9",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-10",
+            "default": "",
+            "id": "palette-10",
+            "label": "Palette 10",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-11",
+            "default": "",
+            "id": "palette-11",
+            "label": "Palette 11",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-12",
+            "default": "",
+            "id": "palette-12",
+            "label": "Palette 12",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-13",
+            "default": "",
+            "id": "palette-13",
+            "label": "Palette 13",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-14",
+            "default": "",
+            "id": "palette-14",
+            "label": "Palette 14",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-palette-15",
+            "default": "",
+            "id": "palette-15",
+            "label": "Palette 15",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Palette",
+      },
+      {
+        "id": "semantic",
+        "items": [
+          {
+            "cssVar": "--zfbexample-color-primary",
+            "default": "1",
+            "id": "semantic-primary",
+            "label": "primary",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-color-accent",
+            "default": "3",
+            "id": "semantic-accent",
+            "label": "accent",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-color-surface",
+            "default": "0",
+            "id": "semantic-surface",
+            "label": "surface",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-color-muted",
+            "default": "8",
+            "id": "semantic-muted",
+            "label": "muted",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbexample-color-danger",
+            "default": "5",
+            "id": "semantic-danger",
+            "label": "danger",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Semantic",
+        "referencesTier": "palette",
+      },
+    ],
+  },
+]
+`;
+
+exports[`liftLegacyConfigToTabs — zfb-tailwind example > produces a stable snapshot 1`] = `
+[
+  {
+    "id": "spacing",
+    "label": "Spacing",
+    "spacingGroupOrder": [
+      "vsp",
+      "hsp",
+    ],
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--zfbtailwindexample-spacing-md",
+            "default": "1rem",
+            "group": "hsp",
+            "id": "zfbtailwindexample-spacing-md",
+            "label": "Spacing M",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-spacing-lg",
+            "default": "2rem",
+            "group": "vsp",
+            "id": "zfbtailwindexample-spacing-lg",
+            "label": "Spacing L",
+            "type": {
+              "kind": "length",
+              "max": 6,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Spacing",
+      },
+    ],
+  },
+  {
+    "id": "font",
+    "label": "Font",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--zfbtailwindexample-text-base",
+            "default": "1rem",
+            "group": "font-size",
+            "id": "zfbtailwindexample-text-base",
+            "label": "Body Text",
+            "type": {
+              "kind": "length",
+              "max": 1.5,
+              "min": 0.75,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-text-heading",
+            "default": "1.75rem",
+            "group": "font-size",
+            "id": "zfbtailwindexample-text-heading",
+            "label": "Heading Text",
+            "type": {
+              "kind": "length",
+              "max": 4,
+              "min": 1,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Typography",
+      },
+    ],
+  },
+  {
+    "id": "size",
+    "label": "Size",
+    "tiers": [
+      {
+        "id": "raw",
+        "items": [
+          {
+            "cssVar": "--zfbtailwindexample-radius",
+            "default": "0.5rem",
+            "group": "radius",
+            "id": "zfbtailwindexample-radius",
+            "label": "Border Radius",
+            "type": {
+              "kind": "length",
+              "max": 2,
+              "min": 0,
+              "step": 0.0625,
+              "unit": "rem",
+            },
+          },
+        ],
+        "label": "Size",
+      },
+    ],
+  },
+  {
+    "colorExtras": {
+      "baseDefaults": {
+        "background": 0,
+        "foreground": 15,
+      },
+      "baseRoles": {
+        "background": "--zfbtailwindexample-bg",
+        "foreground": "--zfbtailwindexample-fg",
+      },
+      "colorSchemes": {
+        "Default": {
+          "background": 0,
+          "cursor": 4,
+          "foreground": 15,
+          "palette": [
+            "#1e1e1e",
+            "#2d6cdf",
+            "#3aa676",
+            "#d97706",
+            "#9b5de5",
+            "#e63946",
+            "#1d3557",
+            "#06b6d4",
+            "#475569",
+            "#94a3b8",
+            "#cbd5e1",
+            "#e2e8f0",
+            "#f1f5f9",
+            "#fef3c7",
+            "#bbf7d0",
+            "#f8fafc",
+          ],
+          "selectionBg": 1,
+          "selectionFg": 15,
+          "shikiTheme": "github-dark",
+        },
+      },
+      "defaultShikiTheme": "github-dark",
+      "id": "zfbtailwindexample-cluster",
+      "label": "zfb Tailwind Example",
+      "paletteCssVarTemplate": "--zfbtailwindexample-palette-{n}",
+      "paletteSize": 16,
+      "panelSettings": {
+        "colorMode": false,
+        "colorScheme": "Default",
+      },
+      "semanticCssNames": {
+        "accent": "--zfbtailwindexample-color-accent",
+        "danger": "--zfbtailwindexample-color-danger",
+        "muted": "--zfbtailwindexample-color-muted",
+        "primary": "--zfbtailwindexample-color-primary",
+        "surface": "--zfbtailwindexample-color-surface",
+      },
+      "semanticDefaults": {
+        "accent": 3,
+        "danger": 5,
+        "muted": 8,
+        "primary": 1,
+        "surface": 0,
+      },
+    },
+    "id": "color",
+    "label": "Color",
+    "tiers": [
+      {
+        "id": "palette",
+        "items": [
+          {
+            "cssVar": "--zfbtailwindexample-palette-0",
+            "default": "",
+            "id": "palette-0",
+            "label": "Palette 0",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-1",
+            "default": "",
+            "id": "palette-1",
+            "label": "Palette 1",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-2",
+            "default": "",
+            "id": "palette-2",
+            "label": "Palette 2",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-3",
+            "default": "",
+            "id": "palette-3",
+            "label": "Palette 3",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-4",
+            "default": "",
+            "id": "palette-4",
+            "label": "Palette 4",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-5",
+            "default": "",
+            "id": "palette-5",
+            "label": "Palette 5",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-6",
+            "default": "",
+            "id": "palette-6",
+            "label": "Palette 6",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-7",
+            "default": "",
+            "id": "palette-7",
+            "label": "Palette 7",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-8",
+            "default": "",
+            "id": "palette-8",
+            "label": "Palette 8",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-9",
+            "default": "",
+            "id": "palette-9",
+            "label": "Palette 9",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-10",
+            "default": "",
+            "id": "palette-10",
+            "label": "Palette 10",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-11",
+            "default": "",
+            "id": "palette-11",
+            "label": "Palette 11",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-12",
+            "default": "",
+            "id": "palette-12",
+            "label": "Palette 12",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-13",
+            "default": "",
+            "id": "palette-13",
+            "label": "Palette 13",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-14",
+            "default": "",
+            "id": "palette-14",
+            "label": "Palette 14",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-palette-15",
+            "default": "",
+            "id": "palette-15",
+            "label": "Palette 15",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Palette",
+      },
+      {
+        "id": "semantic",
+        "items": [
+          {
+            "cssVar": "--zfbtailwindexample-color-primary",
+            "default": "1",
+            "id": "semantic-primary",
+            "label": "primary",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-color-accent",
+            "default": "3",
+            "id": "semantic-accent",
+            "label": "accent",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-color-surface",
+            "default": "0",
+            "id": "semantic-surface",
+            "label": "surface",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-color-muted",
+            "default": "8",
+            "id": "semantic-muted",
+            "label": "muted",
+            "type": {
+              "kind": "color",
+            },
+          },
+          {
+            "cssVar": "--zfbtailwindexample-color-danger",
+            "default": "5",
+            "id": "semantic-danger",
+            "label": "danger",
+            "type": {
+              "kind": "color",
+            },
+          },
+        ],
+        "label": "Semantic",
+        "referencesTier": "palette",
+      },
+    ],
+  },
+]
+`;

--- a/packages/zudo-design-token-panel/src/config/__tests__/lift-legacy-config.test.ts
+++ b/packages/zudo-design-token-panel/src/config/__tests__/lift-legacy-config.test.ts
@@ -1,0 +1,1061 @@
+/**
+ * Snapshot tests for liftLegacyConfigToTabs — the back-compat shim that
+ * synthesises TabConfig[] from a legacy PanelConfig.
+ *
+ * Each describe block uses the exact PanelConfig of a real example app as the
+ * fixture so that the snapshots act as the byte-compat oracle for Wave 4.
+ *
+ * Fixtures covered:
+ *  - zfb             (spacingGroupOrder, cluster, no advanced typography)
+ *  - zfb-tailwind    (identical shape to zfb, different CSS-var family)
+ *  - astro           (same shape, astroexample CSS-var family)
+ *  - vite-react      (same shape, vitereact CSS-var family)
+ *  - next            (same shape, nextexample CSS-var family)
+ *
+ * Acceptance criteria pinned:
+ *  - color cluster lift (palette tier + semantic tier)
+ *  - font tab (no advanced rows in example apps → only 'raw' tier)
+ *  - size tab (pill preservation)
+ *  - spacing tab (spacingGroupOrder preservation)
+ *  - host-supplied tabs short-circuits the shim
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { liftLegacyConfigToTabs } from '../lift-legacy-config';
+import {
+  __resetPanelConfigForTests,
+  getPanelConfig,
+  getPanelTabs,
+  configurePanel,
+  type PanelConfig,
+} from '../panel-config';
+import type { TokenManifest } from '../../tokens/manifest';
+import type { ColorClusterDataConfig } from '../cluster-config';
+
+// ---------------------------------------------------------------------------
+// Shared fixture helpers
+// ---------------------------------------------------------------------------
+
+const EMPTY_MANIFEST: TokenManifest = {
+  spacing: [],
+  typography: [],
+  size: [],
+  color: [],
+};
+
+const EMPTY_CLUSTER: ColorClusterDataConfig = {
+  id: 'empty',
+  paletteSize: 0,
+  baseRoles: {},
+  paletteCssVarTemplate: '--empty-{n}',
+  semanticDefaults: {},
+  semanticCssNames: {},
+  baseDefaults: {},
+  defaultShikiTheme: 'dracula',
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false },
+};
+
+function makeBaseConfig(extra: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    storagePrefix: 'test',
+    consoleNamespace: 'test',
+    modalClassPrefix: 'test-modal',
+    schemaId: 'test/v1',
+    exportFilenameBase: 'test',
+    tokens: EMPTY_MANIFEST,
+    colorCluster: EMPTY_CLUSTER,
+    ...extra,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// zfb example fixture
+// ---------------------------------------------------------------------------
+
+const ZFB_MANIFEST: TokenManifest = {
+  spacing: [
+    {
+      id: 'zfbexample-spacing-md',
+      cssVar: '--zfbexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'zfbexample-spacing-lg',
+      cssVar: '--zfbexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'zfbexample-text-base',
+      cssVar: '--zfbexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'zfbexample-text-heading',
+      cssVar: '--zfbexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'zfbexample-radius',
+      cssVar: '--zfbexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};
+
+const ZFB_CLUSTER: ColorClusterDataConfig = {
+  id: 'zfbexample-cluster',
+  label: 'zfb Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--zfbexample-bg',
+    foreground: '--zfbexample-fg',
+  },
+  paletteCssVarTemplate: '--zfbexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--zfbexample-color-primary',
+    accent: '--zfbexample-color-accent',
+    surface: '--zfbexample-color-surface',
+    muted: '--zfbexample-color-muted',
+    danger: '--zfbexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};
+
+const ZFB_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'zfb-example-tokens',
+  consoleNamespace: 'zfbExample',
+  modalClassPrefix: 'zfb-example-design-token-panel-modal',
+  schemaId: 'zfb-example-design-tokens/v1',
+  exportFilenameBase: 'zfb-example-design-tokens',
+  tokens: ZFB_MANIFEST,
+  colorCluster: ZFB_CLUSTER,
+  applyEndpoint: '/pj/zudo-design-token-panel/examples/zfb/api/dev/apply',
+  applyRouting: { zfbexample: 'styles/global.css' },
+  secondaryColorCluster: null,
+};
+
+// ---------------------------------------------------------------------------
+// zfb-tailwind example fixture
+// ---------------------------------------------------------------------------
+
+const ZFB_TAILWIND_MANIFEST: TokenManifest = {
+  spacing: [
+    {
+      id: 'zfbtailwindexample-spacing-md',
+      cssVar: '--zfbtailwindexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'zfbtailwindexample-spacing-lg',
+      cssVar: '--zfbtailwindexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'zfbtailwindexample-text-base',
+      cssVar: '--zfbtailwindexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'zfbtailwindexample-text-heading',
+      cssVar: '--zfbtailwindexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'zfbtailwindexample-radius',
+      cssVar: '--zfbtailwindexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};
+
+const ZFB_TAILWIND_CLUSTER: ColorClusterDataConfig = {
+  id: 'zfbtailwindexample-cluster',
+  label: 'zfb Tailwind Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--zfbtailwindexample-bg',
+    foreground: '--zfbtailwindexample-fg',
+  },
+  paletteCssVarTemplate: '--zfbtailwindexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--zfbtailwindexample-color-primary',
+    accent: '--zfbtailwindexample-color-accent',
+    surface: '--zfbtailwindexample-color-surface',
+    muted: '--zfbtailwindexample-color-muted',
+    danger: '--zfbtailwindexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};
+
+const ZFB_TAILWIND_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'zfb-tailwind-example-tokens',
+  consoleNamespace: 'zfbTailwindExample',
+  modalClassPrefix: 'zfb-tailwind-example-design-token-panel-modal',
+  schemaId: 'zfb-tailwind-example-design-tokens/v1',
+  exportFilenameBase: 'zfb-tailwind-example-design-tokens',
+  tokens: ZFB_TAILWIND_MANIFEST,
+  colorCluster: ZFB_TAILWIND_CLUSTER,
+  applyEndpoint: '/pj/zudo-design-token-panel/examples/zfb-tailwind/api/dev/apply',
+  applyRouting: { zfbtailwindexample: 'styles/global.css' },
+  secondaryColorCluster: null,
+};
+
+// ---------------------------------------------------------------------------
+// astro example fixture
+// ---------------------------------------------------------------------------
+
+const ASTRO_MANIFEST: TokenManifest = {
+  spacing: [
+    {
+      id: 'astroexample-spacing-md',
+      cssVar: '--astroexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'astroexample-spacing-lg',
+      cssVar: '--astroexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'astroexample-text-base',
+      cssVar: '--astroexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'astroexample-text-heading',
+      cssVar: '--astroexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'astroexample-radius',
+      cssVar: '--astroexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};
+
+const ASTRO_CLUSTER: ColorClusterDataConfig = {
+  id: 'astroexample-cluster',
+  label: 'Astro Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--astroexample-bg',
+    foreground: '--astroexample-fg',
+  },
+  paletteCssVarTemplate: '--astroexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--astroexample-color-primary',
+    accent: '--astroexample-color-accent',
+    surface: '--astroexample-color-surface',
+    muted: '--astroexample-color-muted',
+    danger: '--astroexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};
+
+const ASTRO_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'astro-example-tokens',
+  consoleNamespace: 'astroExample',
+  modalClassPrefix: 'astro-example-design-token-panel-modal',
+  schemaId: 'astro-example-design-tokens/v1',
+  exportFilenameBase: 'astro-example-design-tokens',
+  tokens: ASTRO_MANIFEST,
+  colorCluster: ASTRO_CLUSTER,
+  applyEndpoint: '/api/dev/apply',
+  applyRouting: { astroexample: 'src/styles/tokens.css' },
+  secondaryColorCluster: null,
+};
+
+// ---------------------------------------------------------------------------
+// vite-react example fixture
+// ---------------------------------------------------------------------------
+
+const VITE_REACT_MANIFEST: TokenManifest = {
+  spacing: [
+    {
+      id: 'vitereact-spacing-md',
+      cssVar: '--vitereact-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'vitereact-spacing-lg',
+      cssVar: '--vitereact-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'vitereact-text-base',
+      cssVar: '--vitereact-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'vitereact-text-heading',
+      cssVar: '--vitereact-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'vitereact-radius',
+      cssVar: '--vitereact-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};
+
+const VITE_REACT_CLUSTER: ColorClusterDataConfig = {
+  id: 'vitereact-cluster',
+  label: 'Vite + React Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--vitereact-bg',
+    foreground: '--vitereact-fg',
+  },
+  paletteCssVarTemplate: '--vitereact-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--vitereact-color-primary',
+    accent: '--vitereact-color-accent',
+    surface: '--vitereact-color-surface',
+    muted: '--vitereact-color-muted',
+    danger: '--vitereact-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};
+
+const VITE_REACT_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'vite-react-example-tokens',
+  consoleNamespace: 'viteReactExample',
+  modalClassPrefix: 'vite-react-example-design-token-panel-modal',
+  schemaId: 'vite-react-example-design-tokens/v1',
+  exportFilenameBase: 'vite-react-example-design-tokens',
+  tokens: VITE_REACT_MANIFEST,
+  colorCluster: VITE_REACT_CLUSTER,
+  applyEndpoint: '/api/dev/apply',
+  applyRouting: { vitereact: 'src/styles/tokens.css' },
+  secondaryColorCluster: null,
+};
+
+// ---------------------------------------------------------------------------
+// next example fixture
+// ---------------------------------------------------------------------------
+
+const NEXT_MANIFEST: TokenManifest = {
+  spacing: [
+    {
+      id: 'nextexample-spacing-md',
+      cssVar: '--nextexample-spacing-md',
+      label: 'Spacing M',
+      group: 'hsp',
+      default: '1rem',
+      min: 0,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'nextexample-spacing-lg',
+      cssVar: '--nextexample-spacing-lg',
+      label: 'Spacing L',
+      group: 'vsp',
+      default: '2rem',
+      min: 0,
+      max: 6,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  typography: [
+    {
+      id: 'nextexample-text-base',
+      cssVar: '--nextexample-text-base',
+      label: 'Body Text',
+      group: 'font-size',
+      default: '1rem',
+      min: 0.75,
+      max: 1.5,
+      step: 0.0625,
+      unit: 'rem',
+    },
+    {
+      id: 'nextexample-text-heading',
+      cssVar: '--nextexample-text-heading',
+      label: 'Heading Text',
+      group: 'font-size',
+      default: '1.75rem',
+      min: 1,
+      max: 4,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  size: [
+    {
+      id: 'nextexample-radius',
+      cssVar: '--nextexample-radius',
+      label: 'Border Radius',
+      group: 'radius',
+      default: '0.5rem',
+      min: 0,
+      max: 2,
+      step: 0.0625,
+      unit: 'rem',
+    },
+  ],
+  color: [],
+  spacingGroupOrder: ['vsp', 'hsp'],
+};
+
+const NEXT_CLUSTER: ColorClusterDataConfig = {
+  id: 'nextexample-cluster',
+  label: 'Next.js Example',
+  paletteSize: 16,
+  baseRoles: {
+    background: '--nextexample-bg',
+    foreground: '--nextexample-fg',
+  },
+  paletteCssVarTemplate: '--nextexample-palette-{n}',
+  semanticDefaults: {
+    primary: 1,
+    accent: 3,
+    surface: 0,
+    muted: 8,
+    danger: 5,
+  },
+  semanticCssNames: {
+    primary: '--nextexample-color-primary',
+    accent: '--nextexample-color-accent',
+    surface: '--nextexample-color-surface',
+    muted: '--nextexample-color-muted',
+    danger: '--nextexample-color-danger',
+  },
+  baseDefaults: {
+    background: 0,
+    foreground: 15,
+  },
+  defaultShikiTheme: 'github-dark',
+  colorSchemes: {
+    Default: {
+      background: 0,
+      foreground: 15,
+      cursor: 4,
+      selectionBg: 1,
+      selectionFg: 15,
+      palette: [
+        '#1e1e1e',
+        '#2d6cdf',
+        '#3aa676',
+        '#d97706',
+        '#9b5de5',
+        '#e63946',
+        '#1d3557',
+        '#06b6d4',
+        '#475569',
+        '#94a3b8',
+        '#cbd5e1',
+        '#e2e8f0',
+        '#f1f5f9',
+        '#fef3c7',
+        '#bbf7d0',
+        '#f8fafc',
+      ],
+      shikiTheme: 'github-dark',
+    },
+  },
+  panelSettings: {
+    colorScheme: 'Default',
+    colorMode: false,
+  },
+};
+
+const NEXT_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'next-example-tokens',
+  consoleNamespace: 'nextExample',
+  modalClassPrefix: 'next-example-design-token-panel-modal',
+  schemaId: 'next-example-design-tokens/v1',
+  exportFilenameBase: 'next-example-design-tokens',
+  tokens: NEXT_MANIFEST,
+  colorCluster: NEXT_CLUSTER,
+  applyEndpoint: '/api/dev/apply',
+  applyRouting: { nextexample: 'src/styles/tokens.css' },
+  secondaryColorCluster: null,
+};
+
+// ---------------------------------------------------------------------------
+// Snapshot tests — one per example app
+// ---------------------------------------------------------------------------
+
+describe('liftLegacyConfigToTabs — zfb example', () => {
+  it('produces a stable snapshot', () => {
+    expect(liftLegacyConfigToTabs(ZFB_PANEL_CONFIG)).toMatchSnapshot();
+  });
+
+  it('returns 4 tabs: spacing, font, size, color', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    expect(tabs.map((t) => t.id)).toEqual(['spacing', 'font', 'size', 'color']);
+  });
+
+  it('spacing tab carries spacingGroupOrder from manifest', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const spacingTab = tabs.find((t) => t.id === 'spacing')!;
+    expect((spacingTab as { spacingGroupOrder?: readonly string[] }).spacingGroupOrder).toEqual([
+      'vsp',
+      'hsp',
+    ]);
+  });
+
+  it('spacing tab raw tier has 2 items', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const spacingTab = tabs.find((t) => t.id === 'spacing')!;
+    expect(spacingTab.tiers[0].items).toHaveLength(2);
+  });
+
+  it('font tab has only raw tier (no advanced tokens in zfb manifest)', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const fontTab = tabs.find((t) => t.id === 'font')!;
+    expect(fontTab.tiers).toHaveLength(1);
+    expect(fontTab.tiers[0].id).toBe('raw');
+    expect(fontTab.advancedTiers).toBeUndefined();
+  });
+
+  it('size tab raw tier has 1 item', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const sizeTab = tabs.find((t) => t.id === 'size')!;
+    expect(sizeTab.tiers[0].items).toHaveLength(1);
+  });
+
+  it('color tab has palette tier with 16 items', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const colorTab = tabs.find((t) => t.id === 'color')!;
+    const paletteTier = colorTab.tiers.find((t) => t.id === 'palette')!;
+    expect(paletteTier.items).toHaveLength(16);
+  });
+
+  it('color tab palette items have kind: color', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const colorTab = tabs.find((t) => t.id === 'color')!;
+    const paletteTier = colorTab.tiers.find((t) => t.id === 'palette')!;
+    for (const item of paletteTier.items) {
+      expect(item.type.kind).toBe('color');
+    }
+  });
+
+  it('color tab semantic tier has 5 items and referencesTier: palette', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const colorTab = tabs.find((t) => t.id === 'color')!;
+    const semanticTier = colorTab.tiers.find((t) => t.id === 'semantic')!;
+    expect(semanticTier.items).toHaveLength(5);
+    expect(semanticTier.referencesTier).toBe('palette');
+  });
+
+  it('color tab carries colorExtras with the full cluster', () => {
+    const tabs = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const colorTab = tabs.find((t) => t.id === 'color')!;
+    expect(colorTab.colorExtras).toBeDefined();
+    expect(colorTab.colorExtras?.id).toBe('zfbexample-cluster');
+  });
+
+  it('produces identical output on a second call (deterministic)', () => {
+    const first = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    const second = liftLegacyConfigToTabs(ZFB_PANEL_CONFIG);
+    expect(first).toEqual(second);
+  });
+});
+
+describe('liftLegacyConfigToTabs — zfb-tailwind example', () => {
+  it('produces a stable snapshot', () => {
+    expect(liftLegacyConfigToTabs(ZFB_TAILWIND_PANEL_CONFIG)).toMatchSnapshot();
+  });
+});
+
+describe('liftLegacyConfigToTabs — astro example', () => {
+  it('produces a stable snapshot', () => {
+    expect(liftLegacyConfigToTabs(ASTRO_PANEL_CONFIG)).toMatchSnapshot();
+  });
+});
+
+describe('liftLegacyConfigToTabs — vite-react example', () => {
+  it('produces a stable snapshot', () => {
+    expect(liftLegacyConfigToTabs(VITE_REACT_PANEL_CONFIG)).toMatchSnapshot();
+  });
+});
+
+describe('liftLegacyConfigToTabs — next example', () => {
+  it('produces a stable snapshot', () => {
+    expect(liftLegacyConfigToTabs(NEXT_PANEL_CONFIG)).toMatchSnapshot();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Advanced typography tier splitting
+// ---------------------------------------------------------------------------
+
+describe('liftLegacyConfigToTabs — advanced typography', () => {
+  it('splits advanced tokens into a separate scale tier listed in advancedTiers', () => {
+    const manifestWithAdvanced: TokenManifest = {
+      ...EMPTY_MANIFEST,
+      typography: [
+        {
+          id: 'text-base',
+          cssVar: '--text-base',
+          label: 'Base',
+          group: 'font-size',
+          default: '1rem',
+          min: 0.5,
+          max: 2,
+          step: 0.0625,
+          unit: 'rem',
+        },
+        {
+          id: 'scale-base',
+          cssVar: '--scale-base',
+          label: 'Scale Base',
+          group: 'font-scale',
+          default: '1rem',
+          min: 0.5,
+          max: 2,
+          step: 0.0625,
+          unit: 'rem',
+          advanced: true,
+        },
+      ],
+    };
+    const cfg = makeBaseConfig({ tokens: manifestWithAdvanced });
+    const tabs = liftLegacyConfigToTabs(cfg);
+    const fontTab = tabs.find((t) => t.id === 'font')!;
+    expect(fontTab.tiers).toHaveLength(2);
+    expect(fontTab.tiers[0].id).toBe('raw');
+    expect(fontTab.tiers[1].id).toBe('scale');
+    expect(fontTab.advancedTiers).toEqual(['scale']);
+    expect(fontTab.tiers[0].items).toHaveLength(1);
+    expect(fontTab.tiers[1].items).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pill preservation
+// ---------------------------------------------------------------------------
+
+describe('liftLegacyConfigToTabs — pill preservation', () => {
+  it('pill spec is carried through on size tier items', () => {
+    const manifestWithPill: TokenManifest = {
+      ...EMPTY_MANIFEST,
+      size: [
+        {
+          id: 'radius-full',
+          cssVar: '--radius-full',
+          label: 'Full Radius',
+          group: 'radius',
+          default: '0.5rem',
+          min: 0,
+          max: 2,
+          step: 0.0625,
+          unit: 'rem',
+          pill: { value: '9999px', customDefault: '0.5rem' },
+        },
+      ],
+    };
+    const cfg = makeBaseConfig({ tokens: manifestWithPill });
+    const tabs = liftLegacyConfigToTabs(cfg);
+    const sizeTab = tabs.find((t) => t.id === 'size')!;
+    const item = sizeTab.tiers[0].items[0];
+    expect(item.pill).toEqual({ value: '9999px', customDefault: '0.5rem' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupTitles preservation
+// ---------------------------------------------------------------------------
+
+describe('liftLegacyConfigToTabs — groupTitles preservation', () => {
+  it('groupTitles from manifest are carried onto spacing tab', () => {
+    const manifestWithTitles: TokenManifest = {
+      ...EMPTY_MANIFEST,
+      spacing: [
+        {
+          id: 'sp-md',
+          cssVar: '--sp-md',
+          label: 'Medium',
+          group: 'hsp',
+          default: '1rem',
+          min: 0,
+          max: 4,
+          step: 0.125,
+          unit: 'rem',
+        },
+      ],
+      groupTitles: { hsp: 'Horizontal Space' },
+    };
+    const cfg = makeBaseConfig({ tokens: manifestWithTitles });
+    const tabs = liftLegacyConfigToTabs(cfg);
+    const spacingTab = tabs.find((t) => t.id === 'spacing')!;
+    expect((spacingTab as { groupTitles?: Record<string, string> }).groupTitles).toEqual({
+      hsp: 'Horizontal Space',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Host-supplied tabs short-circuit the shim
+// ---------------------------------------------------------------------------
+
+describe('getPanelTabs — host-supplied tabs win over legacy fields', () => {
+  beforeEach(() => {
+    __resetPanelConfigForTests();
+  });
+
+  afterEach(() => {
+    __resetPanelConfigForTests();
+  });
+
+  it('returns host tabs when tabs is present, not the lifted result', () => {
+    const hostTabs = [
+      {
+        id: 'custom',
+        label: 'Custom',
+        tiers: [{ id: 'raw', label: 'Raw', items: [] }],
+      },
+    ] as const;
+
+    const cfg = makeBaseConfig({
+      tokens: ZFB_MANIFEST,
+      colorCluster: ZFB_CLUSTER,
+      tabs: hostTabs,
+    });
+
+    const tabs = getPanelTabs(cfg);
+    expect(tabs).toBe(hostTabs);
+    expect(tabs[0].id).toBe('custom');
+  });
+
+  it('produces lifted tabs (not host tabs) when tabs is absent', () => {
+    const cfg = makeBaseConfig({ tokens: ZFB_MANIFEST, colorCluster: ZFB_CLUSTER });
+    configurePanel(cfg);
+    const tabs = getPanelTabs(getPanelConfig());
+    // Lifted result starts with spacing tab, not a custom tab — confirming
+    // the shim ran rather than returning host-supplied tabs.
+    expect(tabs[0].id).toBe('spacing');
+    expect(tabs.map((t) => t.id)).toEqual(['spacing', 'font', 'size', 'color']);
+  });
+
+  it('memoises: getPanelTabs returns the same array reference on repeated calls', () => {
+    const cfg = makeBaseConfig({ tokens: ZFB_MANIFEST, colorCluster: ZFB_CLUSTER });
+    configurePanel(cfg);
+    const first = getPanelTabs(getPanelConfig());
+    const second = getPanelTabs(getPanelConfig());
+    expect(first).toBe(second);
+  });
+});

--- a/packages/zudo-design-token-panel/src/config/lift-legacy-config.ts
+++ b/packages/zudo-design-token-panel/src/config/lift-legacy-config.ts
@@ -1,0 +1,188 @@
+/**
+ * Back-compat shim: lift legacy PanelConfig (tokens + colorCluster) onto TabConfig[].
+ *
+ * Hosts that supply `tabs` directly on PanelConfig bypass this module entirely.
+ * This shim is called lazily by getPanelConfig() only when `tabs` is absent.
+ *
+ * Mapping rules:
+ *  - tokens.spacing  → tab 'spacing', tier 'raw' of kind: 'length' items
+ *  - tokens.typography → tab 'font', tier 'raw' (non-advanced) + tier 'scale'
+ *    (advanced === true items); 'scale' listed in advancedTiers
+ *  - tokens.size     → tab 'size', tier 'raw', pill preserved
+ *  - tokens.color + colorCluster → tab 'color', tier 'palette' (kind: 'color')
+ *    + tier 'semantic' (referencesTier: 'palette'); colorExtras carries the
+ *    full cluster config for Wave 7 wiring
+ */
+
+import type { TokenDef, TokenManifest } from '../tokens/manifest';
+import type { ColorClusterDataConfig } from './cluster-config';
+import type { PanelConfig } from './panel-config';
+import type { TabConfig, TierConfig, TierItem, TierValueKind, PillSpec } from '../tokens/tier-model';
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function tokenDefToKind(t: TokenDef): TierValueKind {
+  if (t.control === 'text') return { kind: 'text' };
+  if (t.control === 'select') {
+    return { kind: 'select', options: t.options ?? [] };
+  }
+  // Default: slider → length kind
+  return { kind: 'length', min: t.min, max: t.max, step: t.step, unit: t.unit };
+}
+
+function tokenDefToTierItem(t: TokenDef): TierItem {
+  const base: TierItem = {
+    id: t.id,
+    cssVar: t.cssVar,
+    label: t.label,
+    default: t.default,
+    type: tokenDefToKind(t),
+    ...(t.group !== undefined ? { group: t.group } : {}),
+    ...(t.readonly ? { readonly: true as const } : {}),
+  };
+  if (t.pill) {
+    const pill: PillSpec = { value: t.pill.value, customDefault: t.pill.customDefault };
+    return { ...base, pill };
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Per-tab lift functions
+// ---------------------------------------------------------------------------
+
+function liftSpacingTab(manifest: TokenManifest): TabConfig {
+  const items: TierItem[] = manifest.spacing.map(tokenDefToTierItem);
+  const rawTier: TierConfig = { id: 'raw', label: 'Spacing', items };
+  return {
+    id: 'spacing',
+    label: 'Spacing',
+    tiers: [rawTier],
+    ...(manifest.spacingGroupOrder !== undefined
+      ? { spacingGroupOrder: manifest.spacingGroupOrder }
+      : {}),
+    ...(manifest.groupTitles !== undefined ? { groupTitles: manifest.groupTitles } : {}),
+  } as TabConfig;
+}
+
+function liftFontTab(manifest: TokenManifest): TabConfig {
+  const regular: TokenDef[] = [];
+  const advanced: TokenDef[] = [];
+  for (const t of manifest.typography) {
+    if (t.advanced) {
+      advanced.push(t);
+    } else {
+      regular.push(t);
+    }
+  }
+
+  const tiers: TierConfig[] = [
+    { id: 'raw', label: 'Typography', items: regular.map(tokenDefToTierItem) },
+  ];
+
+  const advancedTiers: string[] = [];
+  if (advanced.length > 0) {
+    tiers.push({ id: 'scale', label: 'Scale', items: advanced.map(tokenDefToTierItem) });
+    advancedTiers.push('scale');
+  }
+
+  return {
+    id: 'font',
+    label: 'Font',
+    tiers,
+    ...(advancedTiers.length > 0 ? { advancedTiers } : {}),
+    ...(manifest.fontGroupOrder !== undefined ? { fontGroupOrder: manifest.fontGroupOrder } : {}),
+    ...(manifest.groupTitles !== undefined ? { groupTitles: manifest.groupTitles } : {}),
+  } as TabConfig;
+}
+
+function liftSizeTab(manifest: TokenManifest): TabConfig {
+  const items: TierItem[] = manifest.size.map(tokenDefToTierItem);
+  const rawTier: TierConfig = { id: 'raw', label: 'Size', items };
+  return {
+    id: 'size',
+    label: 'Size',
+    tiers: [rawTier],
+    ...(manifest.sizeGroupOrder !== undefined ? { sizeGroupOrder: manifest.sizeGroupOrder } : {}),
+    ...(manifest.groupTitles !== undefined ? { groupTitles: manifest.groupTitles } : {}),
+  } as TabConfig;
+}
+
+function liftColorTab(
+  manifest: TokenManifest,
+  colorCluster: ColorClusterDataConfig,
+  secondaryColorCluster?: ColorClusterDataConfig | null,
+): TabConfig {
+  // Palette items from colorCluster — one TierItem per palette slot
+  const paletteItems: TierItem[] = Array.from({ length: colorCluster.paletteSize }, (_, i) => {
+    const cssVar = colorCluster.paletteCssVarTemplate.replace('{n}', String(i));
+    return {
+      id: `palette-${i}`,
+      cssVar,
+      label: `Palette ${i}`,
+      default: '',
+      type: { kind: 'color' as const },
+    };
+  });
+
+  // Per-token color rows from the manifest (cluster-less hosts)
+  const colorTokenItems: TierItem[] = manifest.color.map(tokenDefToTierItem);
+
+  const paletteTier: TierConfig = {
+    id: 'palette',
+    label: 'Palette',
+    items: [...paletteItems, ...colorTokenItems],
+  };
+
+  // Semantic items — each references a palette slot (referencesTier: 'palette')
+  const semanticItems: TierItem[] = Object.keys(colorCluster.semanticCssNames).map((name) => ({
+    id: `semantic-${name}`,
+    cssVar: colorCluster.semanticCssNames[name],
+    label: name,
+    default: String(colorCluster.semanticDefaults[name] ?? 0),
+    type: { kind: 'color' as const },
+  }));
+
+  const semanticTier: TierConfig = {
+    id: 'semantic',
+    label: 'Semantic',
+    items: semanticItems,
+    // semantic items reference the palette tier
+    referencesTier: 'palette',
+  };
+
+  return {
+    id: 'color',
+    label: 'Color',
+    tiers: [paletteTier, semanticTier],
+    colorExtras: {
+      ...colorCluster,
+      ...(secondaryColorCluster !== undefined && secondaryColorCluster !== null
+        ? { _secondaryCluster: secondaryColorCluster }
+        : {}),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthesise a TabConfig[] from a legacy PanelConfig.
+ *
+ * Called lazily from getPanelConfig() when the host has not supplied tabs
+ * directly. Legacy hosts see no change — they get the same token data
+ * surfaced through the new shape.
+ */
+export function liftLegacyConfigToTabs(panelConfig: PanelConfig): TabConfig[] {
+  const { tokens, colorCluster, secondaryColorCluster } = panelConfig;
+  return [
+    liftSpacingTab(tokens),
+    liftFontTab(tokens),
+    liftSizeTab(tokens),
+    liftColorTab(tokens, colorCluster, secondaryColorCluster),
+  ];
+}

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -33,7 +33,9 @@
 import type { TokenManifest } from '../tokens/manifest';
 import type { ColorScheme } from './color-schemes';
 import type { ColorClusterDataConfig } from './cluster-config';
+import type { TabConfig } from '../tokens/tier-model';
 import { structuralEqual } from '../utils/structural-equal';
+import { liftLegacyConfigToTabs } from './lift-legacy-config';
 
 /**
  * Apply-routing map.
@@ -135,6 +137,16 @@ export interface PanelConfig {
    * callers that depend on it.
    */
   legacyIdRenameMap?: Record<string, string | null>;
+  /**
+   * Optional host-supplied tab configuration.
+   *
+   * When present, the back-compat shim (`liftLegacyConfigToTabs`) is NOT
+   * called — legacy `tokens` and `colorCluster` fields are ignored for
+   * tab rendering purposes. Hosts that want the new tier-based model opt
+   * in by passing this field. Existing hosts omit it and continue to have
+   * their legacy fields lifted lazily onto the new shape at runtime.
+   */
+  tabs?: readonly TabConfig[];
 }
 
 /**
@@ -201,6 +213,11 @@ let configuredConfig: PanelConfig | null = null;
  * first time `getPanelConfig()` is read after configuration.
  */
 let pendingColorPresets: Record<string, ColorScheme> | null = null;
+/**
+ * Memoised `tabs` for `DEFAULT_PANEL_CONFIG` (the no-host-call fallback path).
+ * Kept separate from the const so we never mutate the exported default object.
+ */
+let defaultConfigTabs: readonly TabConfig[] | null = null;
 
 /**
  * Configure the panel runtime. Call exactly once per page lifecycle, before
@@ -238,12 +255,38 @@ export function getPanelConfig(): PanelConfig {
 }
 
 /**
+ * Return the `TabConfig[]` for the active config.
+ *
+ * When the host supplied `tabs` on the config, they are returned as-is and
+ * the legacy `tokens` / `colorCluster` fields are ignored. When `tabs` is
+ * absent, `liftLegacyConfigToTabs` is called lazily and the result is
+ * memoised on the singleton so the lift runs at most once per
+ * `configurePanel` call.
+ */
+export function getPanelTabs(cfg: PanelConfig = getPanelConfig()): readonly TabConfig[] {
+  if (cfg.tabs !== undefined) return cfg.tabs;
+  // Default fallback path: memoised on defaultConfigTabs so DEFAULT_PANEL_CONFIG
+  // is never mutated.
+  if (cfg === DEFAULT_PANEL_CONFIG) {
+    if (defaultConfigTabs === null) {
+      defaultConfigTabs = liftLegacyConfigToTabs(cfg);
+    }
+    return defaultConfigTabs;
+  }
+  // configuredConfig path: attach tabs in place for memoisation.
+  const tabs = liftLegacyConfigToTabs(cfg);
+  (cfg as { tabs: readonly TabConfig[] }).tabs = tabs;
+  return tabs;
+}
+
+/**
  * Test-only: clear the singleton so unit tests can exercise different configs
  * in isolation.
  */
 export function __resetPanelConfigForTests(): void {
   configuredConfig = null;
   pendingColorPresets = null;
+  defaultConfigTabs = null;
 }
 
 /**

--- a/packages/zudo-design-token-panel/src/tokens/tier-model.ts
+++ b/packages/zudo-design-token-panel/src/tokens/tier-model.ts
@@ -1,0 +1,84 @@
+/**
+ * Abstract token tier model — type definitions only.
+ *
+ * Canonical source: packages/zudo-design-token-panel/src/tokens/tier-model.ts
+ * Implemented by W1-S1 (#70). This stub ships the agreed contract so that
+ * W1-S3 (the back-compat shim) can compile before the sibling PR lands.
+ *
+ * NOTE: this file is authored by W1-S3 as a local stub matching the type
+ * contract in issue #70. When W1-S1 merges into base/abstract-token-tiers,
+ * that branch's tier-model.ts supersedes this file. The shapes are identical
+ * by contract so the merge will be a no-op diff (or a clean replacement).
+ */
+
+import type { ColorClusterDataConfig } from '../config/cluster-config';
+
+export type TierValueKind =
+  | { kind: 'length'; min: number; max: number; step: number; unit: string }
+  | { kind: 'number'; min: number; max: number; step: number }
+  | { kind: 'select'; options: readonly string[] }
+  | { kind: 'text' }
+  | { kind: 'color' };
+
+export interface PillSpec {
+  value: string;
+  customDefault: string;
+}
+
+export interface TierItem {
+  id: string;
+  cssVar: string;
+  label: string;
+  group?: string;
+  default: string;
+  type: TierValueKind;
+  pill?: PillSpec;
+  readonly?: true;
+}
+
+export interface TierConfig {
+  id: string;
+  label: string;
+  items: readonly TierItem[];
+  referencesTier?: string;
+}
+
+/**
+ * Everything in ColorClusterDataConfig that is NOT palette / semantic data.
+ * Palette and semantic items are lifted into TierConfig items; the rest of
+ * the cluster config (schemes, base roles, HSL picker settings, secondary
+ * cluster metadata) rides here and is consumed by the color tab UI in Wave 7.
+ */
+export type ColorClusterExtras = Omit<ColorClusterDataConfig, never>;
+
+export interface TabConfig {
+  id: string;
+  label: string;
+  tiers: readonly TierConfig[];
+  advancedTiers?: readonly string[];
+  colorExtras?: ColorClusterExtras;
+}
+
+// ---------------------------------------------------------------------------
+// Narrowing helpers
+// ---------------------------------------------------------------------------
+
+export function isLengthKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'length' }> {
+  return k.kind === 'length';
+}
+
+export function isNumberKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'number' }> {
+  return k.kind === 'number';
+}
+
+export function isSelectKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'select' }> {
+  return k.kind === 'select';
+}
+
+export function isTextKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'text' }> {
+  return k.kind === 'text';
+}
+
+export function isColorKind(k: TierValueKind): k is Extract<TierValueKind, { kind: 'color' }> {
+  return k.kind === 'color';
+}


### PR DESCRIPTION
## Summary

- Adds `liftLegacyConfigToTabs(panelConfig): TabConfig[]` in `src/config/lift-legacy-config.ts` that synthesises the new tier-based shape from a legacy `PanelConfig`
- `PanelConfig` gains an optional `tabs?: readonly TabConfig[]` field; when supplied by the host the shim is bypassed entirely
- `getPanelTabs(cfg)` lazily calls the shim when `tabs` is absent and memoises the result on the config object
- Ships a local `src/tokens/tier-model.ts` stub matching the W1-S1 type contract from #70 so this PR compiles before sibling PRs merge

## Mapping implemented

- `tokens.spacing` → tab `spacing`, tier `raw` of `kind: 'length'` items; `spacingGroupOrder` + `groupTitles` preserved as extra fields
- `tokens.typography` → tab `font`, tier `raw` (non-advanced) + tier `scale` (advanced tokens); `scale` listed in `advancedTiers`
- `tokens.size` → tab `size`, tier `raw`; `pill` spec preserved per item
- `tokens.color` + `colorCluster` → tab `color`, tier `palette` (kind: `color`) + tier `semantic` (referencesTier: `palette`); full cluster rides on `colorExtras`

## Test plan

- [x] `pnpm -F zudo-design-token-panel typecheck` passes
- [x] `pnpm -F zudo-design-token-panel test` passes (253/253)
- [x] 5 snapshot tests covering all 5 example apps (zfb, zfb-tailwind, astro, vite-react, next) as byte-compat oracle
- [x] Advanced typography tier split test
- [x] Pill preservation test
- [x] groupTitles preservation test
- [x] Host-supplied `tabs` short-circuits the shim (verified by asserting tabs wins)
- [x] Memoisation: `getPanelTabs` returns the same array reference on repeated calls
- [x] Build succeeds: `pnpm -F zudo-design-token-panel build`

## Type dependency on W1-S1

This PR ships its own `tier-model.ts` stub authored to match the type contract in issue #70. When W1-S1 merges, its `tier-model.ts` supersedes this stub — the shapes are identical by contract so the merge resolves cleanly.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)