### PR TITLE
build(wt-dev): switch pre-push scaffold to lefthook-based setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,15 +14,15 @@ This repo uses `/x-wt-teams` for multi-topic development. Child agents work in g
 
 ### How it's enforced
 
-`.git/hooks/pre-push` checks whether `pwd` is under `worktrees/`. If yes, the push fails with a clear message. If no (main repo), the push proceeds.
+`.git/hooks/pre-push` is a direct script (not managed via `lefthook.yml`) that blocks any push from a git worktree. Detection uses git's own metadata — `--git-dir` differs from `--git-common-dir` iff we are in a linked worktree — so the guard fires regardless of `pwd`. It is deliberately NOT in `lefthook.yml` because lefthook reads config from the worktree's toplevel and would silently skip the guard when invoked from inside a worktree.
 
-The hook is auto-installed by `pnpm install` (via the `prepare` lifecycle script) and can be re-installed manually with:
+The hook is auto-installed by `pnpm install` (which runs `lefthook install && bash scripts/install-git-hooks.sh` via the `prepare` lifecycle script) and can be re-installed manually with:
 
 ```sh
 pnpm init-worktree
 ```
 
-The installer source lives at `scripts/install-git-hooks.sh`; the hook itself at `scripts/hooks/pre-push`.
+The installer source lives at `scripts/install-git-hooks.sh`; the hook itself at `scripts/hooks/pre-push`. `lefthook.yml` manages pre-commit hooks separately.
 
 ### Emergency bypass (human use)
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+# lefthook manages pre-commit hooks here. Add commands under
+# `pre-commit.commands` when this repo needs them, e.g. lint-staged.
+#
+# The pre-push worktree guard is intentionally NOT managed by lefthook —
+# it lives in scripts/hooks/pre-push and is installed directly to
+# .git/hooks/pre-push by scripts/install-git-hooks.sh (run by `pnpm install`
+# via the `prepare` script). See CLAUDE.md "Worktree push policy" for the
+# rationale.
+
+pre-commit:
+  commands: {}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "pnpm -r --if-present lint",
     "b4push": "bash scripts/run-b4push.sh",
     "check:deploy-paths": "bash scripts/check-deploy-paths.sh",
-    "prepare": "bash scripts/install-git-hooks.sh",
+    "prepare": "lefthook install && bash scripts/install-git-hooks.sh",
     "init-worktree": "bash scripts/install-git-hooks.sh"
   },
   "engines": {
@@ -24,11 +24,13 @@
   },
   "homepage": "https://github.com/Takazudo/zudo-design-token-panel",
   "devDependencies": {
+    "lefthook": "^2.1.6",
     "wrangler": "^4.85.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
+      "lefthook",
       "sharp",
       "workerd"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      lefthook:
+        specifier: ^2.1.6
+        version: 2.1.6
       wrangler:
         specifier: ^4.85.0
         version: 4.85.0
@@ -2846,6 +2849,60 @@ packages:
 
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -6812,6 +6869,49 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,13 +1,19 @@
 #!/bin/sh
-# x-wt-teams-push-guard v1
+# x-wt-teams-push-guard v2
 #
 # Repo-scoped pre-push hook. Blocks pushes from /x-wt-teams worktrees (paths
 # under worktrees/) so child agents cannot push intermediate state. Only the
 # manager session — running from the main repo at the repo root — should push.
 #
-# Auto-installed by `pnpm install` (via `prepare`) and manually re-installed
-# by `pnpm init-worktree`. See root CLAUDE.md "Worktree push policy" for the
-# full rationale.
+# Auto-installed by `pnpm install` (via the `prepare` lifecycle script)
+# and manually re-installed by `pnpm init-worktree`. See root CLAUDE.md
+# "Worktree push policy" for the full rationale.
+#
+# NOTE: This hook is intentionally NOT managed via lefthook.yml. lefthook
+# reads config from the worktree's toplevel, so it would silently skip this
+# guard when invoked from inside a worktree. The guard is installed directly
+# to .git/hooks/pre-push (via scripts/install-git-hooks.sh) to guarantee it
+# runs regardless of where git push is called from.
 #
 # Emergency / human bypass:
 #   ALLOW_WORKTREE_PUSH=1 git push ...
@@ -16,23 +22,24 @@ if [ "$ALLOW_WORKTREE_PUSH" = "1" ]; then
   exit 0
 fi
 
-# Worktree detection: git-dir and git-common-dir differ in a worktree, and
-# our convention puts worktrees under `worktrees/`. Both checks must pass to
-# avoid false positives in unrelated layouts.
-GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+# Worktree detection via git's own metadata. In a linked worktree:
+#   --git-dir  → .git/worktrees/<name>  (worktree-specific)
+#   --git-common-dir → .git             (shared main repo)
+# They differ iff we are in a worktree. git sets GIT_DIR in the environment
+# when invoking hooks, so this works even when the hook runner (lefthook)
+# changes the working directory to the git root.
+GIT_DIR_PATH=$(git rev-parse --git-dir 2>/dev/null)
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 
-if [ "$GIT_DIR" = "$GIT_COMMON_DIR" ]; then
+if [ "$GIT_DIR_PATH" = "$GIT_COMMON_DIR" ]; then
   exit 0
 fi
 
-case "$PWD" in
-  *"/worktrees/"*)
-    cat >&2 <<EOF
+cat >&2 <<EOF
 
   Push blocked — you are in a /x-wt-teams worktree.
 
