### PR TITLE
Add visible Open Design Token Panel button to each demo page

### DIFF
--- a/examples/astro/src/pages/about.astro
+++ b/examples/astro/src/pages/about.astro
@@ -18,6 +18,15 @@ const proseHref = `${import.meta.env.BASE_URL}prose`;
     <header>
       <h1 class="astroexample-heading">About this example</h1>
       <p>
+        <button
+          class="astroexample-button"
+          type="button"
+          onclick="window.astroExample?.toggleDesignPanel?.()"
+        >
+          Open Design Token Panel
+        </button>
+      </p>
+      <p>
         The <code>examples/astro</code> sub-package consumes
         <code>@takazudo/zudo-design-token-panel</code> through its built artifact only — there are no
         deep imports into <code>dist/</code>, no bundler aliases, and no framework integration beyond

--- a/examples/astro/src/pages/index.astro
+++ b/examples/astro/src/pages/index.astro
@@ -17,6 +17,15 @@ const proseHref = `${import.meta.env.BASE_URL}prose`;
     <header>
       <h1 class="astroexample-heading">Live token tweaking, in plain Astro</h1>
       <p>
+        <button
+          class="astroexample-button"
+          type="button"
+          onclick="window.astroExample?.toggleDesignPanel?.()"
+        >
+          Open Design Token Panel
+        </button>
+      </p>
+      <p>
         Every visible element on this page is driven by an
         <code>--astroexample-*</code> CSS custom property. Open the panel from the browser console and
         drag any slider — the change applies before the next paint.

--- a/examples/astro/src/pages/prose.astro
+++ b/examples/astro/src/pages/prose.astro
@@ -29,6 +29,16 @@ const aboutHref = `${import.meta.env.BASE_URL}about`;
       <a class="astroexample-link" href={aboutHref}>About</a>
     </nav>
 
+    <p>
+      <button
+        class="astroexample-button"
+        type="button"
+        onclick="window.astroExample?.toggleDesignPanel?.()"
+      >
+        Open Design Token Panel
+      </button>
+    </p>
+
     <main class="astroexample-prose">
       <Content />
     </main>

--- a/examples/next/app/_components/PanelOpenButton.tsx
+++ b/examples/next/app/_components/PanelOpenButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/*
+ * Visible entry-point button for the design-token panel.
+ *
+ * Rendered at the top of every demo page. The home page (`app/page.tsx`)
+ * is itself `"use client"`, but `app/about/page.tsx` and `app/prose/page.mdx`
+ * are server-rendered — they can only embed an `onClick` listener through a
+ * client component, hence this small wrapper.
+ *
+ * The click handler calls the host's namespaced console API
+ * (`window.nextExample.toggleDesignPanel()`). The namespace function is
+ * installed inside `PanelBootstrap`'s `useEffect`, which runs on first
+ * client mount of the root layout. By the time the user can click this
+ * button, the function exists; if not (rare race), the optional-chain
+ * silently no-ops and the user can click again.
+ */
+
+type NextExampleConsoleApi = {
+  nextExample?: { toggleDesignPanel?: () => void };
+};
+
+export default function PanelOpenButton() {
+  return (
+    <button
+      type="button"
+      className="nextexample-button"
+      onClick={() => {
+        (window as unknown as NextExampleConsoleApi).nextExample?.toggleDesignPanel?.();
+      }}
+    >
+      Open Design Token Panel
+    </button>
+  );
+}

--- a/examples/next/app/about/page.tsx
+++ b/examples/next/app/about/page.tsx
@@ -22,6 +22,8 @@
 
 import Link from 'next/link';
 
