### PR TITLE
Panel Section Redesign — Pattern-12 sections, fixed ref-pulldown, cssVar labels, neutral tokens

### DIFF
--- a/packages/zudo-design-token-panel/src/controls/__tests__/tier-ref-selector.test.tsx
+++ b/packages/zudo-design-token-panel/src/controls/__tests__/tier-ref-selector.test.tsx
@@ -155,13 +155,13 @@ function clickTrigger() {
 // ---------------------------------------------------------------------------
 
 describe('TierRefSelector — rendering', () => {
-  it('renders a trigger button with current ref item label and value preview', () => {
+  it('renders a trigger button with current ref item cssVar and value preview', () => {
     renderSelector('ease-out', vi.fn());
 
     const trigger = getTrigger();
-    // The trigger should contain the ref item label "Ease out" and a
+    // The trigger should contain the ref item cssVar "--easing-ease-out" and a
     // truncated preview of its default value.
-    expect(trigger.textContent).toContain('Ease out');
+    expect(trigger.textContent).toContain('--easing-ease-out');
     // "cubic-bezier(0, 0, 0.58, 1)" is 26 chars — fits within PREVIEW_MAX_LEN
     expect(trigger.textContent).toContain('cubic-bezier(0, 0, 0.58, 1)');
   });
@@ -170,8 +170,8 @@ describe('TierRefSelector — rendering', () => {
     // ease-in default is "cubic-bezier(0.42, 0, 1, 1)" — 28 chars, at limit
     renderSelector('ease-in', vi.fn());
     const trigger = getTrigger();
-    // label must be present
-    expect(trigger.textContent).toContain('Ease in');
+    // cssVar must be present
+    expect(trigger.textContent).toContain('--easing-ease-in');
   });
 
   it('does not render the listbox when closed', () => {
@@ -214,11 +214,11 @@ describe('TierRefSelector — opening the dropdown', () => {
     expect(options.length).toBe(4);
   });
 
-  it('each raw item option shows label and value preview', () => {
+  it('each raw item option shows cssVar and value preview', () => {
     renderSelector('linear', vi.fn());
     clickTrigger();
     const options = Array.from(getOptions());
-    const easeInOption = options.find((o) => o.textContent?.includes('Ease in'));
+    const easeInOption = options.find((o) => o.textContent?.includes('--easing-ease-in'));
     expect(easeInOption).not.toBeUndefined();
     // preview of "cubic-bezier(0.42, 0, 1, 1)" (28 chars — at limit, no truncation needed)
     expect(easeInOption?.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
@@ -230,7 +230,7 @@ describe('TierRefSelector — opening the dropdown', () => {
     const options = Array.from(getOptions());
     const selected = options.filter((o) => o.getAttribute('aria-selected') === 'true');
     expect(selected.length).toBe(1);
-    expect(selected[0].textContent).toContain('Ease out');
+    expect(selected[0].textContent).toContain('--easing-ease-out');
   });
 
   it('opens with focus on the currently selected item', () => {
@@ -238,14 +238,14 @@ describe('TierRefSelector — opening the dropdown', () => {
     clickTrigger();
     // ease-out is index 1 in raw items
     const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('Ease out');
+    expect(focused?.textContent).toContain('--easing-ease-out');
   });
 
   it('opens with focus on first item when value is unrecognised', () => {
     renderSelector('unknown-id', vi.fn());
     clickTrigger();
     const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('Ease in');
+    expect(focused?.textContent).toContain('--easing-ease-in');
   });
 
   it('Enter on the trigger opens the dropdown', () => {
@@ -268,7 +268,7 @@ describe('TierRefSelector — keyboard navigation', () => {
     clickTrigger();
     fireKey(getListbox()!, 'ArrowDown');
     const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('Ease out');
+    expect(focused?.textContent).toContain('--easing-ease-out');
   });
 
   it('ArrowUp moves focus to the previous option', () => {
@@ -277,7 +277,7 @@ describe('TierRefSelector — keyboard navigation', () => {
     clickTrigger();
     fireKey(getListbox()!, 'ArrowUp');
     const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('Ease in');
+    expect(focused?.textContent).toContain('--easing-ease-in');
   });
 
   it('ArrowDown does not go past the last option', () => {
@@ -333,8 +333,8 @@ describe('TierRefSelector — picking an option', () => {
     clickTrigger();
 
     const options = Array.from(getOptions());
-    // Click on "Linear" (index 2 in raw items).
-    const linearOption = options.find((o) => o.textContent?.includes('Linear'));
+    // Click on the "linear" option (index 2 in raw items) — identified by cssVar.
+    const linearOption = options.find((o) => o.textContent?.includes('--easing-linear'));
     expect(linearOption).not.toBeUndefined();
     act(() => {
       linearOption!.dispatchEvent(

--- a/packages/zudo-design-token-panel/src/controls/tier-ref-selector.tsx
+++ b/packages/zudo-design-token-panel/src/controls/tier-ref-selector.tsx
@@ -110,7 +110,7 @@ function TierRefSelector({ tab, tierId, itemId, value, onChange }: TierRefSelect
 
   const currentRefItem = refTier ? resolveCurrentRefItem(refTier, value) : undefined;
   const triggerLabel = currentRefItem
-    ? `${currentRefItem.label} — ${truncatePreview(currentRefItem.default)}`
+    ? `${currentRefItem.cssVar} — ${truncatePreview(currentRefItem.default)}`
     : value || '—';
 
   // -------------------------------------------------------------------------
@@ -250,7 +250,12 @@ function TierRefSelector({ tab, tierId, itemId, value, onChange }: TierRefSelect
               }}
               onMouseEnter={() => setFocusedIndex(idx)}
             >
-              <span className="tokenpanel-tier-ref-option-label">{item.label}</span>
+              <span className="tokenpanel-tier-ref-option-label">
+                {item.cssVar}
+                {item.label !== item.cssVar && (
+                  <span className="tokenpanel-row-label-sub">{item.label}</span>
+                )}
+              </span>
               <span className="tokenpanel-tier-ref-option-preview">
                 {truncatePreview(item.default)}
               </span>

--- a/packages/zudo-design-token-panel/src/styles/panel-tokens.css
+++ b/packages/zudo-design-token-panel/src/styles/panel-tokens.css
@@ -2,9 +2,9 @@
  * Panel-private CSS custom properties.
  *
  * The design-token panel package owns its own visual tokens instead of
- * leaking them through the host's theme. The values match what the
- * package's example design system declares, so the default look stays
- * identical to the example.
+ * leaking them through the host's theme. Fallback colors use a low-saturation
+ * neutral dark palette so the panel reads as neutral near-black without any
+ * host theme tokens.
  *
  * Scope
  * -----
@@ -44,18 +44,18 @@
    *   override; bypasses the host's own theme).
    * - Host declares neither             → the fallback paints the panel.
    *
-   * Fallback values are picked to match what the package's example
-   * design-system declares, so the panel's default look stays identical
-   * to the example.
+   * Fallback values use a low-saturation neutral dark palette (~#181818
+   * body / ~#1c1c1c surface family) so the panel reads as neutral near-black
+   * without host theme tokens. Accent and status colors are unchanged.
    * ---------------------------------------------------------------------- */
-  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
-  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
-  --tokentweak-color-muted: var(--color-muted, oklch(70% 0.01 60));
-  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
+  --tokentweak-color-fg: var(--color-fg, oklch(80% 0 0));
+  --tokentweak-color-bg: var(--color-bg, oklch(20.5% 0 0));
+  --tokentweak-color-muted: var(--color-muted, oklch(63% 0 0));
+  --tokentweak-color-surface: var(--color-surface, oklch(22.5% 0 0));
   --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
   --tokentweak-color-accent-hover: var(--color-accent-hover, oklch(55% 0.18 45));
-  --tokentweak-color-code-bg: var(--color-code-bg, oklch(17% 0.005 50));
-  --tokentweak-color-code-fg: var(--color-code-fg, oklch(87% 0.01 60));
+  --tokentweak-color-code-bg: var(--color-code-bg, oklch(19% 0 0));
+  --tokentweak-color-code-fg: var(--color-code-fg, oklch(80% 0 0));
   --tokentweak-color-success: var(--color-success, oklch(65% 0.19 145));
   --tokentweak-color-danger: var(--color-danger, oklch(60% 0.2 10));
   --tokentweak-color-warning: var(--color-warning, oklch(75% 0.17 75));

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -217,21 +217,35 @@
 }
 
 .tokenpanel-tab-section {
+  /* Fieldset-style bordered box; heading floats on the top border. */
+  position: relative;
   flex-shrink: 0;
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: 0.5rem;
+  padding: 18px 14px 14px;
 }
 
 .tokenpanel-tab-section-heading {
-  color: var(--tokentweak-color-muted);
+  /* Absolutely positioned so it overlaps the top border. */
+  position: absolute;
+  top: -0.625rem; /* ~10px — half the line-height so it sits centred on the border */
+  left: 12px;
+  /* Surface-colored bg "cuts" the border behind the text. */
+  background: var(--tokentweak-color-surface);
+  padding: 0 8px;
+  /* Reset browser h3 defaults. */
+  margin: 0;
+  color: var(--tokentweak-color-fg);
   font-weight: 600;
-  margin-bottom: var(--tokentweak-gap-2xs);
   font-size: 0.8125rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  line-height: 1.25rem; /* fixed line-height so top offset is predictable */
+  text-transform: none;
+  letter-spacing: normal;
 }
 
-/* Color-tab uses a slightly bigger heading per the original spec. */
+/* Color-tab uses a slightly bigger heading to maintain its size hierarchy. */
 .tokenpanel-tab-section-heading--color {
-  font-size: 1rem;
+  font-size: 0.875rem;
 }
 
 .tokenpanel-tab-grid {

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -931,3 +931,168 @@
   color: var(--tokentweak-color-fg);
   border-color: var(--tokentweak-color-fg);
 }
+
+/* ===========================================================================
+ * Tier-ref selector (anchored popover with arrow tip)
+ *
+ * Implements the Pattern-12 anchored-popover style for the Easing / Font /
+ * Spacing / Size "semantic → raw" reference selector. The component lives in
+ * controls/tier-ref-selector.tsx; every class and attribute targeted here is
+ * already emitted by that component — NO JSX changes needed.
+ *
+ * Variable mapping (no accent-soft or surface-hi token in this package):
+ *   accent-soft bg  → rgb(from var(--tokentweak-color-accent) r g b / 0.16)
+ *   surface-hi      → var(--tokentweak-color-surface)  (border+shadow carry the elevation)
+ *   line-strong     → var(--tokentweak-color-muted)
+ *
+ * The tick mark on each option is rendered via ::before pseudo-element so the
+ * three-column grid layout (tick | label | preview) works without touching the
+ * existing markup. aria-selected='true' on the <li> makes the tick visible.
+ * ========================================================================= */
+
+/* Relative-positioned anchor for the popover */
+.tokenpanel-tier-ref-selector {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+}
+
+/* Trigger button — compact mono label + chevron */
+.tokenpanel-tier-ref-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background-color: var(--tokentweak-color-surface);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: var(--radius-tokentweak);
+  padding-inline: var(--tokentweak-pad-sm);
+  padding-block: 4px;
+  font-family: var(--tokentweak-font-mono);
+  font-size: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+.tokenpanel-tier-ref-trigger:hover {
+  border-color: var(--tokentweak-color-fg);
+}
+
+/* Open state — accent border + soft focus ring (Pattern 12 verbatim) */
+.tokenpanel-tier-ref-trigger[aria-expanded='true'] {
+  border-color: var(--tokentweak-color-accent);
+  box-shadow: 0 0 0 2px rgb(from var(--tokentweak-color-accent) r g b / 0.16);
+}
+
+/* Label inside the trigger — fills remaining width, truncated */
+.tokenpanel-tier-ref-trigger-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Chevron — muted, does not shrink */
+.tokenpanel-tier-ref-trigger-arrow {
+  color: var(--tokentweak-color-muted);
+  font-size: 9px;
+  flex-shrink: 0;
+}
+
+/* Listbox popover — absolute, beneath trigger, elevated via border + shadow */
+.tokenpanel-tier-ref-listbox {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  right: 0;
+  z-index: 60;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background-color: var(--tokentweak-color-surface);
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: var(--radius-tokentweak);
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.5);
+  outline: none; /* tabIndex={-1} focus ring suppressed; per-option --focused handles it */
+}
+
+/* Arrow tip pointing up at the trigger (::before rotated 45°) */
+.tokenpanel-tier-ref-listbox::before {
+  content: '';
+  position: absolute;
+  top: -7px;
+  left: 22px;
+  width: 12px;
+  height: 12px;
+  background-color: var(--tokentweak-color-surface);
+  border-left: 1px solid var(--tokentweak-color-muted);
+  border-top: 1px solid var(--tokentweak-color-muted);
+  transform: rotate(45deg);
+}
+
+/* Option row — three-column grid: tick | label | preview
+ * Tick is provided by ::before pseudo-element so the existing markup needs
+ * no changes. The tick character is always present; color toggles via
+ * aria-selected. */
+.tokenpanel-tier-ref-option {
+  display: grid;
+  grid-template-columns: 14px 1fr auto;
+  gap: 6px;
+  align-items: center;
+  padding: 5px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: var(--tokentweak-font-mono);
+  font-size: 0.8125rem;
+  color: var(--tokentweak-color-fg);
+  list-style: none;
+}
+
+/* Tick pseudo-element — always rendered, color toggled by aria-selected */
+.tokenpanel-tier-ref-option::before {
+  content: '✓';
+  font-size: 11px;
+  color: transparent; /* hidden by default */
+  line-height: 1;
+}
+
+/* Show tick on selected option */
+.tokenpanel-tier-ref-option[aria-selected='true']::before {
+  color: var(--tokentweak-color-accent);
+}
+
+/* Label — left column, truncated */
+.tokenpanel-tier-ref-option-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Value preview — right column, muted + smaller */
+.tokenpanel-tier-ref-option-preview {
+  font-size: 0.6875rem;
+  color: var(--tokentweak-color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 10rem;
+}
+
+/* Keyboard focus / hover highlight */
+.tokenpanel-tier-ref-option--focused {
+  background-color: rgb(from var(--tokentweak-color-accent) r g b / 0.16);
+}
+
+/* "Literal…" option — italic muted, separator above */
+.tokenpanel-tier-ref-option--literal {
+  font-style: italic;
+  color: var(--tokentweak-color-muted);
+  border-top: 1px solid var(--tokentweak-color-muted);
+  margin-top: 4px;
+  padding-top: 8px;
+}

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -931,3 +931,14 @@
   color: var(--tokentweak-color-fg);
   border-color: var(--tokentweak-color-fg);
 }
+
+/* Secondary human-readable label shown beneath the cssVar primary label when
+   they differ. Developers see the cssVar identity first; the friendly name is
+   a muted subtitle for context only. */
+.tokenpanel-row-label-sub {
+  display: block;
+  font-size: var(--tokentweak-text-micro, 0.6875rem);
+  color: var(--tokentweak-color-muted);
+  font-family: var(--tokentweak-font-mono);
+  line-height: 1.2;
+}

--- a/packages/zudo-design-token-panel/src/tabs/__tests__/generic-tab.test.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/__tests__/generic-tab.test.tsx
@@ -254,7 +254,7 @@ describe('GenericTab — default values', () => {
 });
 
 describe('GenericTab — onChange callbacks', () => {
-  it('renders text input for text items — aria-label matches item label', async () => {
+  it('renders text input for text items — aria-label matches item cssVar', async () => {
     // Verifies the input is present and correctly labeled for accessibility.
     // Full onChange wiring is verified at the integration level (panel.tsx test).
     // jsdom's native event dispatch does not trigger Preact's synthetic onChange,
@@ -266,7 +266,7 @@ describe('GenericTab — onChange callbacks', () => {
       '[data-testid="tier-item-ease-in"] input[type="text"]',
     );
     expect(input).not.toBeNull();
-    expect(input!.getAttribute('aria-label')).toBe('Ease in value');
+    expect(input!.getAttribute('aria-label')).toBe('--test-easing-ease-in value');
   });
 
   it('fires onChange through handleItemChange for a select', async () => {
@@ -279,7 +279,7 @@ describe('GenericTab — onChange callbacks', () => {
       '[data-testid="tier-item-select-item"] select',
     );
     expect(select).not.toBeNull();
-    expect(select!.getAttribute('aria-label')).toBe('Weight value');
+    expect(select!.getAttribute('aria-label')).toBe('--test-select value');
   });
 
   it('fires onChange for color input — correct aria-label', async () => {
@@ -290,7 +290,7 @@ describe('GenericTab — onChange callbacks', () => {
       '[data-testid="tier-item-color-item"] input[type="color"]',
     );
     expect(colorInput).not.toBeNull();
-    expect(colorInput!.getAttribute('aria-label')).toBe('Color value');
+    expect(colorInput!.getAttribute('aria-label')).toBe('--test-color value');
   });
 });
 

--- a/packages/zudo-design-token-panel/src/tabs/_generic-item-editor.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/_generic-item-editor.tsx
@@ -76,7 +76,10 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
         <div className="tokenpanel-row--stacked" data-testid={`tier-item-${item.id}`}>
           <div className="tokenpanel-row-head">
             <span className="tokenpanel-row-label" title={item.cssVar}>
-              {item.label}
+              {item.cssVar}
+              {item.label !== item.cssVar && (
+                <span className="tokenpanel-row-label-sub">{item.label}</span>
+              )}
             </span>
             <div className="tokenpanel-row-input-group">
               <input
@@ -86,7 +89,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
                 onChange={handleNumber}
                 disabled={effectiveReadonly}
                 className="tokenpanel-row-number-input"
-                aria-label={`${item.label} value`}
+                aria-label={`${item.cssVar} value`}
               />
               {unit && <span className="tokenpanel-row-unit">{unit}</span>}
             </div>
@@ -100,7 +103,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
             onChange={handleSlider}
             disabled={effectiveReadonly}
             className="tokenpanel-row-slider"
-            aria-label={`${item.label} slider`}
+            aria-label={`${item.cssVar} slider`}
           />
         </div>
       );
@@ -136,14 +139,17 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
           <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.label}
+            {item.cssVar}
+            {item.label !== item.cssVar && (
+              <span className="tokenpanel-row-label-sub">{item.label}</span>
+            )}
           </span>
           <select
             value={selectDraft}
             onChange={handleChange}
             disabled={isReadonly}
             className="tokenpanel-row-select"
-            aria-label={`${item.label} value`}
+            aria-label={`${item.cssVar} value`}
           >
             {options.map((opt) => (
               <option key={opt} value={opt}>
@@ -162,7 +168,10 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
           <span className="tokenpanel-row-label tokenpanel-row-label--narrow" title={item.cssVar}>
-            {item.label}
+            {item.cssVar}
+            {item.label !== item.cssVar && (
+              <span className="tokenpanel-row-label-sub">{item.label}</span>
+            )}
           </span>
           <input
             type="text"
@@ -170,7 +179,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
             onChange={handleChange}
             disabled={isReadonly}
             className="tokenpanel-row-text-input"
-            aria-label={`${item.label} value`}
+            aria-label={`${item.cssVar} value`}
             spellcheck={false}
             autoCapitalize="off"
             autoCorrect="off"
@@ -187,7 +196,10 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
           <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.label}
+            {item.cssVar}
+            {item.label !== item.cssVar && (
+              <span className="tokenpanel-row-label-sub">{item.label}</span>
+            )}
           </span>
           <input
             type="color"
@@ -195,7 +207,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
             onChange={handleChange}
             disabled={isReadonly}
             className="tokenpanel-row-color-input"
-            aria-label={`${item.label} value`}
+            aria-label={`${item.cssVar} value`}
           />
         </div>
       );

--- a/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
@@ -142,7 +142,10 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                       data-testid={`tier-ref-row-${item.id}`}
                     >
                       <span className="tokenpanel-row-label" title={item.cssVar}>
-                        {item.label}
+                        {item.cssVar}
+                        {item.label !== item.cssVar && (
+                          <span className="tokenpanel-row-label-sub">{item.label}</span>
+                        )}
                       </span>
                       <TierRefSelector
                         tab={tab}

--- a/packages/zudo-design-token-panel/src/tabs/generic-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/generic-tab.tsx
@@ -44,7 +44,10 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
     return (
       <div className="tokenpanel-row" data-testid={`tier-ref-row-${item.id}`}>
         <span className="tokenpanel-row-label" title={item.cssVar}>
-          {item.label}
+          {item.cssVar}
+          {item.label !== item.cssVar && (
+            <span className="tokenpanel-row-label-sub">{item.label}</span>
+          )}
         </span>
         <TierRefSelector
           tab={tab}
@@ -88,7 +91,10 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
         <div className="tokenpanel-row--stacked" data-testid={`tier-item-${item.id}`}>
           <div className="tokenpanel-row-head">
             <span className="tokenpanel-row-label" title={item.cssVar}>
-              {item.label}
+              {item.cssVar}
+              {item.label !== item.cssVar && (
+                <span className="tokenpanel-row-label-sub">{item.label}</span>
+              )}
             </span>
             <div className="tokenpanel-row-input-group">
               <input
@@ -98,7 +104,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
                 onChange={handleNumber}
                 disabled={isReadonly}
                 className="tokenpanel-row-number-input"
-                aria-label={`${item.label} value`}
+                aria-label={`${item.cssVar} value`}
               />
               {unit && <span className="tokenpanel-row-unit">{unit}</span>}
             </div>
@@ -112,7 +118,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
             onChange={handleSlider}
             disabled={isReadonly}
             className="tokenpanel-row-slider"
-            aria-label={`${item.label} slider`}
+            aria-label={`${item.cssVar} slider`}
           />
         </div>
       );
@@ -126,14 +132,17 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
           <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.label}
+            {item.cssVar}
+            {item.label !== item.cssVar && (
+              <span className="tokenpanel-row-label-sub">{item.label}</span>
+            )}
           </span>
           <select
             value={value}
             onChange={handleChange}
             disabled={isReadonly}
             className="tokenpanel-row-select"
-            aria-label={`${item.label} value`}
+            aria-label={`${item.cssVar} value`}
           >
             {options.map((opt) => (
               <option key={opt} value={opt}>
@@ -152,7 +161,10 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
           <span className="tokenpanel-row-label tokenpanel-row-label--narrow" title={item.cssVar}>
-            {item.label}
+            {item.cssVar}
+            {item.label !== item.cssVar && (
+              <span className="tokenpanel-row-label-sub">{item.label}</span>
+            )}
           </span>
           <input
             type="text"
@@ -160,7 +172,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
             onChange={handleChange}
             disabled={isReadonly}
             className="tokenpanel-row-text-input"
-            aria-label={`${item.label} value`}
+            aria-label={`${item.cssVar} value`}
             spellcheck={false}
             autoCapitalize="off"
             autoCorrect="off"
@@ -177,7 +189,10 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
           <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.label}
+            {item.cssVar}
+            {item.label !== item.cssVar && (
+              <span className="tokenpanel-row-label-sub">{item.label}</span>
+            )}
           </span>
           <input
             type="color"
@@ -185,7 +200,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
             onChange={handleChange}
             disabled={isReadonly}
             className="tokenpanel-row-color-input"
-            aria-label={`${item.label} value`}
+            aria-label={`${item.cssVar} value`}
           />
         </div>
       );

--- a/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
@@ -139,7 +139,10 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                       data-testid={`tier-ref-row-${item.id}`}
                     >
                       <span className="tokenpanel-row-label" title={item.cssVar}>
-                        {item.label}
+                        {item.cssVar}
+                        {item.label !== item.cssVar && (
+                          <span className="tokenpanel-row-label-sub">{item.label}</span>
+                        )}
                       </span>
                       <TierRefSelector
                         tab={tab}

--- a/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
@@ -146,7 +146,10 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                       data-testid={`tier-ref-row-${item.id}`}
                     >
                       <span className="tokenpanel-row-label" title={item.cssVar}>
-                        {item.label}
+                        {item.cssVar}
+                        {item.label !== item.cssVar && (
+                          <span className="tokenpanel-row-label-sub">{item.label}</span>
+                        )}
                       </span>
                       <TierRefSelector
                         tab={tab}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/114

---

## Summary

Implements the **Panel Section Redesign** epic (#114). The panel was rebuilt around Pattern 12: fieldset-style sections with a "floating tag" heading overlapping the top border, an anchored popover with arrow tip for the Easing-tab tier-ref pulldown (which had **zero CSS rules** before — it rendered as a bare unstyled list), and cssVar as the primary visible identifier on every row so developers can see what they're editing. Default chrome shifted from warm brown to a low-saturation neutral matching zudo-doc's `#181818` body.

**Strict scope — no new features.** Section chrome, the broken pulldown, row labels, and default fallback colors only. Existing controls (slider/text/select/color/pill) keep their behavior. Color palette and tier model unchanged.

## Implementation summary (Wave 1 — landed)

### #115 — Pattern-12 fieldset section restyle (CSS only)
Rewrote `.tokenpanel-tab-section` and `.tokenpanel-tab-section-heading` in `packages/zudo-design-token-panel/src/styles/panel.css` for the fieldset look: bordered rounded box, ~18/14/14px internal padding, heading positioned absolutely at top-left with surface-coloured background that visually cuts the top border. Heading colour changed from muted to fg, uppercase + letter-spacing removed. Color-tab `--color` heading variant scaled to maintain a subtle size hierarchy. CSS-only — no JSX touched. Matches `12-floating-tag-headings.html` Pattern 12 mockup.

### #116 — Tier-ref pulldown CSS (fixed broken Easing-tab Semantic pulldown)
Added ~165 lines of brand-new rules to `panel.css` for the entire `.tokenpanel-tier-ref-*` selector family — `.tokenpanel-tier-ref-selector`, `-trigger`, `-listbox`, `-option`, `--focused`, `--literal`. Open-state styling targets `[aria-expanded='true']` (the JSX uses the attribute, not a class). Listbox is positioned absolutely beneath the trigger with an arrow tip via `::before` (12px square rotated 45° with surface bg + top/left border inherited from popover). Tick mark on the selected option is a `::before` pseudo-element so the existing markup didn't need changes. No JSX edits.

### #117 — cssVar primary label across all tabs (TSX + 1 CSS rule)
Brought every visible row label across all tabs/tiers into the same convention: cssVar primary, optional muted `.tokenpanel-row-label-sub` subtitle (only when `label !== cssVar`). Files updated:
- `tabs/generic-tab.tsx` (5 render branches + aria-labels)
- `tabs/_generic-item-editor.tsx` (4 render branches + aria-labels)
- `tabs/spacing-tab.tsx` / `font-tab.tsx` / `size-tab.tsx` (ref-tier row each)
- `controls/tier-ref-selector.tsx` (trigger label + option labels)
- `styles/panel.css` (1 new rule: `.tokenpanel-row-label-sub`)
- 2 test files updated to assert cssVar where they previously asserted human labels (13 assertions adjusted)

### #118 — Low-saturation neutral panel tokens
Swapped 6 oklch fallback values in `packages/zudo-design-token-panel/src/styles/panel-tokens.css` from warm-brown (chroma 0.01, hue 50) to zero-chroma neutral dark matching the zudo-doc `#181818` body / `#1c1c1c` surface family. `--tokentweak-color-bg`, `-surface`, `-fg`, `-muted`, `-code-bg`, `-code-fg`. The `var(--color-X, fallback)` indirection ladder is preserved — host themes still win. Accent (orange) and status colors are untouched.

## Files changed (totals)

- 10 files modified, 291 insertions, 60 deletions
- CSS: `panel.css` (202 lines added/changed), `panel-tokens.css` (24 lines)
- TSX: 6 source files updated for cssVar primary labels
- Tests: 2 test files updated (assertion expectations only)

## Verification (Wave 2 — confirm pass)

Wave 2 ran via `-seq` chain (no new commits — verification only):

### #119 — Visual verification
A disposable Opus subagent ran `/headless-browser` + `/verify-ui` against the merged base in two example apps (sequential, per resource-coordination.md):
- **vite-react (React host, consumes dist)**: PASS on all 4 changes that the app exposes (Pattern-12 fieldset on Spacing/Font/Size/Color tabs, cssVar primary labels, neutral chrome at oklch(0.225 0 0) with chroma 0). The tier-ref pulldown (#116) is not exposed on vite-react because its default-manifest has no Easing tab.
- **zfb (Preact host, uses tsconfig paths to src — the key surface for #118 neutral chrome verification)**: tier-ref pulldown (#116) verified at the source-CSS computed-style level — listbox absolute beneath trigger with 1px muted border + box-shadow, arrow tip ::before 12px square rotated 45°, [aria-expanded='true'] trigger gets accent border + soft box-shadow ring, selected option ::before tick in accent orange, "Literal…" italic muted with hairline separator at bottom of list.

### #120 — Build / typecheck / test + cross-runtime
- `pnpm -F @takazudo/zudo-design-token-panel build` — succeeded (dist refreshed; includes all 165 lines of new `.tokenpanel-tier-ref-*` CSS).
- `pnpm typecheck` (root) — passed across all 7 workspace projects (panel + astro + next + vite-react + zfb + zfb-tailwind + doc), zero errors.
- `pnpm -F @takazudo/zudo-design-token-panel test` — 383/383 pass.
- Cross-runtime spot-check on vite-react (React, different runtime from zfb's Preact) — confirmed the panel dist consumes cleanly and renders correctly.

### Independent code review

`/gcoc-review` (Copilot CLI, gpt-4.1) on the combined Wave 1 diff returned zero actionable findings. CSS braces all matched, no stray merge markers, TSX label-render conditional correct, all attribute selectors (`[aria-expanded='true']`, `[aria-selected='true']`) match what the JSX emits, test assertions consistently expect `cssVar` for label + aria-label, panel-tokens.css preserves the `var(--color-X, fallback)` indirection ladder.

CI on PR #121: 3/3 checks green.

## Test plan (for reviewer)

- [x] Open the panel inside any non-overriding host (zfb is the canonical case). The panel chrome should read as neutral dark grey, not warm brown.
- [x] On the Color tab, confirm Primary/Secondary palette + Base + Semantic sections each render inside their own fieldset box with the heading floating on the top border.
- [x] On the Easing tab, click any Semantic-tier ref trigger — confirm the popover anchored beneath with an arrow tip and the "Literal…" option at the bottom under a hairline separator.
- [x] On any tab, confirm each row's primary visible text is the cssVar (e.g., `--zfbexample-easing-modal-open`) with the human label as a small muted subtitle only when they differ.
- [x] Accent (orange) and status colors unchanged.