### PR TITLE
feat(panel): density slider for tab-grid (panel-width-aware columns + user control)

### DIFF
--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -345,6 +345,11 @@ export function storageKey_size(cfg: PanelConfig): string {
   return `${cfg.storagePrefix}-size`;
 }
 
+/** Tab-grid density preference (one of `0` / `1` / `2`). Lives alongside size/position. */
+export function storageKey_density(cfg: PanelConfig): string {
+  return `${cfg.storagePrefix}-density`;
+}
+
 /**
  * Adapter-level visibility-intent flag.
  *

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -12,8 +12,10 @@ import type { TabConfig } from './tokens/tier-model';
 import { usePersist } from './state/persist';
 import {
   type TweakState,
+  type PanelDensity,
   type PanelPosition,
   type PanelSize,
+  DEFAULT_DENSITY,
   DEFAULT_POSITION,
   applyFullState,
   clampPosition,
@@ -21,14 +23,17 @@ import {
   clearAppliedStyles,
   clearPersistedState,
   defaultSize,
+  densityToGridMin,
   emptyOverrides,
   getOpenKey,
   initColorFromScheme,
   initSecondaryFromConfig,
+  loadDensity,
   loadPersistedState,
   loadPosition,
   loadSize,
   savePersistedState,
+  saveDensity,
   savePosition,
   saveSize,
 } from './state/tweak-state';
@@ -107,6 +112,7 @@ export default function DesignTokenTweakPanel() {
   const [activeTab, setActiveTab] = useState<string>(DEFAULT_TAB_ID);
   const [position, setPosition] = useState<PanelPosition>(DEFAULT_POSITION);
   const [size, setSize] = useState<PanelSize>(defaultSize);
+  const [density, setDensity] = useState<PanelDensity>(DEFAULT_DENSITY);
   const [isNarrow, setIsNarrow] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   // tabRefs is now keyed by string to support host-supplied tab ids.
@@ -142,8 +148,15 @@ export default function DesignTokenTweakPanel() {
     const loadedSize = loadSize();
     setSize(loadedSize);
     sizeRef.current = loadedSize;
+    setDensity(loadDensity());
     // Initial narrow-check
     setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
+  }, []);
+
+  // Persist density on change
+  const handleDensityChange = useCallback((next: PanelDensity) => {
+    setDensity(next);
+    saveDensity(next);
   }, []);
 
   // Persist open state
@@ -457,6 +470,10 @@ export default function DesignTokenTweakPanel() {
           width: panelW,
           height: panelH,
           maxHeight: 'calc(100vh - 32px)',
+          // `--tokenpanel-grid-min` is read by .tokenpanel-tab-grid /
+          // .tokenpanel-tab-advanced-grid; switching the variable rewires the
+          // min-card-width without re-rendering the grids.
+          ['--tokenpanel-grid-min' as string]: densityToGridMin(density),
         }}
       >
         {/* Header row (expert/reset) — draggable on desktop only */}
