### PR TITLE
chore(colors): replace oklch values with hex throughout repo

### DIFF
--- a/doc/src/components/page-loading-overlay.astro
+++ b/doc/src/components/page-loading-overlay.astro
@@ -14,7 +14,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: color-mix(in oklch, var(--color-overlay) 60%, transparent);
+    background: color-mix(in srgb, var(--color-overlay) 60%, transparent);
     opacity: 0;
     pointer-events: none;
     transition: opacity 150ms ease-out;

--- a/doc/src/content/docs/reference/color-cluster.mdx
+++ b/doc/src/content/docs/reference/color-cluster.mdx
@@ -130,7 +130,7 @@ A `ColorScheme` is a fully-resolved snapshot: the palette hex values plus role a
 ### `ColorRef`
 
 - A **number** references an index into `palette` (e.g. `2` → `palette[2]`).
-- A **string** is a literal color value (hex, oklch, etc.). The shorthand `"bg"` resolves to the scheme's background; `"fg"` resolves to the foreground.
+- A **string** is a literal color value (hex like `#33ff33`, `rgb(...)`, etc.). The shorthand `"bg"` resolves to the scheme's background; `"fg"` resolves to the foreground.
 
 ### Palette length invariant
 

--- a/examples/zfb-tailwind/components/widgets/modal.tsx
+++ b/examples/zfb-tailwind/components/widgets/modal.tsx
@@ -18,7 +18,7 @@
  *   max-w-[40rem] → arbitrary; reason: modal width is page-local
  *
  * Backdrop:
- *   color-mix(in oklch, var(--zfbtw-bg) 80%, transparent)
+ *   color-mix(in srgb, var(--zfbtw-bg) 80%, transparent)
  *   reason: no overlay token in this wave (spec §133.3 exception G4 row 6)
  *
  * Open/close animation:
