### PR TITLE
refactor(zfb-tailwind): rename font-role tokens to concrete-purpose names

### DIFF
--- a/examples/zfb-tailwind/components/app-shell.tsx
+++ b/examples/zfb-tailwind/components/app-shell.tsx
@@ -64,13 +64,13 @@ export function AppShell({ title = 'zfb + Tailwind v4 — Design Token Panel', a
       <body>
         {/* Topbar — persisted across soft navigations; no animation (CSS names it zfb-topbar) */}
         <header data-zfb-transition-persist="topbar" class="h-size-header-h flex items-center justify-between bg-surface px-hsp-md border-b border-muted">
-          <span class="text-small text-muted">
+          <span class="text-helper text-muted">
             Storage prefix: <code>zfb-tailwind-example-tokens</code>
           </span>
           <button
             type="button"
             id="zfbtw-panel-open"
-            class="px-hsp-sm py-vsp-xs rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary text-small"
+            class="px-hsp-sm py-vsp-xs rounded-md bg-accent text-bg border-none cursor-pointer hover:bg-primary text-helper"
           >
             Open Design Token Panel
           </button>

--- a/examples/zfb-tailwind/components/data/data-table.tsx
+++ b/examples/zfb-tailwind/components/data/data-table.tsx
@@ -2,8 +2,8 @@
  * DataTable — 4-column table with row action buttons (edit / delete).
  *
  * Token consumption (§134.1):
- *   table:  w-full text-small text-fg border border-muted rounded-md
- *   th:     text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm
+ *   table:  w-full text-helper text-fg border border-muted rounded-md
+ *   th:     text-subsection-title text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm
  *   tr:     hover:bg-surface
  *   td:     px-hsp-sm py-vsp-sm border-b border-muted
  *   action: w-size-icon-md h-size-icon-md text-muted hover:text-accent
@@ -21,13 +21,13 @@ const rows = [
 export function DataTable() {
   return (
     <div class="overflow-x-auto">
-      <table class="w-full text-small text-fg border border-muted rounded-md border-collapse">
+      <table class="w-full text-helper text-fg border border-muted rounded-md border-collapse">
         <thead>
           <tr>
-            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Name</th>
-            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Email</th>
-            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Role</th>
-            <th class="text-h4 text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Actions</th>
+            <th class="text-subsection-title text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Name</th>
+            <th class="text-subsection-title text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Email</th>
+            <th class="text-subsection-title text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Role</th>
+            <th class="text-subsection-title text-fg border-b border-muted text-left px-hsp-sm py-vsp-sm">Actions</th>
           </tr>
         </thead>
         <tbody>

--- a/examples/zfb-tailwind/components/data/media-card.tsx
+++ b/examples/zfb-tailwind/components/data/media-card.tsx
@@ -5,7 +5,7 @@
  *   container:  bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col
  *               gap-vsp-sm max-w-[24rem]
  *   image:      w-full aspect-[16/9] bg-muted rounded-md
- *   title:      text-h3 text-fg
+ *   title:      text-section-title text-fg
  *   description:text-body text-fg
  *   cta:        bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md
  */
@@ -22,7 +22,7 @@ export function MediaCard() {
           aria-hidden="true"
         />
       </div>
-      <h3 class="text-h3 text-fg">Intro to Design Tokens</h3>
+      <h3 class="text-section-title text-fg">Intro to Design Tokens</h3>
       <p class="text-body text-fg">
         Design tokens are the smallest atomic values in a design system — spacing,
         colour, typography — stored as CSS custom properties and shared across every

--- a/examples/zfb-tailwind/components/data/profile-card.tsx
+++ b/examples/zfb-tailwind/components/data/profile-card.tsx
@@ -4,8 +4,8 @@
  * Token consumption (§134.4):
  *   container: flex items-center gap-hsp-md px-hsp-md py-vsp-md bg-surface rounded-md border border-muted
  *   avatar:    w-size-avatar-md h-size-avatar-md rounded-md bg-accent
- *   name:      text-h4 text-fg
- *   role:      text-small text-muted
+ *   name:      text-subsection-title text-fg
+ *   role:      text-helper text-muted
  *   action:    bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md
  */
 
@@ -22,8 +22,8 @@ export function ProfileCard({ name, role }: ProfileCardProps) {
         aria-hidden="true"
       />
       <div class="flex flex-col gap-vsp-xs flex-1">
-        <span class="text-h4 text-fg">{name}</span>
-        <span class="text-small text-muted">{role}</span>
+        <span class="text-subsection-title text-fg">{name}</span>
+        <span class="text-helper text-muted">{role}</span>
       </div>
       <button type="button" class="bg-accent text-bg px-hsp-sm py-vsp-sm rounded-md cursor-pointer flex-shrink-0">
         Follow

--- a/examples/zfb-tailwind/components/data/stat-card.tsx
+++ b/examples/zfb-tailwind/components/data/stat-card.tsx
@@ -3,8 +3,8 @@
  *
  * Token consumption (§134.3):
  *   container:  bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col gap-vsp-xs
- *   big number: text-h2 text-primary  (semantic font token — no hardcoded font-size)
- *   label:      text-small text-muted
+ *   big number: text-page-title text-primary  (semantic font token — no hardcoded font-size)
+ *   label:      text-helper text-muted
  */
 
 interface StatCardProps {
@@ -15,8 +15,8 @@ interface StatCardProps {
 export function StatCard({ value, label }: StatCardProps) {
   return (
     <div class="bg-surface px-hsp-md py-vsp-md rounded-md border border-muted flex flex-col gap-vsp-xs">
-      <span class="text-h2 text-primary">{value}</span>
-      <span class="text-small text-muted">{label}</span>
+      <span class="text-page-title text-primary">{value}</span>
+      <span class="text-helper text-muted">{label}</span>
     </div>
   );
 }

--- a/examples/zfb-tailwind/components/widgets/accordion.tsx
+++ b/examples/zfb-tailwind/components/widgets/accordion.tsx
@@ -63,11 +63,11 @@ export function AccordionDemo() {
         <details key={item.id} class="widgets-accordion rounded-md overflow-hidden">
           <summary class="flex items-center justify-between px-hsp-md py-vsp-md bg-surface rounded-md text-body cursor-pointer list-none">
             <span>{item.summary}</span>
-            <span class="text-muted text-small select-none">▾</span>
+            <span class="text-muted text-helper select-none">▾</span>
           </summary>
           <div class="px-hsp-md py-vsp-md border border-muted rounded-md text-body text-fg mt-vsp-xs">
             <p>{item.body}</p>
-            <p class="text-small text-muted mt-vsp-sm">
+            <p class="text-helper text-muted mt-vsp-sm">
               Open timing: <code>easing-tab-open</code> →{' '}
               <code>--zfbtw-easing-tab-open</code>. Close timing:{' '}
               <code>easing-tab-close</code> →{' '}

--- a/examples/zfb-tailwind/components/widgets/modal.tsx
+++ b/examples/zfb-tailwind/components/widgets/modal.tsx
@@ -127,7 +127,7 @@ function ModalInner() {
       >
         <div class="flex flex-col gap-vsp-md">
           <div class="flex items-center justify-between">
-            <h2 class="text-h3 text-fg font-semibold">Modal Dialog</h2>
+            <h2 class="text-section-title text-fg font-semibold">Modal Dialog</h2>
             <button
               type="button"
               class="text-muted text-body hover:text-fg cursor-pointer border-none bg-transparent px-hsp-xs py-vsp-xs"
@@ -141,7 +141,7 @@ function ModalInner() {
             This modal opens via button click and closes via the close button or{' '}
             <kbd>Escape</kbd>.
           </p>
-          <p class="text-small text-muted">
+          <p class="text-helper text-muted">
             Open/close animation uses{' '}
             <code>easing-modal</code> →{' '}
             <code>--zfbtw-easing-modal</code>. Backdrop uses{' '}

--- a/examples/zfb-tailwind/config/default-manifest.ts
+++ b/examples/zfb-tailwind/config/default-manifest.ts
@@ -11,10 +11,13 @@
  * Both scales are declared in styles/global.css and re-exported as
  * Tailwind theme tokens (--spacing-hsp-*, --spacing-vsp-*).
  *
- * The font tab uses a 2-tier setup (Wave 5):
- *   - Tier `raw`: 6 scale items
- *   - Tier `semantic` (referencesTier: 'raw'): text-base and text-heading
- *     each default to a scale item id and emit var(--zfbtw-scale-*)
+ * The font tab uses a 2-tier setup:
+ *   - Tier `raw`: 7 scale items (Tier 1, abstract)
+ *   - Tier `semantic` (referencesTier: 'raw'): 6 concrete-purpose font roles
+ *     (page-title, section-title, subsection-title, body, helper, annotation)
+ *     each defaulting to a scale item id; emits var(--zfbtw-scale-*).
+ *     Names follow the three-tier-font-size-strategy contract: Tier 2 describes
+ *     WHAT the size is for, not which HTML element it lands on.
  *
  * The color tab uses a 2-tier setup (Wave 7):
  *   - Tier `palette`: 16 hex swatches (kind: 'color')
@@ -197,22 +200,49 @@ export const defaultTabs: readonly TabConfig[] = [
         id: 'semantic',
         label: 'Font role',
         // Each item's value is the id of a raw-tier item; emitted as var(--cssVar).
+        // Concrete-purpose role names — see header comment for the tier 2 contract.
         referencesTier: 'raw',
         items: [
           {
-            id: 'zfbtw-text-base',
-            cssVar: '--zfbtw-text-base',
-            label: 'Body Text',
-            // References the raw item id 'zfbtw-scale-base'
+            id: 'zfbtw-text-page-title',
+            cssVar: '--zfbtw-text-page-title',
+            label: 'Page Title',
+            default: 'zfbtw-scale-xl',
+            type: { kind: 'text' },
+          },
+          {
+            id: 'zfbtw-text-section-title',
+            cssVar: '--zfbtw-text-section-title',
+            label: 'Section Title',
+            default: 'zfbtw-scale-lg',
+            type: { kind: 'text' },
+          },
+          {
+            id: 'zfbtw-text-subsection-title',
+            cssVar: '--zfbtw-text-subsection-title',
+            label: 'Sub-section / Table Header',
+            default: 'zfbtw-scale-md',
+            type: { kind: 'text' },
+          },
+          {
+            id: 'zfbtw-text-body',
+            cssVar: '--zfbtw-text-body',
+            label: 'Body',
             default: 'zfbtw-scale-base',
             type: { kind: 'text' },
           },
           {
-            id: 'zfbtw-text-heading',
-            cssVar: '--zfbtw-text-heading',
-            label: 'Heading Text',
-            // References the raw item id 'zfbtw-scale-xl'
-            default: 'zfbtw-scale-xl',
+            id: 'zfbtw-text-helper',
+            cssVar: '--zfbtw-text-helper',
+            label: 'Helper / Caption',
+            default: 'zfbtw-scale-sm',
+            type: { kind: 'text' },
+          },
+          {
+            id: 'zfbtw-text-annotation',
+            cssVar: '--zfbtw-text-annotation',
+            label: 'Annotation',
+            default: 'zfbtw-scale-xs',
             type: { kind: 'text' },
           },
         ],

--- a/examples/zfb-tailwind/pages/components/data.tsx
+++ b/examples/zfb-tailwind/pages/components/data.tsx
@@ -18,20 +18,20 @@ export default function DataPage() {
 
         {/* ── Page header ─────────────────────────────────────────────────── */}
         <div>
-          <h1 class="text-h2 text-primary">Data &amp; media demo</h1>
+          <h1 class="text-page-title text-primary">Data &amp; media demo</h1>
           <p class="text-body">
             Token map: table borders use <code>color-muted</code>,
             row hover uses <code>color-surface</code>,
-            stat number reads <code>text-h2</code>,
+            stat number reads <code>text-page-title</code>,
             avatars resize via <code>size-avatar-sm</code> / <code>size-avatar-md</code>.
           </p>
         </div>
 
         {/* ── 1. Data table ───────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-sm">
-          <h2 class="text-h3 text-fg">Data table with row actions</h2>
-          <p class="text-small text-muted">
-            Table header: <code>text-h4</code>. Body: <code>text-small</code>.
+          <h2 class="text-section-title text-fg">Data table with row actions</h2>
+          <p class="text-helper text-muted">
+            Table header: <code>text-subsection-title</code>. Body: <code>text-helper</code>.
             Borders: <code>color-muted</code>. Row hover: <code>color-surface</code>.
             Action icon size: <code>size-icon-md</code>.
           </p>
@@ -40,8 +40,8 @@ export default function DataPage() {
 
         {/* ── 2. Media card ───────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-sm">
-          <h2 class="text-h3 text-fg">Media card</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-section-title text-fg">Media card</h2>
+          <p class="text-helper text-muted">
             Container: <code>color-surface</code> + <code>color-muted</code> border.
             Image placeholder: CSS gradient, no network fetch.
             CTA: <code>color-accent</code>.
@@ -51,10 +51,10 @@ export default function DataPage() {
 
         {/* ── 3. Stat cards ───────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-sm">
-          <h2 class="text-h3 text-fg">Stat cards</h2>
-          <p class="text-small text-muted">
-            Big number: semantic font token <code>text-h2</code> + <code>color-primary</code>.
-            Label: <code>text-small</code> + <code>color-muted</code>. No hardcoded <code>font-size</code>.
+          <h2 class="text-section-title text-fg">Stat cards</h2>
+          <p class="text-helper text-muted">
+            Big number: semantic font token <code>text-page-title</code> + <code>color-primary</code>.
+            Label: <code>text-helper</code> + <code>color-muted</code>. No hardcoded <code>font-size</code>.
           </p>
           <div class="flex gap-x-hsp-md gap-y-vsp-md flex-wrap">
             <StatCard value="24,891" label="Total users" />
@@ -65,10 +65,10 @@ export default function DataPage() {
 
         {/* ── 4. Profile card ─────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-sm">
-          <h2 class="text-h3 text-fg">Profile card</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-section-title text-fg">Profile card</h2>
+          <p class="text-helper text-muted">
             Avatar: <code>size-avatar-md</code> (tweak in panel to resize).
-            Name: <code>text-h4</code>. Role: <code>text-small color-muted</code>.
+            Name: <code>text-subsection-title</code>. Role: <code>text-helper color-muted</code>.
           </p>
           <div class="flex flex-col gap-vsp-md max-w-[32rem]">
             {/* reason: card list width is page-local */}
@@ -79,8 +79,8 @@ export default function DataPage() {
 
         {/* ── 5. Avatar row ───────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-sm">
-          <h2 class="text-h3 text-fg">Avatar row</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-section-title text-fg">Avatar row</h2>
+          <p class="text-helper text-muted">
             Each avatar reads <code>size-avatar-sm</code> (tweak in panel to resize all at once).
             Background: <code>palette-1</code>–<code>palette-4</code> via inline style.
           </p>

--- a/examples/zfb-tailwind/pages/components/forms.tsx
+++ b/examples/zfb-tailwind/pages/components/forms.tsx
@@ -12,9 +12,9 @@
  *   text-fg             → --zfbtw-fg               (input text)
  *   text-bg             → --zfbtw-bg               (btn text)
  *   text-muted          → --zfbtw-color-muted      (helper/hint)
- *   text-body           → --zfbtw-text-body        (input font-size)
- *   text-small          → --zfbtw-text-small       (helper label)
- *   text-h4             → --zfbtw-text-h4          (section heading)
+ *   text-body              → --zfbtw-text-body              (input font-size)
+ *   text-helper            → --zfbtw-text-helper            (helper label)
+ *   text-subsection-title  → --zfbtw-text-subsection-title  (section heading)
  *   border-muted        → --zfbtw-color-muted      (resting border)
  *   focus:border-accent → --zfbtw-color-accent     (focus border)
  *   disabled:bg-muted   → --zfbtw-color-muted      (disabled bg)
@@ -40,16 +40,16 @@ export default function FormsPage() {
       activePath={`${BASE_PATH}components/forms/`}
     >
       {/* Page heading */}
-      <h1 class="text-h2 text-primary">Form controls demo</h1>
+      <h1 class="text-page-title text-primary">Form controls demo</h1>
 
       {/* §131.3 required intro paragraph */}
       <p class="text-body text-fg leading-relaxed mt-vsp-sm">
         Each widget below is styled entirely with Tailwind utilities that
-        resolve to design tokens. Inputs use <code class="font-mono text-small">px-hsp-sm py-vsp-sm</code> for
-        padding, <code class="font-mono text-small">radius</code> for corners,{' '}
-        <code class="font-mono text-small">color-muted</code> for borders,{' '}
-        <code class="font-mono text-small">color-accent</code> on focus,{' '}
-        <code class="font-mono text-small">color-danger</code> on error. Toggle
+        resolve to design tokens. Inputs use <code class="font-mono text-helper">px-hsp-sm py-vsp-sm</code> for
+        padding, <code class="font-mono text-helper">radius</code> for corners,{' '}
+        <code class="font-mono text-helper">color-muted</code> for borders,{' '}
+        <code class="font-mono text-helper">color-accent</code> on focus,{' '}
+        <code class="font-mono text-helper">color-danger</code> on error. Toggle
         any token in the Design Token Panel to see every widget update live.
       </p>
 
@@ -60,8 +60,8 @@ export default function FormsPage() {
       >
         {/* ── Text input ─────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Text input</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Text input</h2>
+          <p class="text-helper text-muted">
             <code class="font-mono">bg-surface</code> background ·{' '}
             <code class="font-mono">border-muted</code> border ·{' '}
             <code class="font-mono">focus:border-accent</code> focus ring ·{' '}
@@ -93,7 +93,7 @@ export default function FormsPage() {
               disabled
               class={`${inputBase} disabled:bg-muted cursor-not-allowed`}
             />
-            <span class="text-small text-muted">
+            <span class="text-helper text-muted">
               Disabled state: <code class="font-mono">disabled:bg-muted</code> →
               <code class="font-mono"> --zfbtw-color-muted</code>
             </span>
@@ -102,8 +102,8 @@ export default function FormsPage() {
 
         {/* ── Email input ─────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Email input</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Email input</h2>
+          <p class="text-helper text-muted">
             Same utility set as text input; browser provides email-specific
             keyboard on mobile.
           </p>
@@ -122,8 +122,8 @@ export default function FormsPage() {
 
         {/* ── Select ─────────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Select</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Select</h2>
+          <p class="text-helper text-muted">
             Native chevron retained (no <code class="font-mono">appearance-none</code>);
             same token set as text input.
           </p>
@@ -142,8 +142,8 @@ export default function FormsPage() {
 
         {/* ── Textarea ────────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Textarea</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Textarea</h2>
+          <p class="text-helper text-muted">
             <code class="font-mono">min-h-[6rem]</code> arbitrary value —{' '}
             {/* reason: visual minimum is component-local; below-token granularity */}
             visual floor ensures usable initial height.
@@ -163,8 +163,8 @@ export default function FormsPage() {
 
         {/* ── Checkbox group ──────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Checkbox group</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Checkbox group</h2>
+          <p class="text-helper text-muted">
             Native checkbox with{' '}
             <code class="font-mono">accent-color</code> set to{' '}
             <code class="font-mono">--zfbtw-color-accent</code>.
@@ -193,8 +193,8 @@ export default function FormsPage() {
 
         {/* ── Radio group ─────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Radio group</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Radio group</h2>
+          <p class="text-helper text-muted">
             Same <code class="font-mono">accent-color</code> inline-style pattern as
             checkboxes.
           </p>
@@ -221,8 +221,8 @@ export default function FormsPage() {
 
         {/* ── Range slider ────────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Range slider</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Range slider</h2>
+          <p class="text-helper text-muted">
             <code class="font-mono">w-full</code> width ·{' '}
             <code class="font-mono">accent-color</code> fills the track and thumb
             with <code class="font-mono">color-accent</code>.
@@ -241,14 +241,14 @@ export default function FormsPage() {
               class="w-full cursor-pointer"
               style={{ accentColor: 'var(--zfbtw-color-accent)' }}
             />
-            <span class="text-small text-muted">0 – 100</span>
+            <span class="text-helper text-muted">0 – 100</span>
           </div>
         </section>
 
         {/* ── Submit button ───────────────────────────────────────────── */}
         <section class="flex flex-col gap-vsp-xs">
-          <h2 class="text-h4 text-fg font-semibold">Submit button</h2>
-          <p class="text-small text-muted">
+          <h2 class="text-subsection-title text-fg font-semibold">Submit button</h2>
+          <p class="text-helper text-muted">
             <code class="font-mono">bg-primary</code> fill ·{' '}
             <code class="font-mono">text-bg</code> label ·{' '}
             <code class="font-mono">hover:bg-accent</code> hover ·{' '}

--- a/examples/zfb-tailwind/pages/components/status.tsx
+++ b/examples/zfb-tailwind/pages/components/status.tsx
@@ -23,7 +23,7 @@ const BASE_PATH = '/pj/zudo-design-token-panel/examples/zfb-tailwind/';
 function Alerts() {
   return (
     <section class="flex flex-col gap-vsp-md">
-      <h2 class="text-h3 font-semibold text-fg">Alerts / callouts</h2>
+      <h2 class="text-section-title font-semibold text-fg">Alerts / callouts</h2>
       <p class="text-body text-fg">
         Each variant uses a semantic color token for background, text, and border.
         Token contract: <code>bg-accent</code> / <code>bg-success</code> /{' '}
@@ -71,14 +71,14 @@ function Badge({ color, variant, label }: BadgeProps) {
   if (variant === 'filled') {
     return (
       // reason: badge vertical pad is below `spacing-xs`; below-token granularity is local
-      <span class={`bg-${color} text-bg px-hsp-xs py-[0.125rem] rounded-md text-small`}>
+      <span class={`bg-${color} text-bg px-hsp-xs py-[0.125rem] rounded-md text-helper`}>
         {label}
       </span>
     );
   }
   return (
     // reason: badge vertical pad is below `spacing-xs`; below-token granularity is local
-    <span class={`border border-${color} text-${color} px-hsp-xs py-[0.125rem] rounded-md text-small`}>
+    <span class={`border border-${color} text-${color} px-hsp-xs py-[0.125rem] rounded-md text-helper`}>
       {label}
     </span>
   );
@@ -94,17 +94,17 @@ function Badges() {
 
   return (
     <section class="flex flex-col gap-vsp-md">
-      <h2 class="text-h3 font-semibold text-fg">Badges</h2>
+      <h2 class="text-section-title font-semibold text-fg">Badges</h2>
       <p class="text-body text-fg">
         Filled badges: <code>bg-{'{color}'}</code> + <code>text-bg</code>.
         Outlined badges: <code>border-{'{color}'}</code> + <code>text-{'{color}'}</code>.
-        Both use <code>px-hsp-xs</code>, <code>rounded-md</code>, <code>text-small</code>.
+        Both use <code>px-hsp-xs</code>, <code>rounded-md</code>, <code>text-helper</code>.
         Vertical padding <code>py-[0.125rem]</code> is below{' '}
         <code>vsp-xs</code> granularity — local exception per G4 row 5.
       </p>
 
       <div>
-        <p class="text-small text-muted mb-vsp-xs">Filled</p>
+        <p class="text-helper text-muted mb-vsp-xs">Filled</p>
         <div class="flex flex-wrap gap-x-hsp-sm gap-y-vsp-sm">
           {colors.map((c) => (
             <Badge key={`filled-${c}`} color={c} variant="filled" label={c} />
@@ -113,7 +113,7 @@ function Badges() {
       </div>
 
       <div>
-        <p class="text-small text-muted mb-vsp-xs">Outlined</p>
+        <p class="text-helper text-muted mb-vsp-xs">Outlined</p>
         <div class="flex flex-wrap gap-x-hsp-sm gap-y-vsp-sm">
           {colors.map((c) => (
             <Badge key={`outlined-${c}`} color={c} variant="outlined" label={c} />
@@ -132,7 +132,7 @@ interface TagProps {
 
 function Tag({ label }: TagProps) {
   return (
-    <span class="inline-flex items-center gap-hsp-xs bg-surface text-fg px-hsp-sm py-vsp-xs rounded-md text-small border border-muted">
+    <span class="inline-flex items-center gap-hsp-xs bg-surface text-fg px-hsp-sm py-vsp-xs rounded-md text-helper border border-muted">
       {label}
       <button
         type="button"
@@ -149,10 +149,10 @@ function Tags() {
   const tags = ['Design', 'Tokens', 'Tailwind', 'CSS Vars'];
   return (
     <section class="flex flex-col gap-vsp-md">
-      <h2 class="text-h3 font-semibold text-fg">Tags / chips</h2>
+      <h2 class="text-section-title font-semibold text-fg">Tags / chips</h2>
       <p class="text-body text-fg">
         Container: <code>inline-flex items-center gap-hsp-xs bg-surface text-fg</code> +{' '}
-        <code>px-hsp-sm py-vsp-xs rounded-md text-small border border-muted</code>.
+        <code>px-hsp-sm py-vsp-xs rounded-md text-helper border border-muted</code>.
         Close button: <code>text-muted hover:text-danger</code>.
       </p>
       <div class="flex flex-wrap gap-x-hsp-sm gap-y-vsp-sm">
@@ -198,7 +198,7 @@ function Tooltip({ text, tip }: TooltipProps) {
           -translate-x-1/2 mb-vsp-xs
           bg-surface text-fg border border-muted rounded-md
           px-hsp-sm py-vsp-xs
-          text-small
+          text-helper
           whitespace-nowrap
           opacity-0
           pointer-events-none
@@ -219,11 +219,11 @@ function Tooltip({ text, tip }: TooltipProps) {
 function Tooltips() {
   return (
     <section class="flex flex-col gap-vsp-md">
-      <h2 class="text-h3 font-semibold text-fg">Tooltips</h2>
+      <h2 class="text-section-title font-semibold text-fg">Tooltips</h2>
       <p class="text-body text-fg">
         Hover over the annotated terms. Bubble: <code>bg-surface</code>,{' '}
         <code>text-fg</code>, <code>border-muted</code>, <code>rounded-md</code>,{' '}
-        <code>px-hsp-sm py-vsp-xs</code>, <code>text-small</code>.{' '}
+        <code>px-hsp-sm py-vsp-xs</code>, <code>text-helper</code>.{' '}
         Opacity transition uses{' '}
         <code>easing-tab-open</code> (<code>--zfbtw-easing-tab-open</code>).
         Implementation: <code>position: absolute</code> with{' '}
@@ -262,7 +262,7 @@ export default function StatusPage() {
       {/* reason: page-content max-width is a layout constant for this demo; no structural token covers prose-container widths */}
       <div class="flex flex-col gap-vsp-lg max-w-[56rem] mx-auto">
         <header>
-          <h1 class="text-h2 font-bold text-primary">Status surfaces demo</h1>
+          <h1 class="text-page-title font-bold text-primary">Status surfaces demo</h1>
           <p class="text-body text-fg mt-vsp-sm">
             Status surfaces demo for sub-issue #132. Covers alerts, badges, tags/chips,
             and tooltips — all driven by semantic color tokens{' '}

--- a/examples/zfb-tailwind/pages/components/widgets.tsx
+++ b/examples/zfb-tailwind/pages/components/widgets.tsx
@@ -28,7 +28,7 @@ export default function WidgetsPage() {
       {/* reason: page-content max-width is a layout constant for this demo; no structural token covers prose-container widths */}
       <div class="flex flex-col gap-vsp-lg max-w-[56rem] mx-auto">
         <header>
-          <h1 class="text-h2 text-primary font-bold mb-vsp-md">
+          <h1 class="text-page-title text-primary font-bold mb-vsp-md">
             Interactive Widgets
           </h1>
           <p class="text-body text-fg">
@@ -40,7 +40,7 @@ export default function WidgetsPage() {
 
         {/* ── Tabs ──────────────────────────────────────────────────────────── */}
         <section>
-          <h2 class="text-h3 text-fg font-semibold mb-vsp-sm">
+          <h2 class="text-section-title text-fg font-semibold mb-vsp-sm">
             Tabs
           </h2>
           <p class="text-body text-muted mb-vsp-md">
@@ -55,7 +55,7 @@ export default function WidgetsPage() {
 
         {/* ── Accordion ─────────────────────────────────────────────────────── */}
         <section>
-          <h2 class="text-h3 text-fg font-semibold mb-vsp-sm">
+          <h2 class="text-section-title text-fg font-semibold mb-vsp-sm">
             Accordion
           </h2>
           <p class="text-body text-muted mb-vsp-md">
@@ -68,7 +68,7 @@ export default function WidgetsPage() {
 
         {/* ── Modal ─────────────────────────────────────────────────────────── */}
         <section>
-          <h2 class="text-h3 text-fg font-semibold mb-vsp-sm">
+          <h2 class="text-section-title text-fg font-semibold mb-vsp-sm">
             Modal
           </h2>
           <p class="text-body text-muted mb-vsp-md">

--- a/examples/zfb-tailwind/pages/index.tsx
+++ b/examples/zfb-tailwind/pages/index.tsx
@@ -70,7 +70,7 @@ export default function HomePage() {
       {/* reason: page-content max-width is a layout constant for this demo; no structural token covers prose-container widths */}
       <div class="flex flex-col gap-vsp-lg max-w-[56rem] mx-auto">
         <header>
-          <h1 class="text-heading font-bold mb-vsp-md text-primary">
+          <h1 class="text-page-title font-bold mb-vsp-md text-primary">
             Live token tweaking, in zfb + Tailwind v4
           </h1>
           <p>
@@ -79,7 +79,7 @@ export default function HomePage() {
             Tailwind v4 utility classes. Open the panel from the button above
             and drag any slider — the change applies before the next paint.
           </p>
-          <p class="text-small text-muted mt-vsp-md">
+          <p class="text-helper text-muted mt-vsp-md">
             Console API:{' '}
             <code>window.zfbTw.toggleDesignPanel()</code>. Storage
             prefix: <code>zfb-tailwind-example-tokens</code>.
@@ -87,7 +87,7 @@ export default function HomePage() {
         </header>
 
         <section>
-          <h2 class="text-heading font-bold mb-vsp-md text-primary">
+          <h2 class="text-page-title font-bold mb-vsp-md text-primary">
             Cards (spacing + radius + surface)
           </h2>
           <div class="flex flex-col gap-vsp-md">
@@ -106,7 +106,7 @@ export default function HomePage() {
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-vsp-md text-primary">
+          <h2 class="text-page-title font-bold mb-vsp-md text-primary">
             Buttons (accent / primary)
           </h2>
           <p>
@@ -120,7 +120,7 @@ export default function HomePage() {
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-vsp-md text-primary">
+          <h2 class="text-page-title font-bold mb-vsp-md text-primary">
             Easing demo
           </h2>
           <p>
@@ -133,14 +133,14 @@ export default function HomePage() {
         </section>
 
         <section>
-          <h2 class="text-heading font-bold mb-vsp-md text-primary">
+          <h2 class="text-page-title font-bold mb-vsp-md text-primary">
             Palette swatches
           </h2>
           <div class="flex flex-wrap gap-x-hsp-md gap-y-vsp-md">
             {PALETTE_INDICES.map((i) => (
               <div
                 key={i}
-                class="w-16 h-16 rounded-md flex items-end justify-center text-micro text-fg px-hsp-xs py-vsp-xs"
+                class="w-16 h-16 rounded-md flex items-end justify-center text-annotation text-fg px-hsp-xs py-vsp-xs"
                 // reason: dynamic var name from loop index — no static utility possible;
                 // text-shadow is swatch-label legibility over any palette color — no token covers overlay shadows
                 style={`background: var(--zfbtw-palette-${i}); text-shadow: 0 1px 2px rgba(0,0,0,0.7);`}
@@ -149,7 +149,7 @@ export default function HomePage() {
               </div>
             ))}
           </div>
-          <p class="text-small text-muted mt-vsp-md">
+          <p class="text-helper text-muted mt-vsp-md">
             Each swatch reads{' '}
             <code>--zfbtw-palette-{'{n}'}</code>. The cluster's{' '}
             <code>paletteCssVarTemplate</code> is the only thing that decides
@@ -161,12 +161,12 @@ export default function HomePage() {
 
         {/* Raw-scale reference block — intentional Tier-1-direct usage.
             Per the three-tier font-size strategy, real components should use
-            semantic tokens (text-h2, text-body, etc.) backed by Tier 2 — see
+            semantic tokens (text-page-title, text-body, etc.) backed by Tier 2 — see
             the Prose page for that. This block is a per-scale demo so each
             of the seven raw scale tokens is visibly bound to a row, letting
             the Font tab's scale sliders be debugged in isolation. */}
         <section>
-          <h2 class="text-heading font-bold mb-vsp-md text-primary">
+          <h2 class="text-page-title font-bold mb-vsp-md text-primary">
             Font scale tokens (raw tier)
           </h2>
           <p class="mb-vsp-md">
@@ -175,7 +175,7 @@ export default function HomePage() {
             Open the Font tab and drag any scale slider — each row below
             tracks one scale token directly. Production code should NOT use
             <code>text-scale-*</code>; use semantic tokens
-            (<code>text-h2</code>, <code>text-body</code>, etc.) instead —
+            (<code>text-page-title</code>, <code>text-body</code>, etc.) instead —
             see the <a href={`${BASE_PATH}prose/`}>Prose page</a>, where the
             same scale sliders flow through Tier 2 into rendered prose.
           </p>

--- a/examples/zfb-tailwind/pages/prose.tsx
+++ b/examples/zfb-tailwind/pages/prose.tsx
@@ -67,10 +67,10 @@ export default function ProsePage() {
     >
       {/* reason: prose-container max-width is a typography constant for readability; no structural token covers prose-container widths */}
       <div class="max-w-[48rem] mx-auto">
-        <h1 class="text-heading font-bold mb-vsp-xl text-primary leading-tight">
+        <h1 class="text-page-title font-bold mb-vsp-xl text-primary leading-tight">
           Prose Demo
         </h1>
-        <p class="mb-vsp-xl text-small text-muted">
+        <p class="mb-vsp-xl text-helper text-muted">
           All typography and spacing tokens are from the{' '}
           <code>--zfbtw-*</code> namespace.
           Open the panel (<code>window.zfbTw.toggleDesignPanel()</code>){' '}
@@ -79,15 +79,15 @@ export default function ProsePage() {
 
         {/* Semantic heading / body scale showcase — utility classes map to prose
             type-scale tokens. Kept outside .zfbtw-prose so the Tailwind utilities
-            (text-h2, text-body, …) are visible rather than being overridden by the
+            (text-page-title, text-body, …) are visible rather than being overridden by the
             container's :where(h2) rules. */}
         <div class="flex flex-col gap-vsp-sm bg-surface px-hsp-md py-vsp-md rounded-md border border-muted mb-vsp-xl">
-          <p class="text-h2 leading-tight font-bold text-fg">Heading H2 — text-h2</p>
-          <p class="text-h3 leading-tight font-semibold text-fg">Heading H3 — text-h3</p>
-          <p class="text-h4 leading-snug font-semibold text-fg">Heading H4 — text-h4</p>
+          <p class="text-page-title leading-tight font-bold text-fg">Heading H2 — text-page-title</p>
+          <p class="text-section-title leading-tight font-semibold text-fg">Heading H3 — text-section-title</p>
+          <p class="text-subsection-title leading-snug font-semibold text-fg">Heading H4 — text-subsection-title</p>
           <p class="text-body leading-relaxed text-fg">Body text — text-body leading-relaxed</p>
-          <p class="text-small text-muted">Small text — text-small text-muted</p>
-          <p class="text-micro text-muted">Micro text — text-micro text-muted</p>
+          <p class="text-helper text-muted">Small text — text-helper text-muted</p>
+          <p class="text-annotation text-muted">Micro text — text-annotation text-muted</p>
         </div>
 
         {ProseContent ? (

--- a/examples/zfb-tailwind/styles/global.css
+++ b/examples/zfb-tailwind/styles/global.css
@@ -11,7 +11,7 @@
  * 2. Tailwind v4 @theme registration. The @theme block below maps each
  *    --zfbtw-* raw var onto Tailwind's built-in design-system
  *    namespaces so that utility classes like `bg-primary`, `p-vsp-md`, and
- *    `text-h2` work end-to-end.
+ *    `text-page-title` work end-to-end.
  *
  * Tailwind v4 namespace prefix rules (critical — easy to get wrong)
  * ------------------------------------------------------------------
@@ -39,10 +39,6 @@
   --zfbtw-scale-lg:   1.25rem;
   --zfbtw-scale-xl:   1.75rem;
   --zfbtw-scale-2xl:  2.5rem;
-
-  /* Semantic font role tokens (font tab — semantic tier, reference raw scale) */
-  --zfbtw-text-base: var(--zfbtw-scale-base);
-  --zfbtw-text-heading: var(--zfbtw-scale-xl);
 
   /* Size tokens (manifest: size tab) — layout/component dimensions */
   --zfbtw-size-sidenav-w: 14rem;
@@ -113,19 +109,18 @@
   --zfbtw-hsp-lg:  1.5rem;    /* section-level horizontal gutter */
   --zfbtw-hsp-xl:  2rem;      /* outer prose container horizontal padding */
 
-  /* Type scale — semantic tier; MUST reference --zfbtw-scale-* (Tier 1).
-     Hardcoded rem values here would break the Font-tab scale sliders — they'd
-     move the raw tier but not the prose / section-heading content that uses
-     these semantic tokens. See doc/three-tier-font-size-strategy. h3/h4 round
-     to nearby scale steps; the dedicated --zfbtw-scale-md step exists so h4
-     (used as section-heading and table-th across the demos) stays one tier
-     above body. */
-  --zfbtw-text-h2:    var(--zfbtw-scale-xl);    /* 1.75rem */
-  --zfbtw-text-h3:    var(--zfbtw-scale-lg);    /* 1.25rem (was 1.35rem) */
-  --zfbtw-text-h4:    var(--zfbtw-scale-md);    /* 1.125rem (was 1.1rem) */
-  --zfbtw-text-body:  var(--zfbtw-scale-base);  /* 1rem */
-  --zfbtw-text-small: var(--zfbtw-scale-sm);    /* 0.875rem */
-  --zfbtw-text-micro: var(--zfbtw-scale-xs);    /* 0.75rem */
+  /* Type scale — semantic tier (Tier 2); MUST reference --zfbtw-scale-* (Tier 1).
+     Names describe what each size is FOR (purpose / role), not which HTML
+     element it lands on — per doc/three-tier-font-size-strategy. Hardcoded rem
+     values here would break the Font-tab scale sliders. The dedicated
+     --zfbtw-scale-md step exists so subsection-title (used as form sub-section,
+     table th, profile-card name across the demos) stays one tier above body. */
+  --zfbtw-text-page-title:       var(--zfbtw-scale-xl);   /* 1.75rem */
+  --zfbtw-text-section-title:    var(--zfbtw-scale-lg);   /* 1.25rem */
+  --zfbtw-text-subsection-title: var(--zfbtw-scale-md);   /* 1.125rem */
+  --zfbtw-text-body:             var(--zfbtw-scale-base); /* 1rem */
+  --zfbtw-text-helper:           var(--zfbtw-scale-sm);   /* 0.875rem */
+  --zfbtw-text-annotation:       var(--zfbtw-scale-xs);   /* 0.75rem */
 
   /* Line-height tokens */
   --zfbtw-leading-tight:   1.2;
@@ -206,7 +201,7 @@
      ANTI-PATTERN — these expose Tier 1 (raw scale) as Tailwind utilities so
      the home page can render a per-scale demo row (issue #163 acceptance:
      every scale token must be visibly consumed). Production code should use
-     semantic tokens (text-h2, text-body, text-small, …) which themselves now
+     semantic tokens (text-page-title, text-body, text-helper, …) which themselves now
      reference these scales via Tier 2. Three-tier rule: components → Tier 2,
      never Tier 1 directly. */
   --text-scale-xs:   var(--zfbtw-scale-xs);
@@ -217,15 +212,13 @@
   --text-scale-xl:   var(--zfbtw-scale-xl);
   --text-scale-2xl:  var(--zfbtw-scale-2xl);
 
-  /* Font-size utilities: text-h2, text-h3, text-body, text-small, … */
-  --text-heading: var(--zfbtw-text-heading);
-  --text-base:    var(--zfbtw-text-base);
-  --text-h2:      var(--zfbtw-text-h2);
-  --text-h3:      var(--zfbtw-text-h3);
-  --text-h4:      var(--zfbtw-text-h4);
-  --text-body:    var(--zfbtw-text-body);
-  --text-small:   var(--zfbtw-text-small);
-  --text-micro:   var(--zfbtw-text-micro);
+  /* Font-size utilities: text-page-title, text-section-title, text-body, text-helper, … */
+  --text-page-title:       var(--zfbtw-text-page-title);
+  --text-section-title:    var(--zfbtw-text-section-title);
+  --text-subsection-title: var(--zfbtw-text-subsection-title);
+  --text-body:             var(--zfbtw-text-body);
+  --text-helper:           var(--zfbtw-text-helper);
+  --text-annotation:       var(--zfbtw-text-annotation);
 
   /* Line-height utilities: leading-tight, leading-snug, leading-relaxed */
   --leading-tight:   var(--zfbtw-leading-tight);
@@ -264,7 +257,7 @@
     line-height: 1.5;
     background: var(--zfbtw-bg);
     color: var(--zfbtw-fg);
-    font-size: var(--zfbtw-text-base);
+    font-size: var(--zfbtw-scale-base);
   }
 
   img,
@@ -324,7 +317,7 @@
 
   /* Heading styles */
   .zfbtw-prose :where(h2) {
-    font-size: var(--zfbtw-text-h2);
+    font-size: var(--zfbtw-text-page-title);
     line-height: var(--zfbtw-leading-tight);
     font-weight: 700;
     color: var(--zfbtw-color-primary);
@@ -333,14 +326,14 @@
   }
 
   .zfbtw-prose :where(h3) {
-    font-size: var(--zfbtw-text-h3);
+    font-size: var(--zfbtw-text-section-title);
     line-height: var(--zfbtw-leading-tight);
     font-weight: 600;
     color: var(--zfbtw-fg);
   }
 
   .zfbtw-prose :where(h4) {
-    font-size: var(--zfbtw-text-h4);
+    font-size: var(--zfbtw-text-subsection-title);
     line-height: var(--zfbtw-leading-snug);
     font-weight: 600;
     color: var(--zfbtw-fg);
@@ -355,7 +348,7 @@
   /* Inline code */
   .zfbtw-prose :where(code):not(pre code) {
     font-family: var(--zfbtw-font-mono);
-    font-size: var(--zfbtw-text-small);
+    font-size: var(--zfbtw-text-helper);
     background: var(--zfbtw-code-bg);
     color: var(--zfbtw-code-fg);
     padding: var(--zfbtw-hsp-xs) calc(var(--zfbtw-hsp-xs) * 2);
@@ -366,7 +359,7 @@
   /* Code blocks */
   .zfbtw-prose :where(pre) {
     font-family: var(--zfbtw-font-mono);
-    font-size: var(--zfbtw-text-small);
+    font-size: var(--zfbtw-text-helper);
     background: var(--zfbtw-code-bg);
     color: var(--zfbtw-code-fg);
     padding: var(--zfbtw-vsp-md) var(--zfbtw-hsp-sm);
@@ -422,7 +415,7 @@
   .zfbtw-prose :where(table) {
     width: 100%;
     border-collapse: collapse;
-    font-size: var(--zfbtw-text-small);
+    font-size: var(--zfbtw-text-helper);
   }
 
   .zfbtw-prose :where(th) {
@@ -497,7 +490,7 @@
   }
 
   .zfbtw-easing-card-label {
-    font-size: var(--zfbtw-text-base);
+    font-size: var(--zfbtw-text-body);
     font-weight: 600;
   }
 }


### PR DESCRIPTION
## Summary

- Renames the `zfb-tailwind` example's Tier 2 (semantic) font tokens from HTML-element-shaped names (`--zfbtw-text-h2/h3/h4/small/micro` plus the two stand-in placeholders `--zfbtw-text-base` and `--zfbtw-text-heading`) to six concrete-purpose role names that describe *what each size is FOR*.
- Exposes the six new roles as sliders in the panel's Font tab so the demo's actual semantic tokens become tweakable (previously only two placeholders were on the manifest and the six tokens the demo really consumed were missing).
- Rationale grounded in [`zudo-css-wisdom/typography/font-sizing/three-tier-font-size-strategy`](https://github.com/Takazudo/zudo-css-wisdom) (Tier 2 should describe purpose, not HTML elements) and mirrors zudo-text's concrete sibling-token naming style (`--spacing-draft-btn`, `--color-tooltip-bg`, …).

## Changes

### New Tier 2 (semantic) font-role tokens

| Old name | New name | Default → Tier 1 |
|---|---|---|
| `--zfbtw-text-h2` + `--zfbtw-text-heading` (collapsed) | `--zfbtw-text-page-title` | `var(--zfbtw-scale-xl)` |
| `--zfbtw-text-h3` | `--zfbtw-text-section-title` | `var(--zfbtw-scale-lg)` |
| `--zfbtw-text-h4` | `--zfbtw-text-subsection-title` | `var(--zfbtw-scale-md)` |
| `--zfbtw-text-body` | `--zfbtw-text-body` (unchanged) | `var(--zfbtw-scale-base)` |
| `--zfbtw-text-small` | `--zfbtw-text-helper` | `var(--zfbtw-scale-sm)` |
| `--zfbtw-text-micro` | `--zfbtw-text-annotation` | `var(--zfbtw-scale-xs)` |

- `--zfbtw-text-base` removed (its sole consumer, `body { font-size }`, now points at `--zfbtw-scale-base` directly — the HTML root is not a Tier 2 role).
- `--zfbtw-text-heading` removed (it duplicated `text-h2`'s size; collapsed into `--zfbtw-text-page-title`).

### Files updated in lockstep

- `examples/zfb-tailwind/styles/global.css` — `:root` declarations, `@theme` mappings (Tailwind utilities now: `text-page-title`, `text-section-title`, `text-subsection-title`, `text-body`, `text-helper`, `text-annotation`), `.zfbtw-prose :where(...)` rules, header comments.
- `examples/zfb-tailwind/config/default-manifest.ts` — Font-tab semantic tier replaced (2 placeholder items → 6 concrete-role items, each `referencesTier: 'raw'`).
- `examples/zfb-tailwind/pages/*.tsx` and `examples/zfb-tailwind/components/**/*.tsx` — every `text-h2`/`text-h3`/`text-h4`/`text-small`/`text-micro`/`text-heading` Tailwind class renamed; JSDoc reference blocks updated so the docs stay truthful.

## Test Plan

- [x] `pnpm typecheck` — passes (all 6 example apps + the panel package).
- [x] `pnpm -F zfb-tailwind-example build` — succeeds; bundled CSS contains only the six new `.text-*` utility classes and none of the old ones.
- [x] Repo-wide grep for old names (`text-h2|text-h3|text-h4|text-small|text-micro|text-heading|zfbtw-text-base|zfbtw-text-heading`) inside `examples/zfb-tailwind` — zero stragglers.
- [x] `/gcoc-review` of the full diff — clean (no missed renames, manifest defaults correct, prose-CSS var refs correct, body uses `--zfbtw-scale-base`).
- [ ] Visual check on the dev site after merge: confirm the Font tab shows the six new sliders (Page Title / Section Title / Sub-section / Body / Helper / Annotation) and that moving each slider updates the corresponding text in the demos.