### PR TITLE
fix(panel): isolate panel chrome from host --color-* theme (use baked-in dark palette)

### DIFF
--- a/doc/src/content/docs/reference/panel-css-tokens.mdx
+++ b/doc/src/content/docs/reference/panel-css-tokens.mdx
@@ -1,10 +1,10 @@
 ---
 title: Panel CSS tokens
 sidebar_position: 6
-description: "--tokentweak-* private variables, the var(--host, fallback) indirection ladder, the modal data-attribute selector, and the paired stylesheet/host-adapter import obligations."
+description: "--tokentweak-* private variables, the self-contained dark palette baked into panel-tokens.css, the modal data-attribute selector, and the paired stylesheet/host-adapter import obligations."
 ---
 
-The panel ships its own bundled CSS — no Tailwind dependency in the consumer. This page pins the panel-private `--tokentweak-*` namespace, the `var(--host, fallback)` indirection ladder that lets a host retheme without touching panel internals, and the bundled stylesheet's modal-selector contract.
+The panel ships its own bundled CSS — no Tailwind dependency in the consumer, and no reads against the host's `--color-*` theme. This page pins the panel-private `--tokentweak-*` namespace, the self-contained dark palette the panel paints with, the bundled stylesheet's modal-selector contract, and the panel-private override surface for hosts that want a different chrome theme.
 
 ## Panel-private namespace
 
@@ -24,7 +24,7 @@ The bundled stylesheets declare every panel-chrome variable under a panel-privat
 
 - `--tokentweak-*` is the only allowed prefix for panel-private vars. No consumer-namespaced identifiers may appear in the panel chrome.
 - The chrome stylesheet (`panel.css`) MUST read only `--tokentweak-*` — it MUST NOT read host vars like `--color-*` or `--font-mono` directly.
