### PR TITLE
fix(zfb-tailwind): wire prose font tokens to scale; add scale-md

### DIFF
--- a/examples/zfb-tailwind/config/default-manifest.ts
+++ b/examples/zfb-tailwind/config/default-manifest.ts
@@ -164,6 +164,13 @@ export const defaultTabs: readonly TabConfig[] = [
             type: { kind: 'length', min: 0.5, max: 2, step: 0.0625, unit: 'rem' },
           },
           {
+            id: 'zfbtw-scale-md',
+            cssVar: '--zfbtw-scale-md',
+            label: 'Scale MD',
+            default: '1.125rem',
+            type: { kind: 'length', min: 0.5, max: 2.5, step: 0.0625, unit: 'rem' },
+          },
+          {
             id: 'zfbtw-scale-lg',
             cssVar: '--zfbtw-scale-lg',
             label: 'Scale LG',

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -159,15 +159,25 @@ export default function HomePage() {
           </p>
         </section>
 
+        {/* Raw-scale reference block — intentional Tier-1-direct usage.
+            Per the three-tier font-size strategy, real components should use
+            semantic tokens (text-h2, text-body, etc.) backed by Tier 2 — see
+            the Prose page for that. This block is a per-scale demo so each
+            of the six raw scale tokens is visibly bound to a row, letting the
+            Font tab's scale sliders be debugged in isolation. */}
         <section>
           <h2 class="text-heading font-bold mb-vsp-md text-primary">
-            Font scale tokens
+            Font scale tokens (raw tier)
           </h2>
           <p class="mb-vsp-md">
-            The manifest declares six raw scale tokens. Each row below is
-            rendered at exactly that size via a Tailwind utility backed by{' '}
-            <code>var(--zfbtw-scale-*)</code>. Open the Font tab in the panel
-            and move any scale slider — all rows update live.
+            Raw <code>--zfbtw-scale-*</code> values exposed as
+            <code>text-scale-*</code> utilities for slider debugging only.
+            Open the Font tab and drag any scale slider — each row below
+            tracks one scale token directly. Production code should NOT use
+            <code>text-scale-*</code>; use semantic tokens
+            (<code>text-h2</code>, <code>text-body</code>, etc.) instead —
+            see the <a href={`${BASE_PATH}prose/`}>Prose page</a>, where the
+            same scale sliders flow through Tier 2 into rendered prose.
           </p>
           <div class="flex flex-col gap-vsp-sm bg-surface px-hsp-md py-vsp-md rounded-md border border-muted">
             <p class="text-scale-2xl leading-tight text-fg">
@@ -189,11 +199,6 @@ export default function HomePage() {
               xs — <code>text-scale-xs → --zfbtw-scale-xs</code>
             </p>
           </div>
-          <p class="text-small text-muted mt-vsp-sm">
-            Heading and body demos — including the semantic aliases{' '}
-            <code>text-h2</code>, <code>text-body</code>, etc. — are on the{' '}
-            <a href={`${BASE_PATH}prose/`}>Prose page</a>.
-          </p>
         </section>
       </div>
     </AppShell>

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -163,8 +163,8 @@ export default function HomePage() {
             Per the three-tier font-size strategy, real components should use
             semantic tokens (text-h2, text-body, etc.) backed by Tier 2 — see
             the Prose page for that. This block is a per-scale demo so each
-            of the six raw scale tokens is visibly bound to a row, letting the
-            Font tab's scale sliders be debugged in isolation. */}
+            of the seven raw scale tokens is visibly bound to a row, letting
+            the Font tab's scale sliders be debugged in isolation. */}
         <section>
           <h2 class="text-heading font-bold mb-vsp-md text-primary">
             Font scale tokens (raw tier)
@@ -188,6 +188,9 @@ export default function HomePage() {
             </p>
             <p class="text-scale-lg leading-snug text-fg">
               lg — <code class="text-scale-sm">text-scale-lg → --zfbtw-scale-lg</code>
+            </p>
+            <p class="text-scale-md leading-snug text-fg">
+              md — <code class="text-scale-sm">text-scale-md → --zfbtw-scale-md</code>
             </p>
             <p class="text-scale-base leading-relaxed text-fg">
               base — <code class="text-scale-sm">text-scale-base → --zfbtw-scale-base</code>

--- a/examples/zfb-tailwind/styles/global.css
+++ b/examples/zfb-tailwind/styles/global.css
@@ -32,12 +32,13 @@
 /* ── Token declarations ──────────────────────────────────────────────────── */
 :root {
   /* Font scale tokens (font tab — raw tier, in raw tier) */
-  --zfbtw-scale-xs: 0.75rem;
-  --zfbtw-scale-sm: 0.875rem;
+  --zfbtw-scale-xs:   0.75rem;
+  --zfbtw-scale-sm:   0.875rem;
   --zfbtw-scale-base: 1rem;
-  --zfbtw-scale-lg: 1.25rem;
-  --zfbtw-scale-xl: 1.75rem;
-  --zfbtw-scale-2xl: 2.5rem;
+  --zfbtw-scale-md:   1.125rem;   /* sub-heading step — keeps h4 visually above body */
+  --zfbtw-scale-lg:   1.25rem;
+  --zfbtw-scale-xl:   1.75rem;
+  --zfbtw-scale-2xl:  2.5rem;
 
   /* Semantic font role tokens (font tab — semantic tier, reference raw scale) */
   --zfbtw-text-base: var(--zfbtw-scale-base);
@@ -113,14 +114,15 @@
   --zfbtw-hsp-xl:  2rem;      /* outer prose container horizontal padding */
 
   /* Type scale — semantic tier; MUST reference --zfbtw-scale-* (Tier 1).
-     Hardcoded rem values here break the Font-tab scale sliders — they'd move
-     the raw scale tier but not the prose content that uses these semantic
-     tokens. See doc/three-tier-font-size-strategy. h3/h4 round to the nearest
-     scale step (that's the point of a constrained scale — add a scale step
-     rather than breaking this Tier 2 → Tier 1 link). */
+     Hardcoded rem values here would break the Font-tab scale sliders — they'd
+     move the raw tier but not the prose / section-heading content that uses
+     these semantic tokens. See doc/three-tier-font-size-strategy. h3/h4 round
+     to nearby scale steps; the dedicated --zfbtw-scale-md step exists so h4
+     (used as section-heading and table-th across the demos) stays one tier
+     above body. */
   --zfbtw-text-h2:    var(--zfbtw-scale-xl);    /* 1.75rem */
   --zfbtw-text-h3:    var(--zfbtw-scale-lg);    /* 1.25rem (was 1.35rem) */
-  --zfbtw-text-h4:    var(--zfbtw-scale-base);  /* 1rem    (was 1.1rem)  */
+  --zfbtw-text-h4:    var(--zfbtw-scale-md);    /* 1.125rem (was 1.1rem) */
   --zfbtw-text-body:  var(--zfbtw-scale-base);  /* 1rem */
   --zfbtw-text-small: var(--zfbtw-scale-sm);    /* 0.875rem */
   --zfbtw-text-micro: var(--zfbtw-scale-xs);    /* 0.75rem */
@@ -210,6 +212,7 @@
   --text-scale-xs:   var(--zfbtw-scale-xs);
   --text-scale-sm:   var(--zfbtw-scale-sm);
   --text-scale-base: var(--zfbtw-scale-base);
+  --text-scale-md:   var(--zfbtw-scale-md);
   --text-scale-lg:   var(--zfbtw-scale-lg);
   --text-scale-xl:   var(--zfbtw-scale-xl);
   --text-scale-2xl:  var(--zfbtw-scale-2xl);

--- a/examples/zfb-tailwind/styles/global.css
+++ b/examples/zfb-tailwind/styles/global.css
@@ -112,13 +112,18 @@
   --zfbtw-hsp-lg:  1.5rem;    /* section-level horizontal gutter */
   --zfbtw-hsp-xl:  2rem;      /* outer prose container horizontal padding */
 
-  /* Type scale */
-  --zfbtw-text-h2:    1.75rem;
-  --zfbtw-text-h3:    1.35rem;
-  --zfbtw-text-h4:    1.1rem;
-  --zfbtw-text-body:  1rem;
-  --zfbtw-text-small: 0.875rem;
-  --zfbtw-text-micro: 0.75rem;
+  /* Type scale — semantic tier; MUST reference --zfbtw-scale-* (Tier 1).
+     Hardcoded rem values here break the Font-tab scale sliders — they'd move
+     the raw scale tier but not the prose content that uses these semantic
+     tokens. See doc/three-tier-font-size-strategy. h3/h4 round to the nearest
+     scale step (that's the point of a constrained scale — add a scale step
+     rather than breaking this Tier 2 → Tier 1 link). */
+  --zfbtw-text-h2:    var(--zfbtw-scale-xl);    /* 1.75rem */
+  --zfbtw-text-h3:    var(--zfbtw-scale-lg);    /* 1.25rem (was 1.35rem) */
+  --zfbtw-text-h4:    var(--zfbtw-scale-base);  /* 1rem    (was 1.1rem)  */
+  --zfbtw-text-body:  var(--zfbtw-scale-base);  /* 1rem */
+  --zfbtw-text-small: var(--zfbtw-scale-sm);    /* 0.875rem */
+  --zfbtw-text-micro: var(--zfbtw-scale-xs);    /* 0.75rem */
 
   /* Line-height tokens */
   --zfbtw-leading-tight:   1.2;
@@ -196,8 +201,12 @@
   --spacing-hsp-xl:  var(--zfbtw-hsp-xl);
 
   /* Raw font-scale utilities: text-scale-xs … text-scale-2xl
-     Each maps directly to a --zfbtw-scale-* token so demo content can render
-     every raw scale value (acceptance criterion: all six must be visibly consumed). */
+     ANTI-PATTERN — these expose Tier 1 (raw scale) as Tailwind utilities so
+     the home page can render a per-scale demo row (issue #163 acceptance:
+     every scale token must be visibly consumed). Production code should use
+     semantic tokens (text-h2, text-body, text-small, …) which themselves now
+     reference these scales via Tier 2. Three-tier rule: components → Tier 2,
+     never Tier 1 directly. */
   --text-scale-xs:   var(--zfbtw-scale-xs);
   --text-scale-sm:   var(--zfbtw-scale-sm);
   --text-scale-base: var(--zfbtw-scale-base);


### PR DESCRIPTION
## Summary

- Prose-page typography tokens (`--zfbtw-text-h2/h3/h4/body/small/micro`) were hardcoded rem values, so Font-tab scale sliders did almost nothing visible on the prose page. This PR rewires them through `var(--zfbtw-scale-*)` per the three-tier font-size strategy.
- Adds a new `--zfbtw-scale-md: 1.125rem` step (sub-heading) between `base` and `lg` so `text-h4` — used as section heading in `forms.tsx`, table `th` in `data-table.tsx`, and profile name in `profile-card.tsx` — stays visually above body without breaking Tier 2 → Tier 1.
- Relabels the home-page "Font scale tokens" block as an intentional **debug-only** raw-scale reference, and points readers at the Prose page for the real semantic flow. The block keeps every scale token visibly bound to a row (preserves the #163 acceptance: every scale token must be visibly consumed).

## Changes

`examples/zfb-tailwind/styles/global.css`

- Rewire six prose Tier 2 tokens to `var(--zfbtw-scale-*)`:
  - `--zfbtw-text-h2` → `--zfbtw-scale-xl` (1.75rem, exact)
  - `--zfbtw-text-h3` → `--zfbtw-scale-lg` (1.25rem, was 1.35rem)
  - `--zfbtw-text-h4` → `--zfbtw-scale-md` (1.125rem, was 1.1rem)
  - `--zfbtw-text-body` → `--zfbtw-scale-base` (1rem, exact)
  - `--zfbtw-text-small` → `--zfbtw-scale-sm` (0.875rem, exact)
  - `--zfbtw-text-micro` → `--zfbtw-scale-xs` (0.75rem, exact)
- Add new `--zfbtw-scale-md: 1.125rem`.
- Register `--text-scale-md: var(--zfbtw-scale-md)` in `@theme`.
- Annotate the `--text-scale-*` block as Tier-1-direct anti-pattern (debug-only).

`examples/zfb-tailwind/config/default-manifest.ts`

- Insert `zfbtw-scale-md` slider between `scale-base` and `scale-lg` (Font tab now exposes 7 raw-scale sliders).

`examples/zfb-tailwind/pages/index.tsx`

- Add a `md` row to the raw-scale debug block.
- Relabel section comment + prose to mark `text-scale-*` as debug-only and point readers at `/prose/`.

## Test Plan

- `pnpm -F @takazudo/zudo-design-token-panel test --run` → 490 tests pass
- `pnpm typecheck` → clean
- `pnpm -F zfb-tailwind-example build` → 6 pages built
- Open the dev preview / deployed `/prose/`, drag each scale slider in the Font tab — every slider visibly moves real prose content:
  - `scale-xs` → micro text
  - `scale-sm` → small + table cells + inline code
  - `scale-base` → body paragraphs + list items
  - `scale-md` → h4 (section headings, table th, profile name)
  - `scale-lg` → h3
  - `scale-xl` → h2 + page h1 (`text-heading`)
  - `scale-2xl` → unused in prose; exercised by the home-page raw-scale block.