+import PanelOpenButton from '../_components/PanelOpenButton';
+
 const PALETTE_INDICES = Array.from({ length: 16 }, (_, i) => i);
 
 export default function AboutPage() {
@@ -29,6 +31,9 @@ export default function AboutPage() {
     <main className="nextexample-stack">
       <header>
         <h1 className="nextexample-heading">About this example</h1>
+        <p>
+          <PanelOpenButton />
+        </p>
         <p>
           The <code>examples/next</code> sub-package consumes
           <code> @takazudo/zudo-design-token-panel</code> through its built

--- a/examples/next/app/page.tsx
+++ b/examples/next/app/page.tsx
@@ -23,6 +23,7 @@
 
 import Link from 'next/link';
 import { useCallback, useState } from 'react';
+import PanelOpenButton from './_components/PanelOpenButton';
 
 const PALETTE_INDICES = Array.from({ length: 16 }, (_, i) => i);
 
@@ -31,6 +32,9 @@ export default function HomePage() {
     <main className="nextexample-stack">
       <header>
         <h1 className="nextexample-heading">Live token tweaking, in plain Next.js + React</h1>
+        <p>
+          <PanelOpenButton />
+        </p>
         <p>
           Every visible element on this page is driven by a{' '}
           <code>--nextexample-*</code> CSS custom property. Open the panel from

--- a/examples/next/app/prose/page.mdx
+++ b/examples/next/app/prose/page.mdx
@@ -1,4 +1,8 @@
+import PanelOpenButton from '../_components/PanelOpenButton';
+
 # Prose Demo
+
+<PanelOpenButton />
 
 This page demonstrates the full range of markdown-generated HTML elements
 styled through the `--nextexample-*` token namespace.

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -43,6 +43,21 @@ export function App() {
       <header>
         <h1 className="vitereact-heading">Live token tweaking, in plain Vite + React</h1>
         <p>
+          <button
+            type="button"
+            className="vitereact-button"
+            onClick={() => {
+              (
+                window as unknown as {
+                  viteReactExample?: { toggleDesignPanel?: () => void };
+                }
+              ).viteReactExample?.toggleDesignPanel?.();
+            }}
+          >
+            Open Design Token Panel
+          </button>
+        </p>
+        <p>
           Every visible element on this page is driven by a{' '}
           <code>--vitereact-*</code> CSS custom property. Open the panel from
           the browser console and drag any slider — the change applies before

--- a/examples/vite-react/src/components/ProseDemo.tsx
+++ b/examples/vite-react/src/components/ProseDemo.tsx
@@ -23,6 +23,21 @@ export function ProseDemo() {
       <nav className="vitereact-prose-nav">
         <a href={`${import.meta.env.BASE_URL}index.html`}>← Back to component gallery</a>
       </nav>
+      <p>
+        <button
+          type="button"
+          className="vitereact-button"
+          onClick={() => {
+            (
+              window as unknown as {
+                viteReactExample?: { toggleDesignPanel?: () => void };
+              }
+            ).viteReactExample?.toggleDesignPanel?.();
+          }}
+        >
+          Open Design Token Panel
+        </button>
+      </p>
       <main className="vitereact-prose">
         <ProseDemoContent />
       </main>

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -84,6 +84,28 @@ export default function HomePage() {
               Live token tweaking, in zfb + Tailwind v4
             </h1>
             <p>
+              <button
+                type="button"
+                id="zfbtailwindexample-panel-open"
+                class="inline-block p-spacing-md rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary"
+              >
+                Open Design Token Panel
+              </button>
+            </p>
+            {/*
+              The page body is SSR-only — only <PanelMount> below sits inside
+              an <Island> and hydrates. A JSX onClick on the button above
+              would never fire. This sibling <script> attaches the listener
+              natively at parse time; once <PanelMount>'s useEffect installs
+              window.zfbTailwindExample.toggleDesignPanel, the click invokes it.
+            */}
+            <script
+              dangerouslySetInnerHTML={{
+                __html:
+                  "document.getElementById('zfbtailwindexample-panel-open')?.addEventListener('click',function(){var a=window.zfbTailwindExample;if(a&&typeof a.toggleDesignPanel==='function')a.toggleDesignPanel();});",
+              }}
+            />
+            <p>
               Every visible element on this page is driven by a{' '}
               <code>--zfbtailwindexample-*</code> CSS custom property, consumed via
               Tailwind v4 utility classes. Open the panel from the browser console

--- a/examples/zfb-tailwind/pages/prose.tsx
+++ b/examples/zfb-tailwind/pages/prose.tsx
@@ -94,6 +94,22 @@ export default function ProsePage() {
           <h1 class="text-heading font-bold mb-vsp-xl text-primary leading-tight">
             Prose Demo
           </h1>
+          <p class="mb-vsp-xl">
+            <button
+              type="button"
+              id="zfbtailwindexample-panel-open"
+              class="inline-block p-spacing-md rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary"
+            >
+              Open Design Token Panel
+            </button>
+          </p>
+          {/* SSR-only body — see pages/index.tsx for the rationale. */}
+          <script
+            dangerouslySetInnerHTML={{
+              __html:
+                "document.getElementById('zfbtailwindexample-panel-open')?.addEventListener('click',function(){var a=window.zfbTailwindExample;if(a&&typeof a.toggleDesignPanel==='function')a.toggleDesignPanel();});",
+            }}
+          />
           <p class="text-small text-muted mb-vsp-xl">
             All typography and spacing tokens are from the{' '}
             <code>--zfbtailwindexample-*</code> namespace.

--- a/examples/zfb/pages/index.tsx
+++ b/examples/zfb/pages/index.tsx
@@ -71,6 +71,28 @@ export default function HomePage() {
           <header>
             <h1 class="zfbexample-heading">Live token tweaking, in zfb (zudo-front-builder)</h1>
             <p>
+              <button
+                type="button"
+                id="zfbexample-panel-open"
+                class="zfbexample-button"
+              >
+                Open Design Token Panel
+              </button>
+            </p>
+            {/*
+              The page body is SSR-only — only <PanelMount> below sits inside
+              an <Island> and hydrates. A JSX onClick on the button above
+              would never fire. This sibling <script> attaches the listener
+              natively at parse time; once <PanelMount>'s useEffect installs
+              window.zfbExample.toggleDesignPanel, the click invokes it.
+            */}
+            <script
+              dangerouslySetInnerHTML={{
+                __html:
+                  "document.getElementById('zfbexample-panel-open')?.addEventListener('click',function(){var a=window.zfbExample;if(a&&typeof a.toggleDesignPanel==='function')a.toggleDesignPanel();});",
+              }}
+            />
+            <p>
               Every visible element on this page is driven by a{' '}
               <code>--zfbexample-*</code> CSS custom property. Open the panel
               from the browser console and drag any slider — the change applies

--- a/examples/zfb/pages/prose.tsx
+++ b/examples/zfb/pages/prose.tsx
@@ -87,6 +87,23 @@ export default function ProsePage() {
           </a>
         </nav>
 
+        <p style="padding: 1rem 2rem 0;">
+          <button
+            type="button"
+            id="zfbexample-panel-open"
+            class="zfbexample-button"
+          >
+            Open Design Token Panel
+          </button>
+        </p>
+        {/* SSR-only body — see pages/index.tsx for the rationale. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "document.getElementById('zfbexample-panel-open')?.addEventListener('click',function(){var a=window.zfbExample;if(a&&typeof a.toggleDesignPanel==='function')a.toggleDesignPanel();});",
+          }}
+        />
+
         <main class="zfbexample-prose">
           {ProseContent ? (
             <ProseContent components={{ ...defaultComponents }} />


### PR DESCRIPTION
## Summary
- Every demo page across the 5 example apps (`astro`, `next`, `vite-react`, `zfb`, `zfb-tailwind`) now ships a visible **"Open Design Token Panel"** button at the top of the page.
- Visitors no longer need to open devtools and type `window.<ns>.toggleDesignPanel()` to interact with the panel — the same console API is invoked by the button under the hood.
- 12 demo pages modified + 1 new tiny Next.js client component (`PanelOpenButton`). No package source or shared CSS was touched; each demo reuses its existing button styling.

## Changes

### Astro (`examples/astro`)
- `index.astro`, `about.astro`, `prose.astro`: render `<button class="astroexample-button" onclick="window.astroExample?.toggleDesignPanel?.()">Open Design Token Panel</button>` directly. Astro's HTML-attribute model means no extra JS is needed.

### Vite + React (`examples/vite-react`)
- `App.tsx` and `components/ProseDemo.tsx`: standard React `onClick` handler that calls `window.viteReactExample.toggleDesignPanel()`. The component itself is already React-mounted, so this is sufficient.

### Next.js (`examples/next`)
- New `app/_components/PanelOpenButton.tsx` — a small `"use client"` wrapper that renders the styled button. Introduced because `app/about/page.tsx` is a server component and `app/prose/page.mdx` is MDX (the static exporter rejects client-only behavior inline).
- `app/page.tsx` (already `"use client"`): renders `<PanelOpenButton />`.
- `app/about/page.tsx`: imports and renders `<PanelOpenButton />`.
- `app/prose/page.mdx`: imports and renders `<PanelOpenButton />`.

### zfb / zfb-tailwind (`examples/zfb`, `examples/zfb-tailwind`)
- `pages/index.tsx`, `pages/prose.tsx`: render the button + an adjacent inline `<script dangerouslySetInnerHTML>` that calls `addEventListener('click', …)` natively at HTML parse time. Required because the body of these pages is SSR-only — only the trailing `<PanelMount />` sits inside an `<Island>` and hydrates, so a JSX `onClick` on the button would never fire on the client. The script's payload is static (no user input), so there is no XSS surface.
- zfb-tailwind reuses the same Tailwind utility-class combo already used by its existing Action button (`inline-block p-spacing-md rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary`).

## Placement
- Inside the existing `<header>`, immediately after `<h1>`, for pages that have a header section (all index/about pages + zfb-tailwind prose).
- First interactive element under `<main>`/`<nav>`-only layouts (astro prose, zfb prose).
- Wrapped in `<p>` to match the existing per-demo convention (each demo already wraps its Action button in `<p>`).

## Test Plan
- `pnpm typecheck` — passes across all 7 workspace projects, including the `astro check` (zero errors) and the two `zfb check` runs.
- CI (`Build, test, typecheck, lint`) is green on this PR.
- Manual: open each demo's home page in a browser, click "Open Design Token Panel" near the top → panel opens. Click again → panel closes.
- Manual: on the prose pages (`/prose` for astro/next/zfb/zfb-tailwind, `prose.html` for vite-react), confirm the button appears at the start of the prose layout and toggles the panel.