@@ -103,7 +103,7 @@ function ModalInner() {
           }
         }
         .widgets-modal::backdrop {
-          background: color-mix(in oklch, var(--zfbtw-bg) 80%, transparent);
+          background: color-mix(in srgb, var(--zfbtw-bg) 80%, transparent);
           transition:
             background 0.2s var(--zfbtw-easing-modal),
             display 0.2s allow-discrete,
@@ -145,7 +145,7 @@ function ModalInner() {
             Open/close animation uses{' '}
             <code>easing-modal</code> →{' '}
             <code>--zfbtw-easing-modal</code>. Backdrop uses{' '}
-            <code>color-mix(in oklch, var(--zfbtw-bg) 80%, transparent)</code>{' '}
+            <code>color-mix(in srgb, var(--zfbtw-bg) 80%, transparent)</code>{' '}
             (reason: no overlay token in this wave).
           </p>
           <div>

--- a/examples/zfb/components/widgets/modal.tsx
+++ b/examples/zfb/components/widgets/modal.tsx
@@ -103,7 +103,7 @@ function ModalInner() {
             Open/close animation uses{' '}
             <code>easing-modal</code> →{' '}
             <code>--zfb-easing-modal</code>. Backdrop uses{' '}
-            <code>color-mix(in oklch, var(--zfb-bg) 80%, transparent)</code>{' '}
+            <code>color-mix(in srgb, var(--zfb-bg) 80%, transparent)</code>{' '}
             (reason: no overlay token in this wave).
           </p>
           <div>

--- a/examples/zfb/styles/global.css
+++ b/examples/zfb/styles/global.css
@@ -949,7 +949,7 @@ body {
 
 .zfb-modal::backdrop {
   /* reason: derived overlay; no dedicated overlay token in this wave (spec G4 row 6) */
-  background: color-mix(in oklch, var(--zfb-bg) 80%, transparent);
+  background: color-mix(in srgb, var(--zfb-bg) 80%, transparent);
   transition:
     background 0.2s var(--zfb-easing-modal),
     display 0.2s allow-discrete,

--- a/packages/zudo-design-token-panel/README.md
+++ b/packages/zudo-design-token-panel/README.md
@@ -865,10 +865,10 @@ The panel ships its own bundled CSS scoped under a panel-private namespace:
 
 ```css
 :where(.tokenpanel-shell, [data-design-token-panel-modal]) {
-  --tokentweak-color-fg: var(--color-fg, oklch(87% 0.01 60));
-  --tokentweak-color-bg: var(--color-bg, oklch(18% 0.01 50));
-  --tokentweak-color-surface: var(--color-surface, oklch(22% 0.01 50));
-  --tokentweak-color-accent: var(--color-accent, oklch(65% 0.2 45));
+  --tokentweak-color-fg: var(--color-fg, #b8b8b8);
+  --tokentweak-color-bg: var(--color-bg, #181818);
+  --tokentweak-color-surface: var(--color-surface, #1c1c1c);
+  --tokentweak-color-accent: var(--color-accent, #d69a66);
   --tokentweak-font-mono: var(--font-mono, Menlo, Monaco, Consolas, …);
   --tokentweak-pad-md: …;
   --tokentweak-gap-sm: …;

--- a/packages/zudo-design-token-panel/src/apply/__tests__/route-tokens-to-files.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/route-tokens-to-files.test.ts
@@ -16,7 +16,7 @@ describe('routeTokensToFiles — single-prefix grouping', () => {
   it('groups all matching cssVars under their configured prefix', () => {
     const result: RouteResult = routeTokensToFiles(
       {
-        '--brand-p5': 'oklch(99% 0 0)',
+        '--brand-p5': '#fafafa',
         '--brand-spacing-hgap-sm': '24px',
       },
       DEMO_ROUTING,
@@ -27,7 +27,7 @@ describe('routeTokensToFiles — single-prefix grouping', () => {
     expect(group.prefix).toBe('brand');
     expect(group.relativePath).toBe(DEMO_ROUTING.brand);
     expect(group.tokens).toEqual({
-      '--brand-p5': 'oklch(99% 0 0)',
+      '--brand-p5': '#fafafa',
       '--brand-spacing-hgap-sm': '24px',
     });
   });

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -248,7 +248,7 @@ export default function DesignTokenTweakPanel() {
       return;
     }
     // No saved state — page already has correct colors from ColorSchemeProvider.
-    // Just read scheme data for panel display; don't apply (avoids oklch->hex lossy conversion).
+    // Just read scheme data for panel display; don't apply (avoids overwriting host CSS with redundant defaults).
     // The `secondary` slice is always seeded — every fresh-state path
     // includes it so the persisted envelope shape stays stable regardless
     // of the user's path.

--- a/packages/zudo-design-token-panel/src/server/__tests__/create-apply-handler.test.ts
+++ b/packages/zudo-design-token-panel/src/server/__tests__/create-apply-handler.test.ts
@@ -12,20 +12,20 @@ const TOKENS_CSS_FIXTURE = `/**
  */
 
 :root {
-  --zd-p5: oklch(65% 0.2 45); /* accent */
-  --zd-p6: oklch(52% 0.01 50);
+  --zd-p5: #33ff33; /* accent */
+  --zd-p6: #888888;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --zd-p5: oklch(10% 0 0);
+    --zd-p5: #1a1a1a;
   }
 }
 `;
 
 const SECONDARY_TOKENS_CSS_FIXTURE = `:root {
-  --secondary-pa7: oklch(65% 0.2 35);
-  --secondary-pa8: oklch(50% 0.2 35);
+  --secondary-pa7: #dd6644;
+  --secondary-pa8: #aa3333;
 }
 `;
 
@@ -157,7 +157,7 @@ describe('createApplyHandler', () => {
     const rootless = `/* no root block here */\nhtml { color: red; }\n`;
     await fs.writeFile(absPath, rootless, 'utf-8');
 
-    const res = await handler(makeRequest({ tokens: { '--zd-p5': 'oklch(70% 0.3 50)' } }));
+    const res = await handler(makeRequest({ tokens: { '--zd-p5': '#66ff66' } }));
     expect(res.status).toBe(409);
     const json = await readResponseJson(res);
     expect(json.ok).toBe(false);
@@ -174,8 +174,8 @@ describe('createApplyHandler', () => {
     const res = await handler(
       makeRequest({
         tokens: {
-          '--zd-p5': 'oklch(70% 0.3 50)',
-          '--secondary-pa7': 'oklch(70% 0.3 40)',
+          '--zd-p5': '#66ff66',
+          '--secondary-pa7': '#33dd33',
         },
       }),
     );
@@ -199,18 +199,18 @@ describe('createApplyHandler', () => {
       join(tmpRepo, 'tokens/tokens.css'),
       'utf-8',
     );
-    expect(tokensCss).toContain('--zd-p5: oklch(70% 0.3 50);');
+    expect(tokensCss).toContain('--zd-p5: #66ff66;');
     // --zd-p6 was NOT supplied and must remain untouched.
-    expect(tokensCss).toContain('--zd-p6: oklch(52% 0.01 50);');
+    expect(tokensCss).toContain('--zd-p6: #888888;');
     // The nested @media :root block must be untouched.
-    expect(tokensCss).toContain('--zd-p5: oklch(10% 0 0);');
+    expect(tokensCss).toContain('--zd-p5: #1a1a1a;');
 
     const secondaryCss = await fs.readFile(
       join(tmpRepo, 'tokens/secondary-tokens.css'),
       'utf-8',
     );
-    expect(secondaryCss).toContain('--secondary-pa7: oklch(70% 0.3 40);');
-    expect(secondaryCss).toContain('--secondary-pa8: oklch(50% 0.2 35);');
+    expect(secondaryCss).toContain('--secondary-pa7: #33dd33;');
+    expect(secondaryCss).toContain('--secondary-pa8: #aa3333;');
   });
 
   // ----- idempotent re-apply -------------------------------------------------
@@ -219,7 +219,7 @@ describe('createApplyHandler', () => {
     const absPath = join(tmpRepo, 'tokens/tokens.css');
     const before = await fs.stat(absPath);
 
-    const res = await handler(makeRequest({ tokens: { '--zd-p5': 'oklch(65% 0.2 45)' } }));
+    const res = await handler(makeRequest({ tokens: { '--zd-p5': '#33ff33' } }));
     expect(res.status).toBe(200);
     const json = await readResponseJson(res);
     expect(json.ok).toBe(true);
@@ -292,8 +292,8 @@ describe('createApplyHandler', () => {
     const res = await handler(
       makeRequest({
         tokens: {
-          '--zd-p5': 'oklch(99% 0.0 0)',
-          '--secondary-pa7': 'oklch(99% 0.0 0)',
+          '--zd-p5': '#fafafa',
+          '--secondary-pa7': '#fafafa',
         },
       }),
     );

--- a/packages/zudo-design-token-panel/src/server/__tests__/path-safety.test.ts
+++ b/packages/zudo-design-token-panel/src/server/__tests__/path-safety.test.ts
@@ -70,13 +70,13 @@ describe('CSS_VAR_NAME_RE / isValidCssVarName', () => {
 describe('validateAndSanitizeTokens', () => {
   it('accepts a well-formed map and returns the sanitized copy', () => {
     const result = validateAndSanitizeTokens({
-      '--zd-p5': 'oklch(65% 0.2 45)',
-      '--zd-p6': 'oklch(52% 0.01 50)',
+      '--zd-p5': '#33ff33',
+      '--zd-p6': '#888888',
     });
     expect(result.error).toBeUndefined();
     expect(result.sanitized).toEqual({
-      '--zd-p5': 'oklch(65% 0.2 45)',
-      '--zd-p6': 'oklch(52% 0.01 50)',
+      '--zd-p5': '#33ff33',
+      '--zd-p6': '#888888',
     });
   });
 

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -253,7 +253,7 @@
 }
 
 .tokenpanel-empty-state-text {
-  color: var(--tokentweak-color-muted, oklch(70% 0.01 60));
+  color: var(--tokentweak-color-muted, #a8a8a8);
   font-size: 0.8125rem;
   line-height: 1.5;
   max-width: 32rem;

--- a/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
@@ -13,7 +13,7 @@
  * a `PaletteSelector` — the only way to edit those values is to pick a
  * palette index (p0–p15) or one of the `bg`/`fg` extras. The 16 Palette
  * swatches themselves are the only inputs that edit a hex via the HSL
- * popover. No raw-color inputs (rgb / hex text field / lab / oklch) are
+ * popover. No raw-color inputs (rgb / hex text field / lab) are
  * exposed for Base or Semantic rows.
  *
  * Shiki integration is out of scope — the `shikiTheme` field stays on


### PR DESCRIPTION
## Summary

- Replace every `oklch(...)` color value across the repo with simple hex (`#33ff33`-style)
- Swap `color-mix(in oklch, ...)` → `color-mix(in srgb, ...)` for modal backdrops and the doc-site page-loading overlay
- Refresh the README example block in panel package §11 so it reflects the actual hex palette already shipped in `panel-tokens.css`
- Update stale code comments that still referenced `oklch` as a current concern

## Why

OKLCH is useful for a color-picker UI (perceptually-even gradients, predictable lightness math). The current state of this repo doesn't depend on those properties — every consumer just wants a literal color value — so a uniform hex form keeps the value layer simpler and avoids the oklch-vs-hex split.

## Changes

### Package source

- `packages/zudo-design-token-panel/src/styles/panel.css` — `oklch(70% 0.01 60)` → `#a8a8a8` in the `.tokenpanel-empty-state-text` muted fallback
- `packages/zudo-design-token-panel/src/panel.tsx` — drop "avoids oklch->hex lossy conversion" comment, replace with the actual reason (avoid overwriting host CSS with redundant defaults)
- `packages/zudo-design-token-panel/src/tabs/color-tab.tsx` — drop `oklch` from the "raw-color inputs not exposed" comment list
- `packages/zudo-design-token-panel/README.md` §11 — example panel-tokens.css block now shows the actual hex values shipped (`#b8b8b8`, `#181818`, `#1c1c1c`, `#d69a66`) instead of stale `oklch(...)` placeholders

### Tests

Tests keep value distinctness so apply-handler routing assertions still discriminate fixtures from inputs:

| oklch | hex |
|---|---|
| `oklch(65% 0.2 45)` | `#33ff33` |
| `oklch(52% 0.01 50)` | `#888888` |
| `oklch(10% 0 0)` | `#1a1a1a` |
| `oklch(70% 0.3 50)` | `#66ff66` |
| `oklch(70% 0.3 40)` | `#33dd33` |
| `oklch(50% 0.2 35)` | `#aa3333` |
| `oklch(65% 0.2 35)` | `#dd6644` |
| `oklch(99% 0.0 0)` / `oklch(99% 0 0)` | `#fafafa` |

Touches: `create-apply-handler.test.ts`, `path-safety.test.ts`, `route-tokens-to-files.test.ts`.

### Examples & doc site

- `examples/zfb/styles/global.css`, `examples/zfb/components/widgets/modal.tsx` — backdrop swap to `in srgb`
- `examples/zfb-tailwind/components/widgets/modal.tsx` — same swap in CSS, JSDoc, and the in-page code snippet
- `doc/src/components/page-loading-overlay.astro` — page-loading overlay backdrop swap
- `doc/src/content/docs/reference/color-cluster.mdx` — `ColorRef` literal-string example now says "hex like `#33ff33`, `rgb(...)`, etc." instead of "hex, oklch, etc."

## Test Plan

- [x] `pnpm -F @takazudo/zudo-design-token-panel test --run` — 496 / 496 pass
- [x] `pnpm typecheck` — 0 errors across all 7 workspace projects
- [x] CI: Build/test/typecheck/lint pass, doc & example builds pass, preview deploy pass
- [x] Sanity scan: `grep -ri oklch .` (excluding `node_modules`, `dist/`, `worktrees/`, `.git/`) returns no remaining hits

## Notes

`color-mix(in srgb, X 60-80%, transparent)` produces a slightly different alpha-mix curve than `in oklch` against `transparent`, but the visual difference for single-color overlays at 60–80% opacity is negligible. If a future pass needs perceptually-accurate mixing for something more nuanced, the swap can be reverted locally per call-site.