-- The token sheet (`panel-tokens.css`) is the single indirection point where host vars are consumed (see [the indirection ladder below](#host-css-var-indirection-ladder)).
+- The token sheet (`panel-tokens.css`) declares the `--tokentweak-*` values as concrete colors (no `var(--color-*)` reads) so host theme changes cannot bleed into the panel chrome. See [the self-contained palette below](#self-contained-panel-chrome-palette).
 
 ### Files
 
@@ -53,68 +53,76 @@ This means a host that customises `modalClassPrefix` still inherits the bundled 
 
 The class prefix remains useful as a higher-specificity hook for hosts that want to layer custom rules on top of the bundled chrome.
 
-## Host CSS-var indirection ladder
+## Self-contained panel chrome palette
 
-The panel-chrome color tokens are declared in `panel-tokens.css` as a `var(--host, fallback)` ladder so a host that does not define `--color-*` / `--font-mono` still gets a sane paint:
+The panel-chrome color tokens are declared in `panel-tokens.css` as concrete dark-palette values. The panel reads NOTHING from the host's `--color-*` / `--font-mono` theme — host theme changes (including theme tweaks driven through this very panel in a demo) cannot bleed into the panel chrome:
 
 ```css
 :where(.tokenpanel-shell, [data-design-token-panel-modal]) {
-  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
-  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
-  --tokentweak-color-muted: var(--color-muted, oklch(70% 0.01 60));
-  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
-  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
-  --tokentweak-color-accent-hover: var(--color-accent-hover, oklch(55% 0.18 45));
-  --tokentweak-color-code-bg: var(--color-code-bg, oklch(17% 0.005 50));
-  --tokentweak-color-code-fg: var(--color-code-fg, oklch(87% 0.01 60));
-  --tokentweak-color-success: var(--color-success, oklch(65% 0.19 145));
-  --tokentweak-color-danger: var(--color-danger, oklch(60% 0.2 10));
-  --tokentweak-color-warning: var(--color-warning, oklch(75% 0.17 75));
-  --tokentweak-font-mono: var(--font-mono, Menlo, Monaco, Consolas, …);
+  --tokentweak-color-fg: #b8b8b8;
+  --tokentweak-color-bg: #181818;
+  --tokentweak-color-muted: #888888;
+  --tokentweak-color-surface: #1c1c1c;
+  --tokentweak-color-accent: #d69a66;
+  --tokentweak-color-accent-hover: #a7c0e3;
+  --tokentweak-color-code-bg: #383838;
+  --tokentweak-color-code-fg: #e0e0e0;
+  --tokentweak-color-success: #93bb77;
+  --tokentweak-color-danger: #da6871;
+  --tokentweak-color-warning: #dfbb77;
+  --tokentweak-font-mono: Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }
 ```
 
+The palette mirrors a terminal-style "Default Dark" scheme — low-saturation neutrals with a warm accent and a cool accent-hover — so the panel reads as a separate dark surface on top of any host backdrop.
+
 ### Public surface
 
-These are the panel-private variables a host MAY override on the same scope to retheme the panel chrome without touching their own `--color-*` theme:
+These are the panel-private variables a host MAY override on the same scope to retheme the panel chrome:
 
-| Variable | Default fallback | Role |
+| Variable | Default | Role |
 | --- | --- | --- |
-| `--tokentweak-color-fg` | neutral light grey | Foreground text. |
-| `--tokentweak-color-bg` | dark surface | Panel background. |
-| `--tokentweak-color-muted` | mid grey | Muted text and dividers. |
-| `--tokentweak-color-surface` | dark surface variant | Raised surfaces (cards, modals). |
-| `--tokentweak-color-accent` | warm accent | Primary actions and highlights. |
-| `--tokentweak-color-accent-hover` | darker accent | Hover state for accent surfaces. |
-| `--tokentweak-color-code-bg` | very dark surface | Inline / block code background. |
-| `--tokentweak-color-code-fg` | light text | Inline / block code foreground. |
-| `--tokentweak-color-success` | green | Success state colour. |
-| `--tokentweak-color-danger` | red | Danger / error state colour. |
-| `--tokentweak-color-warning` | amber | Warning state colour. |
+| `--tokentweak-color-fg` | `#b8b8b8` | Foreground text. |
+| `--tokentweak-color-bg` | `#181818` | Panel background. |
+| `--tokentweak-color-muted` | `#888888` | Muted text and dividers. |
+| `--tokentweak-color-surface` | `#1c1c1c` | Raised surfaces (cards, modals). |
+| `--tokentweak-color-accent` | `#d69a66` | Primary actions and highlights. |
+| `--tokentweak-color-accent-hover` | `#a7c0e3` | Hover state for accent surfaces. |
+| `--tokentweak-color-code-bg` | `#383838` | Inline / block code background. |
+| `--tokentweak-color-code-fg` | `#e0e0e0` | Inline / block code foreground. |
+| `--tokentweak-color-success` | `#93bb77` | Success state colour. |
+| `--tokentweak-color-danger` | `#da6871` | Danger / error state colour. |
+| `--tokentweak-color-warning` | `#dfbb77` | Warning state colour. |
 | `--tokentweak-font-mono` | system monospace stack | Monospace font for code / values. |
 
-### Override layers
+### Override surface for hosts
 
-A host can override at either level:
+A host that wants a different chrome theme assigns directly to the `--tokentweak-*` names on `.tokenpanel-shell`, `[data-design-token-panel-modal]`, or any ancestor (the panel scope uses `:where()` so specificity is 0):
 
-- **At the `--color-*` level** — cascades into the panel via the fallback ladder. Useful when the host wants its own design system to drive the panel's chrome alongside its app surfaces.
-- **At the `--tokentweak-color-*` level** — panel-only override, bypasses the host theme. Useful when the host wants the panel to look distinct from app surfaces (e.g. a dark panel inside a light app).
-
-### Fallback values
-
-The fallback values are picked to be a sensible neutral dark theme so the panel paints readably without any host theme declared. A host can therefore drop the panel into a brand-new project and see a usable panel before shipping a single `--color-*` token.
-
-### Invariant — panel.css MUST NOT read host vars directly
-
-`panel.css` MUST NOT read `--color-*` or `--font-mono` directly. The only legal site for those reads is the indirection ladder in `panel-tokens.css`. The package's CI pins this with a grep check:
-
-```bash
-grep -n 'var(--color-' src/styles/panel.css   # → 0
-grep -n 'var(--font-mono' src/styles/panel.css # → 0
+```css
+:root {
+  --tokentweak-color-bg: #102030;
+  --tokentweak-color-fg: #eef;
+  --tokentweak-color-accent: #ffb74d;
+}
 ```
 
-<Info title="Why the indirection?">
-Reading host vars directly inside `panel.css` would leak the host's design-system identifiers into the panel chrome. Every chrome rule would silently break for hosts whose theme uses a different name. Routing every host read through the `panel-tokens.css` ladder gives one stable seam to evolve without touching the chrome rules.
+This is the entire host-override contract for panel chrome. `--color-*` and `--font-mono` are NOT part of the override surface — assigning to them on the host page has no effect on the panel.
+
+### Invariant — the panel package MUST NOT read host theme vars
+
+Neither `panel.css` nor `panel-tokens.css` may reference `--color-*` or `--font-mono`. The package's CI pins this with grep checks:
+
+```bash
+grep -n 'var(--color-' src/styles/panel.css        # → 0
+grep -n 'var(--font-mono' src/styles/panel.css     # → 0
+grep -n 'var(--color-' src/styles/panel-tokens.css # → 0
+grep -n 'var(--font-mono' src/styles/panel-tokens.css # → 0
+```
+
+<Info title="Why no host theme reads?">
+The panel is a developer tool that ships inside a host page. If the panel inherited the host's `--color-*` tokens, any host theme change — including theme tweaks driven by the panel itself in a demo — would recolor the panel chrome along with the host. The dev tool would visually merge with the surface it is debugging, which is the opposite of what a dev tool should do. Keeping the palette self-contained makes the panel a stable visual anchor regardless of host theme state.
 </Info>
 
 ## Host-adapter side-effect import (paired-unit obligation)

--- a/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
+++ b/packages/zudo-design-token-panel/PORTABLE-CONTRACT.md
@@ -631,7 +631,7 @@ The panel ships its own bundled CSS. All panel-chrome variables use the
 :where(.tokenpanel-shell, [data-design-token-panel-modal]) {
   --tokentweak-pad-md: …;
   --tokentweak-gap-sm: …;
-  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
+  --tokentweak-color-fg: #b8b8b8;
   /* …every panel-chrome value lives here */
 }
 ```
@@ -663,36 +663,51 @@ prefix.** Every modal `<dialog>` element emits
 `data-design-token-panel-modal=""`. `panel.css` anchors all modal chrome
 rules on `[data-design-token-panel-modal]`.
 
-### 7.4 Host-CSS-var indirection ladder for chrome colors
+### 7.4 Self-contained panel chrome palette (no host theme reads)
 
-The panel-chrome color tokens are declared in `panel-tokens.css` as a
-`var(--host, fallback)` ladder so a host that does not define `--color-*`
-tokens still gets a sane paint:
+The panel-chrome color tokens are declared in `panel-tokens.css` as
+concrete dark-palette values so the panel paints as a neutral dark surface
+regardless of what the host's `--color-*` tokens resolve to:
 
 ```css
 :where(.tokenpanel-shell, [data-design-token-panel-modal]) {
-  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
-  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
-  --tokentweak-color-muted: var(--color-muted, oklch(70% 0.01 60));
-  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
-  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
-  --tokentweak-color-accent-hover: var(--color-accent-hover, oklch(55% 0.18 45));
-  --tokentweak-color-code-bg: var(--color-code-bg, oklch(17% 0.005 50));
-  --tokentweak-color-code-fg: var(--color-code-fg, oklch(87% 0.01 60));
-  --tokentweak-color-success: var(--color-success, oklch(65% 0.19 145));
-  --tokentweak-color-danger: var(--color-danger, oklch(60% 0.2 10));
-  --tokentweak-color-warning: var(--color-warning, oklch(75% 0.17 75));
-  --tokentweak-font-mono: var(--font-mono, Menlo, Monaco, Consolas, …);
+  --tokentweak-color-fg: #b8b8b8;
+  --tokentweak-color-bg: #181818;
+  --tokentweak-color-muted: #888888;
+  --tokentweak-color-surface: #1c1c1c;
+  --tokentweak-color-accent: #d69a66;
+  --tokentweak-color-accent-hover: #a7c0e3;
+  --tokentweak-color-code-bg: #383838;
+  --tokentweak-color-code-fg: #e0e0e0;
+  --tokentweak-color-success: #93bb77;
+  --tokentweak-color-danger: #da6871;
+  --tokentweak-color-warning: #dfbb77;
+  --tokentweak-font-mono: Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 }
 ```
 
-**Invariant:** `panel.css` MUST NOT read `--color-*` or `--font-mono`
-directly. The only legal site for those reads is the indirection ladder in
-`panel-tokens.css`. Acceptance check:
+The panel deliberately does NOT read host `--color-*` / `--font-mono`
+tokens. The panel is a developer tool that ships inside a host page; a
+host theme change — including theme tweaks driven through this very panel
+in a demo — MUST NOT bleed into the panel chrome.
+
+**Override surface for hosts:** a host that wants to retheme the panel
+chrome assigns directly to the `--tokentweak-color-*` /
+`--tokentweak-font-mono` names on `.tokenpanel-shell`,
+`[data-design-token-panel-modal]`, or any ancestor (`:where()` keeps
+specificity at 0). This single name layer is the entire host-override
+contract for panel chrome — `--color-*` reads are not part of it.
+
+**Invariant:** the panel package MUST NOT read `--color-*` or
+`--font-mono` anywhere. Both `panel.css` and `panel-tokens.css` are pinned
+by acceptance grep:
 
 ```bash
-grep -n 'var(--color-' src/styles/panel.css   # → 0
-grep -n 'var(--font-mono' src/styles/panel.css # → 0
+grep -n 'var(--color-' src/styles/panel.css        # → 0
+grep -n 'var(--font-mono' src/styles/panel.css     # → 0
+grep -n 'var(--color-' src/styles/panel-tokens.css # → 0
+grep -n 'var(--font-mono' src/styles/panel-tokens.css # → 0
 ```
 
 ### 7.5 Host-adapter side-effect import (paired-unit obligation)
@@ -847,7 +862,7 @@ Cross-reference table — what each section pins down.
 | Astro `<DesignTokenPanelHost>` prop, lazy-load gate, console API                           | §6            |
 | `--tokentweak-*` namespace and Tailwind-free CSS contract                                   | §7.1          |
 | Modal class prefix and `data-design-token-panel-modal` selector contract                    | §7.3          |
-| Host-CSS-var indirection ladder for chrome colors                                           | §7.4          |
+| Self-contained panel chrome palette (no host theme reads)                                  | §7.4          |
 | Host-adapter side-effect import (paired-unit obligation)                                    | §7.5          |
 | v1/v2 → v3 storage migration and typography-id rename map                                   | §8.3, §8.4    |
 | JSON export/import schema v2 (serde v2)                                                     | §9            |

--- a/packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts
@@ -18,6 +18,9 @@
  *   B. No manifest contains an `advancedTiers:` object-key (TabConfig.advancedTiers was removed in #148).
  *   C. The zfb-tailwind Spacing tab declares exactly 2 tiers: hsp-scale, vsp-scale (#161 removed spacing-scale).
  *   D. The panel source (tabs/) contains no <h4 or <details elements.
+ *   F. The panel CSS sources do NOT read host --color-* / --font-mono — the panel
+ *      ships a self-contained dark palette in panel-tokens.css and host theme
+ *      changes must not bleed into the panel chrome.
  *
  * Cascade test note:
  *   The zfb-tailwind global.css re-exports --zfbtw-hsp-*, --zfbtw-vsp-* as Tailwind theme
@@ -209,5 +212,51 @@ describe('Invariant E — zfb-tailwind global.css cascade is intact', () => {
   it('re-exports --spacing-vsp-md: var(--zfbtw-vsp-md)', () => {
     expect(globalCss).toContain('--spacing-vsp-md');
     expect(globalCss).toContain('var(--zfbtw-vsp-md)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F. Panel CSS sources do NOT read host --color-* / --font-mono
+//
+//    Rationale: the panel is a dev tool that ships inside a host page. If the
+//    panel inherited the host's --color-* tokens, any host theme tweak —
+//    including theme tweaks driven through this very panel in a demo — would
+//    recolor the panel chrome along with the host surface. The contract
+//    documented in PORTABLE-CONTRACT.md §7.4 and doc/reference/panel-css-tokens
+//    pins this: panel-tokens.css and panel.css must use only the
+//    --tokentweak-* private namespace.
+// ---------------------------------------------------------------------------
+
+describe('Invariant F — panel CSS does not read host theme vars', () => {
+  const STYLES_DIR = path.resolve(__dirname, '../styles');
+  const panelTokens = fs.readFileSync(path.join(STYLES_DIR, 'panel-tokens.css'), 'utf8');
+  const panelChrome = fs.readFileSync(path.join(STYLES_DIR, 'panel.css'), 'utf8');
+
+  function stripCssComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, '');
+  }
+
+  it('panel-tokens.css contains no var(--color-*) read', () => {
+    expect(stripCssComments(panelTokens)).not.toMatch(/var\(\s*--color-/);
+  });
+
+  it('panel-tokens.css contains no var(--font-mono) read', () => {
+    expect(stripCssComments(panelTokens)).not.toMatch(/var\(\s*--font-mono/);
+  });
+
+  it('panel.css contains no var(--color-*) read', () => {
+    expect(stripCssComments(panelChrome)).not.toMatch(/var\(\s*--color-/);
+  });
+
+  it('panel.css contains no var(--font-mono) read', () => {
+    expect(stripCssComments(panelChrome)).not.toMatch(/var\(\s*--font-mono/);
+  });
+
+  it('panel-tokens.css declares the baked-in dark --tokentweak-color-bg', () => {
+    expect(panelTokens).toMatch(/--tokentweak-color-bg\s*:\s*#181818/);
+  });
+
+  it('panel-tokens.css declares the baked-in dark --tokentweak-color-fg', () => {
+    expect(panelTokens).toMatch(/--tokentweak-color-fg\s*:\s*#b8b8b8/);
   });
 });

--- a/packages/zudo-design-token-panel/src/styles/panel-tokens.css
+++ b/packages/zudo-design-token-panel/src/styles/panel-tokens.css
@@ -1,10 +1,14 @@
 /**
  * Panel-private CSS custom properties.
  *
- * The design-token panel package owns its own visual tokens instead of
- * leaking them through the host's theme. Fallback colors use a low-saturation
- * neutral dark palette so the panel reads as neutral near-black without any
- * host theme tokens.
+ * The design-token panel package owns its own visual tokens so the panel
+ * chrome reads as a separate concern from the host site. The fallback values
+ * below form a self-contained dark palette sourced from a terminal-style
+ * "Default Dark" scheme (low-saturation neutrals with warm accent / cool
+ * accent-hover). The panel paints with this palette regardless of what the
+ * host's `--color-*` tokens currently resolve to — most notably, recoloring
+ * the host page (e.g. via this very panel's demo) MUST NOT recolor the
+ * panel itself.
  *
  * Scope
  * -----
@@ -24,50 +28,39 @@
  *
  * `:where()` keeps specificity at zero so a host can override any of these
  * tokens with a single-class rule.
+ *
+ * Host override surface
+ * ---------------------
+ * A host that wants to retheme the panel chrome assigns directly to the
+ * `--tokentweak-color-*` / `--tokentweak-font-mono` names on either
+ * `.tokenpanel-shell` or `[data-design-token-panel-modal]` (or any
+ * ancestor — `:where()` keeps specificity at 0). The panel deliberately
+ * does NOT read `--color-*` / `--font-mono` from the host so that
+ * host-side theme changes — including theme tweaks the panel itself
+ * drives in a demo — cannot bleed into the panel chrome.
  */
 :where(.tokenpanel-shell, [data-design-token-panel-modal]) {
   /* ----------------------------------------------------------------------
-   * Host-CSS-var indirection ladder
+   * Color palette (self-contained, dark)
    *
-   * The panel chrome could read host-defined `--color-*` and `--font-mono`
-   * directly, but a host that does not declare those names would paint the
-   * panel with no chrome styling. Wrap each one in a `--tokentweak-*`
-   * indirection that falls back to a sane default so the panel paints
-   * out-of-the-box.
-   *
-   * Ladder semantics:
-   *
-   *   --tokentweak-color-fg: var(--color-fg, <fallback>);
-   *
-   * - Host declares `--color-fg`        → that wins.
-   * - Host declares `--tokentweak-color-fg` directly → that wins (panel-only
-   *   override; bypasses the host's own theme).
-   * - Host declares neither             → the fallback paints the panel.
-   *
-   * Fallback values use a low-saturation neutral dark palette (~#181818
-   * body / ~#1c1c1c surface family) so the panel reads as neutral near-black
-   * without host theme tokens. Accent and status colors are unchanged.
+   * Values mirror a terminal-style "Default Dark" palette so the panel
+   * reads as a neutral dark surface against any host backdrop. Hosts can
+   * override any of these by assigning to the same `--tokentweak-color-*`
+   * name on this scope.
    * ---------------------------------------------------------------------- */
-  --tokentweak-color-fg: var(--color-fg, oklch(80% 0 0));
-  --tokentweak-color-bg: var(--color-bg, oklch(20.5% 0 0));
-  --tokentweak-color-muted: var(--color-muted, oklch(63% 0 0));
-  --tokentweak-color-surface: var(--color-surface, oklch(22.5% 0 0));
-  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
-  --tokentweak-color-accent-hover: var(--color-accent-hover, oklch(55% 0.18 45));
-  --tokentweak-color-code-bg: var(--color-code-bg, oklch(19% 0 0));
-  --tokentweak-color-code-fg: var(--color-code-fg, oklch(80% 0 0));
-  --tokentweak-color-success: var(--color-success, oklch(65% 0.19 145));
-  --tokentweak-color-danger: var(--color-danger, oklch(60% 0.2 10));
-  --tokentweak-color-warning: var(--color-warning, oklch(75% 0.17 75));
-  --tokentweak-font-mono: var(
-    --font-mono,
-    Menlo,
-    Monaco,
-    Consolas,
-    'Liberation Mono',
-    'Courier New',
-    monospace
-  );
+  --tokentweak-color-fg: #b8b8b8;
+  --tokentweak-color-bg: #181818;
+  --tokentweak-color-muted: #888888;
+  --tokentweak-color-surface: #1c1c1c;
+  --tokentweak-color-accent: #d69a66;
+  --tokentweak-color-accent-hover: #a7c0e3;
+  --tokentweak-color-code-bg: #383838;
+  --tokentweak-color-code-fg: #e0e0e0;
+  --tokentweak-color-success: #93bb77;
+  --tokentweak-color-danger: #da6871;
+  --tokentweak-color-warning: #dfbb77;
+  --tokentweak-font-mono: Menlo, Monaco, Consolas, 'Liberation Mono',
+    'Courier New', monospace;
 
   --tokentweak-pad-2xs: 0.125rem;
   --tokentweak-pad-xs: 0.375rem;

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -15,11 +15,12 @@
  * Token strategy
  * --------------
  * Visual tokens are declared in `panel-tokens.css` (sibling file) under
- * `.tokenpanel-shell`. The host's `--color-*` semantic tokens (bg / fg /
- * accent / muted / surface / etc.) are still referenced via `var()`; the
- * portable-panel contract is what makes those names host-supplied.
- * This file deliberately does NOT redeclare semantic colors — that's a
- * different layer of the stack.
+ * `.tokenpanel-shell`. The panel ships its own self-contained dark
+ * palette there — it deliberately does NOT read the host's `--color-*`
+ * tokens so host theme changes (including ones driven through this very
+ * panel in a demo) cannot bleed into the panel chrome. A host that
+ * wants to retheme the panel assigns directly to the `--tokentweak-*`
+ * names; see panel-tokens.css for the full override surface.
  *
  * BEM-ish naming
  * --------------


### PR DESCRIPTION
## Summary
- The panel chrome used to read host `--color-*` tokens through a `var(--host, fallback)` indirection ladder in `panel-tokens.css`, so any host theme change — including a recolor driven by this very panel in a demo — recolored the panel along with the host. The dev tool visually merged with the surface it was supposed to debug.
- Replace the ladder with a self-contained dark palette baked directly into `panel-tokens.css`. The panel now reads no `--color-*` / `--font-mono` from the host at all.
- The `--tokentweak-color-*` / `--tokentweak-font-mono` private namespace remains the host-override surface; only the implicit host-theme read is removed.
- Add `Invariant F` to `manifest-cascade-verification.test.ts` so a future "restore the indirection" edit fails CI immediately. Update `PORTABLE-CONTRACT.md` §7.4 and `doc/.../panel-css-tokens.mdx` to describe the new contract.

## Changes
### Core fix
- `packages/zudo-design-token-panel/src/styles/panel-tokens.css`
  - Replace every `--tokentweak-color-*: var(--color-*, oklch(...))` declaration with concrete hex values from a terminal-style "Default Dark" palette (`#181818` bg, `#1c1c1c` surface, `#b8b8b8` fg, `#888888` muted, `#d69a66` accent, `#a7c0e3` accent-hover, `#383838`/`#e0e0e0` code, plus status colors `#93bb77` / `#da6871` / `#dfbb77`).
  - Replace `--tokentweak-font-mono: var(--font-mono, ...)` with the literal monospace stack.
  - Rewrite the file's docblock to explain the no-host-read contract and point at `--tokentweak-*` as the sole override surface.
- `packages/zudo-design-token-panel/src/styles/panel.css`
  - Update the top-of-file "Token strategy" comment to describe the new self-contained behavior (no behavioral change; this file already only read `--tokentweak-*`).

### Contract docs
- `packages/zudo-design-token-panel/PORTABLE-CONTRACT.md`
  - Rewrite §7.4 — retitled "Self-contained panel chrome palette (no host theme reads)". Replaces the ladder description with the baked-in palette, makes `--tokentweak-*` the entire host-override surface, and tightens the no-host-read invariant to cover both `panel.css` AND `panel-tokens.css`.
  - Update the "Source of truth" table entry to match the new section title.
- `doc/src/content/docs/reference/panel-css-tokens.mdx`
  - Mirror the contract update. Replace the "Host CSS-var indirection ladder" section with "Self-contained panel chrome palette". Update the variable table to show the actual hex defaults, replace the dual-layer override section with the single panel-private override path, and rephrase the "Why no host theme reads?" rationale.

### Regression guard
- `packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts`
  - Add **Invariant F** (six assertions):
    - `panel-tokens.css` and `panel.css` each grep-clean of `var(--color-*)` and `var(--font-mono)` (4 assertions).
    - `panel-tokens.css` declares the baked-in `--tokentweak-color-bg: #181818` and `--tokentweak-color-fg: #b8b8b8` (2 assertions).
  - Updated the file's docblock invariants list to mention Invariant F.

## Test Plan
- [x] `pnpm -F @takazudo/zudo-design-token-panel test --run` — all 496 tests pass (was 490; 6 new in Invariant F).
- [x] `pnpm typecheck` — 0 errors across all 7 workspaces.
- [x] `pnpm -F @takazudo/zudo-design-token-panel build` — clean rebuild; emitted CSS shows 0 `var(--color-*)` / `var(--font-mono)` references.
- [x] Headless-browser computed-style check: load a static page with a hostile red host theme (`--color-bg`, `--color-fg`, `--color-surface` all set to vivid host colors), then read `getComputedStyle(.tokenpanel-shell)` — confirms `backgroundColor: rgb(28,28,28)` and `.tokenpanel-title` color `rgb(184,184,184)` regardless of host theme. Visual confirmation: panel paints as a neutral dark surface on top of the red host page.
- [ ] After merge: open the example apps' deployed previews and confirm the panel reads as a neutral dark surface rather than inheriting the host theme.