@@ -515,30 +532,64 @@ export default function DesignTokenTweakPanel() {
         </div>
 
         {/* Tab bar — data-driven when PanelConfig.tabs is supplied, otherwise
-            falls back to the legacy hard-coded LEGACY_TABS strip. */}
-        <div role="tablist" aria-label="Design token categories" className="tokenpanel-tabbar">
-          {activeTabs.map((tab) => {
-            const isSelected = activeTab === tab.id;
-            return (
-              <button
-                key={tab.id}
-                ref={(el) => {
-                  tabRefs.current[tab.id] = el;
-                }}
-                type="button"
-                role="tab"
-                id={`dtp-tab-${instanceId}-${tab.id}`}
-                aria-selected={isSelected}
-                aria-controls={`dtp-panel-${instanceId}-${tab.id}`}
-                tabIndex={isSelected ? 0 : -1}
-                onClick={() => setActiveTab(tab.id)}
-                onKeyDown={handleTabKeyDown}
-                className={isSelected ? 'tokenpanel-tab-button is-active' : 'tokenpanel-tab-button'}
-              >
-                {tab.label}
-              </button>
-            );
-          })}
+            falls back to the legacy hard-coded LEGACY_TABS strip. The tablist
+            (role="tablist") and the density slider live side-by-side inside
+            `.tokenpanel-tabbar`; the wrapper is a plain container so the
+            tablist only ever has `role=tab` children. */}
+        <div className="tokenpanel-tabbar">
+          <div
+            role="tablist"
+            aria-label="Design token categories"
+            className="tokenpanel-tabbar-tabs"
+          >
+            {activeTabs.map((tab) => {
+              const isSelected = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  ref={(el) => {
+                    tabRefs.current[tab.id] = el;
+                  }}
+                  type="button"
+                  role="tab"
+                  id={`dtp-tab-${instanceId}-${tab.id}`}
+                  aria-selected={isSelected}
+                  aria-controls={`dtp-panel-${instanceId}-${tab.id}`}
+                  tabIndex={isSelected ? 0 : -1}
+                  onClick={() => setActiveTab(tab.id)}
+                  onKeyDown={handleTabKeyDown}
+                  className={
+                    isSelected ? 'tokenpanel-tab-button is-active' : 'tokenpanel-tab-button'
+                  }
+                >
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+          <div className="tokenpanel-density">
+            <label
+              htmlFor={`dtp-density-${instanceId}`}
+              className="tokenpanel-density-label"
+              title="Tab grid density: dense / cozy / wide (forces 1 column)"
+            >
+              Density
+            </label>
+            <input
+              id={`dtp-density-${instanceId}`}
+              type="range"
+              min={0}
+              max={2}
+              step={1}
+              value={density}
+              onInput={(e) => {
+                const raw = Number((e.currentTarget as HTMLInputElement).value);
+                if (raw === 0 || raw === 1 || raw === 2) handleDensityChange(raw);
+              }}
+              className="tokenpanel-density-slider"
+              aria-label="Tab grid density"
+            />
+          </div>
         </div>
 
         {/* Tab panels — reserved ids dispatch to their dedicated components;

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -45,6 +45,7 @@ import {
 import {
   getPanelConfig,
   resolveSecondaryColorCluster,
+  storageKey_density,
   storageKey_open,
   storageKey_position,
   storageKey_size,
@@ -114,6 +115,10 @@ export function getPositionKey(): string {
 
 export function getSizeKey(): string {
   return storageKey_size(getPanelConfig());
+}
+
+export function getDensityKey(): string {
+  return storageKey_density(getPanelConfig());
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +264,52 @@ export function loadSize(): PanelSize {
 export function saveSize(size: PanelSize) {
   try {
     localStorage.setItem(getSizeKey(), JSON.stringify(size));
+  } catch {
+    /* ignore */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tab-grid density
+// ---------------------------------------------------------------------------
+
+/**
+ * User-chosen tab-grid density. Three discrete stops exposed as integers so a
+ * native `<input type="range">` slider can read/write directly:
+ *
+ *   0 = dense  — small min-card width, more columns fit on a wide panel
+ *   1 = cozy   — the auto-fit minmax default
+ *   2 = wide   — forces one column so long var names are fully readable
+ *
+ * Mapped to a CSS `min` length by `densityToGridMin()`; the resolved length is
+ * exposed on the panel shell via the `--tokenpanel-grid-min` custom property
+ * and consumed by `.tokenpanel-tab-grid` / `.tokenpanel-tab-advanced-grid`.
+ */
+export type PanelDensity = 0 | 1 | 2;
+
+export const DEFAULT_DENSITY: PanelDensity = 1;
+
+export function densityToGridMin(density: PanelDensity): string {
+  if (density === 0) return '12rem';
+  if (density === 2) return '100%';
+  return '18rem';
+}
+
+export function loadDensity(): PanelDensity {
+  try {
+    const saved = localStorage.getItem(getDensityKey());
+    if (saved === '0' || saved === '1' || saved === '2') {
+      return Number(saved) as PanelDensity;
+    }
+  } catch {
+    /* ignore */
+  }
+  return DEFAULT_DENSITY;
+}
+
+export function saveDensity(density: PanelDensity) {
+  try {
+    localStorage.setItem(getDensityKey(), String(density));
   } catch {
     /* ignore */
   }

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -285,16 +285,14 @@
   font-size: 0.875rem;
 }
 
+/* Panel-width-aware columns: cards stay 1-col while the panel itself is narrow,
+   reflow to 2-col (or more) once each card can be at least 18rem wide. This
+   tracks the resizable panel, not the viewport, so a wide screen + narrow panel
+   no longer produces cramped cards with heavily ellipsised long token names. */
 .tokenpanel-tab-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
   gap: var(--tokentweak-gap-xs);
-}
-
-@media (min-width: 640px) {
-  .tokenpanel-tab-grid {
-    grid-template-columns: 1fr 1fr;
-  }
 }
 
 .tokenpanel-tab-advanced {
@@ -313,15 +311,9 @@
 
 .tokenpanel-tab-advanced-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
   gap: var(--tokentweak-gap-xs);
   margin-top: var(--tokentweak-gap-2xs);
-}
-
-@media (min-width: 640px) {
-  .tokenpanel-tab-advanced-grid {
-    grid-template-columns: 1fr 1fr;
-  }
 }
 
 /* ===========================================================================

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -142,10 +142,18 @@
 .tokenpanel-tabbar {
   display: flex;
   align-items: center;
-  gap: 2px;
   border-bottom: 1px solid var(--tokentweak-color-muted);
   padding-inline: var(--tokentweak-pad-xl);
   flex-shrink: 0;
+  gap: var(--tokentweak-pad-md);
+}
+
+.tokenpanel-tabbar-tabs {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
 }
 
 .tokenpanel-tab-button {
@@ -170,6 +178,31 @@
   color: var(--tokentweak-color-fg);
   border-bottom-color: var(--tokentweak-color-accent);
   text-decoration: none;
+}
+
+/* Density slider — right side of the tabbar. Three-stop range slider that
+   drives the `--tokenpanel-grid-min` custom property on `.tokenpanel-shell`,
+   which `.tokenpanel-tab-grid` / `.tokenpanel-tab-advanced-grid` read. */
+.tokenpanel-density {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-sm);
+  flex-shrink: 0;
+}
+
+.tokenpanel-density-label {
+  color: var(--tokentweak-color-muted);
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  user-select: none;
+  cursor: pointer;
+}
+
+.tokenpanel-density-slider {
+  width: 5rem;
+  accent-color: var(--tokentweak-color-accent);
+  cursor: pointer;
 }
 
 /* ===========================================================================
@@ -286,12 +319,13 @@
 }
 
 /* Panel-width-aware columns: cards stay 1-col while the panel itself is narrow,
-   reflow to 2-col (or more) once each card can be at least 18rem wide. This
-   tracks the resizable panel, not the viewport, so a wide screen + narrow panel
-   no longer produces cramped cards with heavily ellipsised long token names. */
+   reflow to 2-col (or more) once each card can be at least `--tokenpanel-grid-min`
+   wide. The variable is set on `.tokenpanel-shell` from the density slider in
+   the tabbar (12rem / 18rem / 100% for dense / cozy / wide). Fallback 18rem
+   keeps the rule working if the variable is ever absent. */
 .tokenpanel-tab-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(var(--tokenpanel-grid-min, 18rem), 1fr));
   gap: var(--tokentweak-gap-xs);
 }
 