-  PWD: $PWD
+  GIT_DIR: $GIT_DIR_PATH
 
   Child agents in worktrees should commit locally and report back; the
   manager session merges + pushes from the main repo. See CLAUDE.md
@@ -42,8 +49,4 @@ case "$PWD" in
       ALLOW_WORKTREE_PUSH=1 git push ...
 
 EOF
-    exit 1
-    ;;
-esac
-
-exit 0
+exit 1

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -2,17 +2,20 @@
 # Install repo-scoped git hooks. Idempotent.
 #
 # Called by:
-#   - `pnpm install` (via the `prepare` lifecycle script)
-#   - `pnpm init-worktree` (explicit re-install, e.g. after manually wiring a
-#     worktree outside the normal flow)
+#   - `pnpm install` (via the `prepare` lifecycle script, after lefthook install)
+#   - `pnpm init-worktree` (explicit re-install, e.g. after manually wiring
+#     a worktree outside the normal flow)
 #
-# Git worktrees all share the main repo's .git/hooks directory, so a single
-# install applies everywhere. The hook itself decides whether to block based
-# on the current working directory.
+# lefthook manages pre-commit (via lefthook.yml). This script installs the
+# pre-push worktree guard directly to .git/hooks/pre-push — it is deliberately
+# NOT in lefthook.yml because lefthook reads config from the worktree's
+# toplevel, so it would silently skip the guard when invoked from inside a
+# worktree. Direct install to the shared .git/hooks/ directory ensures the
+# guard always fires regardless of where `git push` is called from.
 
 set -e
 
-HOOK_MARKER="# x-wt-teams-push-guard v1"
+HOOK_MARKER="# x-wt-teams-push-guard v2"
 
 # Skip silently when not in a git repo (e.g. extracted tarball).
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || {
@@ -36,8 +39,7 @@ if [ ! -f "$SOURCE" ]; then
   exit 0
 fi
 
-# Refuse to clobber a foreign pre-push hook. If the user has husky or another
-# hook manager, they need to merge our content manually.
+# Refuse to clobber a foreign pre-push hook (one without our marker).
 if [ -f "$TARGET" ] && ! grep -q "$HOOK_MARKER" "$TARGET"; then
   echo "install-git-hooks: $TARGET exists but isn't ours (missing marker)."
   echo "  Move it aside or merge scripts/hooks/pre-push into it manually,"


### PR DESCRIPTION
## Summary

- Adopt the v2 worktree-push-guard from `~/.claude/skills/dev-scaffold-wt-dev`.
- Add `lefthook` as the pre-commit hook manager (no commands yet — slot only).
- Keep the pre-push worktree guard as a direct `.git/hooks/pre-push` script — **intentionally not in `lefthook.yml`** because lefthook reads config from the worktree's toplevel and would silently skip the guard when invoked from inside a worktree.
- Switch worktree detection from a `PWD` substring check to git-native metadata (`--git-dir` vs `--git-common-dir`), which fires regardless of where `git push` is invoked from.

## Changes

- **`scripts/hooks/pre-push`** — hook v2: detects worktrees via `GIT_DIR != GIT_COMMON_DIR`; surfaces `GIT_DIR` in the block message.
- **`scripts/install-git-hooks.sh`** — marker bumped to `v2`; comments updated to note the lefthook coexistence rationale.
- **`lefthook.yml`** (new) — empty `pre-commit.commands` slot, with a header comment documenting why pre-push is excluded.
- **`package.json`**
  - `prepare`: `lefthook install && bash scripts/install-git-hooks.sh`
  - `devDependencies`: `lefthook ^2.1.6`
  - `pnpm.onlyBuiltDependencies`: add `lefthook` (postinstall syncs hooks)
- **`CLAUDE.md`** — "How it's enforced" subsection rewritten to describe the v2 detection mechanism and lefthook coexistence.

## Test Plan

- [x] `pnpm install` runs `lefthook install` then `scripts/install-git-hooks.sh`; both report success.
- [x] `pnpm exec lefthook --version` prints `lefthook version 2.1.6`.
- [x] `pnpm init-worktree` re-runs the installer (no behavior change).
- [x] Push from `worktrees/_pushguard-poc` (throwaway) blocked with the new `GIT_DIR:` message.
- [x] Push from the main repo unaffected (this very PR was pushed from the repo root).