### PR TITLE
Fix 0514: panel close + zfb-tailwind demo fixes (epic #158)

### DIFF
--- a/examples/zfb-tailwind/components/app-shell.tsx
+++ b/examples/zfb-tailwind/components/app-shell.tsx
@@ -12,13 +12,13 @@
  * Token consumption:
  *   grid-cols-[var(--zfbtw-size-sidenav-w)_1fr]
  *       → sidenav column width (--zfbtw-size-sidenav-w; added by #128)
- *   p-spacing-lg → main content outer padding (--zfbtw-spacing-lg)
+ *   px-hsp-lg py-vsp-lg → main content outer padding (--zfbtw-hsp-lg / --zfbtw-vsp-lg)
  *   bg-bg        → main content background (--zfbtw-bg)
  *   bg-surface   → sidenav background (--zfbtw-color-surface)
- *   p-spacing-md → sidenav inner padding (--zfbtw-spacing-md)
+ *   px-hsp-md py-vsp-md → sidenav inner padding (--zfbtw-hsp-md / --zfbtw-vsp-md)
  *   h-size-header-h → topbar height (--zfbtw-size-header-h; added by #128)
  *   bg-surface   → topbar background
- *   p-spacing-md → topbar inline padding
+ *   px-hsp-md → topbar inline padding
  *
  * Panel Mount
  * -----------
@@ -49,14 +49,14 @@ export function AppShell({ title = 'zfb + Tailwind v4 — Design Token Panel', a
       </head>
       <body>
         {/* Topbar */}
-        <header class="h-size-header-h flex items-center justify-between bg-surface px-spacing-md border-b border-muted">
+        <header class="h-size-header-h flex items-center justify-between bg-surface px-hsp-md border-b border-muted">
           <span class="text-small text-muted">
             Storage prefix: <code>zfb-tailwind-example-tokens</code>
           </span>
           <button
             type="button"
             id="zfbtw-panel-open"
-            class="px-spacing-sm py-spacing-xs rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary text-small"
+            class="px-hsp-sm py-vsp-xs rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary text-small"
           >
             Open Design Token Panel
           </button>
@@ -81,10 +81,10 @@ export function AppShell({ title = 'zfb + Tailwind v4 — Design Token Panel', a
           no token-only utility expresses this combination
         */}
         <div class="grid grid-cols-[var(--zfbtw-size-sidenav-w)_1fr] min-h-screen">
-          <aside class="bg-surface p-spacing-md">
+          <aside class="bg-surface px-hsp-md py-vsp-md">
             <Sidenav activePath={activePath} />
           </aside>
-          <main class="p-spacing-lg bg-bg">
+          <main class="px-hsp-lg py-vsp-lg bg-bg">
             {children}
           </main>
         </div>

--- a/examples/zfb-tailwind/components/app-shell.tsx
+++ b/examples/zfb-tailwind/components/app-shell.tsx
@@ -20,6 +20,17 @@
  *   bg-surface   → topbar background
  *   px-hsp-md → topbar inline padding
  *
+ * View Transitions
+ * ----------------
+ * <ClientRouter /> (in <head>) emits the opt-in meta tags and global CSS for the
+ * zfb-runtime SPA router. The `<ClientRouterBootstrap>` island (when="load")
+ * registers the browser-side click intercept by executing the side-effect import.
+ *
+ * The topbar (<header>) and sidenav (<aside>) carry `data-zfb-transition-persist`
+ * so zfb's DOM byte-move keeps the same DOM nodes across soft navigations, and the
+ * paired `view-transition-name` CSS rules suppress animation for those chrome elements
+ * while the root cross-fade animates only the page content area.
+ *
  * Panel Mount
  * -----------
  * AppShell includes <PanelMount> wrapped in <Island> so every page gets the
@@ -27,6 +38,8 @@
  */
 
 import { Island, type IslandProps } from '@takazudo/zfb';
+import { ClientRouter } from '@takazudo/zfb-runtime';
+import ClientRouterBootstrap from './client-router-bootstrap';
 import PanelMount from './panel-mount';
 import { Sidenav } from './sidenav';
 import '../styles/global.css';
@@ -46,10 +59,11 @@ export function AppShell({ title = 'zfb + Tailwind v4 — Design Token Panel', a
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>{title}</title>
+        {ClientRouter({ fallback: 'animate' }) as unknown as preact.JSX.Element}
       </head>
       <body>
-        {/* Topbar */}
-        <header class="h-size-header-h flex items-center justify-between bg-surface px-hsp-md border-b border-muted">
+        {/* Topbar — persisted across soft navigations; no animation (CSS names it zfb-topbar) */}
+        <header data-zfb-transition-persist="topbar" class="h-size-header-h flex items-center justify-between bg-surface px-hsp-md border-b border-muted">
           <span class="text-small text-muted">
             Storage prefix: <code>zfb-tailwind-example-tokens</code>
           </span>
@@ -81,13 +95,24 @@ export function AppShell({ title = 'zfb + Tailwind v4 — Design Token Panel', a
           no token-only utility expresses this combination
         */}
         <div class="grid grid-cols-[var(--zfbtw-size-sidenav-w)_1fr] min-h-screen">
-          <aside class="bg-surface px-hsp-md py-vsp-md">
+          {/* Sidenav — persisted across soft navigations; no animation (CSS names it zfb-sidenav) */}
+          <aside data-zfb-transition-persist="sidenav" class="bg-surface px-hsp-md py-vsp-md">
             <Sidenav activePath={activePath} />
           </aside>
           <main class="px-hsp-lg py-vsp-lg bg-bg">
             {children}
           </main>
         </div>
+
+        {/*
+          ClientRouterBootstrap registers the zfb-runtime SPA router click intercept.
+          Must use when="load" (not "visible") so the intercept is registered before
+          the user can click any link — "visible" risks a race where the island is
+          still deferred at first navigation.
+        */}
+        <Island when="load" ssrFallback={null}>
+          {(<ClientRouterBootstrap />) as unknown as IslandProps['children']}
+        </Island>
 
         {/*
           PanelMount is the `"use client"` island that bootstraps the panel adapter.

--- a/examples/zfb-tailwind/components/client-router-bootstrap.tsx
+++ b/examples/zfb-tailwind/components/client-router-bootstrap.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+/**
+ * ClientRouterBootstrap — `"use client"` island that registers the zfb-runtime
+ * SPA router click intercept in the browser.
+ *
+ * Why this island is necessary
+ * ----------------------------
+ * `<ClientRouter />` (from `@takazudo/zfb-runtime`) emits opt-in meta tags and
+ * global CSS into `<head>` at SSR time. Its module-level side-effect calls
+ * `init()` — but only when `typeof document !== "undefined"`. During SSR the
+ * guard is false, so the click intercept is never registered server-side.
+ *
+ * This island's sole job is to import `@takazudo/zfb-runtime/client-router` on
+ * the client. The subpath's module-level code re-runs the same `init()` call
+ * (idempotent) inside a real browser context, wiring up the router.
+ *
+ * Mount with `when="load"` (not `"visible"`) so the intercept is registered as
+ * soon as the islands runtime mounts the marker — before the user can click any
+ * link. Using `"visible"` risks a race where the island is still deferred when
+ * the first navigation fires.
+ *
+ * Returns null — renders nothing visually.
+ */
+
+// Load-bearing side-effect import: registers click + form-submit intercepts.
+// Must run client-side only (gated by the "use client" marker above).
+import "@takazudo/zfb-runtime/client-router";
+import type { JSX } from "preact";
+
+function ClientRouterBootstrap(): JSX.Element | null {
+  return null;
+}
+
+// Stable display name for SSR/hydration marker matching.
+ClientRouterBootstrap.displayName = "ClientRouterBootstrap";
+
+export default ClientRouterBootstrap;

--- a/examples/zfb-tailwind/components/data/avatar-row.tsx
+++ b/examples/zfb-tailwind/components/data/avatar-row.tsx
@@ -2,7 +2,7 @@
  * AvatarRow — 4 small avatars using size-avatar-sm, each with a palette background.
  *
  * Token consumption (§134.5):
- *   container: flex gap-spacing-sm
+ *   container: flex gap-hsp-sm
  *   each item: w-size-avatar-sm h-size-avatar-sm rounded-md
  *              bg via inline-style: var(--zfbtw-palette-{i})
  *
@@ -15,7 +15,7 @@ const AVATAR_PALETTE_INDICES = [1, 2, 3, 4] as const;
 
 export function AvatarRow() {
   return (
-    <div class="flex gap-spacing-sm" role="list" aria-label="Avatar row">
+    <div class="flex gap-hsp-sm" role="list" aria-label="Avatar row">
       {AVATAR_PALETTE_INDICES.map((i) => (
         <div
           key={i}

--- a/examples/zfb-tailwind/components/data/data-table.tsx
+++ b/examples/zfb-tailwind/components/data/data-table.tsx
@@ -3,9 +3,9 @@
  *
  * Token consumption (§134.1):
  *   table:  w-full text-small text-fg border border-muted rounded-md
- *   th:     text-h4 text-fg border-b border-muted text-left p-spacing-sm
+ *   th:     text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm
  *   tr:     hover:bg-surface
- *   td:     p-spacing-sm border-b border-muted
+ *   td:     px-hsp-sm py-vsp-sm border-b border-muted
  *   action: w-size-icon-md h-size-icon-md text-muted hover:text-accent
  *           inline-flex items-center justify-center rounded-md
  */
@@ -24,20 +24,20 @@ export function DataTable() {
       <table class="w-full text-small text-fg border border-muted rounded-md border-collapse">
         <thead>
           <tr>
-            <th class="text-h4 text-fg border-b border-muted text-left p-spacing-sm">Name</th>
-            <th class="text-h4 text-fg border-b border-muted text-left p-spacing-sm">Email</th>
-            <th class="text-h4 text-fg border-b border-muted text-left p-spacing-sm">Role</th>
-            <th class="text-h4 text-fg border-b border-muted text-left p-spacing-sm">Actions</th>
+            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Name</th>
+            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Email</th>
+            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Role</th>
+            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Actions</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
             <tr key={row.email} class="hover:bg-surface">
-              <td class="p-spacing-sm border-b border-muted">{row.name}</td>
-              <td class="p-spacing-sm border-b border-muted">{row.email}</td>
-              <td class="p-spacing-sm border-b border-muted">{row.role}</td>
-              <td class="p-spacing-sm border-b border-muted">
-                <span class="inline-flex gap-spacing-xs">
+              <td class="px-hsp-sm py-vsp-sm border-b border-muted">{row.name}</td>
+              <td class="px-hsp-sm py-vsp-sm border-b border-muted">{row.email}</td>
+              <td class="px-hsp-sm py-vsp-sm border-b border-muted">{row.role}</td>
+              <td class="px-hsp-sm py-vsp-sm border-b border-muted">
+                <span class="inline-flex gap-hsp-xs">
                   <button
                     type="button"
                     aria-label={`Edit ${row.name}`}

--- a/examples/zfb-tailwind/components/data/media-card.tsx
+++ b/examples/zfb-tailwind/components/data/media-card.tsx
@@ -2,17 +2,17 @@
  * MediaCard — card with image placeholder, title, description, CTA.
  *
  * Token consumption (§134.2):
- *   container:  bg-surface p-spacing-md rounded-md border border-muted flex flex-col
- *               gap-spacing-sm max-w-[24rem]
+ *   container:  bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col
+ *               gap-vsp-sm max-w-[24rem]
  *   image:      w-full aspect-[16/9] bg-muted rounded-md
  *   title:      text-h3 text-fg
  *   description:text-body text-fg
- *   cta:        bg-accent text-bg p-spacing-sm rounded-md
+ *   cta:        bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md
  */
 
 export function MediaCard() {
   return (
-    <div class="bg-surface p-spacing-md rounded-md border border-muted flex flex-col gap-spacing-sm max-w-[24rem]">
+    <div class="bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col gap-vsp-sm max-w-[24rem]">
       {/* reason: card width is page-local */}
       <div class="w-full aspect-[16/9] bg-muted rounded-md">
         {/* reason: image aspect is a media constant, not a token — CSS gradient placeholder; no network fetch */}
@@ -28,7 +28,7 @@ export function MediaCard() {
         colour, typography — stored as CSS custom properties and shared across every
         component.
       </p>
-      <button type="button" class="bg-accent text-bg p-spacing-sm rounded-md cursor-pointer">
+      <button type="button" class="bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md cursor-pointer">
         Learn more
       </button>
     </div>

--- a/examples/zfb-tailwind/components/data/profile-card.tsx
+++ b/examples/zfb-tailwind/components/data/profile-card.tsx
@@ -2,11 +2,11 @@
  * ProfileCard — avatar + name + role + action button.
  *
  * Token consumption (§134.4):
- *   container: flex items-center gap-spacing-md p-spacing-md bg-surface rounded-md border border-muted
+ *   container: flex items-center gap-hsp-md px-hsp-md py-vsp-md bg-surface rounded-md border border-muted
  *   avatar:    w-size-avatar-md h-size-avatar-md rounded-md bg-accent
  *   name:      text-h4 text-fg
  *   role:      text-small text-muted
- *   action:    bg-accent text-bg p-spacing-sm rounded-md
+ *   action:    bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md
  */
 
 interface ProfileCardProps {
@@ -16,16 +16,16 @@ interface ProfileCardProps {
 
 export function ProfileCard({ name, role }: ProfileCardProps) {
   return (
-    <div class="flex items-center gap-spacing-md p-spacing-md bg-surface rounded-md border border-muted">
+    <div class="flex items-center gap-hsp-md px-hsp-md py-vsp-md bg-surface rounded-md border border-muted">
       <div
         class="w-size-avatar-md h-size-avatar-md rounded-md bg-accent flex-shrink-0"
         aria-hidden="true"
       />
-      <div class="flex flex-col gap-spacing-xs flex-1">
+      <div class="flex flex-col gap-vsp-xs flex-1">
         <span class="text-h4 text-fg">{name}</span>
         <span class="text-small text-muted">{role}</span>
       </div>
-      <button type="button" class="bg-accent text-bg p-spacing-sm rounded-md cursor-pointer flex-shrink-0">
+      <button type="button" class="bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md cursor-pointer flex-shrink-0">
         Follow
       </button>
     </div>

--- a/examples/zfb-tailwind/components/data/stat-card.tsx
+++ b/examples/zfb-tailwind/components/data/stat-card.tsx
@@ -2,7 +2,7 @@
  * StatCard — metric display with a prominent large number.
  *
  * Token consumption (§134.3):
- *   container:  bg-surface p-spacing-md rounded-md border border-muted flex flex-col gap-spacing-xs
+ *   container:  bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col gap-vsp-xs
  *   big number: text-h2 text-primary  (semantic font token — no hardcoded font-size)
  *   label:      text-small text-muted
  */
@@ -14,7 +14,7 @@ interface StatCardProps {
 
 export function StatCard({ value, label }: StatCardProps) {
   return (
-    <div class="bg-surface p-spacing-md rounded-md border border-muted flex flex-col gap-spacing-xs">
+    <div class="bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col gap-vsp-xs">
       <span class="text-h2 text-primary">{value}</span>
       <span class="text-small text-muted">{label}</span>
     </div>

--- a/examples/zfb-tailwind/components/panel-mount.tsx
+++ b/examples/zfb-tailwind/components/panel-mount.tsx
@@ -122,6 +122,27 @@ async function loadPanelModule(state: DesignTokenPanelAdapterState) {
       // Configure FIRST — every other panel API reads getPanelConfig() and
       // must observe the host's intended values, not the package sentinel.
       mod.configurePanel(panelConfig);
+
+      // Wire the panel into zfb-runtime's SPA navigation lifecycle.
+      // onBeforeSwap: zfb:before-swap fires just before DOM swap — panel uses
+      //   this to tear down / re-mount as needed across soft navigations.
+      // onPageLoad: zfb:after-swap fires after DOM swap, mirrors astro:page-load
+      //   and astro:after-swap — panel re-reads tokens from the new page DOM.
+      // Each registration returns an unsubscribe function; panel calls it on
+      // teardown. addEventListener is idempotent for the same function ref,
+      // but the adapter pattern calls these with new closures each time, so
+      // the returned removeEventListener call is the correct cleanup path.
+      mod.setLifecycleAdapter({
+        onBeforeSwap: (cb) => {
+          document.addEventListener('zfb:before-swap', cb);
+          return () => document.removeEventListener('zfb:before-swap', cb);
+        },
+        onPageLoad: (cb) => {
+          document.addEventListener('zfb:after-swap', cb);
+          return () => document.removeEventListener('zfb:after-swap', cb);
+        },
+      });
+
       try {
         mod.reapplyPersistedOverrides();
       } catch (err) {

--- a/examples/zfb-tailwind/components/sidenav.tsx
+++ b/examples/zfb-tailwind/components/sidenav.tsx
@@ -2,11 +2,11 @@
  * Sidenav — side navigation component for the zfb-tailwind example.
  *
  * Token consumption:
- *   p-spacing-md  → padding container (--zfbtw-spacing-md)
+ *   px-hsp-md py-vsp-md → padding container (--zfbtw-hsp-md / --zfbtw-vsp-md)
  *   bg-surface    → background (--zfbtw-color-surface)
  *   text-body     → link font size (--zfbtw-text-body)
  *   gap-vsp-xs    → gap between links (--zfbtw-vsp-xs)
- *   px-spacing-sm py-spacing-xs → per-link row padding
+ *   px-hsp-sm py-vsp-xs → per-link row padding
  *   text-accent   → active link color (--zfbtw-color-accent)
  *   rounded-md    → active link pill corner (--zfbtw-radius)
  */
@@ -28,7 +28,7 @@ interface SidenavProps {
 
 export function Sidenav({ activePath = '/' }: SidenavProps) {
   return (
-    <nav class="flex flex-col gap-vsp-xs p-spacing-md bg-surface h-full">
+    <nav class="flex flex-col gap-vsp-xs px-hsp-md py-vsp-md bg-surface h-full">
       {NAV_LINKS.map((link) => {
         const isActive = activePath === link.path;
         return (
@@ -37,8 +37,8 @@ export function Sidenav({ activePath = '/' }: SidenavProps) {
             href={link.path}
             class={
               isActive
-                ? 'text-body px-spacing-sm py-spacing-xs rounded-md text-accent font-semibold'
-                : 'text-body px-spacing-sm py-spacing-xs rounded-md text-fg hover:bg-bg'
+                ? 'text-body px-hsp-sm py-vsp-xs rounded-md text-accent font-semibold'
+                : 'text-body px-hsp-sm py-vsp-xs rounded-md text-fg hover:bg-bg'
             }
           >
             {link.label}

--- a/examples/zfb-tailwind/components/widgets/accordion.tsx
+++ b/examples/zfb-tailwind/components/widgets/accordion.tsx
@@ -2,9 +2,9 @@
  * AccordionDemo — 3 expandable sections using native <details>/<summary>.
  *
  * Token consumption:
- *   flex items-center justify-between p-spacing-md bg-surface rounded-md text-body cursor-pointer
+ *   flex items-center justify-between px-hsp-md py-vsp-md bg-surface rounded-md text-body cursor-pointer
  *     → summary row
- *   p-spacing-md border border-muted rounded-md text-body
+ *   px-hsp-md py-vsp-md border border-muted rounded-md text-body
  *     → content area
  *
  * Height transition (progressive enhancement):
@@ -37,7 +37,7 @@ const ITEMS = [
 
 export function AccordionDemo() {
   return (
-    <div class="flex flex-col gap-spacing-sm">
+    <div class="flex flex-col gap-vsp-sm">
       {/*
         Scoped transition rules for accordion open/close.
         Cannot be placed in global.css per task scope constraints.
@@ -61,13 +61,13 @@ export function AccordionDemo() {
 
       {ITEMS.map((item) => (
         <details key={item.id} class="widgets-accordion rounded-md overflow-hidden">
-          <summary class="flex items-center justify-between p-spacing-md bg-surface rounded-md text-body cursor-pointer list-none">
+          <summary class="flex items-center justify-between px-hsp-md py-vsp-md bg-surface rounded-md text-body cursor-pointer list-none">
             <span>{item.summary}</span>
             <span class="text-muted text-small select-none">▾</span>
           </summary>
-          <div class="p-spacing-md border border-muted rounded-md text-body text-fg mt-spacing-xs">
+          <div class="px-hsp-md py-vsp-md border border-muted rounded-md text-body text-fg mt-vsp-xs">
             <p>{item.body}</p>
-            <p class="text-small text-muted mt-spacing-sm">
+            <p class="text-small text-muted mt-vsp-sm">
               Open timing: <code>easing-tab-open</code> →{' '}
               <code>--zfbtw-easing-tab-open</code>. Close timing:{' '}
               <code>easing-tab-close</code> →{' '}

--- a/examples/zfb-tailwind/components/widgets/modal.tsx
+++ b/examples/zfb-tailwind/components/widgets/modal.tsx
@@ -13,8 +13,8 @@
  * hoists the element to the top layer, so it is NOT affected by <main inert>.
  *
  * Token consumption:
- *   bg-primary text-bg p-spacing-sm rounded-md  → trigger button
- *   bg-surface text-fg p-spacing-lg rounded-md max-w-[40rem] w-full  → modal panel
+ *   bg-primary text-bg px-hsp-sm py-vsp-sm rounded-md  → trigger button
+ *   bg-surface text-fg px-hsp-lg py-vsp-lg rounded-md max-w-[40rem] w-full  → modal panel
  *   max-w-[40rem] → arbitrary; reason: modal width is page-local
  *
  * Backdrop:
@@ -113,7 +113,7 @@ function ModalInner() {
 
       <button
         type="button"
-        class="bg-primary text-bg p-spacing-sm rounded-md border-none cursor-pointer"
+        class="bg-primary text-bg px-hsp-sm py-vsp-sm rounded-md border-none cursor-pointer"
         onClick={() => setIsOpen(true)}
       >
         Open Modal
@@ -123,14 +123,14 @@ function ModalInner() {
           does not block the dialog; showModal() moves it to the top layer */}
       <dialog
         ref={dialogRef}
-        class="widgets-modal bg-surface text-fg p-spacing-lg rounded-md max-w-[40rem] w-full border border-muted"
+        class="widgets-modal bg-surface text-fg px-hsp-lg py-vsp-lg rounded-md max-w-[40rem] w-full border border-muted"
       >
-        <div class="flex flex-col gap-spacing-md">
+        <div class="flex flex-col gap-vsp-md">
           <div class="flex items-center justify-between">
             <h2 class="text-h3 text-fg font-semibold">Modal Dialog</h2>
             <button
               type="button"
-              class="text-muted text-body hover:text-fg cursor-pointer border-none bg-transparent p-spacing-xs"
+              class="text-muted text-body hover:text-fg cursor-pointer border-none bg-transparent px-hsp-xs py-vsp-xs"
               onClick={() => setIsOpen(false)}
               aria-label="Close modal"
             >
@@ -151,7 +151,7 @@ function ModalInner() {
           <div>
             <button
               type="button"
-              class="bg-primary text-bg p-spacing-sm rounded-md border-none cursor-pointer"
+              class="bg-primary text-bg px-hsp-sm py-vsp-sm rounded-md border-none cursor-pointer"
               onClick={() => setIsOpen(false)}
             >
               Close

--- a/examples/zfb-tailwind/components/widgets/tabs.tsx
+++ b/examples/zfb-tailwind/components/widgets/tabs.tsx
@@ -2,8 +2,8 @@
  * TabsDemo — 3-tab horizontal nav with animated active indicator.
  *
  * Token consumption:
- *   flex gap-spacing-md border-b border-muted  → tab container
- *   px-spacing-md py-spacing-sm text-body text-muted  → resting tab label
+ *   flex gap-hsp-md border-b border-muted  → tab container
+ *   px-hsp-md py-vsp-sm text-body text-muted  → resting tab label
  *   text-accent  → active tab label
  *
  * Indicator animation:
@@ -24,13 +24,13 @@ export function TabsDemo() {
   return (
     <div>
       {/* Tab list */}
-      <div class="relative flex gap-spacing-md border-b border-muted">
+      <div class="relative flex gap-hsp-md border-b border-muted">
         {TABS.map((tab, i) => (
           <button
             key={tab}
             type="button"
             onClick={() => setActiveIndex(i)}
-            class={`px-spacing-md py-spacing-sm text-body cursor-pointer border-none bg-transparent ${
+            class={`px-hsp-md py-vsp-sm text-body cursor-pointer border-none bg-transparent ${
               activeIndex === i ? 'text-accent font-semibold' : 'text-muted'
             }`}
           >
@@ -56,7 +56,7 @@ export function TabsDemo() {
       </div>
 
       {/* Tab panels */}
-      <div class="p-spacing-md text-body text-fg">
+      <div class="px-hsp-md py-vsp-md text-body text-fg">
         {activeIndex === 0 && (
           <p>
             <strong>Overview panel.</strong> Indicator slides on{' '}

--- a/examples/zfb-tailwind/config/default-manifest.ts
+++ b/examples/zfb-tailwind/config/default-manifest.ts
@@ -5,12 +5,11 @@
  * with the declarations in `styles/global.css` so the panel can rewrite
  * the same names live and the apply pipeline can rewrite them on disk.
  *
- * The spacing tab uses a 3-tier setup:
- *   - Tier `spacing-scale`: 4-step raw spacing scale (xs/sm/md/lg)
+ * The spacing tab uses a 2-tier setup:
  *   - Tier `hsp-scale`: 5-step horizontal spacing scale (xs..xl)
  *   - Tier `vsp-scale`: 7-step vertical spacing scale (2xs..2xl)
- * All three scales are declared in styles/global.css and re-exported as
- * Tailwind theme tokens (--spacing-spacing-*, --spacing-hsp-*, --spacing-vsp-*).
+ * Both scales are declared in styles/global.css and re-exported as
+ * Tailwind theme tokens (--spacing-hsp-*, --spacing-vsp-*).
  *
  * The font tab uses a 2-tier setup (Wave 5):
  *   - Tier `raw`: 6 scale items
@@ -37,40 +36,6 @@ export const defaultTabs: readonly TabConfig[] = [
     id: 'spacing',
     label: 'Spacing',
     tiers: [
-      {
-        id: 'spacing-scale',
-        label: 'Spacing scale',
-        items: [
-          {
-            id: 'zfbtw-spacing-xs',
-            cssVar: '--zfbtw-spacing-xs',
-            label: 'Spacing XS',
-            default: '0.25rem',
-            type: { kind: 'length', min: 0, max: 1, step: 0.0625, unit: 'rem' },
-          },
-          {
-            id: 'zfbtw-spacing-sm',
-            cssVar: '--zfbtw-spacing-sm',
-            label: 'Spacing S',
-            default: '0.5rem',
-            type: { kind: 'length', min: 0, max: 1.5, step: 0.0625, unit: 'rem' },
-          },
-          {
-            id: 'zfbtw-spacing-md',
-            cssVar: '--zfbtw-spacing-md',
-            label: 'Spacing M',
-            default: '1rem',
-            type: { kind: 'length', min: 0, max: 4, step: 0.0625, unit: 'rem' },
-          },
-          {
-            id: 'zfbtw-spacing-lg',
-            cssVar: '--zfbtw-spacing-lg',
-            label: 'Spacing L',
-            default: '2rem',
-            type: { kind: 'length', min: 0, max: 6, step: 0.0625, unit: 'rem' },
-          },
-        ],
-      },
       {
         id: 'hsp-scale',
         label: 'Horizontal spacing',

--- a/examples/zfb-tailwind/pages/components/data.tsx
+++ b/examples/zfb-tailwind/pages/components/data.tsx
@@ -56,7 +56,7 @@ export default function DataPage() {
             Big number: semantic font token <code>text-h2</code> + <code>color-primary</code>.
             Label: <code>text-small</code> + <code>color-muted</code>. No hardcoded <code>font-size</code>.
           </p>
-          <div class="flex gap-spacing-md flex-wrap">
+          <div class="flex gap-x-hsp-md gap-y-vsp-md flex-wrap">
             <StatCard value="24,891" label="Total users" />
             <StatCard value="98.6%" label="Uptime this month" />
             <StatCard value="1,204" label="Active sessions" />
@@ -70,7 +70,7 @@ export default function DataPage() {
             Avatar: <code>size-avatar-md</code> (tweak in panel to resize).
             Name: <code>text-h4</code>. Role: <code>text-small color-muted</code>.
           </p>
-          <div class="flex flex-col gap-spacing-md max-w-[32rem]">
+          <div class="flex flex-col gap-vsp-md max-w-[32rem]">
             {/* reason: card list width is page-local */}
             <ProfileCard name="Alice Martin" role="Product Designer" />
             <ProfileCard name="Bob Chen" role="Frontend Engineer" />

--- a/examples/zfb-tailwind/pages/components/forms.tsx
+++ b/examples/zfb-tailwind/pages/components/forms.tsx
@@ -18,10 +18,11 @@
  *   border-muted        → --zfbtw-color-muted      (resting border)
  *   focus:border-accent → --zfbtw-color-accent     (focus border)
  *   disabled:bg-muted   → --zfbtw-color-muted      (disabled bg)
- *   p-spacing-sm        → --zfbtw-spacing-sm       (input/btn padding)
+ *   px-hsp-sm py-vsp-sm → --zfbtw-hsp-sm / --zfbtw-vsp-sm  (input/btn padding)
  *   rounded-md          → --zfbtw-radius           (corners)
- *   gap-spacing-xs      → --zfbtw-spacing-xs       (label-control gap)
- *   gap-spacing-md      → --zfbtw-spacing-md       (between field groups)
+ *   gap-vsp-xs          → --zfbtw-vsp-xs           (label-control gap, flex-col)
+ *   gap-hsp-xs          → --zfbtw-hsp-xs           (label-control gap, inline-flex row)
+ *   gap-vsp-md          → --zfbtw-vsp-md           (between field groups)
  */
 
 import { AppShell } from '../../components/app-shell';
@@ -30,7 +31,7 @@ const BASE_PATH = '/pj/zudo-design-token-panel/examples/zfb-tailwind/';
 
 /** Shared classes for all text inputs, email inputs, selects, textareas. */
 const inputBase =
-  'bg-surface border border-muted focus:border-accent focus:outline-none rounded-md p-spacing-sm text-body text-fg w-full';
+  'bg-surface border border-muted focus:border-accent focus:outline-none rounded-md px-hsp-sm py-vsp-sm text-body text-fg w-full';
 
 export default function FormsPage() {
   return (
@@ -44,7 +45,7 @@ export default function FormsPage() {
       {/* §131.3 required intro paragraph */}
       <p class="text-body text-fg leading-relaxed mt-vsp-sm">
         Each widget below is styled entirely with Tailwind utilities that
-        resolve to design tokens. Inputs use <code class="font-mono text-small">spacing-sm</code> for
+        resolve to design tokens. Inputs use <code class="font-mono text-small">px-hsp-sm py-vsp-sm</code> for
         padding, <code class="font-mono text-small">radius</code> for corners,{' '}
         <code class="font-mono text-small">color-muted</code> for borders,{' '}
         <code class="font-mono text-small">color-accent</code> on focus,{' '}
@@ -54,11 +55,11 @@ export default function FormsPage() {
 
       {/* Form — SSR-only; inputs accept user input natively; no submit handler needed */}
       <form
-        class="flex flex-col gap-spacing-md mt-vsp-md"
+        class="flex flex-col gap-vsp-md mt-vsp-md"
         onSubmit={(e) => e.preventDefault()}
       >
         {/* ── Text input ─────────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Text input</h2>
           <p class="text-small text-muted">
             <code class="font-mono">bg-surface</code> background ·{' '}
@@ -68,7 +69,7 @@ export default function FormsPage() {
           </p>
 
           {/* Active (normal) */}
-          <div class="flex flex-col gap-spacing-xs">
+          <div class="flex flex-col gap-vsp-xs">
             <label class="text-body text-fg" for="input-text">
               Full name
             </label>
@@ -81,7 +82,7 @@ export default function FormsPage() {
           </div>
 
           {/* Disabled — demonstrates disabled:bg-muted (§131.1, criterion #4) */}
-          <div class="flex flex-col gap-spacing-xs">
+          <div class="flex flex-col gap-vsp-xs">
             <label class="text-body text-muted" for="input-text-disabled">
               Full name (disabled)
             </label>
@@ -100,13 +101,13 @@ export default function FormsPage() {
         </section>
 
         {/* ── Email input ─────────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Email input</h2>
           <p class="text-small text-muted">
             Same utility set as text input; browser provides email-specific
             keyboard on mobile.
           </p>
-          <div class="flex flex-col gap-spacing-xs">
+          <div class="flex flex-col gap-vsp-xs">
             <label class="text-body text-fg" for="input-email">
               Email address
             </label>
@@ -120,13 +121,13 @@ export default function FormsPage() {
         </section>
 
         {/* ── Select ─────────────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Select</h2>
           <p class="text-small text-muted">
             Native chevron retained (no <code class="font-mono">appearance-none</code>);
             same token set as text input.
           </p>
-          <div class="flex flex-col gap-spacing-xs">
+          <div class="flex flex-col gap-vsp-xs">
             <label class="text-body text-fg" for="select-role">
               Role
             </label>
@@ -140,14 +141,14 @@ export default function FormsPage() {
         </section>
 
         {/* ── Textarea ────────────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Textarea</h2>
           <p class="text-small text-muted">
             <code class="font-mono">min-h-[6rem]</code> arbitrary value —{' '}
             {/* reason: visual minimum is component-local; below-token granularity */}
             visual floor ensures usable initial height.
           </p>
-          <div class="flex flex-col gap-spacing-xs">
+          <div class="flex flex-col gap-vsp-xs">
             <label class="text-body text-fg" for="textarea-bio">
               Bio
             </label>
@@ -161,7 +162,7 @@ export default function FormsPage() {
         </section>
 
         {/* ── Checkbox group ──────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Checkbox group</h2>
           <p class="text-small text-muted">
             Native checkbox with{' '}
@@ -170,14 +171,14 @@ export default function FormsPage() {
             No Tailwind utility maps to <code class="font-mono">accent-color</code>{' '}
             in §131.1, so the value is applied via inline style.
           </p>
-          <fieldset class="flex flex-col gap-spacing-xs border-none p-0 m-0">
-            <legend class="text-body text-fg mb-spacing-xs">Interests</legend>
+          <fieldset class="flex flex-col gap-vsp-xs border-none p-0 m-0">
+            <legend class="text-body text-fg mb-vsp-xs">Interests</legend>
             {[
               { id: 'cb-design', label: 'Design systems' },
               { id: 'cb-tokens', label: 'Design tokens' },
               { id: 'cb-tailwind', label: 'Tailwind CSS' },
             ].map(({ id, label }) => (
-              <label key={id} class="inline-flex items-center gap-spacing-xs cursor-pointer text-body text-fg">
+              <label key={id} class="inline-flex items-center gap-hsp-xs cursor-pointer text-body text-fg">
                 {/* reason: no Tailwind utility for accent-color in §131.1 allowlist */}
                 <input
                   type="checkbox"
@@ -191,20 +192,20 @@ export default function FormsPage() {
         </section>
 
         {/* ── Radio group ─────────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Radio group</h2>
           <p class="text-small text-muted">
             Same <code class="font-mono">accent-color</code> inline-style pattern as
             checkboxes.
           </p>
-          <fieldset class="flex flex-col gap-spacing-xs border-none p-0 m-0">
-            <legend class="text-body text-fg mb-spacing-xs">Preferred theme</legend>
+          <fieldset class="flex flex-col gap-vsp-xs border-none p-0 m-0">
+            <legend class="text-body text-fg mb-vsp-xs">Preferred theme</legend>
             {[
               { id: 'radio-dark', label: 'Dark' },
               { id: 'radio-light', label: 'Light' },
               { id: 'radio-system', label: 'System default' },
             ].map(({ id, label }) => (
-              <label key={id} class="inline-flex items-center gap-spacing-xs cursor-pointer text-body text-fg">
+              <label key={id} class="inline-flex items-center gap-hsp-xs cursor-pointer text-body text-fg">
                 {/* reason: no Tailwind utility for accent-color in §131.1 allowlist */}
                 <input
                   type="radio"
@@ -219,14 +220,14 @@ export default function FormsPage() {
         </section>
 
         {/* ── Range slider ────────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Range slider</h2>
           <p class="text-small text-muted">
             <code class="font-mono">w-full</code> width ·{' '}
             <code class="font-mono">accent-color</code> fills the track and thumb
             with <code class="font-mono">color-accent</code>.
           </p>
-          <div class="flex flex-col gap-spacing-xs">
+          <div class="flex flex-col gap-vsp-xs">
             <label class="text-body text-fg" for="range-opacity">
               Opacity
             </label>
@@ -245,19 +246,19 @@ export default function FormsPage() {
         </section>
 
         {/* ── Submit button ───────────────────────────────────────────── */}
-        <section class="flex flex-col gap-spacing-xs">
+        <section class="flex flex-col gap-vsp-xs">
           <h2 class="text-h4 text-fg font-semibold">Submit button</h2>
           <p class="text-small text-muted">
             <code class="font-mono">bg-primary</code> fill ·{' '}
             <code class="font-mono">text-bg</code> label ·{' '}
             <code class="font-mono">hover:bg-accent</code> hover ·{' '}
-            <code class="font-mono">p-spacing-sm</code> padding ·{' '}
+            <code class="font-mono">px-hsp-sm py-vsp-sm</code> padding ·{' '}
             <code class="font-mono">rounded-md</code> corners.
           </p>
           <div>
             <button
               type="submit"
-              class="bg-primary text-bg px-spacing-sm py-spacing-sm rounded-md hover:bg-accent cursor-pointer text-body border-none"
+              class="bg-primary text-bg px-hsp-sm py-vsp-sm rounded-md hover:bg-accent cursor-pointer text-body border-none"
             >
               Submit form
             </button>

--- a/examples/zfb-tailwind/pages/components/status.tsx
+++ b/examples/zfb-tailwind/pages/components/status.tsx
@@ -22,36 +22,36 @@ const BASE_PATH = '/pj/zudo-design-token-panel/examples/zfb-tailwind/';
 
 function Alerts() {
   return (
-    <section class="flex flex-col gap-spacing-md">
+    <section class="flex flex-col gap-vsp-md">
       <h2 class="text-h3 font-semibold text-fg">Alerts / callouts</h2>
       <p class="text-body text-fg">
         Each variant uses a semantic color token for background, text, and border.
         Token contract: <code>bg-accent</code> / <code>bg-success</code> /{' '}
         <code>bg-warning</code> / <code>bg-danger</code> with{' '}
         <code>text-bg</code> text and matching <code>border-*</code> outline.
-        Padding: <code>p-spacing-md</code>. Corners: <code>rounded-md</code>.
+        Padding: <code>px-hsp-md py-vsp-md</code>. Corners: <code>rounded-md</code>.
       </p>
 
       {/* info */}
-      <div class="bg-accent text-bg p-spacing-md rounded-md border border-accent">
+      <div class="bg-accent text-bg px-hsp-md py-vsp-md rounded-md border border-accent">
         <strong>Info:</strong> uses <code>bg-accent</code>, <code>text-bg</code>,{' '}
         <code>border-accent</code>. Token: <code>color-accent</code>.
       </div>
 
       {/* success */}
-      <div class="bg-success text-bg p-spacing-md rounded-md border border-success">
+      <div class="bg-success text-bg px-hsp-md py-vsp-md rounded-md border border-success">
         <strong>Success:</strong> uses <code>bg-success</code>, <code>text-bg</code>,{' '}
         <code>border-success</code>. Token: <code>color-success</code>.
       </div>
 
       {/* warning */}
-      <div class="bg-warning text-bg p-spacing-md rounded-md border border-warning">
+      <div class="bg-warning text-bg px-hsp-md py-vsp-md rounded-md border border-warning">
         <strong>Warning:</strong> uses <code>bg-warning</code>, <code>text-bg</code>,{' '}
         <code>border-warning</code>. Token: <code>color-warning</code>.
       </div>
 
       {/* danger */}
-      <div class="bg-danger text-bg p-spacing-md rounded-md border border-danger">
+      <div class="bg-danger text-bg px-hsp-md py-vsp-md rounded-md border border-danger">
         <strong>Danger:</strong> uses <code>bg-danger</code>, <code>text-bg</code>,{' '}
         <code>border-danger</code>. Token: <code>color-danger</code>.
       </div>
@@ -71,14 +71,14 @@ function Badge({ color, variant, label }: BadgeProps) {
   if (variant === 'filled') {
     return (
       // reason: badge vertical pad is below `spacing-xs`; below-token granularity is local
-      <span class={`bg-${color} text-bg px-spacing-xs py-[0.125rem] rounded-md text-small`}>
+      <span class={`bg-${color} text-bg px-hsp-xs py-[0.125rem] rounded-md text-small`}>
         {label}
       </span>
     );
   }
   return (
     // reason: badge vertical pad is below `spacing-xs`; below-token granularity is local
-    <span class={`border border-${color} text-${color} px-spacing-xs py-[0.125rem] rounded-md text-small`}>
+    <span class={`border border-${color} text-${color} px-hsp-xs py-[0.125rem] rounded-md text-small`}>
       {label}
     </span>
   );
@@ -93,19 +93,19 @@ function Badges() {
   ];
 
   return (
-    <section class="flex flex-col gap-spacing-md">
+    <section class="flex flex-col gap-vsp-md">
       <h2 class="text-h3 font-semibold text-fg">Badges</h2>
       <p class="text-body text-fg">
         Filled badges: <code>bg-{'{color}'}</code> + <code>text-bg</code>.
         Outlined badges: <code>border-{'{color}'}</code> + <code>text-{'{color}'}</code>.
-        Both use <code>px-spacing-xs</code>, <code>rounded-md</code>, <code>text-small</code>.
+        Both use <code>px-hsp-xs</code>, <code>rounded-md</code>, <code>text-small</code>.
         Vertical padding <code>py-[0.125rem]</code> is below{' '}
-        <code>spacing-xs</code> granularity — local exception per G4 row 5.
+        <code>vsp-xs</code> granularity — local exception per G4 row 5.
       </p>
 
       <div>
-        <p class="text-small text-muted mb-spacing-xs">Filled</p>
-        <div class="flex flex-wrap gap-spacing-sm">
+        <p class="text-small text-muted mb-vsp-xs">Filled</p>
+        <div class="flex flex-wrap gap-x-hsp-sm gap-y-vsp-sm">
           {colors.map((c) => (
             <Badge key={`filled-${c}`} color={c} variant="filled" label={c} />
           ))}
@@ -113,8 +113,8 @@ function Badges() {
       </div>
 
       <div>
-        <p class="text-small text-muted mb-spacing-xs">Outlined</p>
-        <div class="flex flex-wrap gap-spacing-sm">
+        <p class="text-small text-muted mb-vsp-xs">Outlined</p>
+        <div class="flex flex-wrap gap-x-hsp-sm gap-y-vsp-sm">
           {colors.map((c) => (
             <Badge key={`outlined-${c}`} color={c} variant="outlined" label={c} />
           ))}
@@ -132,7 +132,7 @@ interface TagProps {
 
 function Tag({ label }: TagProps) {
   return (
-    <span class="inline-flex items-center gap-spacing-xs bg-surface text-fg px-spacing-sm py-spacing-xs rounded-md text-small border border-muted">
+    <span class="inline-flex items-center gap-hsp-xs bg-surface text-fg px-hsp-sm py-vsp-xs rounded-md text-small border border-muted">
       {label}
       <button
         type="button"
@@ -148,14 +148,14 @@ function Tag({ label }: TagProps) {
 function Tags() {
   const tags = ['Design', 'Tokens', 'Tailwind', 'CSS Vars'];
   return (
-    <section class="flex flex-col gap-spacing-md">
+    <section class="flex flex-col gap-vsp-md">
       <h2 class="text-h3 font-semibold text-fg">Tags / chips</h2>
       <p class="text-body text-fg">
-        Container: <code>inline-flex items-center gap-spacing-xs bg-surface text-fg</code> +{' '}
-        <code>px-spacing-sm py-spacing-xs rounded-md text-small border border-muted</code>.
+        Container: <code>inline-flex items-center gap-hsp-xs bg-surface text-fg</code> +{' '}
+        <code>px-hsp-sm py-vsp-xs rounded-md text-small border border-muted</code>.
         Close button: <code>text-muted hover:text-danger</code>.
       </p>
-      <div class="flex flex-wrap gap-spacing-sm">
+      <div class="flex flex-wrap gap-x-hsp-sm gap-y-vsp-sm">
         {tags.map((t) => (
           <Tag key={t} label={t} />
         ))}
@@ -195,9 +195,9 @@ function Tooltip({ text, tip }: TooltipProps) {
       <span
         class="
           absolute bottom-full left-1/2
-          -translate-x-1/2 mb-spacing-xs
+          -translate-x-1/2 mb-vsp-xs
           bg-surface text-fg border border-muted rounded-md
-          px-spacing-sm py-spacing-xs
+          px-hsp-sm py-vsp-xs
           text-small
           whitespace-nowrap
           opacity-0
@@ -218,22 +218,22 @@ function Tooltip({ text, tip }: TooltipProps) {
 
 function Tooltips() {
   return (
-    <section class="flex flex-col gap-spacing-md">
+    <section class="flex flex-col gap-vsp-md">
       <h2 class="text-h3 font-semibold text-fg">Tooltips</h2>
       <p class="text-body text-fg">
         Hover over the annotated terms. Bubble: <code>bg-surface</code>,{' '}
         <code>text-fg</code>, <code>border-muted</code>, <code>rounded-md</code>,{' '}
-        <code>px-spacing-sm py-spacing-xs</code>, <code>text-small</code>.{' '}
+        <code>px-hsp-sm py-vsp-xs</code>, <code>text-small</code>.{' '}
         Opacity transition uses{' '}
         <code>easing-tab-open</code> (<code>--zfbtw-easing-tab-open</code>).
         Implementation: <code>position: absolute</code> with{' '}
         <code>translateX(-50%)</code> on the sibling bubble span.
       </p>
 
-      <div class="flex flex-wrap gap-spacing-lg text-body text-fg bg-surface p-spacing-md rounded-md border border-muted">
+      <div class="flex flex-wrap gap-x-hsp-lg gap-y-vsp-lg text-body text-fg bg-surface px-hsp-md py-vsp-md rounded-md border border-muted">
         <span>
           Token panel adjusts{' '}
-          <Tooltip text="spacing-md" tip="--zfbtw-spacing-md (default 1rem)" />{' '}
+          <Tooltip text="hsp-md / vsp-md" tip="--zfbtw-hsp-md / --zfbtw-vsp-md (default 1rem)" />{' '}
           live in the browser.
         </span>
         <span>
@@ -260,10 +260,10 @@ export default function StatusPage() {
       activePath={`${BASE_PATH}components/status/`}
     >
       {/* reason: page-content max-width is a layout constant for this demo; no structural token covers prose-container widths */}
-      <div class="flex flex-col gap-spacing-lg max-w-[56rem] mx-auto">
+      <div class="flex flex-col gap-vsp-lg max-w-[56rem] mx-auto">
         <header>
           <h1 class="text-h2 font-bold text-primary">Status surfaces demo</h1>
-          <p class="text-body text-fg mt-spacing-sm">
+          <p class="text-body text-fg mt-vsp-sm">
             Status surfaces demo for sub-issue #132. Covers alerts, badges, tags/chips,
             and tooltips — all driven by semantic color tokens{' '}
             <code>color-accent</code>, <code>color-success</code>,{' '}

--- a/examples/zfb-tailwind/pages/components/widgets.tsx
+++ b/examples/zfb-tailwind/pages/components/widgets.tsx
@@ -26,9 +26,9 @@ export default function WidgetsPage() {
       activePath={`${BASE_PATH}components/widgets/`}
     >
       {/* reason: page-content max-width is a layout constant for this demo; no structural token covers prose-container widths */}
-      <div class="flex flex-col gap-spacing-lg max-w-[56rem] mx-auto">
+      <div class="flex flex-col gap-vsp-lg max-w-[56rem] mx-auto">
         <header>
-          <h1 class="text-h2 text-primary font-bold mb-spacing-md">
+          <h1 class="text-h2 text-primary font-bold mb-vsp-md">
             Interactive Widgets
           </h1>
           <p class="text-body text-fg">
@@ -40,25 +40,25 @@ export default function WidgetsPage() {
 
         {/* ── Tabs ──────────────────────────────────────────────────────────── */}
         <section>
-          <h2 class="text-h3 text-fg font-semibold mb-spacing-sm">
+          <h2 class="text-h3 text-fg font-semibold mb-vsp-sm">
             Tabs
           </h2>
-          <p class="text-body text-muted mb-spacing-md">
+          <p class="text-body text-muted mb-vsp-md">
             Active indicator slides using{' '}
             <code>easing-tab-open</code>{' '}
             (→&nbsp;<code>--zfbtw-easing-tab-open</code>).
           </p>
-          <div class="bg-surface p-spacing-md rounded-md border border-muted">
+          <div class="bg-surface px-hsp-md py-vsp-md rounded-md border border-muted">
             <TabsDemo />
           </div>
         </section>
 
         {/* ── Accordion ─────────────────────────────────────────────────────── */}
         <section>
-          <h2 class="text-h3 text-fg font-semibold mb-spacing-sm">
+          <h2 class="text-h3 text-fg font-semibold mb-vsp-sm">
             Accordion
           </h2>
-          <p class="text-body text-muted mb-spacing-md">
+          <p class="text-body text-muted mb-vsp-md">
             Height transitions use{' '}
             <code>easing-tab-open</code> / <code>easing-tab-close</code>{' '}
             for open/close respectively (progressive enhancement, Chrome 131+).
@@ -68,10 +68,10 @@ export default function WidgetsPage() {
 
         {/* ── Modal ─────────────────────────────────────────────────────────── */}
         <section>
-          <h2 class="text-h3 text-fg font-semibold mb-spacing-sm">
+          <h2 class="text-h3 text-fg font-semibold mb-vsp-sm">
             Modal
           </h2>
-          <p class="text-body text-muted mb-spacing-md">
+          <p class="text-body text-muted mb-vsp-md">
             Fade-and-scale animation uses{' '}
             <code>easing-modal</code>{' '}
             (→&nbsp;<code>--zfbtw-easing-modal</code>). Close via

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -12,8 +12,8 @@
  *   bg-surface  → background-color: var(--color-surface)
  *               → var(--zfbtw-color-surface)
  *
- *   p-spacing-md → padding: var(--spacing-spacing-md)
- *                → var(--zfbtw-spacing-md)
+ *   px-hsp-md py-vsp-md → padding: var(--spacing-hsp-md) / var(--spacing-vsp-md)
+ *                       → var(--zfbtw-hsp-md) / var(--zfbtw-vsp-md)
  *
  *   rounded-md  → border-radius: var(--radius-md)
  *               → var(--zfbtw-radius)
@@ -68,9 +68,9 @@ export default function HomePage() {
       activePath={BASE_PATH}
     >
       {/* reason: page-content max-width is a layout constant for this demo; no structural token covers prose-container widths */}
-      <div class="flex flex-col gap-spacing-lg max-w-[56rem] mx-auto">
+      <div class="flex flex-col gap-vsp-lg max-w-[56rem] mx-auto">
         <header>
-          <h1 class="text-heading font-bold mb-spacing-md text-primary">
+          <h1 class="text-heading font-bold mb-vsp-md text-primary">
             Live token tweaking, in zfb + Tailwind v4
           </h1>
           <p>
@@ -79,7 +79,7 @@ export default function HomePage() {
             Tailwind v4 utility classes. Open the panel from the button above
             and drag any slider — the change applies before the next paint.
           </p>
-          <p class="text-small text-muted mt-spacing-md">
+          <p class="text-small text-muted mt-vsp-md">
             Console API:{' '}
             <code>window.zfbTw.toggleDesignPanel()</code>. Storage
             prefix: <code>zfb-tailwind-example-tokens</code>.
@@ -87,31 +87,31 @@ export default function HomePage() {
         </header>
 
         <section>
-          <h2 class="text-heading font-bold mb-spacing-md text-primary">
+          <h2 class="text-heading font-bold mb-vsp-md text-primary">
             Cards (spacing + radius + surface)
           </h2>
-          <div class="flex flex-col gap-spacing-md">
-            <div class="bg-surface text-fg p-spacing-md rounded-md border border-muted">
+          <div class="flex flex-col gap-vsp-md">
+            <div class="bg-surface text-fg px-hsp-md py-vsp-md rounded-md border border-muted">
               <strong>Card A.</strong> Padding driven by{' '}
-              <code>p-spacing-md</code> (→ <code>--zfbtw-spacing-md</code>),
+              <code>px-hsp-md py-vsp-md</code> (→ <code>--zfbtw-hsp-md</code> / <code>--zfbtw-vsp-md</code>),
               corners by <code>rounded-md</code> (→ <code>--zfbtw-radius</code>),
               background by <code>bg-surface</code>.
             </div>
-            <div class="bg-surface text-fg p-spacing-md rounded-md border border-muted">
+            <div class="bg-surface text-fg px-hsp-md py-vsp-md rounded-md border border-muted">
               <strong>Card B.</strong> Stack gap driven by{' '}
-              <code>gap-spacing-lg</code>; outline by{' '}
+              <code>gap-vsp-lg</code>; outline by{' '}
               <code>border-muted</code>.
             </div>
           </div>
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-spacing-md text-primary">
+          <h2 class="text-heading font-bold mb-vsp-md text-primary">
             Buttons (accent / primary)
           </h2>
           <p>
             <button
-              class="inline-block p-spacing-md rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary"
+              class="inline-block px-hsp-md py-vsp-md rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary"
               type="button"
             >
               Action button
@@ -120,7 +120,7 @@ export default function HomePage() {
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-spacing-md text-primary">
+          <h2 class="text-heading font-bold mb-vsp-md text-primary">
             Easing demo
           </h2>
           <p>
@@ -133,14 +133,14 @@ export default function HomePage() {
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-spacing-md text-primary">
+          <h2 class="text-heading font-bold mb-vsp-md text-primary">
             Palette swatches
           </h2>
-          <div class="flex flex-wrap gap-spacing-md">
+          <div class="flex flex-wrap gap-x-hsp-md gap-y-vsp-md">
             {PALETTE_INDICES.map((i) => (
               <div
                 key={i}
-                class="w-16 h-16 rounded-md flex items-end justify-center text-micro text-fg p-spacing-xs"
+                class="w-16 h-16 rounded-md flex items-end justify-center text-micro text-fg px-hsp-xs py-vsp-xs"
                 // reason: dynamic var name from loop index — no static utility possible;
                 // text-shadow is swatch-label legibility over any palette color — no token covers overlay shadows
                 style={`background: var(--zfbtw-palette-${i}); text-shadow: 0 1px 2px rgba(0,0,0,0.7);`}
@@ -149,7 +149,7 @@ export default function HomePage() {
               </div>
             ))}
           </div>
-          <p class="text-small text-muted mt-spacing-md">
+          <p class="text-small text-muted mt-vsp-md">
             Each swatch reads{' '}
             <code>--zfbtw-palette-{'{n}'}</code>. The cluster's{' '}
             <code>paletteCssVarTemplate</code> is the only thing that decides
@@ -160,10 +160,10 @@ export default function HomePage() {
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-spacing-md text-primary">
+          <h2 class="text-heading font-bold mb-vsp-md text-primary">
             Typography scale
           </h2>
-          <div class="flex flex-col gap-vsp-sm bg-surface p-spacing-md rounded-md border border-muted">
+          <div class="flex flex-col gap-vsp-sm bg-surface px-hsp-md py-vsp-md rounded-md border border-muted">
             <p class="text-h2 leading-tight font-bold text-fg">Heading H2 — text-h2</p>
             <p class="text-h3 leading-tight font-semibold text-fg">Heading H3 — text-h3</p>
             <p class="text-h4 leading-snug font-semibold text-fg">Heading H4 — text-h4</p>

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -161,16 +161,39 @@ export default function HomePage() {
 
         <section>
           <h2 class="text-heading font-bold mb-vsp-md text-primary">
-            Typography scale
+            Font scale tokens
           </h2>
+          <p class="mb-vsp-md">
+            The manifest declares six raw scale tokens. Each row below is
+            rendered at exactly that size via a Tailwind utility backed by{' '}
+            <code>var(--zfbtw-scale-*)</code>. Open the Font tab in the panel
+            and move any scale slider — all rows update live.
+          </p>
           <div class="flex flex-col gap-vsp-sm bg-surface px-hsp-md py-vsp-md rounded-md border border-muted">
-            <p class="text-h2 leading-tight font-bold text-fg">Heading H2 — text-h2</p>
-            <p class="text-h3 leading-tight font-semibold text-fg">Heading H3 — text-h3</p>
-            <p class="text-h4 leading-snug font-semibold text-fg">Heading H4 — text-h4</p>
-            <p class="text-body leading-relaxed text-fg">Body text — text-body leading-relaxed</p>
-            <p class="text-small text-muted">Small text — text-small text-muted</p>
-            <p class="text-micro text-muted">Micro text — text-micro text-muted</p>
+            <p class="text-scale-2xl leading-tight text-fg">
+              2xl — <code class="text-scale-sm">text-scale-2xl → --zfbtw-scale-2xl</code>
+            </p>
+            <p class="text-scale-xl leading-tight text-fg">
+              xl — <code class="text-scale-sm">text-scale-xl → --zfbtw-scale-xl</code>
+            </p>
+            <p class="text-scale-lg leading-snug text-fg">
+              lg — <code class="text-scale-sm">text-scale-lg → --zfbtw-scale-lg</code>
+            </p>
+            <p class="text-scale-base leading-relaxed text-fg">
+              base — <code class="text-scale-sm">text-scale-base → --zfbtw-scale-base</code>
+            </p>
+            <p class="text-scale-sm text-fg">
+              sm — <code>text-scale-sm → --zfbtw-scale-sm</code>
+            </p>
+            <p class="text-scale-xs text-muted">
+              xs — <code>text-scale-xs → --zfbtw-scale-xs</code>
+            </p>
           </div>
+          <p class="text-small text-muted mt-vsp-sm">
+            Heading and body demos — including the semantic aliases{' '}
+            <code>text-h2</code>, <code>text-body</code>, etc. — are on the{' '}
+            <a href={`${BASE_PATH}prose/`}>Prose page</a>.
+          </p>
         </section>
       </div>
     </AppShell>

--- a/examples/zfb-tailwind/pages/prose.tsx
+++ b/examples/zfb-tailwind/pages/prose.tsx
@@ -77,6 +77,19 @@ export default function ProsePage() {
           to tweak them live.
         </p>
 
+        {/* Semantic heading / body scale showcase — utility classes map to prose
+            type-scale tokens. Kept outside .zfbtw-prose so the Tailwind utilities
+            (text-h2, text-body, …) are visible rather than being overridden by the
+            container's :where(h2) rules. */}
+        <div class="flex flex-col gap-vsp-sm bg-surface px-hsp-md py-vsp-md rounded-md border border-muted mb-vsp-xl">
+          <p class="text-h2 leading-tight font-bold text-fg">Heading H2 — text-h2</p>
+          <p class="text-h3 leading-tight font-semibold text-fg">Heading H3 — text-h3</p>
+          <p class="text-h4 leading-snug font-semibold text-fg">Heading H4 — text-h4</p>
+          <p class="text-body leading-relaxed text-fg">Body text — text-body leading-relaxed</p>
+          <p class="text-small text-muted">Small text — text-small text-muted</p>
+          <p class="text-micro text-muted">Micro text — text-micro text-muted</p>
+        </div>
+
         {ProseContent ? (
           <article class="zfbtw-prose">
             <ProseContent />

--- a/examples/zfb-tailwind/styles/global.css
+++ b/examples/zfb-tailwind/styles/global.css
@@ -479,3 +479,41 @@
     font-weight: 600;
   }
 }
+
+/* ── View Transitions (Strategy B — same-document SPA soft-swap) ─────────── */
+/*
+ * These rules support the zfb-runtime <ClientRouter /> SPA router.
+ * Persisted chrome elements (topbar + sidenav) carry data-zfb-transition-persist
+ * in app-shell.tsx; zfb's DOM byte-move keeps their DOM nodes alive across pages.
+ * We assign each a view-transition-name and then suppress their animation so they
+ * appear static. Only the ::view-transition-old/new(root) pseudo-elements animate,
+ * producing a cross-fade on the main content area.
+ */
+
+@keyframes zfbtw-content-fade-in {
+  from { opacity: 0; transform: translateY(-0.5rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes zfbtw-content-fade-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+/* Assign stable view-transition-name to persisted chrome elements. */
+[data-zfb-transition-persist="topbar"]  { view-transition-name: zfbtw-topbar; }
+[data-zfb-transition-persist="sidenav"] { view-transition-name: zfbtw-sidenav; }
+
+/* Suppress animation for persisted chrome — they don't move between pages. */
+::view-transition-old(zfbtw-topbar),
+::view-transition-new(zfbtw-topbar),
+::view-transition-group(zfbtw-topbar),
+::view-transition-old(zfbtw-sidenav),
+::view-transition-new(zfbtw-sidenav),
+::view-transition-group(zfbtw-sidenav) {
+  animation: none;
+}
+
+/* Root cross-fade: only the page content area animates. */
+::view-transition-old(root) { animation: 150ms ease-in  both zfbtw-content-fade-out; }
+::view-transition-new(root) { animation: 300ms ease-out both zfbtw-content-fade-in; }

--- a/examples/zfb-tailwind/styles/global.css
+++ b/examples/zfb-tailwind/styles/global.css
@@ -195,6 +195,16 @@
   --spacing-hsp-lg:  var(--zfbtw-hsp-lg);
   --spacing-hsp-xl:  var(--zfbtw-hsp-xl);
 
+  /* Raw font-scale utilities: text-scale-xs … text-scale-2xl
+     Each maps directly to a --zfbtw-scale-* token so demo content can render
+     every raw scale value (acceptance criterion: all six must be visibly consumed). */
+  --text-scale-xs:   var(--zfbtw-scale-xs);
+  --text-scale-sm:   var(--zfbtw-scale-sm);
+  --text-scale-base: var(--zfbtw-scale-base);
+  --text-scale-lg:   var(--zfbtw-scale-lg);
+  --text-scale-xl:   var(--zfbtw-scale-xl);
+  --text-scale-2xl:  var(--zfbtw-scale-2xl);
+
   /* Font-size utilities: text-h2, text-h3, text-body, text-small, … */
   --text-heading: var(--zfbtw-text-heading);
   --text-base:    var(--zfbtw-text-base);

--- a/examples/zfb-tailwind/styles/global.css
+++ b/examples/zfb-tailwind/styles/global.css
@@ -31,13 +31,6 @@
 
 /* ── Token declarations ──────────────────────────────────────────────────── */
 :root {
-  /* Spacing tokens (manifest: spacing tab) — xs/sm are component-padding tokens;
-     md/lg are page-padding tokens used by AppShell / sidenav */
-  --zfbtw-spacing-xs: 0.25rem;
-  --zfbtw-spacing-sm: 0.5rem;
-  --zfbtw-spacing-md: 1rem;
-  --zfbtw-spacing-lg: 2rem;
-
   /* Font scale tokens (font tab — raw tier, in raw tier) */
   --zfbtw-scale-xs: 0.75rem;
   --zfbtw-scale-sm: 0.875rem;
@@ -176,13 +169,6 @@
   --color-danger:  var(--zfbtw-color-danger);
   --color-bg:      var(--zfbtw-bg);
   --color-fg:      var(--zfbtw-fg);
-
-  /* Spacing utilities for manifest spacing tokens: p-spacing-xs, p-spacing-sm, … */
-  --spacing-spacing-xs: var(--zfbtw-spacing-xs);
-  --spacing-spacing-sm: var(--zfbtw-spacing-sm);
-  /* spacing-md / spacing-lg are already mapped — do not re-add */
-  --spacing-spacing-md: var(--zfbtw-spacing-md);
-  --spacing-spacing-lg: var(--zfbtw-spacing-lg);
 
   /* Size utilities: w-size-sidenav-w, h-size-header-h, w-size-avatar-sm, etc.
      Per G3: size tokens live under --spacing-size-* to generate w- and h- utilities */
@@ -470,7 +456,7 @@
   .zfbtw-easing-card {
     display: block;
     width: 100%;
-    padding: var(--zfbtw-spacing-md);
+    padding: var(--zfbtw-hsp-md);
     background: var(--zfbtw-color-surface);
     border: 1px solid var(--zfbtw-color-muted);
     border-radius: var(--zfbtw-radius);

--- a/packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts
@@ -16,15 +16,14 @@
  * Invariants under test:
  *   A. No manifest contains a `group:` object-key (TierItem.group was removed in #148).
  *   B. No manifest contains an `advancedTiers:` object-key (TabConfig.advancedTiers was removed in #148).
- *   C. The zfb-tailwind Spacing tab declares exactly 3 tiers: spacing-scale, hsp-scale, vsp-scale.
+ *   C. The zfb-tailwind Spacing tab declares exactly 2 tiers: hsp-scale, vsp-scale (#161 removed spacing-scale).
  *   D. The panel source (tabs/) contains no <h4 or <details elements.
  *
- * Cascade test note (step 5 from task):
- *   The zfb-tailwind global.css re-exports --zfbtw-spacing-*, --zfbtw-hsp-*, --zfbtw-vsp-*
- *   as Tailwind theme tokens (--spacing-spacing-*, --spacing-hsp-*, --spacing-vsp-*).
- *   Since #153 chose Option A (token restructure only, global.css untouched), the consumer
- *   chain remains intact. This is asserted below by confirming that global.css still
- *   references each of the 16 spacing/hsp/vsp CSS variables.
+ * Cascade test note:
+ *   The zfb-tailwind global.css re-exports --zfbtw-hsp-*, --zfbtw-vsp-* as Tailwind theme
+ *   tokens (--spacing-hsp-*, --spacing-vsp-*). The --zfbtw-spacing-* raw tier and its
+ *   --spacing-spacing-* re-exports were removed in #161. This is asserted below by confirming
+ *   global.css references all 12 remaining hsp/vsp CSS variables.
  *
  * Browser-based cascade testing is deferred — see procedure in packages/zudo-design-token-panel/CLAUDE.md.
  */
@@ -96,15 +95,15 @@ describe('Invariant B — no advancedTiers: field in any manifest', () => {
 });
 
 // ---------------------------------------------------------------------------
-// C. zfb-tailwind Spacing tab has exactly 3 tiers: spacing-scale, hsp-scale, vsp-scale
-//    (per #153 Option A — 3-tier flat structure)
+// C. zfb-tailwind Spacing tab has exactly 2 tiers: hsp-scale, vsp-scale
+//    (per #161 — spacing-scale tier removed)
 // ---------------------------------------------------------------------------
 
-describe('Invariant C — zfb-tailwind Spacing tab has 3 tiers', () => {
+describe('Invariant C — zfb-tailwind Spacing tab has 2 tiers', () => {
   const source = readManifest('zfb-tailwind');
 
-  it('contains spacing-scale tier id', () => {
-    expect(source).toContain("id: 'spacing-scale'");
+  it('does NOT contain spacing-scale tier id (removed in #161)', () => {
+    expect(source).not.toContain("id: 'spacing-scale'");
   });
 
   it('contains hsp-scale tier id', () => {
@@ -113,12 +112,6 @@ describe('Invariant C — zfb-tailwind Spacing tab has 3 tiers', () => {
 
   it('contains vsp-scale tier id', () => {
     expect(source).toContain("id: 'vsp-scale'");
-  });
-
-  it('spacing-scale has 4 items (xs/sm/md/lg)', () => {
-    // Count occurrences of --zfbtw-spacing- cssVar declarations
-    const matches = source.match(/cssVar:\s*'--zfbtw-spacing-/g) ?? [];
-    expect(matches.length).toBe(4);
   });
 
   it('hsp-scale has 5 items (xs..xl)', () => {
@@ -131,11 +124,10 @@ describe('Invariant C — zfb-tailwind Spacing tab has 3 tiers', () => {
     expect(matches.length).toBe(7);
   });
 
-  it('total spacing tier items is 16', () => {
-    const spacing = source.match(/cssVar:\s*'--zfbtw-spacing-/g)?.length ?? 0;
+  it('total spacing tier items is 12', () => {
     const hsp = source.match(/cssVar:\s*'--zfbtw-hsp-/g)?.length ?? 0;
     const vsp = source.match(/cssVar:\s*'--zfbtw-vsp-/g)?.length ?? 0;
-    expect(spacing + hsp + vsp).toBe(16);
+    expect(hsp + vsp).toBe(12);
   });
 });
 
@@ -173,8 +165,8 @@ describe('Invariant D — panel tabs source has no blocked semantic elements', (
 });
 
 // ---------------------------------------------------------------------------
-// E. zfb-tailwind cascade — global.css still re-exports all spacing variables
-//    (confirms #153 Option A did not disrupt the consumer chain in global.css)
+// E. zfb-tailwind cascade — global.css still re-exports all hsp/vsp variables
+//    (confirms #161 spacing-scale removal did not disrupt the hsp/vsp consumer chain)
 // ---------------------------------------------------------------------------
 
 describe('Invariant E — zfb-tailwind global.css cascade is intact', () => {
@@ -183,13 +175,13 @@ describe('Invariant E — zfb-tailwind global.css cascade is intact', () => {
     'utf8',
   );
 
-  // Each raw variable must be declared in global.css.
-  const spacingVars = ['--zfbtw-spacing-xs', '--zfbtw-spacing-sm', '--zfbtw-spacing-md', '--zfbtw-spacing-lg'];
-  for (const v of spacingVars) {
-    it(`declares ${v}`, () => {
-      expect(globalCss).toContain(v);
-    });
-  }
+  // --zfbtw-spacing-* raw vars were removed in #161 — confirm they are gone.
+  it('does NOT declare --zfbtw-spacing-xs (removed in #161)', () => {
+    expect(globalCss).not.toContain('--zfbtw-spacing-xs');
+  });
+  it('does NOT re-export --spacing-spacing-xs (removed in #161)', () => {
+    expect(globalCss).not.toContain('--spacing-spacing-xs');
+  });
 
   const hspVars = ['--zfbtw-hsp-xs', '--zfbtw-hsp-sm', '--zfbtw-hsp-md', '--zfbtw-hsp-lg', '--zfbtw-hsp-xl'];
   for (const v of hspVars) {
@@ -209,11 +201,6 @@ describe('Invariant E — zfb-tailwind global.css cascade is intact', () => {
   }
 
   // Tailwind consumer bridge (--spacing-* re-exports) should be intact.
-  it('re-exports --spacing-spacing-xs: var(--zfbtw-spacing-xs)', () => {
-    expect(globalCss).toContain('--spacing-spacing-xs');
-    expect(globalCss).toContain('var(--zfbtw-spacing-xs)');
-  });
-
   it('re-exports --spacing-hsp-md: var(--zfbtw-hsp-md)', () => {
     expect(globalCss).toContain('--spacing-hsp-md');
     expect(globalCss).toContain('var(--zfbtw-hsp-md)');

--- a/packages/zudo-design-token-panel/src/__tests__/panel-close-storage-sync.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/panel-close-storage-sync.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression test for the panel-close storage desync bug (#157 items 1 & 2).
+ *
+ * Problem 1 — ESC key does not close the panel (#157 item 1):
+ *   The panel had no document-level keyboard listener. Pressing Escape would
+ *   close native <dialog> modals (export/import/apply) but had no effect on
+ *   the panel itself.
+ *
+ * Problem 2 — panel auto-reopens after internal close (#157 item 2):
+ *   Closing via the X button called setOpen(false), which ran the
+ *   useEffect([open]) block and removed localStorage['-open']. But it did NOT
+ *   touch localStorage[':visible']. On the next page load, index.tsx's
+ *   reapplyFromStorage() calls wasVisible() which reads ':visible' === '1',
+ *   and shows the panel — re-opening it against the user's intent.
+ *
+ * Fix (Approach A):
+ *   panel.tsx's useEffect([open]) now writes ':visible' to '1'/'0' in lockstep
+ *   with the '-open' key write. ESC is handled by a document-level keydown
+ *   effect installed only while open===true, which calls setOpen(false).
+ *
+ * Storage shape after close (MANDATORY — the root cause IS the desync):
+ *   - localStorage[`${storagePrefix}:visible`] === '0'
+ *   - localStorage[`${storagePrefix}-open`] === null
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getOpenKey } from '../state/tweak-state';
+import {
+  __resetPanelConfigForTests,
+  getPanelConfig,
+  panelRootId,
+  storageKey_visible,
+} from '../config/panel-config';
+
+const STORAGE_KEY_VISIBLE = storageKey_visible(getPanelConfig());
+const PANEL_ROOT_ID = panelRootId(getPanelConfig());
+const OPEN_PANEL_HEADER_TEXT = 'Design Tokens';
+const TOGGLE_EVENT = 'toggle-design-token-panel';
+
+/**
+ * Wait until Preact has flushed pending effects. Preact uses
+ * requestAnimationFrame to flush effects (with a setTimeout(35) fallback
+ * inside w), so we wait long enough for either path to fire and then yield
+ * to any further microtasks.
+ */
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+describe('panel close — storage sync', () => {
+  beforeEach(() => {
+    __resetPanelConfigForTests();
+    localStorage.clear();
+    document.body.innerHTML = '';
+    const w = window as unknown as Record<string, unknown>;
+    delete w.__zudoDesignTokenPanelAdapter;
+    delete w.__zudoDesignTokenPanelLifecycle;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('X-click clears both -open (null) and :visible ("0") so next page-load does not reopen', async () => {
+    await import('../index');
+
+    // Open the panel via toggle event.
+    window.dispatchEvent(new CustomEvent(TOGGLE_EVENT));
+    await waitForEffectFlush();
+
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root, 'panel root mounts').not.toBeNull();
+    expect(root!.textContent ?? '').toContain(OPEN_PANEL_HEADER_TEXT);
+    expect(localStorage.getItem(getOpenKey())).toBe('1');
+    expect(localStorage.getItem(STORAGE_KEY_VISIBLE)).toBe('1');
+
+    // Click the X close button inside the panel.
+    const closeBtn = root!.querySelector<HTMLElement>('.tokenpanel-close-btn');
+    expect(closeBtn, 'close button renders while panel is open').not.toBeNull();
+    closeBtn!.click();
+    await waitForEffectFlush();
+
+    // Panel content should be gone.
+    expect(root!.textContent ?? '').not.toContain(OPEN_PANEL_HEADER_TEXT);
+
+    // MANDATORY storage assertions — both keys must reflect "closed".
+    // -open must be absent (null), not '0'.
+    expect(
+      localStorage.getItem(getOpenKey()),
+      'after X-click: -open must be null',
+    ).toBeNull();
+    // :visible must be '0', not '1' — this is the key that wasVisible() reads.
+    // Before the fix it remained '1', causing reapplyFromStorage to reopen the
+    // panel on next load.
+    expect(
+      localStorage.getItem(STORAGE_KEY_VISIBLE),
+      'after X-click: :visible must be "0"',
+    ).toBe('0');
+  });
+
+  it('ESC does NOT close the panel when a modal is open (modal has priority)', async () => {
+    // jsdom does not implement HTMLDialogElement.showModal(), so we define a
+    // no-op on the prototype to prevent the exception that would otherwise
+    // abort the test before the modal state is set.
+    if (!HTMLDialogElement.prototype.showModal) {
+      HTMLDialogElement.prototype.showModal = () => undefined;
+    }
+    vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(() => undefined);
+
+    await import('../index');
+
+    // Open the panel.
+    window.dispatchEvent(new CustomEvent(TOGGLE_EVENT));
+    await waitForEffectFlush();
+
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root!.textContent ?? '').toContain(OPEN_PANEL_HEADER_TEXT);
+
+    // Click the Export button to open a modal (sets showExport=true in panel state).
+    const exportBtn = root!.querySelector<HTMLElement>('.tokenpanel-action-link');
+    expect(exportBtn, 'Export button should render').not.toBeNull();
+    exportBtn!.click();
+    await waitForEffectFlush();
+
+    // Now dispatch ESC. With showExport=true, the panel's ESC handler must
+    // stand down and let the native <dialog> handle it first.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await waitForEffectFlush();
+
+    // Panel must still be open — the ESC handler should have returned early
+    // due to the modal-priority guard.
+    expect(
+      localStorage.getItem(getOpenKey()),
+      'after ESC with modal open: -open must still be "1"',
+    ).toBe('1');
+    expect(
+      localStorage.getItem(STORAGE_KEY_VISIBLE),
+      'after ESC with modal open: :visible must still be "1"',
+    ).toBe('1');
+
+    vi.restoreAllMocks();
+  });
+
+  it('ESC key clears both -open (null) and :visible ("0") when no modal is open', async () => {
+    await import('../index');
+
+    // Open via toggle event.
+    window.dispatchEvent(new CustomEvent(TOGGLE_EVENT));
+    await waitForEffectFlush();
+
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root!.textContent ?? '').toContain(OPEN_PANEL_HEADER_TEXT);
+    expect(localStorage.getItem(getOpenKey())).toBe('1');
+    expect(localStorage.getItem(STORAGE_KEY_VISIBLE)).toBe('1');
+
+    // Dispatch ESC on the document.
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await waitForEffectFlush();
+
+    // Panel should be closed.
+    expect(root!.textContent ?? '').not.toContain(OPEN_PANEL_HEADER_TEXT);
+
+    // MANDATORY storage assertions.
+    expect(
+      localStorage.getItem(getOpenKey()),
+      'after ESC: -open must be null',
+    ).toBeNull();
+    expect(
+      localStorage.getItem(STORAGE_KEY_VISIBLE),
+      'after ESC: :visible must be "0"',
+    ).toBe('0');
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/zfbtw-manifest-validation.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/zfbtw-manifest-validation.test.ts
@@ -1,11 +1,12 @@
 /**
  * Validation test for the zfb-tailwind default manifest's Spacing tab.
  *
- * Exercises the tier-model pipeline with a TabConfig that mirrors the three
+ * Exercises the tier-model pipeline with a TabConfig that mirrors the two
  * spacing tiers declared in examples/zfb-tailwind/config/default-manifest.ts:
- *   - spacing-scale: 4 items (xs/sm/md/lg)
- *   - hsp-scale:     5 items (xs..xl)
- *   - vsp-scale:     7 items (2xs..2xl)
+ *   - hsp-scale: 5 items (xs..xl)
+ *   - vsp-scale: 7 items (2xs..2xl)
+ *
+ * The spacing-scale tier (4 items: xs/sm/md/lg) was removed in #161.
  *
  * Does NOT import from examples/zfb-tailwind to avoid inverting the
  * dependency graph. The TabConfig literal is kept in sync with the manifest
@@ -28,40 +29,6 @@ const ZFBTW_SPACING_TAB: TabConfig = {
   id: 'spacing',
   label: 'Spacing',
   tiers: [
-    {
-      id: 'spacing-scale',
-      label: 'Spacing scale',
-      items: [
-        {
-          id: 'zfbtw-spacing-xs',
-          cssVar: '--zfbtw-spacing-xs',
-          label: 'Spacing XS',
-          default: '0.25rem',
-          type: { kind: 'length', min: 0, max: 1, step: 0.0625, unit: 'rem' },
-        },
-        {
-          id: 'zfbtw-spacing-sm',
-          cssVar: '--zfbtw-spacing-sm',
-          label: 'Spacing S',
-          default: '0.5rem',
-          type: { kind: 'length', min: 0, max: 1.5, step: 0.0625, unit: 'rem' },
-        },
-        {
-          id: 'zfbtw-spacing-md',
-          cssVar: '--zfbtw-spacing-md',
-          label: 'Spacing M',
-          default: '1rem',
-          type: { kind: 'length', min: 0, max: 4, step: 0.0625, unit: 'rem' },
-        },
-        {
-          id: 'zfbtw-spacing-lg',
-          cssVar: '--zfbtw-spacing-lg',
-          label: 'Spacing L',
-          default: '2rem',
-          type: { kind: 'length', min: 0, max: 6, step: 0.0625, unit: 'rem' },
-        },
-      ],
-    },
     {
       id: 'hsp-scale',
       label: 'Horizontal spacing',
@@ -173,15 +140,14 @@ function emit(tab: TabConfig, tierId: string, itemId: string): string {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('zfb-tailwind manifest — Spacing tab: 3-tier structure', () => {
-  it('has exactly 3 tiers', () => {
-    expect(ZFBTW_SPACING_TAB.tiers.length).toBe(3);
+describe('zfb-tailwind manifest — Spacing tab: 2-tier structure', () => {
+  it('has exactly 2 tiers', () => {
+    expect(ZFBTW_SPACING_TAB.tiers.length).toBe(2);
   });
 
-  it('spacing-scale tier has 4 items', () => {
+  it('does NOT have spacing-scale tier (removed in #161)', () => {
     const tier = ZFBTW_SPACING_TAB.tiers.find((t) => t.id === 'spacing-scale');
-    expect(tier).toBeDefined();
-    expect(tier!.items.length).toBe(4);
+    expect(tier).toBeUndefined();
   });
 
   it('hsp-scale tier has 5 items', () => {
@@ -196,21 +162,15 @@ describe('zfb-tailwind manifest — Spacing tab: 3-tier structure', () => {
     expect(tier!.items.length).toBe(7);
   });
 
-  it('total items across all tiers is 16', () => {
+  it('total items across all tiers is 12', () => {
     const total = ZFBTW_SPACING_TAB.tiers.reduce((sum, t) => sum + t.items.length, 0);
-    expect(total).toBe(16);
+    expect(total).toBe(12);
   });
 
-  it('no tier uses referencesTier (all three are primitive tiers)', () => {
+  it('no tier uses referencesTier (both are primitive tiers)', () => {
     for (const tier of ZFBTW_SPACING_TAB.tiers) {
       expect(tier.referencesTier).toBeUndefined();
     }
-  });
-
-  it('emits literal default for spacing-scale items', () => {
-    expect(emit(ZFBTW_SPACING_TAB, 'spacing-scale', 'zfbtw-spacing-xs')).toBe('0.25rem');
-    expect(emit(ZFBTW_SPACING_TAB, 'spacing-scale', 'zfbtw-spacing-md')).toBe('1rem');
-    expect(emit(ZFBTW_SPACING_TAB, 'spacing-scale', 'zfbtw-spacing-lg')).toBe('2rem');
   });
 
   it('emits literal default for hsp-scale items', () => {

--- a/packages/zudo-design-token-panel/src/controls/text-row.tsx
+++ b/packages/zudo-design-token-panel/src/controls/text-row.tsx
@@ -48,7 +48,7 @@ function TextRow({ token, value, onChange }: TextRowProps) {
 
   return (
     <div className="tokenpanel-row">
-      <span className="tokenpanel-row-label tokenpanel-row-label--narrow" title={token.cssVar}>
+      <span className="tokenpanel-row-label" title={token.cssVar}>
         {token.cssVar}
       </span>
       <input

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -8,7 +8,7 @@ import FontTab from './tabs/font-tab';
 import SizeTab from './tabs/size-tab';
 import SpacingTab from './tabs/spacing-tab';
 import GenericTab from './tabs/generic-tab';
-import { getPanelConfig } from './config/panel-config';
+import { getPanelConfig, storageKey_visible } from './config/panel-config';
 import type { TabConfig } from './tokens/tier-model';
 import { usePersist } from './state/persist';
 import {
@@ -160,7 +160,12 @@ export default function DesignTokenTweakPanel() {
     saveDensity(next);
   }, []);
 
-  // Persist open state
+  // Persist open state, and keep the adapter-level :visible key in sync.
+  // The adapter (index.tsx) only writes :visible from its public API paths
+  // (show/hide/toggle), so an internal close (X button, ESC) would leave
+  // :visible='1' while -open is absent — causing the panel to reopen on the
+  // next page load via reapplyFromStorage → wasVisible(). Writing :visible
+  // here ensures every close path (public API or internal UI) stays in lockstep.
   useEffect(() => {
     try {
       const openKey = getOpenKey();
@@ -169,7 +174,32 @@ export default function DesignTokenTweakPanel() {
     } catch {
       /* ignore */
     }
+    try {
+      const visibleKey = storageKey_visible(getPanelConfig());
+      localStorage.setItem(visibleKey, open ? '1' : '0');
+    } catch {
+      /* ignore */
+    }
   }, [open]);
+
+  // ESC key closes the panel when no modal is open. When a modal is open the
+  // native <dialog> handles ESC first (fires cancel → onClose), and we must
+  // not also close the panel. Effect is installed only while open===true so
+  // the listener is automatically removed when the panel is closed.
+  useEffect(() => {
+    if (!open) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key !== 'Escape') return;
+      // If any modal is open, let the native <dialog> handle Escape.
+      if (showExport || showImport || showApply) return;
+      e.preventDefault();
+      setOpen(false);
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [open, showExport, showImport, showApply]);
 
   // Sync `open` from the authoritative `localStorage[OPEN_KEY]` whenever the
   // adapter (`index.tsx`) signals a change. The adapter writes OPEN_KEY itself

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -668,12 +668,6 @@
   white-space: nowrap;
 }
 
-/* Text-row narrows the label so the wide free-form input gets room. */
-.tokenpanel-row-label--narrow {
-  flex: 0 0 auto;
-  max-width: 12rem;
-}
-
 .tokenpanel-row-input-group {
   display: flex;
   align-items: center;

--- a/packages/zudo-design-token-panel/src/tabs/_generic-item-editor.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/_generic-item-editor.tsx
@@ -167,7 +167,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label tokenpanel-row-label--narrow" title={item.cssVar}>
+          <span className="tokenpanel-row-label" title={item.cssVar}>
             {item.cssVar}
             {item.label !== item.cssVar && (
               <span className="tokenpanel-row-label-sub">{item.label}</span>

--- a/packages/zudo-design-token-panel/src/tabs/generic-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/generic-tab.tsx
@@ -160,7 +160,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label tokenpanel-row-label--narrow" title={item.cssVar}>
+          <span className="tokenpanel-row-label" title={item.cssVar}>
             {item.cssVar}
             {item.label !== item.cssVar && (
               <span className="tokenpanel-row-label-sub">{item.label}</span>


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/158

---

## Summary

Bundles 5 sub-issues from epic #158 (originated from feedback issue #157):

- **Panel package**: ESC key closes the panel with modal-priority guard; X-click no longer leaves a stale `:visible='1'` that auto-reopens on the next page load; text-rows now use a balanced 1:1 column layout matching select-rows.
- **zfb-tailwind example**: removed the redundant `--zfbtw-spacing-*` tier (12 utility names migrated to `hsp` + `vsp` across ~15 files using the axis-mapping rule); added Strategy B ViewTransition SPA routing via `@takazudo/zfb-runtime` with panel lifecycle adapter wired to `zfb:before-swap` / `zfb:after-swap`; every `--zfbtw-scale-*` token (xs/sm/base/lg/xl/2xl) is now visibly exercised on the home page, with the heading sample moved to the prose page.

## Sub-issues

| Wave | Sub | Topic |
|---|---|---|
| 1 | #159 | Panel close behaviour — ESC handler + sync `:visible` on internal close |
| 1 | #160 | Text-row 1:1 column layout — drop `--narrow` modifier |
| 1 | #161 | Spacing tier removal — drop `--zfbtw-spacing-*`, keep only hsp + vsp |
| 2 | #162 | ViewTransition for zfb-tailwind + panel lifecycle adapter (depends on #161) |
| 2 | #163 | Demo improvements — every font-scale token + heading-block move (depends on #161) |

## Changes

**Panel package** (`packages/zudo-design-token-panel/`)
- `src/panel.tsx`: new ESC handler effect installed only while `open === true`; respects modal-priority (returns early if export/import/apply dialog is open). `useEffect([open])` now writes both `-open` and `:visible` keys in lockstep, fixing the stale-storage bug that re-opened the panel after X-close.
- `src/__tests__/panel-close-storage-sync.test.tsx`: new regression test asserting both storage keys directly (X-click, ESC, ESC-with-modal-open).
- `src/styles/panel.css`: removed `.tokenpanel-row-label--narrow`; three consumer files updated to drop the modifier.

**zfb-tailwind example** (`examples/zfb-tailwind/`)
- `config/default-manifest.ts`: spacing-scale tier removed (4 items dropped), now 2 tiers / 12 items total (hsp 5 + vsp 7).
- `styles/global.css`: removed `--zfbtw-spacing-*` `:root` decls + `--spacing-spacing-*` `@theme` re-exports; `.zfbtw-easing-card` rewritten to use `var(--zfbtw-hsp-md)`; added view-transition CSS (`view-transition-name` for persisted chrome, root cross-fade).
- 15 component/page files: migrated 139 `*-spacing-*` utility usages using the axis-mapping rule (horizontal → hsp, vertical → vsp, all-axis → split).
- New `components/client-router-bootstrap.tsx` — `"use client"` island with the load-bearing `import "@takazudo/zfb-runtime/client-router"` side-effect.
- `components/app-shell.tsx`: renders `<ClientRouter />`, mounts the bootstrap island with `when="load"`, adds `data-zfb-transition-persist` on sidenav + topbar.
- `components/panel-mount.tsx`: `mod.setLifecycleAdapter({ onBeforeSwap, onPageLoad })` wired to `zfb:before-swap` / `zfb:after-swap` with proper `removeEventListener` cleanup.
- `pages/index.tsx`: heading sample moved out; new font-scale showcase consumes all six `--zfbtw-scale-*` tokens via `text-scale-{2xl|xl|lg|base|sm|xs}`.
- `pages/prose.tsx`: receives the heading sample.

**Tests** (`packages/zudo-design-token-panel/src/__tests__/`)
- `manifest-cascade-verification.test.ts`: Invariants C (3→2 tiers, 16→12 items) and E (drop spacing-scale assertions) updated.
- `zfbtw-manifest-validation.test.ts`: test mirror reflects the new 2-tier (hsp + vsp) structure.

## Test plan

- [x] `pnpm -F @takazudo/zudo-design-token-panel test --run` — 490/490 tests pass (41 files)
- [x] `pnpm typecheck` — clean across workspace (panel + 5 examples + doc site)
- [x] `pnpm -F zfb-tailwind-example build` — 6 pages built successfully
- [x] CI on GitHub — Build doc site / Build, test, typecheck, lint — all green
- [x] `/gcoc-review` on the full diff — no concrete bugs; speculative architectural concerns dismissed after verification (all four MEDIUM claims grep-verified false; HIGH cleanup concern verified — `setLifecycleAdapter` returns proper `removeEventListener` callbacks)

## Implementation notes

Implemented via `/x-wt-teams` in subagents-execution-mode with 5 parallel sonnet child agents across 2 waves:

- Wave 1 (parallel): #159, #160, #161
- Wave 2 (parallel, after Wave 1 merge): #162, #163 — both depend on #161 because both touch files (`app-shell.tsx`, `pages/*.tsx`) that #161 mechanically rewrites; sequencing avoided 3-way merge conflicts.