### PR TITLE
feat(panel): resizable panel with px-fixed size and localStorage persistence

### DIFF
--- a/packages/zudo-design-token-panel/src/__tests__/clamp-size.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/clamp-size.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+/**
+ * Coverage for `clampSize` — width/height bounds clamping used by both
+ * `loadSize` and the panel's resize handler / window-resize re-clamp effect.
+ *
+ * Caps are sourced from `MIN_PANEL_WIDTH / MIN_PANEL_HEIGHT / MAX_PANEL_WIDTH
+ * / MAX_PANEL_HEIGHT` and the current viewport (`innerWidth -
+ * SIZE_VIEWPORT_MARGIN`, `innerHeight - SIZE_VIEWPORT_MARGIN`). The viewport
+ * upper bound matters when a saved size from a wider monitor is loaded on a
+ * narrower one — the panel should shrink to fit, not render off-screen.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clampSize,
+  MAX_PANEL_HEIGHT,
+  MAX_PANEL_WIDTH,
+  MIN_PANEL_HEIGHT,
+  MIN_PANEL_WIDTH,
+} from '../state/tweak-state';
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+const ORIGINAL_INNER_HEIGHT = window.innerHeight;
+
+function setViewport(w: number, h: number): void {
+  Object.defineProperty(window, 'innerWidth', { value: w, configurable: true });
+  Object.defineProperty(window, 'innerHeight', { value: h, configurable: true });
+}
+
+describe('clampSize', () => {
+  beforeEach(() => {
+    setViewport(1920, 1080);
+  });
+
+  afterEach(() => {
+    setViewport(ORIGINAL_INNER_WIDTH, ORIGINAL_INNER_HEIGHT);
+  });
+
+  it('returns sizes inside the legal range unchanged', () => {
+    const result = clampSize(800, 600);
+    expect(result).toEqual({ width: 800, height: 600 });
+  });
+
+  it('clamps width to MIN_PANEL_WIDTH when smaller', () => {
+    const result = clampSize(50, 400);
+    expect(result.width).toBe(MIN_PANEL_WIDTH);
+    expect(result.height).toBe(400);
+  });
+
+  it('clamps height to MIN_PANEL_HEIGHT when smaller', () => {
+    const result = clampSize(800, 50);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(MIN_PANEL_HEIGHT);
+  });
+
+  it('clamps to MIN_PANEL_WIDTH × MIN_PANEL_HEIGHT for fully degenerate values', () => {
+    const result = clampSize(0, 0);
+    expect(result.width).toBe(MIN_PANEL_WIDTH);
+    expect(result.height).toBe(MIN_PANEL_HEIGHT);
+  });
+
+  it('clamps width to MAX_PANEL_WIDTH on a huge viewport when caller passes a huge value', () => {
+    setViewport(4000, 3000);
+    const result = clampSize(99999, 99999);
+    expect(result.width).toBe(MAX_PANEL_WIDTH);
+    expect(result.height).toBe(MAX_PANEL_HEIGHT);
+  });
+
+  it('clamps to viewport-minus-margin on a small viewport (saved value too big)', () => {
+    setViewport(1024, 768);
+    const result = clampSize(1500, 900);
+    // SIZE_VIEWPORT_MARGIN = 32, so caps are (1024-32, 768-32) = (992, 736).
+    expect(result.width).toBe(992);
+    expect(result.height).toBe(736);
+  });
+
+  it('respects MIN_PANEL_* even when the viewport is smaller than the minimum', () => {
+    // Pathological tiny viewport — keep the minimum so the panel stays usable
+    // when the user re-enlarges the window.
+    setViewport(100, 100);
+    const result = clampSize(50, 50);
+    expect(result.width).toBe(MIN_PANEL_WIDTH);
+    expect(result.height).toBe(MIN_PANEL_HEIGHT);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/load-size.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/load-size.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+/**
+ * Coverage for `defaultSize` + `loadSize` — the size storage track that
+ * mirrors `loadPosition`/`savePosition` for the user-resized panel
+ * dimensions.
+ *
+ * Save semantics use `saveSize`; `loadSize` is the read-side that the panel
+ * calls on mount, and it falls back to `defaultSize()` on missing /
+ * malformed entries, matching how `loadPosition` falls back to
+ * `defaultPosition()`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  defaultSize,
+  getSizeKey,
+  loadSize,
+  MIN_PANEL_HEIGHT,
+  MIN_PANEL_WIDTH,
+  type PanelSize,
+} from '../state/tweak-state';
+import { __resetPanelConfigForTests } from '../config/panel-config';
+import { installFixturePanelConfig } from './_test-helpers';
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+const ORIGINAL_INNER_HEIGHT = window.innerHeight;
+
+function setViewport(w: number, h: number): void {
+  Object.defineProperty(window, 'innerWidth', { value: w, configurable: true });
+  Object.defineProperty(window, 'innerHeight', { value: h, configurable: true });
+}
+
+describe('defaultSize', () => {
+  beforeEach(() => {
+    installFixturePanelConfig();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    setViewport(ORIGINAL_INNER_WIDTH, ORIGINAL_INNER_HEIGHT);
+    localStorage.clear();
+    __resetPanelConfigForTests();
+  });
+
+  it('matches the historical min(1200, 0.8*vw) × min(800, 0.8*vh) rule on a 1440×900 viewport', () => {
+    setViewport(1440, 900);
+    const size = defaultSize();
+    expect(size.width).toBeCloseTo(1152); // 0.8 * 1440
+    expect(size.height).toBeCloseTo(720); // 0.8 * 900
+  });
+
+  it('caps at 1200 × 800 on a large 1920×1080 viewport', () => {
+    setViewport(1920, 1080);
+    const size = defaultSize();
+    expect(size.width).toBe(1200);
+    expect(size.height).toBe(800);
+  });
+});
+
+describe('loadSize', () => {
+  beforeEach(() => {
+    installFixturePanelConfig();
+    localStorage.clear();
+    setViewport(1920, 1080);
+  });
+
+  afterEach(() => {
+    setViewport(ORIGINAL_INNER_WIDTH, ORIGINAL_INNER_HEIGHT);
+    localStorage.clear();
+    __resetPanelConfigForTests();
+  });
+
+  it('returns defaultSize() when localStorage is empty (no saved entry)', () => {
+    const size = loadSize();
+    const expected = defaultSize();
+    expect(size.width).toBe(expected.width);
+    expect(size.height).toBe(expected.height);
+  });
+
+  it('returns the saved value verbatim when localStorage has a valid entry within bounds', () => {
+    const saved: PanelSize = { width: 900, height: 600 };
+    localStorage.setItem(getSizeKey(), JSON.stringify(saved));
+    const size = loadSize();
+    expect(size.width).toBe(900);
+    expect(size.height).toBe(600);
+  });
+
+  it('clamps an oversized saved value to the current viewport', () => {
+    setViewport(1024, 768);
+    const saved: PanelSize = { width: 5000, height: 5000 };
+    localStorage.setItem(getSizeKey(), JSON.stringify(saved));
+    const size = loadSize();
+    // SIZE_VIEWPORT_MARGIN = 32; caps = (1024-32, 768-32).
+    expect(size.width).toBe(992);
+    expect(size.height).toBe(736);
+  });
+
+  it('clamps an undersized saved value up to MIN_PANEL_WIDTH × MIN_PANEL_HEIGHT', () => {
+    const saved: PanelSize = { width: 10, height: 10 };
+    localStorage.setItem(getSizeKey(), JSON.stringify(saved));
+    const size = loadSize();
+    expect(size.width).toBe(MIN_PANEL_WIDTH);
+    expect(size.height).toBe(MIN_PANEL_HEIGHT);
+  });
+
+  it('returns defaultSize() when the saved entry is malformed JSON', () => {
+    localStorage.setItem(getSizeKey(), '{not valid json');
+    const size = loadSize();
+    const expected = defaultSize();
+    expect(size.width).toBe(expected.width);
+    expect(size.height).toBe(expected.height);
+  });
+
+  it('returns defaultSize() when the saved entry has missing/non-numeric fields', () => {
+    localStorage.setItem(getSizeKey(), JSON.stringify({ width: 'oops', height: 600 }));
+    const size = loadSize();
+    const expected = defaultSize();
+    expect(size.width).toBe(expected.width);
+    expect(size.height).toBe(expected.height);
+  });
+
+  it('returns defaultSize() when the saved entry has the wrong shape', () => {
+    localStorage.setItem(getSizeKey(), JSON.stringify({ unrelated: 'field' }));
+    const size = loadSize();
+    const expected = defaultSize();
+    expect(size.width).toBe(expected.width);
+    expect(size.height).toBe(expected.height);
+  });
+});

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -340,6 +340,11 @@ export function storageKey_position(cfg: PanelConfig): string {
   return `${cfg.storagePrefix}-position`;
 }
 
+/** User-resized panel size `{ width, height }` (pixels). Lives alongside position. */
+export function storageKey_size(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-size`;
+}
+
 /**
  * Adapter-level visibility-intent flag.
  *

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -13,19 +13,24 @@ import { usePersist } from './state/persist';
 import {
   type TweakState,
   type PanelPosition,
+  type PanelSize,
   DEFAULT_POSITION,
   applyFullState,
   clampPosition,
+  clampSize,
   clearAppliedStyles,
   clearPersistedState,
+  defaultSize,
   emptyOverrides,
   getOpenKey,
   initColorFromScheme,
   initSecondaryFromConfig,
   loadPersistedState,
   loadPosition,
+  loadSize,
   savePersistedState,
   savePosition,
+  saveSize,
 } from './state/tweak-state';
 
 // --- Tab configuration ---
@@ -44,9 +49,10 @@ const NARROW_BREAKPOINT = 900;
 function computePanelSize(
   viewportW: number,
   _viewportH: number,
+  storedSize: PanelSize,
 ): {
-  width: string;
-  height: string;
+  width: number | string;
+  height: number | string;
   narrow: boolean;
 } {
   const narrow = viewportW < NARROW_BREAKPOINT;
@@ -57,9 +63,11 @@ function computePanelSize(
       narrow,
     };
   }
+  // Wide mode: fixed px sourced from user-resizable state. `loadSize` /
+  // `defaultSize` already clamp to viewport, so we can trust the values here.
   return {
-    width: `min(1200px, 80vw)`,
-    height: `min(800px, 80vh)`,
+    width: storedSize.width,
+    height: storedSize.height,
     narrow,
   };
 }
@@ -98,6 +106,7 @@ export default function DesignTokenTweakPanel() {
   // activeTab holds a string to support host-supplied non-reserved tab ids.
   const [activeTab, setActiveTab] = useState<string>(DEFAULT_TAB_ID);
   const [position, setPosition] = useState<PanelPosition>(DEFAULT_POSITION);
+  const [size, setSize] = useState<PanelSize>(defaultSize);
   const [isNarrow, setIsNarrow] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   // tabRefs is now keyed by string to support host-supplied tab ids.
@@ -110,13 +119,17 @@ export default function DesignTokenTweakPanel() {
   const positionRef = useRef<PanelPosition>(DEFAULT_POSITION);
   // Keep ref in sync with state for use in drag handlers (avoids stale closure)
   positionRef.current = position;
+  const sizeRef = useRef<PanelSize>(size);
+  sizeRef.current = size;
   // Track active drag listeners for cleanup on unmount
   const dragCleanupRef = useRef<(() => void) | null>(null);
+  // Track active resize listeners for cleanup on unmount
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   const { persistColor, persistSpacing, persistFont, persistSize, persistSecondary, persistTab } =
     usePersist(setState);
 
-  // Restore open state and position from localStorage after mount (avoids SSR hydration mismatch)
+  // Restore open state, position, and size from localStorage after mount (avoids SSR hydration mismatch)
   useEffect(() => {
     try {
       if (localStorage.getItem(getOpenKey()) === '1') setOpen(true);
@@ -126,6 +139,9 @@ export default function DesignTokenTweakPanel() {
     const loaded = loadPosition();
     setPosition(loaded);
     positionRef.current = loaded;
+    const loadedSize = loadSize();
+    setSize(loadedSize);
+    sizeRef.current = loadedSize;
     // Initial narrow-check
     setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
   }, []);
@@ -247,17 +263,85 @@ export default function DesignTokenTweakPanel() {
     };
   }, []);
 
-  // Clean up drag listeners on unmount
-  useEffect(() => {
-    return () => {
-      dragCleanupRef.current?.();
+  // Resize handler for the bottom-right grip — mirrors handleDragStart's
+  // structure: writes directly to the DOM during the drag (to avoid 60 fps
+  // re-renders of the whole panel) and commits the final value to React
+  // state + localStorage on mouseup.
+  const handleResizeStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    // Resize disabled on narrow viewports — the panel is centered and the
+    // grip is hidden anyway, but guard defensively.
+    if (window.innerWidth < NARROW_BREAKPOINT) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const startWidth = sizeRef.current.width;
+    const startHeight = sizeRef.current.height;
+
+    function onMouseMove(ev: MouseEvent) {
+      const deltaX = ev.clientX - startX;
+      const deltaY = ev.clientY - startY;
+      // Bottom-right grip: drag right/down grows the panel. The panel is
+      // anchored top-right, so growing width pushes the left edge leftward,
+      // and growing height extends the bottom edge — both natural.
+      const next = clampSize(startWidth + deltaX, startHeight + deltaY);
+      if (panelRef.current) {
+        panelRef.current.style.width = `${next.width}px`;
+        panelRef.current.style.height = `${next.height}px`;
+      }
+      sizeRef.current = next;
+    }
+
+    function onMouseUp() {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      resizeCleanupRef.current = null;
+      const finalSize = sizeRef.current;
+      setSize(finalSize);
+      saveSize(finalSize);
+      // Re-clamp position against the new size — a wider panel may need its
+      // anchor pulled back into the viewport.
+      const finalPos = clampPosition(
+        positionRef.current.top,
+        positionRef.current.right,
+        finalSize.width,
+        finalSize.height,
+      );
+      if (finalPos.top !== positionRef.current.top || finalPos.right !== positionRef.current.right) {
+        setPosition(finalPos);
+        savePosition(finalPos);
+      }
+    }
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    resizeCleanupRef.current = () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
     };
   }, []);
 
-  // Re-clamp position on window resize + update narrow-mode flag
+  // Clean up drag + resize listeners on unmount
+  useEffect(() => {
+    return () => {
+      dragCleanupRef.current?.();
+      resizeCleanupRef.current?.();
+    };
+  }, []);
+
+  // Re-clamp position + size on window resize, update narrow-mode flag
   useEffect(() => {
     function handleResize() {
       setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
+      // Re-clamp size first — a viewport shrink might force a smaller panel,
+      // and the new dimensions feed into the position clamp below.
+      setSize((prev) => {
+        const clamped = clampSize(prev.width, prev.height);
+        if (clamped.width !== prev.width || clamped.height !== prev.height) {
+          saveSize(clamped);
+        }
+        return clamped;
+      });
       const panelWidth = panelRef.current?.offsetWidth ?? 600;
       const panelHeight = panelRef.current?.offsetHeight ?? 600;
       setPosition((prev) => {
@@ -347,6 +431,7 @@ export default function DesignTokenTweakPanel() {
   } = computePanelSize(
     typeof window !== 'undefined' ? window.innerWidth : 1024,
     typeof window !== 'undefined' ? window.innerHeight : 768,
+    size,
   );
 
   // In narrow mode, ignore saved position — center safely near the top.
@@ -520,6 +605,20 @@ export default function DesignTokenTweakPanel() {
             );
           })}
         </div>
+
+        {/* Bottom-right resize grip. Hidden in narrow (centered) mode where
+            the panel is sized by CSS expressions and dragging would conflict
+            with the touch-first layout. */}
+        {!(narrow || isNarrow) && (
+          <div
+            className="tokenpanel-resize-handle"
+            onMouseDown={handleResizeStart}
+            role="separator"
+            aria-label="Resize panel"
+            aria-orientation="horizontal"
+            title="Drag to resize"
+          />
+        )}
       </div>
 
       {showExport && state && (

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -608,14 +608,17 @@ export default function DesignTokenTweakPanel() {
 
         {/* Bottom-right resize grip. Hidden in narrow (centered) mode where
             the panel is sized by CSS expressions and dragging would conflict
-            with the touch-first layout. */}
+            with the touch-first layout.
+
+            ARIA: `role="separator"` would imply a 1D resizer between two
+            regions; this grip resizes the panel on both axes, which has no
+            standard role. We keep just `aria-label` for SR users — keyboard
+            resize is intentionally out of scope. */}
         {!(narrow || isNarrow) && (
           <div
             className="tokenpanel-resize-handle"
             onMouseDown={handleResizeStart}
-            role="separator"
             aria-label="Resize panel"
-            aria-orientation="horizontal"
             title="Drag to resize"
           />
         )}

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -47,6 +47,7 @@ import {
   resolveSecondaryColorCluster,
   storageKey_open,
   storageKey_position,
+  storageKey_size,
   storageKey_stateV1,
   storageKey_stateV2,
   storageKey_stateV3,
@@ -111,6 +112,10 @@ export function getPositionKey(): string {
   return storageKey_position(getPanelConfig());
 }
 
+export function getSizeKey(): string {
+  return storageKey_size(getPanelConfig());
+}
+
 // ---------------------------------------------------------------------------
 // Panel position
 // ---------------------------------------------------------------------------
@@ -173,6 +178,91 @@ export function savePosition(pos: PanelPosition) {
 
 /** Keep at least VISIBLE_MIN px of the panel on-screen so the user can grab it back. */
 export const VISIBLE_MIN = 60;
+
+// ---------------------------------------------------------------------------
+// Panel size (user-resizable)
+// ---------------------------------------------------------------------------
+
+export interface PanelSize {
+  width: number;
+  height: number;
+}
+
+/** Minimum panel size — small enough to feel snappy, large enough to keep the header + tabbar usable. */
+export const MIN_PANEL_WIDTH = 320;
+export const MIN_PANEL_HEIGHT = 240;
+
+/** Hard upper caps so the panel never grows past sensible bounds even before viewport clamping. */
+export const MAX_PANEL_WIDTH = 1600;
+export const MAX_PANEL_HEIGHT = 1200;
+
+/**
+ * SSR-safe static fallback. Matches the historical CSS expression
+ * `min(1200, 0.8 * vw)` × `min(800, 0.8 * vh)` evaluated for a 1024×768
+ * viewport so the package stays usable when imported during SSR (no
+ * window). Runtime callers should prefer `defaultSize()`.
+ */
+export const DEFAULT_SIZE: PanelSize = { width: 1024 * 0.8, height: 768 * 0.8 };
+
+/**
+ * Compute the first-open panel size in px. Mirrors the historical CSS
+ * `min(1200, 0.8 * vw)` × `min(800, 0.8 * vh)` rule so existing users
+ * experience the same default size after this PR ships.
+ */
+export function defaultSize(): PanelSize {
+  if (typeof window === 'undefined') return DEFAULT_SIZE;
+  return {
+    width: Math.min(1200, 0.8 * window.innerWidth),
+    height: Math.min(800, 0.8 * window.innerHeight),
+  };
+}
+
+/** Margin kept around the panel when clamping size against the viewport. */
+const SIZE_VIEWPORT_MARGIN = 32;
+
+/**
+ * Clamp a `{ width, height }` against the configured min caps and the current
+ * viewport. The viewport upper bound prevents a panel saved on a 4K monitor
+ * from rendering off-screen when reopened on a 1080p laptop.
+ */
+export function clampSize(width: number, height: number): PanelSize {
+  const vw = typeof window !== 'undefined' ? window.innerWidth : MAX_PANEL_WIDTH;
+  const vh = typeof window !== 'undefined' ? window.innerHeight : MAX_PANEL_HEIGHT;
+  const maxW = Math.max(MIN_PANEL_WIDTH, Math.min(MAX_PANEL_WIDTH, vw - SIZE_VIEWPORT_MARGIN));
+  const maxH = Math.max(MIN_PANEL_HEIGHT, Math.min(MAX_PANEL_HEIGHT, vh - SIZE_VIEWPORT_MARGIN));
+  return {
+    width: Math.max(MIN_PANEL_WIDTH, Math.min(width, maxW)),
+    height: Math.max(MIN_PANEL_HEIGHT, Math.min(height, maxH)),
+  };
+}
+
+export function loadSize(): PanelSize {
+  try {
+    const saved = localStorage.getItem(getSizeKey());
+    if (saved) {
+      const parsed = JSON.parse(saved) as PanelSize;
+      if (
+        typeof parsed.width === 'number' &&
+        typeof parsed.height === 'number' &&
+        Number.isFinite(parsed.width) &&
+        Number.isFinite(parsed.height)
+      ) {
+        return clampSize(parsed.width, parsed.height);
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return defaultSize();
+}
+
+export function saveSize(size: PanelSize) {
+  try {
+    localStorage.setItem(getSizeKey(), JSON.stringify(size));
+  } catch {
+    /* ignore */
+  }
+}
 
 // `_panelHeight` is currently unused — see B2 fix note below. Kept on the
 // signature (with the underscore prefix that TypeScript treats as

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -48,6 +48,43 @@
   box-shadow: 0 4px 24px rgb(0 0 0 / 0.25);
 }
 
+/* ===========================================================================
+ * Resize grip (bottom-right corner)
+ *
+ * Windows-style diagonal-stripes hint, hidden in narrow (touch) mode by the
+ * panel component skipping the element altogether. The three stripes are
+ * drawn with `repeating-linear-gradient` so no SVG or extra DOM is needed.
+ * ========================================================================= */
+
+.tokenpanel-resize-handle {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 16px;
+  height: 16px;
+  cursor: nwse-resize;
+  user-select: none;
+  /* Three short diagonal lines drawn in muted color, mirroring the Windows
+     bottom-right grip. The mask clips the gradient to a triangle so the
+     stripes only appear in the bottom-right wedge. */
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0,
+    transparent 2px,
+    var(--tokentweak-color-muted) 2px,
+    var(--tokentweak-color-muted) 3px
+  );
+  -webkit-mask-image: linear-gradient(135deg, transparent 50%, #000 50%);
+  mask-image: linear-gradient(135deg, transparent 50%, #000 50%);
+  border-bottom-right-radius: var(--radius-tokentweak);
+  transition: opacity 150ms ease;
+  opacity: 0.7;
+}
+.tokenpanel-resize-handle:hover,
+.tokenpanel-resize-handle:focus-visible {
+  opacity: 1;
+}
+
 .tokenpanel-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The design token panel sized itself with CSS expressions (`min(1200px, 80vw) × min(800px, 80vh)`) and could not be resized by the user. This PR switches wide-mode sizing to fixed pixels driven by a state value the user can change via a Windows-style ◢ grip in the bottom-right corner. The chosen size persists in localStorage under a new `-size` key, parallel to how open/close state and drag position are already persisted.

Default size matches the previous CSS rule (`min(1200, 0.8 × vw) × min(800, 0.8 × vh)`) so existing users see the same first-open size after upgrading. Narrow mode (`window.innerWidth < 900`) keeps the old CSS-expression sizing and hides the grip — the px-fixed rule only applies to wide mode where dragging is meaningful.

## Changes

- **`state/tweak-state.ts`** — New `PanelSize` type plus `defaultSize` / `loadSize` / `saveSize` / `clampSize` helpers, mirroring the existing position track. Clamp bounds: `MIN 320×240`, `MAX 1600×1200`, plus a viewport-minus-32px-margin upper cap so a panel saved on a 4K monitor shrinks to fit on a 1080p screen.
- **`config/panel-config.ts`** — New `storageKey_size` (`${storagePrefix}-size`).
- **`panel.tsx`** — `size` state + `sizeRef`; `handleResizeStart` callback that writes directly to the DOM during the drag (mirroring `handleDragStart` to avoid 60fps re-renders) and commits to React state + localStorage on mouseup; on commit, position is re-clamped against the new size so the panel can't end up off-screen. The window-resize listener now also re-clamps size.
- **`styles/panel.css`** — `.tokenpanel-resize-handle` rendered as a 16×16 absolute element with a diagonal-stripe gradient masked to a bottom-right triangle (no SVG/extra DOM).
- **Tests** — `clamp-size.test.ts` and `load-size.test.ts` mirror the existing position-side suites: empty / valid / malformed / oversized / undersized / wrong-shape inputs and viewport-boundary cases.

## Test Plan

- [x] `pnpm typecheck` — clean across all 7 workspace projects
- [x] `pnpm -F @takazudo/zudo-design-token-panel test` — 36 test files / 399 tests pass (including 14 new size-related tests)
- [x] Browser verification via Playwright against the vite-react example:
  - [x] Drag grip resizes panel; bounding box matches expected dims
  - [x] localStorage stores `{"width":N,"height":M}` under `<prefix>-size`
  - [x] After reload + reopen, panel reappears at the saved size
  - [x] Shrinking past minimum clamps to 320×240
  - [x] Growing past viewport clamps to `viewport - 32px`
- [x] ARIA fix per gcoc-review feedback: dropped incorrect `role="separator"` / `aria-orientation="horizontal"` (the grip is 2D, not a separator)