@@ -311,7 +345,7 @@
 
 .tokenpanel-tab-advanced-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(var(--tokenpanel-grid-min, 18rem), 1fr));
   gap: var(--tokentweak-gap-xs);
   margin-top: var(--tokentweak-gap-2xs);
 }


### PR DESCRIPTION
## Summary

Two commits, stacked:

1. **CSS-only base** — `.tokenpanel-tab-grid` and `.tokenpanel-tab-advanced-grid` previously switched 1-col → 2-col at viewport `@media (min-width: 640px)`. Replaced with `grid-template-columns: repeat(auto-fit, minmax(var(--tokenpanel-grid-min, 18rem), 1fr))` so the column count tracks the *panel's own width* (which is independently resizable), not the viewport.

2. **Density slider** — a 3-stop `<input type="range">` lives at the right side of the tabbar. It drives the `--tokenpanel-grid-min` custom property on `.tokenpanel-shell`. Persisted to localStorage per `panelConfig.storagePrefix` (matching the existing position/size pattern). Defaults to stop 1 so existing sessions behave the same as before this PR.

Why both: auto-fit alone fixes the *layout* but not the *legibility* of long token names in a dev tool. The slider lets the user push to "wide" when they need to read every `--prefix-...-tab-open` in full, and pull to "dense" when scanning many tokens at once.

## Density stops

| Stop | Min card width | Behavior |
|------|----------------|----------|
| 0 (left) | `12rem` | dense — more columns fit on a wide panel |
| 1 (middle, default) | `18rem` | cozy — the auto-fit minmax default |
| 2 (right) | `100%` | wide — forces 1 column, long var names fully visible |

## Changes

- `src/styles/panel.css` — grid uses `minmax(var(--tokenpanel-grid-min, 18rem), 1fr)`; tabbar restructured to host the slider on the right; added `.tokenpanel-density*` styles. Color-palette / color-base grids are untouched.
- `src/panel.tsx` — `density` state, `loadDensity` on mount, `saveDensity` on slider input, `--tokenpanel-grid-min` applied as inline custom property on `.tokenpanel-shell`. Tabbar split into wrapper + `role=tablist` inner so the tablist still has only `role=tab` children.
- `src/state/tweak-state.ts` — `PanelDensity` type, `DEFAULT_DENSITY`, `densityToGridMin`, `loadDensity`, `saveDensity`, `getDensityKey`.
- `src/config/panel-config.ts` — `storageKey_density()` helper mirroring `storageKey_size` / `storageKey_position`.

## Test Plan

Verified column counts at 9 combinations (3 panel widths × 3 density stops):

| Panel width | Density 0 (12rem) | Density 1 (18rem) | Density 2 (100%) |
|---|---|---|---|
| 500px | 2 cols | 1 col | 1 col |
| 700px | 3 cols | 2 cols | 1 col |
| 1000px | 4 cols | 3 cols | 1 col |

- `pnpm -F @takazudo/zudo-design-token-panel typecheck` clean.
- `pnpm -F @takazudo/zudo-design-token-panel test` — 400 / 400 passing.
- Visual screenshots confirm the slider sits in the right side of the tabbar at all panel widths.

## Notes

- Density preference is **global** (one setting affects all tabs). Per-tab density was considered but felt premature — easy to extend later via the same `panelConfig` plumbing.
- Dropdown popover overflow (visible in the original screenshots when a `<select>` is opened on a long-value option) is a separate native-`<select>` issue and is **not** addressed here.