### PR TITLE
fix(panel): change position origin from top-right to top-left

### DIFF
--- a/packages/zudo-design-token-panel/src/__tests__/clamp-position.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/clamp-position.test.ts
@@ -67,7 +67,7 @@ describe('clampPosition', () => {
 
   it('returns positions inside the legal range unchanged', () => {
     const result = clampPosition(100, 50, 600, 500);
-    expect(result).toEqual({ top: 100, right: 50 });
+    expect(result).toEqual({ top: 100, left: 50 });
   });
 
   it('clamps top to maxTop = innerHeight - VISIBLE_MIN', () => {
@@ -87,17 +87,17 @@ describe('clampPosition', () => {
     expect(result.top).toBe(-(VISIBLE_MIN / 2));
   });
 
-  it('clamps right symmetrically on the horizontal axis (panelWidth scales the lower bound)', () => {
-    // Maximum: panel can be pushed past the left edge but VISIBLE_MIN must
-    // remain visible.
-    const farLeft = clampPosition(0, 99999, 600, 500);
-    expect(farLeft.right).toBe(window.innerWidth - VISIBLE_MIN);
-    // Minimum: panel can be pushed past the right edge by panelWidth -
+  it('clamps left symmetrically on the horizontal axis (panelWidth scales the lower bound)', () => {
+    // Maximum: panel can be pushed past the right edge but VISIBLE_MIN must
+    // remain visible (a sliver of the header on the left).
+    const farRight = clampPosition(0, 99999, 600, 500);
+    expect(farRight.left).toBe(window.innerWidth - VISIBLE_MIN);
+    // Minimum: panel can be pushed past the left edge by panelWidth -
     // VISIBLE_MIN. The horizontal axis IS symmetric because the header
     // spans the full panel width — any leftover horizontal slice contains
     // a draggable strip of the header.
-    const farRight = clampPosition(0, -99999, 600, 500);
-    expect(farRight.right).toBe(-(600 - VISIBLE_MIN));
+    const farLeft = clampPosition(0, -99999, 600, 500);
+    expect(farLeft.left).toBe(-(600 - VISIBLE_MIN));
   });
 
   it('vertical lower bound does NOT depend on panelHeight (regression for B2 + codex review follow-up)', () => {
@@ -112,7 +112,7 @@ describe('clampPosition', () => {
 
   it('produces a deterministic result on degenerate (smaller-than-VISIBLE_MIN) viewports', () => {
     // when the viewport is narrower / shorter
-    // than VISIBLE_MIN, the raw maxTop / maxRight could fall below their
+    // than VISIBLE_MIN, the raw maxTop / maxLeft could fall below their
     // respective minimums and Math.min/Math.max would emit Math.max's
     // first argument. Pin the actual return so a future regression in
     // bound-collapse logic is caught.
@@ -121,19 +121,19 @@ describe('clampPosition', () => {
     // Vertical: minTopRaw = -30, maxTopRaw = -40 (innerHeight - VISIBLE_MIN).
     // Collapse maxTop to minTopRaw — both bounds become -30.
     expect(result.top).toBe(-(VISIBLE_MIN / 2));
-    // Horizontal: minRight = -540 (-(panelWidth - VISIBLE_MIN)),
-    // maxRightRaw = -40. minRight < maxRightRaw so no collapse needed.
-    expect(result.right).toBeGreaterThanOrEqual(-540);
-    expect(result.right).toBeLessThanOrEqual(-40);
+    // Horizontal: minLeft = -540 (-(panelWidth - VISIBLE_MIN)),
+    // maxLeftRaw = -40. minLeft < maxLeftRaw so no collapse needed.
+    expect(result.left).toBeGreaterThanOrEqual(-540);
+    expect(result.left).toBeLessThanOrEqual(-40);
   });
 
   it('handles a viewport narrower than panelWidth without inverting horizontal bounds', () => {
-    // When innerWidth < VISIBLE_MIN, maxRightRaw goes negative below
-    // minRight; the collapse keeps both at minRight so the result stays
+    // When innerWidth < VISIBLE_MIN, maxLeftRaw goes negative below
+    // minLeft; the collapse keeps both at minLeft so the result stays
     // deterministic.
     setViewport(20, 800);
     const result = clampPosition(100, 0, 600, 500);
-    expect(Number.isFinite(result.right)).toBe(true);
+    expect(Number.isFinite(result.left)).toBe(true);
     expect(Number.isFinite(result.top)).toBe(true);
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/load-position.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/load-position.test.ts
@@ -3,9 +3,9 @@
 /**
  * Centered-default behaviour for the panel's first-open position.
  *
- * Pre-fix: `DEFAULT_POSITION` was a hard-coded `{ top: 60, right: 20 }` static
+ * Pre-fix: `DEFAULT_POSITION` was a hard-coded `{ top: 60, left: 20 }` static
  * constant, so fresh-localStorage installs always landed the panel in the
- * upper-right corner — far from where the user expects it.
+ * upper-left corner — far from where the user expects it.
  *
  * Post-fix: `defaultPosition()` computes a runtime viewport-centered position
  * (panelW = min(1200, 0.8 * innerWidth), centered both axes), and
@@ -14,9 +14,11 @@
  * `DEFAULT_POSITION` is retained as the SSR fallback inside
  * `defaultPosition()` (typeof window === 'undefined' branch).
  *
- * Saved-value behaviour is UNCHANGED — a valid `{top, right}` entry in
+ * Saved-value behaviour is UNCHANGED — a valid `{top, left}` entry in
  * localStorage still loads verbatim, so existing users keep their dragged
- * position exactly as today.
+ * position exactly as today. Note: payloads persisted under the previous
+ * top-right model (`{top, right}`) are rejected as malformed and fall back
+ * to the centered default — a one-time reset acceptable for a UX bugfix.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -56,11 +58,11 @@ describe('defaultPosition', () => {
     // panelW = min(1200, 0.8*1440) = min(1200, 1152) = 1152
     // panelH = min(800, 0.8*900)  = min(800, 720)  = 720
     // top  = round((900 - 720) / 2) = 90
-    // right = round((1440 - 1152) / 2) = 144
+    // left = round((1440 - 1152) / 2) = 144
     expect(pos.top).toBeGreaterThanOrEqual(88);
     expect(pos.top).toBeLessThanOrEqual(92);
-    expect(pos.right).toBeGreaterThanOrEqual(142);
-    expect(pos.right).toBeLessThanOrEqual(146);
+    expect(pos.left).toBeGreaterThanOrEqual(142);
+    expect(pos.left).toBeLessThanOrEqual(146);
   });
 
   it('returns the viewport center for a 1920×1080 viewport (panel capped at 1200×800)', () => {
@@ -69,21 +71,21 @@ describe('defaultPosition', () => {
     // panelW = min(1200, 0.8*1920) = min(1200, 1536) = 1200
     // panelH = min(800, 0.8*1080) = min(800, 864) = 800
     // top  = round((1080 - 800) / 2) = 140
-    // right = round((1920 - 1200) / 2) = 360
+    // left = round((1920 - 1200) / 2) = 360
     expect(pos.top).toBeGreaterThanOrEqual(138);
     expect(pos.top).toBeLessThanOrEqual(142);
-    expect(pos.right).toBeGreaterThanOrEqual(358);
-    expect(pos.right).toBeLessThanOrEqual(362);
+    expect(pos.left).toBeGreaterThanOrEqual(358);
+    expect(pos.left).toBeLessThanOrEqual(362);
   });
 
-  it('returns {top:0, right:0} on a degenerate 0×0 viewport (no negative offsets)', () => {
+  it('returns {top:0, left:0} on a degenerate 0×0 viewport (no negative offsets)', () => {
     setViewport(0, 0);
     const pos = defaultPosition();
     // panelW = min(1200, 0) = 0; panelH = min(800, 0) = 0
     // top  = max(0, round(0)) = 0
-    // right = max(0, round(0)) = 0
+    // left = max(0, round(0)) = 0
     expect(pos.top).toBe(0);
-    expect(pos.right).toBe(0);
+    expect(pos.left).toBe(0);
   });
 
   it('returns deterministic non-negative offsets for a narrow viewport (375×667)', () => {
@@ -92,11 +94,11 @@ describe('defaultPosition', () => {
     // panelW = min(1200, 0.8*375) = min(1200, 300) = 300
     // panelH = min(800, 0.8*667) = min(800, 533.6) = 533.6
     // top  = round((667 - 533.6) / 2) = round(66.7) ≈ 67
-    // right = round((375 - 300) / 2) = round(37.5) ≈ 38
+    // left = round((375 - 300) / 2) = round(37.5) ≈ 38
     expect(pos.top).toBeGreaterThanOrEqual(65);
     expect(pos.top).toBeLessThanOrEqual(69);
-    expect(pos.right).toBeGreaterThanOrEqual(36);
-    expect(pos.right).toBeLessThanOrEqual(40);
+    expect(pos.left).toBeGreaterThanOrEqual(36);
+    expect(pos.left).toBeLessThanOrEqual(40);
   });
 });
 
@@ -117,18 +119,18 @@ describe('loadPosition', () => {
     const pos = loadPosition();
     const expected = defaultPosition();
     expect(pos.top).toBe(expected.top);
-    expect(pos.right).toBe(expected.right);
+    expect(pos.left).toBe(expected.left);
     // Sanity: centered values, not the static {60, 20}.
     expect(pos.top).not.toBe(DEFAULT_POSITION.top);
-    expect(pos.right).not.toBe(DEFAULT_POSITION.right);
+    expect(pos.left).not.toBe(DEFAULT_POSITION.left);
   });
 
   it('returns the saved value verbatim when localStorage has a valid entry', () => {
-    const saved: PanelPosition = { top: 300, right: 400 };
+    const saved: PanelPosition = { top: 300, left: 400 };
     localStorage.setItem(getPositionKey(), JSON.stringify(saved));
     const pos = loadPosition();
     expect(pos.top).toBe(300);
-    expect(pos.right).toBe(400);
+    expect(pos.left).toBe(400);
   });
 
   it('returns defaultPosition() when the saved entry is malformed JSON', () => {
@@ -136,15 +138,15 @@ describe('loadPosition', () => {
     const pos = loadPosition();
     const expected = defaultPosition();
     expect(pos.top).toBe(expected.top);
-    expect(pos.right).toBe(expected.right);
+    expect(pos.left).toBe(expected.left);
   });
 
   it('returns defaultPosition() when the saved entry has missing/non-numeric fields', () => {
-    localStorage.setItem(getPositionKey(), JSON.stringify({ top: 'oops', right: 20 }));
+    localStorage.setItem(getPositionKey(), JSON.stringify({ top: 'oops', left: 20 }));
     const pos = loadPosition();
     const expected = defaultPosition();
     expect(pos.top).toBe(expected.top);
-    expect(pos.right).toBe(expected.right);
+    expect(pos.left).toBe(expected.left);
   });
 
   it('returns defaultPosition() when the saved entry is a JSON literal with the wrong shape', () => {
@@ -152,6 +154,17 @@ describe('loadPosition', () => {
     const pos = loadPosition();
     const expected = defaultPosition();
     expect(pos.top).toBe(expected.top);
-    expect(pos.right).toBe(expected.right);
+    expect(pos.left).toBe(expected.left);
+  });
+
+  it('rejects payloads persisted under the legacy top-right model and falls back to default', () => {
+    // Old persisted shape was `{ top, right }`. After the origin switch,
+    // `loadPosition` only accepts `{ top, left }`; legacy payloads are
+    // treated as malformed and the user gets a one-time reset to centered.
+    localStorage.setItem(getPositionKey(), JSON.stringify({ top: 50, right: 100 }));
+    const pos = loadPosition();
+    const expected = defaultPosition();
+    expect(pos.top).toBe(expected.top);
+    expect(pos.left).toBe(expected.left);
   });
 });

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -335,7 +335,7 @@ export function storageKey_open(cfg: PanelConfig): string {
   return `${cfg.storagePrefix}-open`;
 }
 
-/** Drag position `{ top, right }` so the panel reappears where the user left it. */
+/** Drag position `{ top, left }` so the panel reappears where the user left it. */
 export function storageKey_position(cfg: PanelConfig): string {
   return `${cfg.storagePrefix}-position`;
 }

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -221,7 +221,7 @@ export default function DesignTokenTweakPanel() {
     e.preventDefault();
     const startX = e.clientX;
     const startY = e.clientY;
-    const startRight = positionRef.current.right;
+    const startLeft = positionRef.current.left;
     const startTop = positionRef.current.top;
     const panelWidth = panelRef.current?.offsetWidth ?? 600;
     const panelHeight = panelRef.current?.offsetHeight ?? 600;
@@ -231,7 +231,7 @@ export default function DesignTokenTweakPanel() {
       const deltaY = ev.clientY - startY;
       const clamped = clampPosition(
         startTop + deltaY,
-        startRight - deltaX,
+        startLeft + deltaX,
         panelWidth,
         panelHeight,
       );
@@ -240,7 +240,7 @@ export default function DesignTokenTweakPanel() {
       // the final value to React state in one shot.
       if (panelRef.current) {
         panelRef.current.style.top = `${clamped.top}px`;
-        panelRef.current.style.right = `${clamped.right}px`;
+        panelRef.current.style.left = `${clamped.left}px`;
       }
       positionRef.current = clamped;
     }
@@ -282,8 +282,9 @@ export default function DesignTokenTweakPanel() {
       const deltaX = ev.clientX - startX;
       const deltaY = ev.clientY - startY;
       // Bottom-right grip: drag right/down grows the panel. The panel is
-      // anchored top-right, so growing width pushes the left edge leftward,
-      // and growing height extends the bottom edge — both natural.
+      // anchored top-left, so growing width pushes the right edge rightward
+      // (toward the cursor), and growing height extends the bottom edge —
+      // both natural.
       const next = clampSize(startWidth + deltaX, startHeight + deltaY);
       if (panelRef.current) {
         panelRef.current.style.width = `${next.width}px`;
@@ -303,11 +304,11 @@ export default function DesignTokenTweakPanel() {
       // anchor pulled back into the viewport.
       const finalPos = clampPosition(
         positionRef.current.top,
-        positionRef.current.right,
+        positionRef.current.left,
         finalSize.width,
         finalSize.height,
       );
-      if (finalPos.top !== positionRef.current.top || finalPos.right !== positionRef.current.right) {
+      if (finalPos.top !== positionRef.current.top || finalPos.left !== positionRef.current.left) {
         setPosition(finalPos);
         savePosition(finalPos);
       }
@@ -345,7 +346,7 @@ export default function DesignTokenTweakPanel() {
       const panelWidth = panelRef.current?.offsetWidth ?? 600;
       const panelHeight = panelRef.current?.offsetHeight ?? 600;
       setPosition((prev) => {
-        const clamped = clampPosition(prev.top, prev.right, panelWidth, panelHeight);
+        const clamped = clampPosition(prev.top, prev.left, panelWidth, panelHeight);
         savePosition(clamped);
         return clamped;
       });
@@ -444,7 +445,7 @@ export default function DesignTokenTweakPanel() {
           transform: 'translateX(-50%)',
           right: 'auto' as const,
         }
-      : { position: 'fixed' as const, top: position.top, right: position.right };
+      : { position: 'fixed' as const, top: position.top, left: position.left };
 
   return (
     <>

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -122,7 +122,7 @@ export function getSizeKey(): string {
 
 export interface PanelPosition {
   top: number;
-  right: number;
+  left: number;
 }
 
 /**
@@ -131,13 +131,13 @@ export interface PanelPosition {
  * Runtime callers should prefer `defaultPosition()`, which returns a
  * viewport-centered position when `window` is available.
  */
-export const DEFAULT_POSITION: PanelPosition = { top: 60, right: 20 };
+export const DEFAULT_POSITION: PanelPosition = { top: 60, left: 20 };
 
 /**
  * Compute a viewport-centered default panel position for first-open behaviour.
  *
  * The panel CSS-sizes itself up to 1200×800 but caps at 80% of the viewport,
- * so we mirror the same min/0.8x rule here. The resulting `top` / `right`
+ * so we mirror the same min/0.8x rule here. The resulting `top` / `left`
  * place the panel at the geometric center of the viewport.
  *
  * Falls back to the static `DEFAULT_POSITION` when `window` is undefined
@@ -149,8 +149,8 @@ export function defaultPosition(): PanelPosition {
   const panelW = Math.min(1200, 0.8 * window.innerWidth);
   const panelH = Math.min(800, 0.8 * window.innerHeight);
   const top = Math.max(0, Math.round((window.innerHeight - panelH) / 2));
-  const right = Math.max(0, Math.round((window.innerWidth - panelW) / 2));
-  return { top, right };
+  const left = Math.max(0, Math.round((window.innerWidth - panelW) / 2));
+  return { top, left };
 }
 
 export function loadPosition(): PanelPosition {
@@ -158,7 +158,7 @@ export function loadPosition(): PanelPosition {
     const saved = localStorage.getItem(getPositionKey());
     if (saved) {
       const parsed = JSON.parse(saved) as PanelPosition;
-      if (typeof parsed.top === 'number' && typeof parsed.right === 'number') {
+      if (typeof parsed.top === 'number' && typeof parsed.left === 'number') {
         return parsed;
       }
     }
@@ -271,7 +271,7 @@ export function saveSize(size: PanelSize) {
 // churn, and so a future "tall panel" carve-out has the data on hand.
 export function clampPosition(
   top: number,
-  right: number,
+  left: number,
   panelWidth: number,
   _panelHeight: number,
 ): PanelPosition {
@@ -279,8 +279,13 @@ export function clampPosition(
   // px of grip visible so the user can drag it back. The header spans the
   // full panel width, so any leftover horizontal slice contains a draggable
   // strip of the header.
-  const minRight = -(panelWidth - VISIBLE_MIN);
-  const maxRightRaw = window.innerWidth - VISIBLE_MIN;
+  //
+  // Top-left origin: `left` is the offset from the viewport's left edge to
+  // the panel's left edge. minLeft pushes the panel past the LEFT edge
+  // (only VISIBLE_MIN of the right-side header strip remains visible);
+  // maxLeft pushes the panel past the RIGHT edge.
+  const minLeftRaw = -(panelWidth - VISIBLE_MIN);
+  const maxLeftRaw = window.innerWidth - VISIBLE_MIN;
   // Vertical: ASYMMETRIC with the horizontal axis on purpose.
   //
   // The drag handle is the panel header (`panel.tsx` attaches `onMouseDown`
@@ -296,12 +301,6 @@ export function clampPosition(
   // "scroll content into view" carve-out that a taller-than-viewport panel
   // would otherwise need. `panelHeight` is therefore unused on the lower
   // bound today.
-  //
-  // The pre-fix code's tautology bug (`panelHeight > 0 ? 0 : 0` always
-  // yielding 0) is replaced with the simpler `window.innerHeight -
-  // VISIBLE_MIN`. The original `Math.max(..., 0)` only mattered on
-  // viewports shorter than VISIBLE_MIN, which we treat as a degenerate
-  // case and don't special-case any more.
   const minTopRaw = -(VISIBLE_MIN / 2);
   const maxTopRaw = window.innerHeight - VISIBLE_MIN;
   // guard against narrow / degenerate viewports
@@ -310,10 +309,10 @@ export function clampPosition(
   // resulting Math.max/Math.min chain still produces a deterministic value
   // instead of relying on argument order.
   const maxTop = Math.max(maxTopRaw, minTopRaw);
-  const maxRight = Math.max(maxRightRaw, minRight);
+  const maxLeft = Math.max(maxLeftRaw, minLeftRaw);
   return {
     top: Math.max(minTopRaw, Math.min(top, maxTop)),
-    right: Math.max(minRight, Math.min(right, maxRight)),
+    left: Math.max(minLeftRaw, Math.min(left, maxLeft)),
   };
 }
 
@@ -1114,11 +1113,11 @@ function hydratePanelPosition(raw: unknown): PanelPosition | undefined {
   const o = raw as Record<string, unknown>;
   if (
     typeof o.top === 'number' &&
-    typeof o.right === 'number' &&
+    typeof o.left === 'number' &&
     Number.isFinite(o.top) &&
-    Number.isFinite(o.right)
+    Number.isFinite(o.left)
   ) {
-    return { top: o.top, right: o.right };
+    return { top: o.top, left: o.left };
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary
- Switches the design-token panel's position origin from top-right (`top` + `right`) to top-left (`top` + `left`) so the bottom-right resize grip behaves intuitively.
- With the previous anchor, dragging the grip rightward grew the width but moved the LEFT edge leftward (the right edge stayed pinned at its anchor). Now the left edge stays pinned and the right edge follows the cursor — same idea on the vertical axis.
- Old `{top, right}` payloads in `localStorage` are treated as malformed and fall back to the centered default. One-time UX reset; no migration path because the geometry isn't recoverable from `right` alone without also knowing the panel's saved width at write time.

## Changes
### `packages/zudo-design-token-panel/src/state/tweak-state.ts`
- `PanelPosition` → `{ top, left }` (was `{ top, right }`).
- `DEFAULT_POSITION` → `{ top: 60, left: 20 }`.
- `defaultPosition()` returns `left = round((innerWidth − panelW) / 2)` to keep the first-open centered behaviour.
- `loadPosition()` accepts only `{ top, left }`; legacy payloads → centered default.
- `clampPosition(top, left, panelWidth, _panelHeight)` — horizontal math inverted (`minLeft = -(panelWidth - VISIBLE_MIN)`, `maxLeft = innerWidth - VISIBLE_MIN`). The asymmetric vertical clamp from #125's review follow-up is preserved verbatim — the header-as-drag-handle rationale didn't change.
- `hydratePanelPosition()` validates `left` instead of `right`.

### `packages/zudo-design-token-panel/src/panel.tsx`
- Drag handler: `startLeft + deltaX` (was `startRight - deltaX`); DOM write uses `style.left` (was `style.right`).
- Resize handler: re-clamp after mouseup uses `left` instead of `right`; updated the inline rationale (left-edge fixed, growing width pushes the right edge toward the cursor).
- Window-resize listener: re-clamp uses `prev.left`.
- Render: `panelPos = { top, left: position.left }` in wide mode. Narrow-mode block is untouched (still `left: 50%`, `transform: translateX(-50%)`).

### `packages/zudo-design-token-panel/src/config/panel-config.ts`
- Doc comment on `storageKey_position()` updated from `{ top, right }` to `{ top, left }`.

### Tests
- `__tests__/clamp-position.test.ts` — renamed assertions, kept all bound-edge / degenerate-viewport scenarios.
- `__tests__/load-position.test.ts` — renamed assertions, plus a new regression test asserting that legacy `{ top, right }` payloads fall back to the centered default.

## Test Plan
- [x] `pnpm test` — 400 tests pass across all workspaces.
- [x] `pnpm build` — vite library build + tsc + astro asset copy clean.
- [x] `pnpm typecheck` — all 7 workspaces (`zudo-design-token-panel`, `examples/{astro,next,vite-react,zfb,zfb-tailwind}`, `doc`) clean.
- [x] `pnpm lint` — clean.
- [x] Manual browser verification on `examples/vite-react` at 1440×900:
  - Initial open: panel centred at `left: 144px, top: 90px`.
  - Drag bottom-right grip `+100 right, +50 down`: left edge unchanged (Δ0), right edge moves `+100`, width grows by `100`, height by `50`.
  - Drag header `-80 left, +60 down`: panel moves by exactly that delta.
  - `localStorage` saves `{"top":150,"left":64}` (uses the new `left` key, no `right`).

## Notes
- Existing users will see a one-time re-center on first open after this PR ships. Acceptable cost for a UX bugfix on a self-contained panel.
- No public API surface changed beyond the `PanelPosition` interface itself, which is package-internal — call sites are the panel component and its tests.