### PR TITLE
feat(color-picker): OKLCH/HSL dual-mode color picker

### DIFF
--- a/.claude/skills/test-flow-color-picker-axis-direction/SKILL.md
+++ b/.claude/skills/test-flow-color-picker-axis-direction/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: test-flow-color-picker-axis-direction
+description: Verify the OKLCH/HSL dual-mode ColorPicker (packages/zudo-design-token-panel) renders its L (lightness), H (hue), and C/S (chroma/saturation) slider axes in the CORRECT direction — left edge = min value, right edge = max value, gradient and thumb position both aligned. Use when /verify-ui-ai dispatches a subagent for color-picker-axis-direction verification, or when a future PR changes the picker and you want to re-confirm the direction is still correct.
+---
+
+# Test flow: ColorPicker axis direction (L / H / C-S)
+
+This test produces a binary PASS / FAIL verdict on whether the ColorPicker's three primary value-axis sliders (L, H, and C in OKLCH mode; H, S, L in HSL mode) render correctly — left edge of each track corresponds to the MIN value of that channel, right edge to the MAX value, and the thumb position matches the value's fraction across the track.
+
+The verdict is per-mode, per-slider, so the report can pinpoint exactly which slider in which mode is wrong (if any) and how it is wrong (gradient flipped vs thumb position mirrored vs both).
+
+## Scenario
+
+1. cd to /home/takazudo/repos/myoss/zdtp.
+2. Confirm the example app dev server is reachable. The canonical example for this test is zfb-tailwind (the one that produced the original bug-report screenshots). Its dev URL is http://localhost:44328.
+   - If port 44328 is already responding, REUSE that server. Do NOT relaunch.
+   - If port 44328 is NOT responding, start the dev server in the background and wait for ready:
+     - `pnpm -F zfb-tailwind-example dev` (also boots a tokens-bin sidecar on 24686)
+     - Wait until http://localhost:44328 returns 200 (poll with a short until loop, max 60s).
+3. Open the page at viewport 1440x900 (a non-zoomed desktop default that matches the bug-report screenshots).
+4. The floating "Design Tokens" panel is visible by default. Switch to the Color tab.
+5. Click the first color swatch in the Palette section (label starts with `--zfbtw-palette-`) to open the ColorPicker popover.
+6. The popover header shows a mode toggle (OKLCH | HSL). Start in OKLCH mode (the default).
+
+## Verification — OKLCH mode
+
+Perform each check below. For each, capture (a) a screenshot of the picker popover for evidence and (b) record the DOM measurement.
+
+### Check OKLCH-L (lightness)
+
+- Type `#000000` into the hex input. Wait for the picker to re-render.
+- Record the L-slider thumb's `left` CSS percentage (DOM measurement). Expected: ≤ 5%.
+- Record the visual color sample at the LEFT edge of the L-slider track (capture a small swatch). Expected: very dark / near-black.
+- Type `#ffffff` into the hex input. Wait for re-render.
+- Record the L-slider thumb's `left` CSS percentage. Expected: ≥ 95%.
+- Record the visual color sample at the RIGHT edge of the L-slider track. Expected: very light / near-white.
+
+### Check OKLCH-H (hue)
+
+- Type `#ff0000` into the hex input (pure red, H ≈ 29° in OKLCH but we will use HSL hex for predictable input; the resulting OKLCH H is non-zero but predictable).
+  - Actually for unambiguous H=0° testing, use the hex `#dc143c` or any color where the OKLCH H rounds to a value near 0. If the H thumb position does not match the expected value, retry with a hex whose OKLCH H is verified externally.
+- The simpler test: use the hex input value computed from the displayed picker state — read the H-slider's aria-valuenow (DOM measurement) and the thumb's `left` CSS percentage. Verify: thumb-left-percent ≈ (aria-valuenow / 360) * 100, within ±3% tolerance.
+- Set the hex to a series of values whose OKLCH H spans the gradient. Record the thumb-left-percent at each step and confirm monotonically-increasing (or at least non-decreasing) as the H value increases.
+- Capture the gradient direction by sampling color values at LEFT edge (expected: red ~ rgb(2,55,55) — OKLCH(displayed L%, displayed C, 0)) and RIGHT edge (expected: same red after the rainbow wraps at 360°).
+- The KEY observation is monotonic mapping of value to position with left = low, right = high.
+
+### Check OKLCH-C (chroma)
+
+- Read the C-slider's current aria-valuenow and the thumb's `left` CSS percentage. Compute expected-left-percent = aria-valuenow / MAX_OKLCH_CHROMA (which is 0.37 per packages/zudo-design-token-panel/src/components/color-picker/constants).
+- Verify thumb-left-percent matches expected, within ±3%.
+- Sample the LEFT edge of the C track. Expected: grayscale (chroma 0).
+- Sample the RIGHT edge. Expected: most saturated for the current L and H.
+
+## Verification — HSL mode
+
+Click the HSL button in the mode toggle. Re-run analogous checks:
+
+### Check HSL-H (hue) — identical procedure to OKLCH-H.
+
+### Check HSL-S (saturation)
+
+- aria-valuenow span is 0..100. Expected thumb-left-percent = aria-valuenow.
+- LEFT edge of S track = gray, RIGHT edge = fully saturated.
+
+### Check HSL-L (lightness)
+
+- aria-valuenow span is 0..100. Expected thumb-left-percent = aria-valuenow.
+- LEFT edge of L track = black, RIGHT edge = white.
+
+## Measurements (mechanical — these should drive the verdict, not subjective AI judgment)
+
+For each slider in each mode, compute:
+
+- `thumbPositionError = abs(thumbLeftPercent - expectedLeftPercent)` — PASS if ≤ 3%.
+- `gradientDirection` = which color appears at the LEFT vs RIGHT edge — PASS if LEFT matches MIN-value color and RIGHT matches MAX-value color (e.g. L-slider: LEFT=dark, RIGHT=light).
+
+The AI judgment ONLY applies to (b) gradientDirection (subjective "this color region is darker than that color region" — which a small color-distance computation would also resolve mechanically if needed, but for L6 we accept AI's perceptual call).
+
+## Verdict criteria
+
+PER-SLIDER PASS if BOTH `thumbPositionError` ≤ 3% AND gradientDirection matches expected.
+PER-SLIDER FAIL otherwise — report which (gradient or thumb or both) is wrong, in which direction it is wrong.
+
+OVERALL VERDICT:
+- All 6 checks PASS (OKLCH L+H+C, HSL H+S+L) → overall PASS.
+- Any check FAIL → overall FAIL.
+
+## Output schema
+
+The verification subagent MUST return a structured result containing exactly:
+
+```
+{
+  "verdict": "PASS" | "FAIL",
+  "summary": "<one-line human-readable verdict>",
+  "modes": {
+    "oklch": {
+      "L": { "thumbPositionError": number, "gradientDirection": "correct" | "reversed" | "inconclusive", "verdict": "PASS" | "FAIL", "notes": string },
+      "H": { ... same shape ... },
+      "C": { ... same shape ... }
+    },
+    "hsl": {
+      "H": { ... },
+      "S": { ... },
+      "L": { ... }
+    }
+  },
+  "screenshots": [
+    { "label": "oklch-after-#000000", "path": "<absolute path>" },
+    { "label": "oklch-after-#ffffff", "path": "<absolute path>" },
+    ...
+  ],
+  "toolUsed": "verify-ui" | "headless-browser",
+  "devServerStartedByThisRun": boolean,
+  "devServerStopped": boolean
+}
+```
+
+The `summary` field must be one line, no markdown.
+
+## Browser-driving skill preference
+
+Use `/headless-browser` (Tier 2 Playwright CLI) — this flow requires multi-step interaction (typing hex values, switching modes, clicking swatches, capturing screenshots at multiple states), and is beyond `/verify-ui`'s deterministic computed-style-only checks.
+
+`/verify-ui` is acceptable as a fallback if `/headless-browser` is unavailable, but its single-page-read shape will require more round trips for this multi-step flow.
+
+## Cleanup
+
+If this test started the dev server (`devServerStartedByThisRun: true`), stop it on exit so it does not leak. Use `lsof -ti:44328 | xargs kill -9 2>/dev/null || true` and `lsof -ti:24686 | xargs kill -9 2>/dev/null || true`. Record `devServerStopped: true` in the output.
+
+If the test reused an already-running server, do NOT stop it (someone else may still want it). Record `devServerStartedByThisRun: false, devServerStopped: false`.
+
+## Don'ts
+
+- Don't assume the bug exists — the user has reported it but the static analysis shows the code is correct. Approach with healthy skepticism in BOTH directions.
+- Don't trust visual color-perception alone — back perceptual judgments with the mechanical thumb-position measurement (which is precise and deterministic).
+- Don't run the full test suite or any other build steps in the verification subagent — this skill is for one specific verification.
+- Don't modify any source code — verification is read-only on the application.

--- a/packages/zudo-design-token-panel/package.json
+++ b/packages/zudo-design-token-panel/package.json
@@ -63,7 +63,11 @@
   "peerDependencies": {
     "preact": "^10.29.1"
   },
+  "dependencies": {
+    "culori": "^4.0.2"
+  },
   "devDependencies": {
+    "@types/culori": "^4.0.1",
     "@types/node": "^22.0.0",
     "jsdom": "^25.0.0",
     "preact": "^10.29.1",

--- a/packages/zudo-design-token-panel/src/__tests__/alpha-pipeline.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/alpha-pipeline.test.ts
@@ -50,6 +50,33 @@ describe('colorRefToIndex — alpha ignored for similarity', () => {
   });
 });
 
+describe('colorRefToIndex — ref normalization', () => {
+  // The fix for the codex-adversarial finding: equivalent color notations must
+  // resolve to the same palette slot via exact-match (not fall through to the
+  // alpha-dropping RGB distance match).
+
+  it('rgba() ref matches an equivalent 8-digit hex palette entry exactly', () => {
+    // rgba(255,0,0,0.5) normalizes to #ff000080
+    // Palette has both an opaque red and the translucent red — we want the
+    // translucent slot, not the opaque one. Without normalization the
+    // rawIdx miss would fall through to RGB distance and pick the first
+    // RGB-equivalent (the opaque slot), silently losing alpha.
+    const result = colorRefToIndex('rgba(255,0,0,0.5)', ['#ff0000', '#ff000080'], 0);
+    expect(result).toBe(1);
+  });
+
+  it('4-char shorthand ref matches an 8-digit hex palette entry', () => {
+    // #f008 → #ff000088
+    const result = colorRefToIndex('#f008', ['#ffffff', '#ff000088'], 0);
+    expect(result).toBe(1);
+  });
+
+  it('rgb() ref still matches an opaque 6-digit hex palette entry', () => {
+    const result = colorRefToIndex('rgb(255,0,0)', ['#ff0000', '#000000'], 0);
+    expect(result).toBe(0);
+  });
+});
+
 describe('setCssVar — 8-digit hex round-trip in jsdom', () => {
   it('sets and retrieves an 8-digit hex CSS custom property', () => {
     setCssVar('--test-alpha-color', '#ff000080');

--- a/packages/zudo-design-token-panel/src/__tests__/alpha-pipeline.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/alpha-pipeline.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+/**
+ * Tests for the alpha-aware persist + apply pipeline (issue #174).
+ *
+ * Covers:
+ *  - cssColorToHex: 8-digit pass-through, 4-char shorthand expansion,
+ *    rgba() with alpha < 1, rgb() 6-digit regression guards.
+ *  - colorRefToIndex: alpha ignored for similarity search.
+ *  - setCssVar: 8-digit hex round-trip via document.documentElement.style.
+ */
+import { describe, it, expect } from 'vitest';
+import { cssColorToHex, colorRefToIndex, setCssVar } from '../state/tweak-state';
+
+describe('cssColorToHex — 8-digit and 4-char alpha support', () => {
+  it('passes through an 8-digit hex unchanged', () => {
+    expect(cssColorToHex('#ff000080')).toBe('#ff000080');
+  });
+
+  it('expands 4-char shorthand #RGBA to #RRGGBBAA', () => {
+    expect(cssColorToHex('#f00f')).toBe('#ff0000ff');
+  });
+
+  it('converts rgba() with alpha < 1 to 8-digit hex', () => {
+    // rgba(255, 0, 0, 0.5) → alpha byte: round(0.5 * 255) = 128 = 0x80
+    expect(cssColorToHex('rgba(255, 0, 0, 0.5)')).toBe('#ff000080');
+  });
+
+  it('rgb() without alpha still returns 6-digit hex', () => {
+    expect(cssColorToHex('rgb(255, 0, 0)')).toBe('#ff0000');
+  });
+
+  it('rgba() with alpha === 1 returns 6-digit hex', () => {
+    expect(cssColorToHex('rgba(255, 0, 0, 1)')).toBe('#ff0000');
+  });
+
+  it('#ff0000 regression guard — still returns 6-digit', () => {
+    expect(cssColorToHex('#ff0000')).toBe('#ff0000');
+  });
+
+  it('foobar regression guard — still returns #000000', () => {
+    expect(cssColorToHex('foobar')).toBe('#000000');
+  });
+});
+
+describe('colorRefToIndex — alpha ignored for similarity', () => {
+  it('matches an 8-digit hex ref to a 6-digit palette entry by RGB proximity', () => {
+    // #3366cc80 has RGB #3366cc — nearest to palette[0]=#3366cc, not palette[1]=#000000
+    const result = colorRefToIndex('#3366cc80', ['#3366cc', '#000000'], 0);
+    expect(result).toBe(0);
+  });
+});
+
+describe('setCssVar — 8-digit hex round-trip in jsdom', () => {
+  it('sets and retrieves an 8-digit hex CSS custom property', () => {
+    setCssVar('--test-alpha-color', '#ff000080');
+    const value = document.documentElement.style.getPropertyValue('--test-alpha-color');
+    expect(value).toBe('#ff000080');
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/css-color-to-hex.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/css-color-to-hex.test.ts
@@ -31,9 +31,9 @@ describe('cssColorToHex', () => {
       expect(cssColorToHex('rgb(255, 0, 128)')).toBe('#ff0080');
     });
 
-    it('converts rgba() string via manual parser (ignores alpha)', async () => {
+    it('converts rgba() string via manual parser — preserves alpha < 1 as 8-digit hex', async () => {
       const { cssColorToHex } = await import('../state/tweak-state');
-      expect(cssColorToHex('rgba(0, 255, 64, 0.5)')).toBe('#00ff40');
+      expect(cssColorToHex('rgba(0, 255, 64, 0.5)')).toBe('#00ff4080');
     });
 
     it('returns #000000 for initial/inherit/empty', async () => {

--- a/packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts
@@ -17,7 +17,8 @@
  *   A. No manifest contains a `group:` object-key (TierItem.group was removed in #148).
  *   B. No manifest contains an `advancedTiers:` object-key (TabConfig.advancedTiers was removed in #148).
  *   C. The zfb-tailwind Spacing tab declares exactly 2 tiers: hsp-scale, vsp-scale (#161 removed spacing-scale).
- *   D. The panel source (tabs/) contains no <h4 or <details elements.
+ *   D. The panel source (tabs/ + components/color-picker/) contains no <h4, <details,
+ *      or <summary elements.
  *   F. The panel CSS sources do NOT read host --color-* / --font-mono — the panel
  *      ships a self-contained dark palette in panel-tokens.css and host theme
  *      changes must not bleed into the panel chrome.
@@ -135,34 +136,63 @@ describe('Invariant C — zfb-tailwind Spacing tab has 2 tiers', () => {
 });
 
 // ---------------------------------------------------------------------------
-// D. Panel source — no <h4 or <details elements in tabs/
+// D. Panel source — no <h4, <details, or <summary elements in tabs/ or
+//    components/color-picker/. The hostile-host policy in the package CLAUDE.md
+//    forbids these tags anywhere the panel renders into the host DOM.
 // ---------------------------------------------------------------------------
 
-describe('Invariant D — panel tabs source has no blocked semantic elements', () => {
+describe('Invariant D — panel source has no blocked semantic elements', () => {
   const TABS_DIR = path.resolve(__dirname, '../tabs');
+  const COLOR_PICKER_DIR = path.resolve(__dirname, '../components/color-picker');
 
-  function findTabSources(): string[] {
+  /**
+   * Collect source files from a directory, excluding test files and __tests__ subdirs.
+   * Filters .tsx / .ts files at the top level only — recursion is not needed since
+   * the directories under test are flat (apart from __tests__).
+   */
+  function readPanelSources(dir: string): string[] {
     return fs
-      .readdirSync(TABS_DIR)
-      .filter((f) => (f.endsWith('.tsx') || f.endsWith('.ts')) && !f.startsWith('__'))
-      .map((f) => fs.readFileSync(path.join(TABS_DIR, f), 'utf8'));
+      .readdirSync(dir, { withFileTypes: true })
+      .filter(
+        (e) =>
+          e.isFile() &&
+          (e.name.endsWith('.tsx') || e.name.endsWith('.ts')) &&
+          !e.name.startsWith('__'),
+      )
+      .map((e) => fs.readFileSync(path.join(dir, e.name), 'utf8'));
   }
 
-  it('no <h4 element in any tab source', () => {
-    for (const source of findTabSources()) {
+  function findPanelSources(): string[] {
+    return [...readPanelSources(TABS_DIR), ...readPanelSources(COLOR_PICKER_DIR)];
+  }
+
+  it('no <h4 element in any panel source', () => {
+    for (const source of findPanelSources()) {
       expect(source).not.toMatch(/<h4[\s/>]/);
     }
   });
 
-  it('no <details element in any tab source', () => {
-    for (const source of findTabSources()) {
+  it('no <details element in any panel source', () => {
+    for (const source of findPanelSources()) {
       expect(source).not.toMatch(/<details[\s/>]/);
     }
   });
 
-  it('no <summary element in any tab source', () => {
-    for (const source of findTabSources()) {
+  it('no <summary element in any panel source', () => {
+    for (const source of findPanelSources()) {
       expect(source).not.toMatch(/<summary[\s/>]/);
+    }
+  });
+
+  it('no <button element in any panel source (hostile-host policy)', () => {
+    for (const source of findPanelSources()) {
+      expect(source).not.toMatch(/<button[\s/>]/);
+    }
+  });
+
+  it('no <table element in any panel source (hostile-host policy)', () => {
+    for (const source of findPanelSources()) {
+      expect(source).not.toMatch(/<table[\s/>]/);
     }
   });
 });

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker-drag.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker-drag.test.tsx
@@ -1,0 +1,439 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for the ColorPicker drag-handle feature (issue #180).
+ *
+ * Behaviors under test:
+ *  1. The drag handle <span> renders in the header with the correct ARIA shape
+ *     (role="presentation", aria-hidden="true") and the braille-dots glyph ⠿.
+ *  2. pointerdown on the drag handle captures the pointer and starts a drag
+ *     session — verified indirectly via subsequent pointermove producing a
+ *     position-locked container style.
+ *  3. pointermove translates the container by (clientX - startX, clientY - startY)
+ *     and applies it as `position: fixed; left; top` on the container.
+ *  4. pointerup re-clamps dragPos to the viewport (rect.left/top stays inside
+ *     [pad, viewport - pad - size]).
+ *  5. The drag handle's pointerdown does NOT propagate to the document-level
+ *     outside-click handler — usePopoverClose remains silent during drag.
+ *  6. DOM hygiene — the drag handle is a <span>, not a banned semantic tag.
+ *
+ * Test environment caveats (mirrors color-picker.test.tsx setup):
+ *  - PointerEvent shim — jsdom does not polyfill PointerEvent natively.
+ *  - setPointerCapture/releasePointerCapture are not implemented in jsdom; the
+ *    component swallows the resulting throws via try/catch.
+ *  - getBoundingClientRect on jsdom returns zero-sized rects by default. Tests
+ *    that depend on rect.width / rect.height stub the function on the relevant
+ *    element so the clamp math has meaningful numbers.
+ */
+
+// jsdom does not polyfill PointerEvent. Provide a minimal shim that carries
+// pointerId + clientX/clientY through to handlers (MouseEvent base already
+// carries clientX/clientY).
+if (typeof PointerEvent === 'undefined') {
+  class PointerEventShim extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = PointerEventShim;
+}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { useRef } from 'preact/compat';
+import type { JSX } from 'preact';
+import { ColorPicker } from '../color-picker';
+import type { ColorPickerProps } from '../color-picker';
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  try {
+    window.localStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  container.remove();
+});
+
+function PickerWrapper(
+  props: Omit<ColorPickerProps, 'anchorRef' | 'onClose'> & {
+    onClose?: () => void;
+  },
+): JSX.Element {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={anchorRef} style={{ width: 40, height: 40 }} />
+      <ColorPicker
+        {...props}
+        anchorRef={anchorRef as React.RefObject<HTMLElement | null>}
+        onClose={props.onClose ?? (() => {})}
+      />
+    </div>
+  );
+}
+
+function renderPicker(
+  partial: Partial<ColorPickerProps> & { onClose?: () => void } = {},
+): void {
+  act(() => {
+    render(
+      <PickerWrapper
+        color={partial.color ?? '#ff0000'}
+        onChange={partial.onChange ?? vi.fn()}
+        label={partial.label}
+        defaultMode={partial.defaultMode}
+        onClose={partial.onClose ?? (() => {})}
+      />,
+      container,
+    );
+  });
+}
+
+function getDialog(): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[role="dialog"]');
+  if (!el) throw new Error('dialog not found');
+  return el;
+}
+
+function getDragHandle(): HTMLElement {
+  const el = container.querySelector<HTMLElement>(
+    '.tokenpanel-color-picker-drag-handle',
+  );
+  if (!el) throw new Error('drag handle not found');
+  return el;
+}
+
+// Stub getBoundingClientRect on `el` so the container appears to have a
+// concrete viewport-relative rect. jsdom returns zeros otherwise, which
+// makes both the translate math and the clamp meaningless.
+function stubRect(
+  el: HTMLElement,
+  rect: { left: number; top: number; width: number; height: number },
+): void {
+  el.getBoundingClientRect = () =>
+    ({
+      left: rect.left,
+      top: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      width: rect.width,
+      height: rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect);
+}
+
+function firePointer(
+  el: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  init: { clientX?: number; clientY?: number; pointerId?: number } = {},
+): void {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        pointerId: init.pointerId ?? 1,
+        clientX: init.clientX ?? 0,
+        clientY: init.clientY ?? 0,
+      }),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Drag handle rendering & ARIA shape
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag handle rendering', () => {
+  it('renders the drag handle as a <span> in the header', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.tagName).toBe('SPAN');
+  });
+
+  it('drag handle has role="presentation" and aria-hidden="true"', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.getAttribute('role')).toBe('presentation');
+    expect(handle.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('drag handle contains the braille-dots glyph (⠿)', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.textContent).toBe('⠿');
+  });
+
+  it('drag handle sits inside the header (before the label)', () => {
+    renderPicker();
+    const header = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-header',
+    );
+    expect(header).not.toBeNull();
+    const firstChild = header!.firstElementChild;
+    expect(firstChild).not.toBeNull();
+    expect(firstChild!.classList.contains('tokenpanel-color-picker-drag-handle'))
+      .toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Drag flow — pointerdown → pointermove → pointerup
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag flow', () => {
+  it('pointermove after pointerdown applies a fixed left/top to the container', () => {
+    renderPicker();
+    const dialog = getDialog();
+    // Container starts at (100, 100) with size 320x400.
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+    firePointer(handle, 'pointermove', { clientX: 150, clientY: 130 });
+
+    // delta = (40, 20) → newLeft = 140, newTop = 120
+    expect(dialog.style.position).toBe('fixed');
+    expect(dialog.style.left).toBe('140px');
+    expect(dialog.style.top).toBe('120px');
+  });
+
+  it('subsequent pointermove updates dragPos to the latest delta', () => {
+    renderPicker();
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 10, clientY: 10 });
+    firePointer(handle, 'pointermove', { clientX: 50, clientY: 50 });
+    firePointer(handle, 'pointermove', { clientX: 200, clientY: 150 });
+
+    // delta = (190, 140) from base (100, 100) → (290, 240)
+    expect(dialog.style.left).toBe('290px');
+    expect(dialog.style.top).toBe('240px');
+  });
+
+  it('pointermove without prior pointerdown does NOT move the popover', () => {
+    renderPicker();
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    // Snapshot whatever style was applied by the auto-positioning pass.
+    const initialLeft = dialog.style.left;
+    const initialTop = dialog.style.top;
+
+    firePointer(handle, 'pointermove', { clientX: 500, clientY: 500 });
+
+    expect(dialog.style.left).toBe(initialLeft);
+    expect(dialog.style.top).toBe(initialTop);
+  });
+
+  it('pointermove with mismatched pointerId is ignored', () => {
+    renderPicker();
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', {
+      pointerId: 7,
+      clientX: 10,
+      clientY: 10,
+    });
+    // A move event from a DIFFERENT pointer must not perturb dragPos.
+    firePointer(handle, 'pointermove', {
+      pointerId: 99,
+      clientX: 999,
+      clientY: 999,
+    });
+
+    // dragPos still null → style remains the auto-positioned one. Since auto
+    // is used pre-pointerdown effect, just verify no extreme jump happened.
+    // (left should NOT be the 999-based delta.)
+    expect(dialog.style.left).not.toBe('999px');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Pointerup re-clamps to the viewport
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — pointerup clamps to viewport', () => {
+  // jsdom defaults to window.innerWidth=1024, innerHeight=768. The clamp
+  // formula is: left ∈ [pad, vw - pad - width] (pad=8). So for w=320, the
+  // right bound is 1024 - 8 - 320 = 696. Anything past 696 should be pulled
+  // back to 696 on release.
+  it('clamps left to the right edge minus padding', () => {
+    renderPicker();
+    const dialog = getDialog();
+    // Place container far off the right edge of the viewport on release.
+    const handle = getDragHandle();
+
+    // Phase 1: stubRect at start. pointerdown captures baseLeft=100.
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    // Phase 2: simulate that the user dragged the container so its real
+    // rect.left is now 5000 (way off-screen). The pointerup handler reads
+    // getBoundingClientRect again to do its clamp math.
+    stubRect(dialog, { left: 5000, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 5010, clientY: 210 });
+
+    // Expected clamp on left: vw - pad - width = 1024 - 8 - 320 = 696
+    expect(dialog.style.left).toBe('696px');
+  });
+
+  it('clamps left to the padding when negative', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    // Pretend the container's rect ended up at left=-500 after dragging.
+    stubRect(dialog, { left: -500, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: -490, clientY: 210 });
+
+    expect(dialog.style.left).toBe('8px'); // pad
+  });
+
+  it('clamps top to the bottom edge minus padding', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    // Drag so the container's rect.top sits far below the viewport.
+    stubRect(dialog, { left: 200, top: 5000, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 210, clientY: 5010 });
+
+    // vh - pad - height = 768 - 8 - 400 = 360
+    expect(dialog.style.top).toBe('360px');
+  });
+
+  it('clamps top to the padding when negative', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    stubRect(dialog, { left: 200, top: -500, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 210, clientY: -490 });
+
+    expect(dialog.style.top).toBe('8px'); // pad
+  });
+
+  it('pointercancel ends the drag (treated like pointerup, applies clamp)', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    stubRect(dialog, { left: 5000, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointercancel', { clientX: 5010, clientY: 210 });
+
+    expect(dialog.style.left).toBe('696px');
+  });
+
+  it('after pointerup, a subsequent pointermove does NOT move the popover', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+    stubRect(dialog, { left: 200, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 210, clientY: 210 });
+
+    const leftAfterUp = dialog.style.left;
+    const topAfterUp = dialog.style.top;
+
+    // Drag session is over; further moves should not change position.
+    firePointer(handle, 'pointermove', { clientX: 999, clientY: 999 });
+
+    expect(dialog.style.left).toBe(leftAfterUp);
+    expect(dialog.style.top).toBe(topAfterUp);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Drag handle does NOT trigger outside-click close
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag handle and usePopoverClose', () => {
+  it('pointerdown on the drag handle does NOT call onClose', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('a full drag (down → move → up) does NOT call onClose', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+    firePointer(handle, 'pointermove', { clientX: 200, clientY: 150 });
+    stubRect(dialog, { left: 190, top: 140, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 200, clientY: 150 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. DOM hygiene — drag handle does not introduce banned tags
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag handle DOM hygiene', () => {
+  it('drag handle is a <span>, not a banned semantic tag', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.tagName).toBe('SPAN');
+    // Smoke check: still no banned tags anywhere in the dialog.
+    const banned = container.querySelectorAll('a,button,h1,h2,h3,h4,h5,h6,p,ul,ol,li');
+    expect(banned.length).toBe(0);
+  });
+
+  it('drag handle does NOT carry role="button" or tabIndex (presentational)', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.getAttribute('role')).not.toBe('button');
+    // No keyboard activation expected — it's a pure pointer affordance.
+    expect(handle.tabIndex).toBe(-1);
+  });
+});

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker.test.tsx
@@ -37,6 +37,7 @@ import { useRef } from 'preact/compat';
 import type { JSX } from 'preact';
 import { ColorPicker, LOCAL_STORAGE_KEY } from '../color-picker';
 import type { ColorPickerProps } from '../color-picker';
+import { oklchaToHex } from '../../../utils/color-oklch';
 
 // ---------------------------------------------------------------------------
 // Test harness helpers
@@ -413,8 +414,13 @@ describe('ColorPicker — hex input', () => {
       '.tokenpanel-color-picker-hex-input',
     )!;
     act(() => {
-      input.value = '#ff';
-      input.dispatchEvent(new Event('change', { bubbles: true }));
+      Object.defineProperty(input, 'value', {
+        value: '#ff',
+        writable: true,
+        configurable: true,
+      });
+      // Preact wires controlled text inputs to the native "input" event.
+      input.dispatchEvent(new Event('input', { bubbles: true }));
     });
     expect(onChange).not.toHaveBeenCalled();
   });
@@ -641,5 +647,213 @@ describe('ColorPicker — slider rendering', () => {
     renderPicker();
     const sliders = container.querySelectorAll('[role="slider"]');
     expect(sliders.length).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. H1 — Hue circular-distance regression guard
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — hue circular-distance (H1 regression)', () => {
+  // Generate deterministic test colors in OKLCH space so the test does not
+  // depend on the specific sRGB→OKLCH conversion of an opaque hex guess.
+  // L=44 matches PRESET_L_ROWS row 3 (tolerance < 2). C=0.18 = PRESET_C_FIXED.
+  const nearZeroHex = oklchaToHex({ l: 44, c: 0.18, h: 2, a: 100 });
+  const near359Hex = oklchaToHex({ l: 44, c: 0.18, h: 358, a: 100 });
+
+  it('selects H=0° col at row 3 for a color with hue near 0° (h=2°)', () => {
+    renderPicker({ color: nearZeroHex });
+    // Row 3 = PRESET_L_ROWS[3] = 44. Col 0 = H=0°.
+    const cell = container.querySelector<HTMLElement>(
+      '[data-grid-row="3"][data-grid-col="0"]',
+    );
+    expect(cell).not.toBeNull();
+    expect(cell!.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('selects H=0° col at row 3 for a color with hue near 359° (h=358°) — shortest-arc check', () => {
+    renderPicker({ color: near359Hex });
+    // 358° is only 2° away from 0° via the short arc. The old (h1-h2+360)%360
+    // formula would compute 358, not 2, and the cell would NOT be selected.
+    const cell = container.querySelector<HTMLElement>(
+      '[data-grid-row="3"][data-grid-col="0"]',
+    );
+    expect(cell).not.toBeNull();
+    expect(cell!.getAttribute('aria-selected')).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. H2 — Hex input not clobbered by external prop while user is mid-typing
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — hex input not clobbered mid-typing (H2 regression)', () => {
+  it('does NOT overwrite a partial hex input when the color prop changes externally', () => {
+    renderPicker({ color: '#3366cc' });
+
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+
+    // Simulate user clearing the field and typing a partial value.
+    act(() => {
+      Object.defineProperty(input, 'value', {
+        value: '#33',
+        writable: true,
+        configurable: true,
+      });
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    // Sanity: partial input should not have called onChange.
+    // Now re-render with a different external color.
+    act(() => {
+      render(<PickerWrapper color="#999999" onChange={vi.fn()} />, container);
+    });
+
+    // The input field must still show the in-progress value.
+    const inputAfter = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    expect(inputAfter.value).toBe('#33');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. M2 — role=row wrappers in preset grid
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — role=row wrappers in preset grid (M2)', () => {
+  it('renders 6 role=row containers in mini mode', () => {
+    renderPicker();
+    const rows = container.querySelectorAll('[role="grid"] [role="row"]');
+    expect(rows.length).toBe(6);
+  });
+
+  it('each role=row contains 6 gridcells in mini mode', () => {
+    renderPicker();
+    const rows = container.querySelectorAll('[role="grid"] [role="row"]');
+    rows.forEach((row) => {
+      const cells = row.querySelectorAll('[role="gridcell"]');
+      expect(cells.length).toBe(6);
+    });
+  });
+
+  it('renders 6 role=row containers in expanded mode, each with 12 cells', () => {
+    renderPicker();
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    fireClick(expandBtn);
+    const rows = container.querySelectorAll('[role="grid"] [role="row"]');
+    expect(rows.length).toBe(6);
+    rows.forEach((row) => {
+      const cells = row.querySelectorAll('[role="gridcell"]');
+      expect(cells.length).toBe(12);
+    });
+  });
+
+  it('arrow key navigation still works after role=row wrapper is added', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    // Move focus from [0,0] right to [0,1] with ArrowRight.
+    const firstCell = container.querySelector<HTMLElement>(
+      '[data-grid-row="0"][data-grid-col="0"]',
+    )!;
+    act(() => {
+      firstCell.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      );
+    });
+    // After ArrowRight the second cell [0,1] gets focus. Press Enter.
+    const secondCell = container.querySelector<HTMLElement>(
+      '[data-grid-row="0"][data-grid-col="1"]',
+    )!;
+    act(() => {
+      secondCell.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 13. M3 — commit normalizes hex to lowercase
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — commit normalizes hex to lowercase (M3)', () => {
+  it('calls onChange with lowercase hex when user types uppercase', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      Object.defineProperty(input, 'value', {
+        value: '#ABCDEF',
+        writable: true,
+        configurable: true,
+      });
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith('#abcdef');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 14. M5 — partial-hex test fires input event (not change)
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — partial hex does NOT call onChange (M5 regression)', () => {
+  it('does NOT call onChange for a partial hex string dispatched via input event', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      Object.defineProperty(input, 'value', {
+        value: '#33',
+        writable: true,
+        configurable: true,
+      });
+      // Preact wires controlled text inputs to the native "input" event.
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 15. Bonus — defaultMode is initial-only
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — defaultMode is initial-only', () => {
+  it('later changes to defaultMode prop do NOT update the active mode', () => {
+    renderPicker({ defaultMode: 'oklch' });
+
+    // Re-render with a different defaultMode.
+    act(() => {
+      render(
+        <PickerWrapper
+          color="#ff0000"
+          onChange={vi.fn()}
+          defaultMode="hsl"
+        />,
+        container,
+      );
+    });
+
+    // Mode should still be OKLCH — defaultMode is initial-only.
+    const dialog = getDialog();
+    const oklchBtn = dialog.querySelectorAll(
+      '[role="group"] [role="button"]',
+    )[0] as HTMLElement;
+    const hslBtn = dialog.querySelectorAll(
+      '[role="group"] [role="button"]',
+    )[1] as HTMLElement;
+    expect(oklchBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(hslBtn.getAttribute('aria-pressed')).toBe('false');
   });
 });

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker.test.tsx
@@ -1,0 +1,645 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for ColorPicker.
+ *
+ * Scope:
+ *  1. Rendering — dialog, header, mode toggle, expand button, hex input, preview,
+ *     slider section, preset grid
+ *  2. Mode toggle — OKLCH ↔ HSL; localStorage persistence; no onChange emit
+ *  3. Shell toggle — mini ↔ expanded; grid column count; readout visibility
+ *  4. Hex input — commit on valid 6-digit; commit on valid 8-digit; no commit on partial
+ *  5. Preset grid — structure, aria-selected, click commits hex
+ *  6. usePopoverClose — Escape closes; outside pointerdown closes;
+ *     inside pointerdown does NOT close; no scroll close (regression guard)
+ *  7. useSyncedHex — prop update syncs; ignored while dragging
+ *  8. DOM hygiene — no <button>, no blocked semantic tags
+ *  9. Slider rendering — all 4 OKLCH sliders; all 4 HSL sliders
+ */
+
+// jsdom does not polyfill PointerEvent. Provide a minimal shim.
+if (typeof PointerEvent === 'undefined') {
+  class PointerEventShim extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = PointerEventShim;
+}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { useRef } from 'preact/compat';
+import type { JSX } from 'preact';
+import { ColorPicker, LOCAL_STORAGE_KEY } from '../color-picker';
+import type { ColorPickerProps } from '../color-picker';
+
+// ---------------------------------------------------------------------------
+// Test harness helpers
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  // Clear localStorage before each test so mode persistence does not bleed.
+  try {
+    window.localStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  container.remove();
+});
+
+/**
+ * Wrapper component that owns an anchorRef and renders ColorPicker with it.
+ * This mirrors real usage: parent keeps ref to its trigger element.
+ */
+function PickerWrapper(props: Omit<ColorPickerProps, 'anchorRef' | 'onClose'> & {
+  onClose?: () => void;
+}): JSX.Element {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={anchorRef} style={{ width: 40, height: 40 }} />
+      <ColorPicker
+        {...props}
+        anchorRef={anchorRef as React.RefObject<HTMLElement | null>}
+        onClose={props.onClose ?? (() => {})}
+      />
+    </div>
+  );
+}
+
+function renderPicker(
+  partial: Partial<ColorPickerProps> & { onClose?: () => void } = {},
+): void {
+  act(() => {
+    render(
+      <PickerWrapper
+        color={partial.color ?? '#ff0000'}
+        onChange={partial.onChange ?? vi.fn()}
+        label={partial.label}
+        defaultMode={partial.defaultMode}
+        onClose={partial.onClose ?? (() => {})}
+      />,
+      container,
+    );
+  });
+}
+
+function getDialog(): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[role="dialog"]');
+  if (!el) throw new Error('dialog not found');
+  return el;
+}
+
+function fireKey(el: Element, key: string): void {
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+// Note: firePointerDown is used only via opts.outside=true path to test
+// outside-click close behavior. The el parameter is unused in that case.
+function firePointerDownOutside(): void {
+  act(() => {
+    document.body.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+    );
+  });
+}
+
+function firePointerDownInside(el: Element): void {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+    );
+  });
+}
+
+function fireClick(el: Element): void {
+  act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Rendering
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — rendering', () => {
+  it('renders a dialog element with aria-label containing "Color picker"', () => {
+    renderPicker();
+    const dialog = getDialog();
+    expect(dialog.getAttribute('aria-label')).toContain('Color picker');
+  });
+
+  it('renders the label in the header when label prop is passed', () => {
+    renderPicker({ label: 'Background' });
+    const dialog = getDialog();
+    expect(dialog.textContent).toContain('Background');
+  });
+
+  it('renders the mode toggle group with OKLCH and HSL buttons', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const modeGroup = dialog.querySelector('[role="group"][aria-label="Color mode"]');
+    expect(modeGroup).not.toBeNull();
+    const btns = modeGroup!.querySelectorAll('[role="button"]');
+    expect(btns.length).toBe(2);
+    expect(btns[0].textContent).toBe('OKLCH');
+    expect(btns[1].textContent).toBe('HSL');
+  });
+
+  it('renders the expand/collapse button', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const btn = dialog.querySelector<HTMLElement>('.tokenpanel-color-picker-expand-btn');
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute('role')).toBe('button');
+  });
+
+  it('renders the hex input with the initial color', () => {
+    renderPicker({ color: '#aabbcc' });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    );
+    expect(input).not.toBeNull();
+    expect(input!.value).toBe('#aabbcc');
+  });
+
+  it('renders the preview color div', () => {
+    renderPicker({ color: '#aabbcc' });
+    const preview = container.querySelector('.tokenpanel-color-picker-preview-color');
+    expect(preview).not.toBeNull();
+  });
+
+  it('renders no checkerboard when color is 6-digit hex (fully opaque)', () => {
+    renderPicker({ color: '#ff0000' });
+    const checker = container.querySelector('.tokenpanel-color-picker-preview-checkerboard');
+    expect(checker).toBeNull();
+  });
+
+  it('renders the checkerboard when color is 8-digit hex with alpha', () => {
+    renderPicker({ color: '#ff000080' });
+    const checker = container.querySelector('.tokenpanel-color-picker-preview-checkerboard');
+    expect(checker).not.toBeNull();
+  });
+
+  it('renders the preset grid with role=grid', () => {
+    renderPicker();
+    const grid = container.querySelector('[role="grid"]');
+    expect(grid).not.toBeNull();
+  });
+
+  it('renders 36 grid cells in mini mode (6 rows × 6 cols)', () => {
+    renderPicker();
+    const cells = container.querySelectorAll('[role="gridcell"]');
+    expect(cells.length).toBe(36);
+  });
+
+  it('renders the sliders section', () => {
+    renderPicker();
+    const sliders = container.querySelector('.tokenpanel-color-picker-sliders');
+    expect(sliders).not.toBeNull();
+  });
+
+  it('does NOT render the readout in mini mode', () => {
+    renderPicker();
+    const readout = container.querySelector('.tokenpanel-color-picker-readout');
+    expect(readout).toBeNull();
+  });
+
+  it('renders with data-mode-shell="mini" by default', () => {
+    renderPicker();
+    const dialog = getDialog();
+    expect(dialog.getAttribute('data-mode-shell')).toBe('mini');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Mode toggle
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — mode toggle', () => {
+  it('defaults to OKLCH mode when no defaultMode is given', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const modeGroup = dialog.querySelector('[role="group"][aria-label="Color mode"]');
+    const btns = modeGroup!.querySelectorAll<HTMLElement>('[role="button"]');
+    expect(btns[0].getAttribute('aria-pressed')).toBe('true'); // OKLCH
+    expect(btns[1].getAttribute('aria-pressed')).toBe('false'); // HSL
+  });
+
+  it('switches to HSL mode when HSL button is clicked', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const modeGroup = dialog.querySelector('[role="group"]');
+    const hslBtn = modeGroup!.querySelectorAll<HTMLElement>('[role="button"]')[1];
+    fireClick(hslBtn);
+    expect(hslBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('persists mode to localStorage on toggle', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const hslBtn = dialog.querySelectorAll('[role="group"] [role="button"]')[1] as HTMLElement;
+    fireClick(hslBtn);
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('hsl');
+  });
+
+  it('reads persisted mode from localStorage on mount', () => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker();
+    const dialog = getDialog();
+    const oklchBtn = dialog.querySelectorAll('[role="group"] [role="button"]')[0] as HTMLElement;
+    const hslBtn = dialog.querySelectorAll('[role="group"] [role="button"]')[1] as HTMLElement;
+    expect(oklchBtn.getAttribute('aria-pressed')).toBe('false');
+    expect(hslBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does NOT call onChange when toggling modes', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const dialog = getDialog();
+    const hslBtn = dialog.querySelectorAll('[role="group"] [role="button"]')[1] as HTMLElement;
+    fireClick(hslBtn);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows 4 sliders in OKLCH mode: L, C, H, A', () => {
+    renderPicker({ defaultMode: 'oklch' });
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    expect(rows.length).toBe(4);
+    const labels = Array.from(rows).map(
+      (r) => r.querySelector('.tokenpanel-color-picker-slider-label')?.textContent,
+    );
+    expect(labels).toEqual(['L', 'C', 'H', 'A']);
+  });
+
+  it('shows 4 sliders in HSL mode: H, S, L, A', () => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker();
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    expect(rows.length).toBe(4);
+    const labels = Array.from(rows).map(
+      (r) => r.querySelector('.tokenpanel-color-picker-slider-label')?.textContent,
+    );
+    expect(labels).toEqual(['H', 'S', 'L', 'A']);
+  });
+
+  it('toggles mode via Enter key on mode button', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const hslBtn = dialog.querySelectorAll('[role="group"] [role="button"]')[1] as HTMLElement;
+    act(() => {
+      hslBtn.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+    });
+    expect(hslBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Shell toggle (mini ↔ expanded)
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — shell toggle', () => {
+  it('starts in mini mode with 36 cells', () => {
+    renderPicker();
+    expect(container.querySelectorAll('[role="gridcell"]').length).toBe(36);
+  });
+
+  it('switches to expanded mode and shows 72 cells (6×12) on expand click', () => {
+    renderPicker();
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    fireClick(expandBtn);
+    expect(container.querySelectorAll('[role="gridcell"]').length).toBe(72);
+    expect(getDialog().getAttribute('data-mode-shell')).toBe('expanded');
+  });
+
+  it('shows readout in expanded mode', () => {
+    renderPicker();
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    fireClick(expandBtn);
+    const readout = container.querySelector('.tokenpanel-color-picker-readout');
+    expect(readout).not.toBeNull();
+  });
+
+  it('collapses back to mini mode on second expand click', () => {
+    renderPicker();
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    fireClick(expandBtn);
+    fireClick(expandBtn);
+    expect(container.querySelectorAll('[role="gridcell"]').length).toBe(36);
+    expect(getDialog().getAttribute('data-mode-shell')).toBe('mini');
+  });
+
+  it('expand button toggles aria-expanded attribute', () => {
+    renderPicker();
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    expect(expandBtn.getAttribute('aria-expanded')).toBe('false');
+    fireClick(expandBtn);
+    expect(expandBtn.getAttribute('aria-expanded')).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Hex input
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — hex input', () => {
+  it('calls onChange with a valid 6-digit hex on input', () => {
+    const onChange = vi.fn();
+    renderPicker({ color: '#ff0000', onChange });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      // Preact wires controlled text inputs to the native "input" event.
+      Object.defineProperty(input, 'value', {
+        value: '#00ff00',
+        writable: true,
+        configurable: true,
+      });
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith('#00ff00');
+  });
+
+  it('calls onChange with a valid 8-digit hex on input', () => {
+    const onChange = vi.fn();
+    renderPicker({ color: '#ff000080', onChange });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      // Preact wires controlled text inputs to the native "input" event.
+      // Set via Object.defineProperty so the getter reports the new value,
+      // then fire "input" to trigger the onChange handler.
+      Object.defineProperty(input, 'value', {
+        value: '#00ff0080',
+        writable: true,
+        configurable: true,
+      });
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith('#00ff0080');
+  });
+
+  it('does NOT call onChange for a partial hex string', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      input.value = '#ff';
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('syncs hex input value when the color prop changes', () => {
+    renderPicker({ color: '#ff0000' });
+    // Re-render with a new color
+    act(() => {
+      render(
+        <PickerWrapper color="#0000ff" onChange={vi.fn()} />,
+        container,
+      );
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    );
+    expect(input!.value).toBe('#0000ff');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Preset grid
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — preset grid', () => {
+  it('first grid cell has tabIndex=0, rest have tabIndex=-1', () => {
+    renderPicker();
+    const cells = container.querySelectorAll<HTMLElement>('[role="gridcell"]');
+    expect(cells[0]!.tabIndex).toBe(0);
+    // All other cells should be -1
+    const others = Array.from(cells).slice(1);
+    expect(others.every((c) => c.tabIndex === -1)).toBe(true);
+  });
+
+  it('all grid cells have data-grid-row and data-grid-col attributes', () => {
+    renderPicker();
+    const cells = container.querySelectorAll<HTMLElement>('[role="gridcell"]');
+    cells.forEach((cell) => {
+      expect(cell.hasAttribute('data-grid-row')).toBe(true);
+      expect(cell.hasAttribute('data-grid-col')).toBe(true);
+    });
+  });
+
+  it('clicking a preset cell calls onChange with a valid hex', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const cell = container.querySelector<HTMLElement>('[role="gridcell"]');
+    fireClick(cell!);
+    expect(onChange).toHaveBeenCalledOnce();
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(/^#[0-9a-fA-F]{6}$/.test(emitted) || /^#[0-9a-fA-F]{8}$/.test(emitted)).toBe(true);
+  });
+
+  it('grid cells have data-oog attribute (in/out-of-gamut marker)', () => {
+    renderPicker();
+    const cells = container.querySelectorAll<HTMLElement>('[role="gridcell"]');
+    cells.forEach((cell) => {
+      const oog = cell.getAttribute('data-oog');
+      expect(oog === 'true' || oog === 'false').toBe(true);
+    });
+  });
+
+  it('Enter key on a grid cell commits the preset', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    const cell = container.querySelector<HTMLElement>('[role="gridcell"]')!;
+    act(() => {
+      cell.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. usePopoverClose
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — usePopoverClose', () => {
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    fireKey(document.body, 'Escape');
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when pointerdown fires outside the dialog', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    firePointerDownOutside();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call onClose when pointerdown fires inside the dialog', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    const dialog = getDialog();
+    firePointerDownInside(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does NOT close on scroll (regression guard — no scroll listener)', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+      document.dispatchEvent(new Event('scroll', { bubbles: true }));
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. useSyncedHex — prop-driven sync and drag gate
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — useSyncedHex', () => {
+  it('syncs internal hex when the color prop changes while not dragging', () => {
+    renderPicker({ color: '#ff0000' });
+    act(() => {
+      render(<PickerWrapper color="#00ff00" onChange={vi.fn()} />, container);
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    );
+    expect(input!.value).toBe('#00ff00');
+  });
+
+  it('does NOT sync the color prop while a slider drag is in flight', () => {
+    // Render with red.
+    renderPicker({ color: '#ff0000' });
+
+    // Trigger pointerdown on the first slider track (role="slider") to flip
+    // isDraggingRef.current = true via CustomSlider's addEventListener handler.
+    const sliderTrack = container.querySelector<HTMLElement>('[role="slider"]')!;
+    act(() => {
+      sliderTrack.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+      );
+    });
+
+    // Re-render with a new external color — the drag gate should suppress sync.
+    act(() => {
+      render(<PickerWrapper color="#00ff00" onChange={vi.fn()} />, container);
+    });
+
+    // Hex input must still show the original value — drag is still in flight.
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    expect(input.value).toBe('#ff0000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. DOM hygiene
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — DOM hygiene', () => {
+  it('renders no <button> elements', () => {
+    renderPicker();
+    expect(container.querySelectorAll('button').length).toBe(0);
+  });
+
+  it('renders no <h1>–<h6> elements', () => {
+    renderPicker();
+    const headings = container.querySelectorAll('h1,h2,h3,h4,h5,h6');
+    expect(headings.length).toBe(0);
+  });
+
+  it('renders no <ul>, <ol>, <li> elements', () => {
+    renderPicker();
+    const lists = container.querySelectorAll('ul,ol,li');
+    expect(lists.length).toBe(0);
+  });
+
+  it('renders no <p> elements', () => {
+    renderPicker();
+    expect(container.querySelectorAll('p').length).toBe(0);
+  });
+
+  it('renders no <a> elements', () => {
+    renderPicker();
+    expect(container.querySelectorAll('a').length).toBe(0);
+  });
+
+  it('all interactive role="button" elements have tabIndex=0', () => {
+    renderPicker();
+    const btns = container.querySelectorAll<HTMLElement>('[role="button"]');
+    btns.forEach((btn) => {
+      expect(btn.tabIndex).toBe(0);
+    });
+  });
+
+  it('the hex input is a permitted form element', () => {
+    renderPicker();
+    const inputs = container.querySelectorAll('input');
+    // Exactly one input for hex
+    expect(inputs.length).toBe(1);
+    expect(inputs[0]!.type).toBe('text');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Slider rendering
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — slider rendering', () => {
+  it('renders 4 slider rows in OKLCH mode', () => {
+    renderPicker({ defaultMode: 'oklch' });
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    expect(rows.length).toBe(4);
+  });
+
+  it('renders 4 slider rows in HSL mode', () => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker();
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    expect(rows.length).toBe(4);
+  });
+
+  it('each slider host has role="slider"', () => {
+    renderPicker();
+    const sliders = container.querySelectorAll('[role="slider"]');
+    expect(sliders.length).toBe(4);
+  });
+});

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/custom-slider.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/custom-slider.test.tsx
@@ -418,3 +418,65 @@ describe('CustomSlider — DOM hygiene', () => {
     expect(row?.tagName.toLowerCase()).toBe('div');
   });
 });
+
+// ---------------------------------------------------------------------------
+// 6. Pointer step-snap (review fix: pointer must honor config.step)
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — pointer step snapping', () => {
+  // Mount with a known geometry so valueFromPointerX can compute a real value.
+  function mountWithGeom(config: SliderConfig, value: number) {
+    const result = renderSlider(config, value);
+    const host = getSliderHost();
+    host.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 100,
+        top: 0,
+        height: 10,
+        right: 100,
+        bottom: 10,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return this;
+        },
+      }) as DOMRect;
+    return { ...result, host };
+  }
+
+  it('snaps pointer x to integer step on a step:1 slider', () => {
+    // x=37.4 of width=100 → raw fraction=0.374 → raw value=134.64
+    // step=1 → snapped to 135
+    const { onChange, host } = mountWithGeom(INTEGER_CONFIG, 0);
+    firePointerDown(host, 37.4);
+    expect(onChange).toHaveBeenCalledWith(135);
+  });
+
+  it('snaps pointer x to fractional step on a step:0.01 slider', () => {
+    // x=33 of width=100 → raw fraction=0.33 → raw value=0.33
+    // step=0.01 → snapped to 0.33 (exact)
+    const { onChange, host } = mountWithGeom(FRACTIONAL_CONFIG, 0);
+    firePointerDown(host, 33.4);
+    // 33.4/100 = 0.334; snapped to 0.33
+    expect(onChange).toHaveBeenCalledWith(expect.closeTo(0.33, 10));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. ARIA valuetext (review fix: screen readers get formatted display)
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — aria-valuetext', () => {
+  it('sets aria-valuetext to the formatted value', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const host = getSliderHost();
+    expect(host.getAttribute('aria-valuetext')).toBe('180°');
+  });
+
+  it('updates aria-valuetext when value changes', () => {
+    renderSlider(FRACTIONAL_CONFIG, 0.42);
+    const host = getSliderHost();
+    expect(host.getAttribute('aria-valuetext')).toBe('0.42');
+  });
+});

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/custom-slider.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/custom-slider.test.tsx
@@ -1,0 +1,404 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for CustomSlider.
+ *
+ * Scope:
+ *  1. Rendering — label, slider host, value span, gradient, thumb position
+ *  2. Keyboard — ArrowRight/Left, Shift modifier, Home, End
+ *  3. Pointer events — pointerdown → onDragStart; pointermove → onChange;
+ *     pointerup → onDragEnd (event-sequencing only; no geometry assertions)
+ *  4. Clamping — values stay within [min, max]
+ *  5. ARIA — role=slider, aria-valuemin/max/now, aria-label
+ */
+
+// jsdom does not polyfill PointerEvent. Provide a minimal shim that extends
+// MouseEvent so dispatchEvent can carry clientX and pointerId as needed.
+if (typeof PointerEvent === 'undefined') {
+  class PointerEventShim extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = PointerEventShim;
+}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { CustomSlider } from '../custom-slider';
+import type { SliderConfig } from '../custom-slider';
+
+// ---------------------------------------------------------------------------
+// Fixture
+// ---------------------------------------------------------------------------
+
+const INTEGER_CONFIG: SliderConfig = {
+  key: 'hue',
+  label: 'H',
+  ariaLabel: 'Hue',
+  min: 0,
+  max: 360,
+  step: 1,
+  format: (v) => `${Math.round(v)}°`,
+};
+
+const FRACTIONAL_CONFIG: SliderConfig = {
+  key: 'lightness',
+  label: 'L',
+  ariaLabel: 'Lightness',
+  min: 0,
+  max: 1,
+  step: 0.01,
+  format: (v) => v.toFixed(2),
+};
+
+const GRADIENT = 'linear-gradient(to right, oklch(0 0 0), oklch(1 0 0))';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  container.remove();
+});
+
+function renderSlider(
+  config: SliderConfig,
+  value: number,
+  callbacks: {
+    onChange?: (v: number) => void;
+    onDragStart?: () => void;
+    onDragEnd?: () => void;
+  } = {},
+) {
+  const onChange = callbacks.onChange ?? vi.fn();
+  const onDragStart = callbacks.onDragStart ?? vi.fn();
+  const onDragEnd = callbacks.onDragEnd ?? vi.fn();
+
+  act(() => {
+    render(
+      <CustomSlider
+        config={config}
+        value={value}
+        gradient={GRADIENT}
+        onChange={onChange}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+      />,
+      container,
+    );
+  });
+
+  return { onChange, onDragStart, onDragEnd };
+}
+
+function getSliderHost(): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[role="slider"]');
+  if (!el) throw new Error('slider host not found');
+  return el;
+}
+
+function fireKey(el: Element, key: string, shift = false) {
+  act(() => {
+    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, shiftKey: shift }));
+  });
+}
+
+function firePointerDown(el: Element, clientX = 0) {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, clientX, pointerId: 1 }),
+    );
+  });
+}
+
+function firePointerMove(el: Element, clientX = 0) {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointermove', { bubbles: true, clientX, pointerId: 1 }),
+    );
+  });
+}
+
+function firePointerUp(el: Element) {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointerup', { bubbles: true, pointerId: 1 }),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Rendering
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — rendering', () => {
+  it('renders the label span with the config label', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const label = container.querySelector('.tokenpanel-color-picker-slider-label');
+    expect(label).not.toBeNull();
+    expect(label!.textContent).toBe('H');
+  });
+
+  it('renders the slider host with role=slider and tabindex=0', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const host = getSliderHost();
+    expect(host.getAttribute('role')).toBe('slider');
+    expect(host.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('renders the slider host with aria-valuemin/max/now', () => {
+    renderSlider(INTEGER_CONFIG, 90);
+    const host = getSliderHost();
+    expect(host.getAttribute('aria-valuemin')).toBe('0');
+    expect(host.getAttribute('aria-valuemax')).toBe('360');
+    expect(host.getAttribute('aria-valuenow')).toBe('90');
+  });
+
+  it('renders the slider host with aria-label from config', () => {
+    renderSlider(INTEGER_CONFIG, 90);
+    const host = getSliderHost();
+    expect(host.getAttribute('aria-label')).toBe('Hue');
+  });
+
+  it('renders the track div inside the slider host', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const track = container.querySelector('.tokenpanel-color-picker-slider-track');
+    expect(track).not.toBeNull();
+  });
+
+  it('sets the gradient on the track background style', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const track = container.querySelector<HTMLElement>('.tokenpanel-color-picker-slider-track');
+    expect(track).not.toBeNull();
+    // The background style must contain the gradient value
+    expect(track!.style.background).toBe(GRADIENT);
+  });
+
+  it('renders the thumb with left% proportional to the value fraction', () => {
+    // value=90 of [0..360] → fraction=0.25 → left=25%
+    renderSlider(INTEGER_CONFIG, 90);
+    const thumb = container.querySelector<HTMLElement>('.tokenpanel-color-picker-slider-thumb');
+    expect(thumb).not.toBeNull();
+    expect(thumb!.style.left).toBe('25%');
+  });
+
+  it('renders the value span with the formatted value', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const valueSpan = container.querySelector('.tokenpanel-color-picker-slider-value');
+    expect(valueSpan).not.toBeNull();
+    expect(valueSpan!.textContent).toBe('180°');
+  });
+
+  it('renders exactly 3 top-level children in the row: label, slider host, value', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const row = container.querySelector('.tokenpanel-color-picker-slider-row');
+    expect(row).not.toBeNull();
+    // Children: label span, slider div, value span
+    expect(row!.children.length).toBe(3);
+    expect(row!.children[0].className).toContain('slider-label');
+    expect(row!.children[1].getAttribute('role')).toBe('slider');
+    expect(row!.children[2].className).toContain('slider-value');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Keyboard navigation
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — keyboard navigation (integer step)', () => {
+  it('ArrowRight increases value by step', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'ArrowRight');
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(181);
+  });
+
+  it('ArrowLeft decreases value by step', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'ArrowLeft');
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(179);
+  });
+
+  it('ArrowUp increases value by step', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'ArrowUp');
+    expect(onChange).toHaveBeenCalledWith(181);
+  });
+
+  it('ArrowDown decreases value by step', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'ArrowDown');
+    expect(onChange).toHaveBeenCalledWith(179);
+  });
+
+  it('Shift+ArrowRight increases value by 10× step', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'ArrowRight', true);
+    expect(onChange).toHaveBeenCalledWith(190);
+  });
+
+  it('Shift+ArrowLeft decreases value by 10× step', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'ArrowLeft', true);
+    expect(onChange).toHaveBeenCalledWith(170);
+  });
+
+  it('Home sets value to min', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'Home');
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('End sets value to max', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'End');
+    expect(onChange).toHaveBeenCalledWith(360);
+  });
+
+  it('clamps ArrowRight at max', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 360);
+    fireKey(getSliderHost(), 'ArrowRight');
+    expect(onChange).toHaveBeenCalledWith(360);
+  });
+
+  it('clamps ArrowLeft at min', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 0);
+    fireKey(getSliderHost(), 'ArrowLeft');
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('ignores unrelated keys', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    fireKey(getSliderHost(), 'Tab');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('CustomSlider — keyboard navigation (fractional step)', () => {
+  it('ArrowRight increases value by fractional step', () => {
+    const { onChange } = renderSlider(FRACTIONAL_CONFIG, 0.5);
+    fireKey(getSliderHost(), 'ArrowRight');
+    expect(onChange).toHaveBeenCalledOnce();
+    // 0.5 + 0.01 = 0.51 — no rounding applied (sub-1 step passes through)
+    expect(onChange).toHaveBeenCalledWith(expect.closeTo(0.51, 10));
+  });
+
+  it('Shift+ArrowRight increases by 10× step for fractional config', () => {
+    const { onChange } = renderSlider(FRACTIONAL_CONFIG, 0.5);
+    fireKey(getSliderHost(), 'ArrowRight', true);
+    // coarse = 0.01 * 10 = 0.1 → 0.5 + 0.1 = 0.6
+    expect(onChange).toHaveBeenCalledWith(expect.closeTo(0.6, 10));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Pointer events (event sequencing — no geometry)
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — pointer event sequencing', () => {
+  it('pointerdown fires onDragStart', () => {
+    const { onDragStart } = renderSlider(INTEGER_CONFIG, 180);
+    firePointerDown(getSliderHost());
+    expect(onDragStart).toHaveBeenCalledOnce();
+  });
+
+  it('pointermove after pointerdown fires onChange', () => {
+    // jsdom returns zero-width rects, so valueFromPointerX returns null and
+    // onChange is NOT called on moves (geometry is unavailable). The test
+    // verifies the handler is wired without throwing.
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    firePointerDown(getSliderHost());
+    firePointerMove(getSliderHost(), 50);
+    // onChange may or may not be called (jsdom rect is zero-width); the test
+    // asserts it does not throw, and onDragStart was still invoked.
+    expect(onChange).toBeDefined(); // guard: no error thrown
+  });
+
+  it('pointerup after pointerdown fires onDragEnd', () => {
+    const { onDragEnd } = renderSlider(INTEGER_CONFIG, 180);
+    firePointerDown(getSliderHost());
+    firePointerUp(getSliderHost());
+    expect(onDragEnd).toHaveBeenCalledOnce();
+  });
+
+  it('pointermove without prior pointerdown does not fire onChange', () => {
+    const { onChange } = renderSlider(INTEGER_CONFIG, 180);
+    firePointerMove(getSliderHost(), 50);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('pointerup without prior pointerdown does not fire onDragEnd', () => {
+    const { onDragEnd } = renderSlider(INTEGER_CONFIG, 180);
+    firePointerUp(getSliderHost());
+    expect(onDragEnd).not.toHaveBeenCalled();
+  });
+
+  it('onDragStart fires before onDragEnd in a drag sequence', () => {
+    const order: string[] = [];
+    renderSlider(INTEGER_CONFIG, 180, {
+      onDragStart: () => order.push('start'),
+      onDragEnd: () => order.push('end'),
+    });
+    firePointerDown(getSliderHost());
+    firePointerMove(getSliderHost(), 100);
+    firePointerUp(getSliderHost());
+    expect(order).toEqual(['start', 'end']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Value clamping
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — value clamping in keyboard handler', () => {
+  it('value above max is clamped to max on ArrowRight', () => {
+    // Simulate value=355 with step=10 → 355+10=365 clamped to 360
+    const config: SliderConfig = { ...INTEGER_CONFIG, step: 10 };
+    const { onChange } = renderSlider(config, 355);
+    fireKey(getSliderHost(), 'ArrowRight');
+    expect(onChange).toHaveBeenCalledWith(360);
+  });
+
+  it('value below min is clamped to min on ArrowLeft', () => {
+    const config: SliderConfig = { ...INTEGER_CONFIG, step: 10 };
+    const { onChange } = renderSlider(config, 5);
+    fireKey(getSliderHost(), 'ArrowLeft');
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. DOM hygiene
+// ---------------------------------------------------------------------------
+
+describe('CustomSlider — DOM hygiene', () => {
+  it('renders no <button> elements', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    expect(container.querySelectorAll('button').length).toBe(0);
+  });
+
+  it('renders no <input> elements', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    expect(container.querySelectorAll('input').length).toBe(0);
+  });
+
+  it('renders the outer wrapper as a div', () => {
+    renderSlider(INTEGER_CONFIG, 180);
+    const row = container.querySelector('.tokenpanel-color-picker-slider-row');
+    expect(row?.tagName.toLowerCase()).toBe('div');
+  });
+});

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/custom-slider.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/custom-slider.test.tsx
@@ -316,16 +316,32 @@ describe('CustomSlider — pointer event sequencing', () => {
     expect(onDragStart).toHaveBeenCalledOnce();
   });
 
-  it('pointermove after pointerdown fires onChange', () => {
-    // jsdom returns zero-width rects, so valueFromPointerX returns null and
-    // onChange is NOT called on moves (geometry is unavailable). The test
-    // verifies the handler is wired without throwing.
+  it('pointermove after pointerdown fires onChange with geometry-based value', () => {
+    // jsdom returns zero-width rects by default, so mock getBoundingClientRect
+    // to give the slider host a known non-zero width. This lets valueFromPointerX
+    // compute a real value so we can assert onChange is called correctly.
     const { onChange } = renderSlider(INTEGER_CONFIG, 180);
-    firePointerDown(getSliderHost());
-    firePointerMove(getSliderHost(), 50);
-    // onChange may or may not be called (jsdom rect is zero-width); the test
-    // asserts it does not throw, and onDragStart was still invoked.
-    expect(onChange).toBeDefined(); // guard: no error thrown
+    const host = getSliderHost();
+    host.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        width: 100,
+        top: 0,
+        height: 10,
+        right: 100,
+        bottom: 10,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return this;
+        },
+      }) as DOMRect;
+
+    // pointerdown at x=0 → value = min (0)
+    firePointerDown(host, 0);
+    // pointermove at x=75 → fraction=0.75 → value = 0 + 0.75*360 = 270
+    firePointerMove(host, 75);
+    expect(onChange).toHaveBeenCalledWith(270);
   });
 
   it('pointerup after pointerdown fires onDragEnd', () => {

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
@@ -56,6 +56,30 @@
   gap: var(--tokentweak-gap-2xs);
 }
 
+/* Drag handle — braille-dots glyph in the header's leading slot.
+ * cursor: grab → grabbing; touch-action: none lets pointer events handle
+ * the gesture (otherwise the browser's pan/scroll hijacks it on touch).
+ * aria-hidden in JSX so assistive tech skips the glyph. */
+.tokenpanel-color-picker-drag-handle {
+  flex-shrink: 0;
+  cursor: grab;
+  color: var(--tokentweak-color-muted);
+  font-size: var(--tokentweak-text-caption);
+  line-height: 1;
+  padding: var(--tokentweak-pad-2xs);
+  border-radius: var(--radius-tokentweak);
+  user-select: none;
+  touch-action: none;
+}
+
+.tokenpanel-color-picker-drag-handle:hover {
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-picker-drag-handle:active {
+  cursor: grabbing;
+}
+
 .tokenpanel-color-picker-label {
   flex: 1;
   min-width: 0;

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
@@ -222,6 +222,16 @@
   gap: 2px;
 }
 
+/* role="row" wrappers carry ARIA grid semantics but must not break the
+   CSS grid track layout — promote their cells to direct grid items so
+   hue runs across the X axis and brightness down the Y axis (matching
+   the pgen reference). Without this, the row wrappers become the grid
+   items themselves and the inner cells stack vertically, transposing
+   the axes. */
+.tokenpanel-color-picker-grid > [role='row'] {
+  display: contents;
+}
+
 .tokenpanel-color-picker[data-mode-shell='expanded'] .tokenpanel-color-picker-grid {
   grid-template-columns: repeat(12, 1fr);
 }

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
@@ -1,0 +1,335 @@
+/**
+ * OklchPicker — color picker popover CSS.
+ *
+ * BEM namespace: tokenpanel-color-picker-*
+ * Tokens: --tokentweak-* and --radius-tokentweak only.
+ * Cascade: imported by panel.css immediately after panel-tokens.css.
+ *
+ * Layout summary
+ * --------------
+ * Root (.tokenpanel-color-picker) is a fixed-positioned popover card.
+ * Two size modes are controlled by data-mode-shell="mini" (default, 320px)
+ * and data-mode-shell="expanded" (520px).
+ *
+ * Internal structure:
+ *   header (label + mode toggle + expand btn)
+ *   top-row (preview swatch + hex input)
+ *   grid (preset color cells, role="grid")
+ *   sliders (one row per channel: L/C/H/α)
+ *   readout (expanded mode only — full channel values + out-of-gamut notice)
+ */
+
+/* ===========================================================================
+ * Root popover card
+ * ========================================================================= */
+
+.tokenpanel-color-picker {
+  position: fixed;
+  width: 320px;
+  padding: var(--tokentweak-pad-md);
+  background: var(--tokentweak-color-surface);
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: var(--radius-tokentweak);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--tokentweak-gap-2xs);
+  z-index: 70;
+  color: var(--tokentweak-color-fg);
+  font-size: var(--tokentweak-text-caption);
+  /* Solid surface — matches .tokenpanel-popover (no backdrop-filter). */
+}
+
+.tokenpanel-color-picker[data-mode-shell='expanded'] {
+  width: 520px;
+  padding: var(--tokentweak-pad-lg);
+  gap: var(--tokentweak-gap-xs);
+}
+
+/* ===========================================================================
+ * Header row (label + mode toggle pill + expand button)
+ * ========================================================================= */
+
+.tokenpanel-color-picker-header {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-gap-2xs);
+}
+
+.tokenpanel-color-picker-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--tokentweak-color-fg);
+  font-family: var(--tokentweak-font-mono);
+  font-size: var(--tokentweak-text-caption);
+}
+
+/* Mode toggle — rounded pill wrapper (role="group") */
+.tokenpanel-color-picker-mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--tokentweak-color-bg);
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: 999px;
+  padding: 2px;
+  flex-shrink: 0;
+}
+
+/* Individual mode button (div role="button") */
+.tokenpanel-color-picker-mode-btn {
+  border-radius: 999px;
+  padding-inline: var(--tokentweak-pad-xs);
+  padding-block: var(--tokentweak-pad-2xs);
+  font-size: var(--tokentweak-text-micro);
+  color: var(--tokentweak-color-muted);
+  cursor: pointer;
+  user-select: none;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+  white-space: nowrap;
+}
+
+.tokenpanel-color-picker-mode-btn:hover {
+  color: var(--tokentweak-color-fg);
+}
+
+/* Activated mode — accent background, foreground text */
+.tokenpanel-color-picker-mode-btn[aria-pressed='true'] {
+  background-color: var(--tokentweak-color-accent);
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-picker-mode-btn:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+}
+
+/* Expand/collapse button */
+.tokenpanel-color-picker-expand-btn {
+  flex-shrink: 0;
+  color: var(--tokentweak-color-muted);
+  cursor: pointer;
+  user-select: none;
+  padding: var(--tokentweak-pad-2xs);
+  border-radius: var(--radius-tokentweak);
+  transition: color 120ms ease;
+}
+
+.tokenpanel-color-picker-expand-btn:hover {
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-picker-expand-btn:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+}
+
+/* ===========================================================================
+ * Top row (color preview + hex input)
+ * ========================================================================= */
+
+.tokenpanel-color-picker-top-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-gap-2xs);
+}
+
+/* Preview swatch — relative wrapper for checkerboard + color overlay */
+.tokenpanel-color-picker-preview {
+  position: relative;
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  border-radius: var(--radius-tokentweak);
+  border: 1px solid var(--tokentweak-color-muted);
+  overflow: hidden;
+}
+
+/* Checkerboard background layer (visible through alpha channel) */
+.tokenpanel-color-picker-preview-checkerboard {
+  position: absolute;
+  inset: 0;
+  background-image: repeating-conic-gradient(#808080 0% 25%, #c0c0c0 0% 50%);
+  background-size: 10px 10px;
+}
+
+/* Actual color overlay on top of checkerboard */
+.tokenpanel-color-picker-preview-color {
+  position: absolute;
+  inset: 0;
+  /* background-color is set inline by the component */
+}
+
+/* Hex text input */
+.tokenpanel-color-picker-hex-input {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--tokentweak-font-mono);
+  font-size: var(--tokentweak-text-caption);
+  background: var(--tokentweak-color-bg);
+  color: var(--tokentweak-color-fg);
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: var(--radius-tokentweak);
+  padding: var(--tokentweak-pad-2xs) var(--tokentweak-pad-xs);
+  transition: border-color 120ms ease;
+}
+
+.tokenpanel-color-picker-hex-input:hover {
+  border-color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-picker-hex-input:focus {
+  border-color: var(--tokentweak-color-accent);
+  outline: none;
+}
+
+/* ===========================================================================
+ * Preset grid (role="grid")
+ * ========================================================================= */
+
+.tokenpanel-color-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr); /* mini default */
+  gap: 2px;
+}
+
+.tokenpanel-color-picker[data-mode-shell='expanded'] .tokenpanel-color-picker-grid {
+  grid-template-columns: repeat(12, 1fr);
+}
+
+/* Grid cell (div role="gridcell") */
+.tokenpanel-color-picker-grid-cell {
+  position: relative; /* needed for ::after OOG marker */
+  aspect-ratio: 1;
+  border-radius: var(--radius-tokentweak);
+  cursor: pointer;
+  /* background-color is set inline by the component */
+  transition: box-shadow 120ms ease;
+}
+
+.tokenpanel-color-picker-grid-cell:hover {
+  box-shadow: 0 0 0 2px var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-picker-grid-cell[aria-selected='true'] {
+  box-shadow: 0 0 0 2px var(--tokentweak-color-accent);
+}
+
+.tokenpanel-color-picker-grid-cell:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+}
+
+/* Out-of-gamut dashed border overlay (data-oog="true").
+   The one literal oklch() here is the gamut-clip visual spec: a near-white
+   semi-transparent dashed border visible against any cell color. */
+.tokenpanel-color-picker-grid-cell[data-oog='true']::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border: 1px dashed oklch(98% 0 0 / 0.4);
+  border-radius: var(--radius-tokentweak);
+  pointer-events: none;
+}
+
+/* ===========================================================================
+ * Sliders (L / C / H / α channels)
+ * ========================================================================= */
+
+.tokenpanel-color-picker-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tokentweak-gap-2xs);
+}
+
+/* Single slider row: label | track+thumb | value */
+.tokenpanel-color-picker-slider-row {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-gap-2xs);
+}
+
+.tokenpanel-color-picker-slider-label {
+  flex-shrink: 0;
+  width: 1.25rem;
+  font-size: var(--tokentweak-text-micro);
+  color: var(--tokentweak-color-muted);
+  user-select: none;
+}
+
+/* Custom slider (div role="slider") — track + thumb */
+.tokenpanel-color-picker-slider {
+  flex: 1;
+  position: relative;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.tokenpanel-color-picker-slider:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-tokentweak);
+}
+
+/* Slider track */
+.tokenpanel-color-picker-slider-track {
+  width: 100%;
+  height: 18px;
+  border-radius: 9px;
+  overflow: hidden;
+  border: 1px solid var(--tokentweak-color-muted);
+  /* background (gradient) is set inline by the component (alpha channel) or
+     statically by component for L/C/H channels */
+}
+
+/* Slider thumb — a circle absolutely positioned by inline left% */
+.tokenpanel-color-picker-slider-thumb {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--tokentweak-color-fg);
+  border: 2px solid var(--tokentweak-color-bg);
+  box-shadow: 0 0 0 1px var(--tokentweak-color-muted);
+  pointer-events: none;
+  /* left is set inline by the component as a percentage */
+}
+
+.tokenpanel-color-picker-slider-value {
+  flex-shrink: 0;
+  width: 3rem;
+  text-align: right;
+  font-family: var(--tokentweak-font-mono);
+  font-size: var(--tokentweak-text-micro);
+  color: var(--tokentweak-color-fg);
+}
+
+/* ===========================================================================
+ * Readout (expanded shell only — full channel values + OOG notice)
+ * ========================================================================= */
+
+.tokenpanel-color-picker-readout {
+  display: none;
+  font-family: var(--tokentweak-font-mono);
+  font-size: var(--tokentweak-text-micro);
+  color: var(--tokentweak-color-muted);
+  padding-top: var(--tokentweak-pad-2xs);
+  border-top: 1px solid var(--tokentweak-color-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tokenpanel-color-picker[data-mode-shell='expanded'] .tokenpanel-color-picker-readout {
+  display: block;
+}

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
@@ -271,6 +271,9 @@
   align-items: center;
   cursor: pointer;
   user-select: none;
+  /* Disable native touch gestures so horizontal drags don't get hijacked by
+     the browser's pan/scroll and emit pointercancel mid-drag on touch devices. */
+  touch-action: none;
 }
 
 .tokenpanel-color-picker-slider:focus-visible {

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
@@ -327,8 +327,28 @@ export function ColorPicker({
   onClose,
 }: ColorPickerProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
+  const dragHandleRef = useRef<HTMLSpanElement>(null);
   const isDraggingRef = useRef(false);
   const [hex, setHex] = useSyncedHex(color, isDraggingRef);
+
+  // ── Drag-handle state ─────────────────────────────────────────────────────
+  // dragPos holds the current dragged-to position (left, top in viewport px).
+  // null means auto-positioned (normal anchor-relative behavior).
+  // Session-only: the popover unmounts when the parent closes it, so dragPos
+  // resets to null on every open.
+  const [dragPos, setDragPos] = useState<{ left: number; top: number } | null>(
+    null,
+  );
+  // Ref tracking the pointer start position and the popover's base rect for
+  // the current drag gesture. Never causes a re-render.
+  const dragSession = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    baseLeft: number;
+    baseTop: number;
+  } | null>(null);
+  const isDraggingHandle = useRef(false);
 
   const [mode, setMode] = useState<ColorPickerMode>(() =>
     readPersistedMode(defaultMode),
@@ -494,6 +514,96 @@ export function ColorPicker({
     );
   }, [anchorRef, shell]);
 
+  // ── Drag-handle pointer handlers ─────────────────────────────────────────
+  // Mirrors pgen's color-picker-oklch drag implementation. Wired via
+  // addEventListener (not Preact JSX onPointer* props) for the same reason as
+  // custom-slider.tsx — Preact's jsdom feature-detection registers PointerEvent
+  // listeners with wrong casing, so tests dispatching 'pointerdown' miss them.
+  // Pointer capture keeps move/up flowing even if the pointer leaves the handle.
+  useEffect(() => {
+    const el = dragHandleRef.current;
+    if (!el) return;
+
+    function handlePointerDown(e: PointerEvent) {
+      e.preventDefault();
+      // Stop propagation so the document-level outside-click handler can't
+      // possibly receive this pointerdown. Defensive — even though the handle
+      // sits inside containerRef, mirroring pgen's pattern keeps the contract
+      // explicit.
+      e.stopPropagation();
+      const container = containerRef.current;
+      if (!container) return;
+      // Freeze the current rendered position (absolute left/top in viewport).
+      // Use getBoundingClientRect so we always operate in `top` space regardless
+      // of whether the auto-position used `top` or `bottom` CSS.
+      const rect = container.getBoundingClientRect();
+      dragSession.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        baseLeft: rect.left,
+        baseTop: rect.top,
+      };
+      isDraggingHandle.current = true;
+      try {
+        el!.setPointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement setPointerCapture; ignore.
+      }
+    }
+
+    function handlePointerMove(e: PointerEvent) {
+      if (!isDraggingHandle.current || !dragSession.current) return;
+      if (e.pointerId !== dragSession.current.pointerId) return;
+      const { startX, startY, baseLeft, baseTop } = dragSession.current;
+      const newLeft = baseLeft + (e.clientX - startX);
+      const newTop = baseTop + (e.clientY - startY);
+      setDragPos({ left: newLeft, top: newTop });
+    }
+
+    function handlePointerUp(e: PointerEvent) {
+      if (!isDraggingHandle.current || !dragSession.current) return;
+      if (e.pointerId !== dragSession.current.pointerId) return;
+      isDraggingHandle.current = false;
+      dragSession.current = null;
+      try {
+        el!.releasePointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement releasePointerCapture; ignore.
+      }
+      // Re-clamp to keep the popover fully on-screen after release.
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const pad = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const clampedLeft = Math.max(
+        pad,
+        Math.min(vw - pad - rect.width, rect.left),
+      );
+      const clampedTop = Math.max(
+        pad,
+        Math.min(vh - pad - rect.height, rect.top),
+      );
+      setDragPos({ left: clampedLeft, top: clampedTop });
+    }
+
+    el.addEventListener('pointerdown', handlePointerDown);
+    el.addEventListener('pointermove', handlePointerMove);
+    el.addEventListener('pointerup', handlePointerUp);
+    el.addEventListener('pointercancel', handlePointerUp);
+
+    return () => {
+      el.removeEventListener('pointerdown', handlePointerDown);
+      el.removeEventListener('pointermove', handlePointerMove);
+      el.removeEventListener('pointerup', handlePointerUp);
+      el.removeEventListener('pointercancel', handlePointerUp);
+    };
+    // Empty dep array — handlers close over stable refs only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Checkerboard is only needed when the color has a non-opaque alpha byte.
   const hasAlpha = /^#[0-9a-fA-F]{8}$/.test(hex);
 
@@ -504,17 +614,35 @@ export function ColorPicker({
     isDraggingRef.current = false;
   }, []);
 
+  // Final container style — dragPos takes precedence over auto-positioning
+  // once the user has grabbed the handle and moved the popover.
+  const containerStyle: JSX.CSSProperties = dragPos
+    ? { position: 'fixed', left: dragPos.left, top: dragPos.top }
+    : autoStyle;
+
   return (
     <div
       ref={containerRef}
       className="tokenpanel-color-picker"
       data-mode-shell={shell}
-      style={autoStyle}
+      style={containerStyle}
       role="dialog"
       aria-label={label ? `${label} color picker` : 'Color picker'}
     >
       {/* Header ─────────────────────────────────────────────────────────── */}
       <div className="tokenpanel-color-picker-header">
+        {/* Drag handle — braille-dots glyph (⠿, U+283F) per pgen mockup.
+            role="presentation"+aria-hidden so assistive tech skips the glyph.
+            <span> chosen over <div> per zdtp panel-DOM-hygiene policy: span is
+            not in the host-resettable tag list and matches pgen's pattern. */}
+        <span
+          ref={dragHandleRef}
+          className="tokenpanel-color-picker-drag-handle"
+          role="presentation"
+          aria-hidden="true"
+        >
+          ⠿
+        </span>
         <span className="tokenpanel-color-picker-label">{label ?? 'Color'}</span>
 
         {/* Mode toggle: OKLCH | HSL */}

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
@@ -1,0 +1,661 @@
+// @ts-check
+/**
+ * ColorPicker — dual-mode (OKLCH | HSL) color picker for the design-token panel.
+ *
+ * Renders as a "popover body only" component — the parent is responsible for
+ * mounting/unmounting based on an open/closed boolean. No trigger swatch, no
+ * portal, no createPortal.
+ *
+ * Issue #175 (Wave 2 of the OKLCH Picker epic, issue #174-base).
+ *
+ * Design rules (see packages/zudo-design-token-panel/CLAUDE.md):
+ *   - All interactive elements use <div role="button" tabIndex={0}> with
+ *     explicit Enter/Space onKeyDown handlers. No <button> or <h*> allowed.
+ *   - BEM class names: tokenpanel-color-picker-* (locked external contract).
+ *   - usePopoverClose: pointerdown + Escape only — NO scroll listener.
+ *   - Mode persisted to localStorage under key tokenpanel.colorPicker.mode.
+ *   - Alpha always shown; alpha ∈ [0, 100] scale throughout.
+ *   - useSyncedHex: incoming color prop ignored while isDraggingRef.current.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'preact/compat';
+import type { JSX } from 'preact';
+
+import { hexToHsla, hslaToHex } from '../../utils/color-hsla';
+import {
+  type Oklcha,
+  clampToSrgbGamut,
+  hexToOklcha,
+  hslaToOklcha,
+  isInSrgbGamut,
+  MAX_OKLCH_CHROMA,
+  oklchaToCss,
+  oklchaToHex,
+} from '../../utils/color-oklch';
+import { CustomSlider, type SliderConfig } from './custom-slider';
+
+/* ── Public API ─────────────────────────────────────────────────────────── */
+
+export type ColorPickerMode = 'oklch' | 'hsl';
+
+export interface ColorPickerProps {
+  /** Current hex color (#RRGGBB or #RRGGBBAA). Source of truth. */
+  color: string;
+  /** Called when the user commits a new color via any sub-control. */
+  onChange: (hex: string) => void;
+  /** Optional label rendered in the picker header. */
+  label?: string;
+  /**
+   * Initial mode. The runtime mode is uncontrolled inside the component
+   * and persisted via localStorage[LOCAL_STORAGE_KEY]. Defaults to 'oklch'.
+   */
+  defaultMode?: ColorPickerMode;
+  /** Element to anchor the popover against (popover sits below/above it). */
+  anchorRef: React.RefObject<HTMLElement | null>;
+  /** Called when the picker requests to close itself (Escape / outside click). */
+  onClose: () => void;
+}
+
+/* ── Constants ──────────────────────────────────────────────────────────── */
+
+export const LOCAL_STORAGE_KEY = 'tokenpanel.colorPicker.mode';
+
+// 6×6 preset grid spec.
+// L values step ≈ -17 from 95 down to 10 (rounded for clean lightness bands).
+const PRESET_L_ROWS = [95, 78, 61, 44, 27, 10];
+// Mini shell (6 cols): hue 0° → 300° in 60° steps.
+const PRESET_H_COLS_MINI = [0, 60, 120, 180, 240, 300];
+// Expanded shell (12 cols): hue 0° → 330° in 30° steps.
+const PRESET_H_COLS_EXPANDED = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
+const PRESET_C_FIXED = 0.18;
+
+/* ── Local helpers ──────────────────────────────────────────────────────── */
+
+function oklchSliderConfigs(): SliderConfig[] {
+  return [
+    {
+      key: 'l',
+      label: 'L',
+      ariaLabel: 'Lightness',
+      min: 0,
+      max: 100,
+      step: 1,
+      format: (v) => `${Math.round(v)}%`,
+    },
+    {
+      key: 'c',
+      label: 'C',
+      ariaLabel: 'Chroma',
+      min: 0,
+      max: MAX_OKLCH_CHROMA,
+      step: 0.001,
+      format: (v) => v.toFixed(3),
+    },
+    {
+      key: 'h',
+      label: 'H',
+      ariaLabel: 'Hue',
+      min: 0,
+      max: 360,
+      step: 1,
+      format: (v) => `${Math.round(v)}°`,
+    },
+    {
+      key: 'a',
+      label: 'A',
+      ariaLabel: 'Alpha',
+      min: 0,
+      max: 100,
+      step: 1,
+      format: (v) => `${Math.round(v)}%`,
+    },
+  ];
+}
+
+function hslSliderConfigs(): SliderConfig[] {
+  return [
+    {
+      key: 'h',
+      label: 'H',
+      ariaLabel: 'Hue',
+      min: 0,
+      max: 360,
+      step: 1,
+      format: (v) => `${Math.round(v)}°`,
+    },
+    {
+      key: 's',
+      label: 'S',
+      ariaLabel: 'Saturation',
+      min: 0,
+      max: 100,
+      step: 1,
+      format: (v) => `${Math.round(v)}%`,
+    },
+    {
+      key: 'l',
+      label: 'L',
+      ariaLabel: 'Lightness',
+      min: 0,
+      max: 100,
+      step: 1,
+      format: (v) => `${Math.round(v)}%`,
+    },
+    {
+      key: 'a',
+      label: 'A',
+      ariaLabel: 'Alpha',
+      min: 0,
+      max: 100,
+      step: 1,
+      format: (v) => `${Math.round(v)}%`,
+    },
+  ];
+}
+
+function presetOklchForCell(
+  rowIdx: number,
+  colIdx: number,
+  alpha: number,
+  hCols: readonly number[],
+): Oklcha {
+  return {
+    l: PRESET_L_ROWS[rowIdx] ?? 50,
+    c: PRESET_C_FIXED,
+    h: hCols[colIdx] ?? 0,
+    a: alpha,
+  };
+}
+
+function readPersistedMode(fallback: ColorPickerMode): ColorPickerMode {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (raw === 'oklch' || raw === 'hsl') return raw;
+  } catch {
+    // localStorage can throw in sandboxed iframes or test envs — fall through.
+  }
+  return fallback;
+}
+
+function writePersistedMode(mode: ColorPickerMode): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, mode);
+  } catch {
+    // Ignore quota / sandbox errors.
+  }
+}
+
+/**
+ * Ignore incoming `color` prop changes while a slider drag is in flight.
+ *
+ * Returns the hex that internal state should sync to. While dragging is
+ * active the most-recent local hex is preserved.
+ */
+function useSyncedHex(
+  externalHex: string,
+  isDraggingRef: React.RefObject<boolean>,
+): [string, (next: string) => void] {
+  const [hex, setHex] = useState(externalHex);
+  useEffect(() => {
+    if (isDraggingRef.current) return;
+    setHex(externalHex);
+  }, [externalHex, isDraggingRef]);
+  return [hex, setHex];
+}
+
+/**
+ * Compute a `position: fixed` style that places the popover below (or above,
+ * if flipped) the anchor element, then clamps all edges inside the viewport.
+ *
+ * When vertical space is scarce on both sides, the popover is pinned to the
+ * top edge (top = pad) and given a max-height + overflow: auto so it scrolls
+ * rather than clips.
+ */
+export function getFixedPopoverStyle(
+  anchor: HTMLElement | null,
+  estW: number,
+  estH: number,
+): JSX.CSSProperties {
+  if (!anchor) return { position: 'fixed' };
+  const rect = anchor.getBoundingClientRect();
+  const gap = 4;
+  const pad = 8;
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const below = vh - rect.bottom - gap - pad;
+  const above = rect.top - gap - pad;
+  const flipAbove = below < estH && above > below;
+
+  // Horizontal: clamp left so the popover stays inside the viewport.
+  let left = rect.left;
+  if (left + estW > vw - pad) left = vw - pad - estW;
+  if (left < pad) left = pad;
+
+  // Vertical: derive a top value from the chosen placement.
+  let top: number;
+  if (flipAbove) {
+    top = rect.top - gap - estH;
+  } else {
+    top = rect.bottom + gap;
+  }
+
+  // Clamp top to keep the popover fully visible.
+  if (top < pad) top = pad;
+  if (top + estH > vh - pad) top = vh - pad - estH;
+
+  const style: JSX.CSSProperties = { position: 'fixed', left, top };
+
+  // When the content is taller than the viewport, pin to the top edge and
+  // let the popover scroll rather than clip off-screen.
+  if (estH > vh - 2 * pad) {
+    style.top = pad;
+    style.maxHeight = vh - 2 * pad;
+    style.overflowY = 'auto';
+  }
+
+  return style;
+}
+
+/**
+ * Close the popover on outside pointerdown or Escape key.
+ *
+ * Deliberately does NOT close on scroll — a scroll event on the host page
+ * should not dismiss an in-flight color edit.
+ */
+export function usePopoverClose(
+  containerRef: React.RefObject<HTMLElement | null>,
+  onClose: () => void,
+): void {
+  // Stable ref so effect deps don't change on every render.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    function handlePointerDown(e: PointerEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        onCloseRef.current();
+      }
+    }
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') onCloseRef.current();
+    }
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape);
+    };
+    // containerRef is a stable object — its .current changes but the ref
+    // itself doesn't. Omit from deps intentionally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+/* ── Main component ─────────────────────────────────────────────────────── */
+
+/**
+ * ColorPicker — popover body only.
+ *
+ * The parent renders `{isOpen && <ColorPicker ... />}`. This component does
+ * NOT render a trigger swatch and does NOT use createPortal.
+ */
+export function ColorPicker({
+  color,
+  onChange,
+  label,
+  defaultMode = 'oklch',
+  anchorRef,
+  onClose,
+}: ColorPickerProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef(false);
+  const [hex, setHex] = useSyncedHex(color, isDraggingRef);
+
+  const [mode, setMode] = useState<ColorPickerMode>(() =>
+    readPersistedMode(defaultMode),
+  );
+  const [shell, setShell] = useState<'mini' | 'expanded'>('mini');
+
+  const [hexInput, setHexInput] = useState(hex);
+  useEffect(() => setHexInput(hex), [hex]);
+
+  usePopoverClose(containerRef, onClose);
+
+  // OKLCH and HSL projections of the current hex.
+  // Recomputed on render — hex is the single source of truth.
+  const oklch = useMemo(() => hexToOklcha(hex), [hex]);
+  const hsla = useMemo(() => hexToHsla(hex), [hex]);
+
+  const commit = useCallback(
+    (next: string) => {
+      setHex(next);
+      setHexInput(next);
+      onChange(next);
+    },
+    [setHex, onChange],
+  );
+
+  const commitOklch = useCallback(
+    (partial: Partial<Oklcha>) => {
+      const next: Oklcha = {
+        l: partial.l ?? oklch.l,
+        c: partial.c ?? oklch.c,
+        h: partial.h ?? oklch.h,
+        a: partial.a ?? oklch.a,
+      };
+      commit(oklchaToHex(next));
+    },
+    [oklch, commit],
+  );
+
+  const commitHsl = useCallback(
+    (partial: { h?: number; s?: number; l?: number; a?: number }) => {
+      const next = {
+        h: partial.h ?? hsla.h,
+        s: partial.s ?? hsla.s,
+        l: partial.l ?? hsla.l,
+        a: partial.a ?? hsla.a,
+      };
+      commit(hslaToHex(next.h, next.s, next.l, next.a));
+    },
+    [hsla, commit],
+  );
+
+  const handleHexChange = (value: string) => {
+    setHexInput(value);
+    if (
+      /^#[0-9a-fA-F]{6}$/.test(value) ||
+      /^#[0-9a-fA-F]{8}$/.test(value)
+    ) {
+      commit(value);
+    }
+  };
+
+  // Active hue columns depend on the current shell.
+  const presetHCols =
+    shell === 'expanded' ? PRESET_H_COLS_EXPANDED : PRESET_H_COLS_MINI;
+
+  const handlePresetClick = useCallback(
+    (rowIdx: number, colIdx: number) => {
+      const preset = presetOklchForCell(rowIdx, colIdx, oklch.a, presetHCols);
+      const safe = clampToSrgbGamut(preset);
+      commit(oklchaToHex(safe));
+    },
+    [oklch.a, presetHCols, commit],
+  );
+
+  const handleGridKeyDown = useCallback(
+    (
+      e: KeyboardEvent,
+      rowIdx: number,
+      colIdx: number,
+    ) => {
+      let nextRow = rowIdx;
+      let nextCol = colIdx;
+      if (e.key === 'ArrowRight')
+        nextCol = Math.min(presetHCols.length - 1, colIdx + 1);
+      else if (e.key === 'ArrowLeft') nextCol = Math.max(0, colIdx - 1);
+      else if (e.key === 'ArrowDown')
+        nextRow = Math.min(PRESET_L_ROWS.length - 1, rowIdx + 1);
+      else if (e.key === 'ArrowUp') nextRow = Math.max(0, rowIdx - 1);
+      else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handlePresetClick(rowIdx, colIdx);
+        return;
+      } else return;
+      e.preventDefault();
+      const next = containerRef.current?.querySelector<HTMLElement>(
+        `[data-grid-row="${nextRow}"][data-grid-col="${nextCol}"]`,
+      );
+      next?.focus();
+    },
+    [presetHCols, handlePresetClick],
+  );
+
+  const handleModeToggle = (next: ColorPickerMode) => {
+    // Mode toggle is pure view-state — no onChange emit.
+    writePersistedMode(next);
+    setMode(next);
+  };
+
+  const oklchConfigs = useMemo(() => oklchSliderConfigs(), []);
+  const hslConfigs = useMemo(() => hslSliderConfigs(), []);
+
+  // Slider gradients.
+  // Syntax: "<angle> in <space>" — NOT "in <space> <angle>".
+  const sliderGradients = useMemo(() => {
+    if (mode === 'oklch') {
+      return {
+        l: `linear-gradient(90deg in oklch, ${oklchaToCss({ l: 0, c: oklch.c, h: oklch.h, a: 100 })}, ${oklchaToCss({ l: 100, c: oklch.c, h: oklch.h, a: 100 })})`,
+        c: `linear-gradient(90deg in oklch, ${oklchaToCss({ l: oklch.l, c: 0, h: oklch.h, a: 100 })}, ${oklchaToCss({ l: oklch.l, c: MAX_OKLCH_CHROMA, h: oklch.h, a: 100 })})`,
+        h: `linear-gradient(90deg in oklch longer hue, ${oklchaToCss({ l: oklch.l, c: oklch.c, h: 0, a: 100 })}, ${oklchaToCss({ l: oklch.l, c: oklch.c, h: 360, a: 100 })})`,
+        a: `linear-gradient(90deg in oklch, ${oklchaToCss({ ...oklch, a: 0 })}, ${oklchaToCss({ ...oklch, a: 100 })})`,
+      };
+    }
+    return {
+      h: `linear-gradient(90deg in oklch longer hue, ${oklchaToCss(hslaToOklcha({ h: 0, s: hsla.s, l: hsla.l, a: 100 }))}, ${oklchaToCss(hslaToOklcha({ h: 360, s: hsla.s, l: hsla.l, a: 100 }))})`,
+      s: `linear-gradient(90deg in oklch, ${oklchaToCss(hslaToOklcha({ h: hsla.h, s: 0, l: hsla.l, a: 100 }))}, ${oklchaToCss(hslaToOklcha({ h: hsla.h, s: 100, l: hsla.l, a: 100 }))})`,
+      l: `linear-gradient(90deg in oklch, ${oklchaToCss(hslaToOklcha({ h: hsla.h, s: hsla.s, l: 0, a: 100 }))}, ${oklchaToCss(hslaToOklcha({ h: hsla.h, s: hsla.s, l: 100, a: 100 }))})`,
+      a: `linear-gradient(90deg in oklch, ${oklchaToCss(hslaToOklcha({ ...hsla, a: 0 }))}, ${oklchaToCss(hslaToOklcha({ ...hsla, a: 100 }))})`,
+    };
+  }, [mode, oklch, hsla]);
+
+  // Popover positioning — recompute when shell changes (different width).
+  const [autoStyle, setAutoStyle] = useState<JSX.CSSProperties>(() => ({
+    position: 'fixed',
+    visibility: 'hidden',
+  }));
+  useLayoutEffect(() => {
+    const anchor = anchorRef.current;
+    if (!anchor) {
+      setAutoStyle({ position: 'fixed', visibility: 'hidden' });
+      return;
+    }
+    setAutoStyle(getFixedPopoverStyle(anchor, shell === 'mini' ? 320 : 520, 400));
+  }, [anchorRef, shell]);
+
+  const selectedOklch = useMemo(() => hexToOklcha(hex), [hex]);
+
+  // Checkerboard is only needed when the color has a non-opaque alpha byte.
+  const hasAlpha = /^#[0-9a-fA-F]{8}$/.test(hex);
+
+  const onDragStart = useCallback(() => {
+    isDraggingRef.current = true;
+  }, []);
+  const onDragEnd = useCallback(() => {
+    isDraggingRef.current = false;
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className="tokenpanel-color-picker"
+      data-mode-shell={shell}
+      style={autoStyle}
+      role="dialog"
+      aria-label={label ? `${label} color picker` : 'Color picker'}
+    >
+      {/* Header ─────────────────────────────────────────────────────────── */}
+      <div className="tokenpanel-color-picker-header">
+        <span className="tokenpanel-color-picker-label">{label ?? 'Color'}</span>
+
+        {/* Mode toggle: OKLCH | HSL */}
+        <div
+          className="tokenpanel-color-picker-mode-toggle"
+          role="group"
+          aria-label="Color mode"
+        >
+          <div
+            role="button"
+            tabIndex={0}
+            className="tokenpanel-color-picker-mode-btn"
+            aria-pressed={mode === 'oklch'}
+            onClick={() => handleModeToggle('oklch')}
+            onKeyDown={(e: KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleModeToggle('oklch');
+              }
+            }}
+          >
+            OKLCH
+          </div>
+          <div
+            role="button"
+            tabIndex={0}
+            className="tokenpanel-color-picker-mode-btn"
+            aria-pressed={mode === 'hsl'}
+            onClick={() => handleModeToggle('hsl')}
+            onKeyDown={(e: KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleModeToggle('hsl');
+              }
+            }}
+          >
+            HSL
+          </div>
+        </div>
+
+        {/* Expand / collapse toggle */}
+        <div
+          role="button"
+          tabIndex={0}
+          className="tokenpanel-color-picker-expand-btn"
+          aria-label={shell === 'mini' ? 'Expand picker' : 'Collapse picker'}
+          aria-expanded={shell === 'expanded'}
+          onClick={() => setShell(shell === 'mini' ? 'expanded' : 'mini')}
+          onKeyDown={(e: KeyboardEvent) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setShell(shell === 'mini' ? 'expanded' : 'mini');
+            }
+          }}
+        >
+          {shell === 'mini' ? '⤢' : '⤡'}
+        </div>
+      </div>
+
+      {/* Top row: preview swatch + hex input ───────────────────────────── */}
+      <div className="tokenpanel-color-picker-top-row">
+        <div className="tokenpanel-color-picker-preview">
+          {hasAlpha && (
+            <div className="tokenpanel-color-picker-preview-checkerboard" />
+          )}
+          <div
+            className="tokenpanel-color-picker-preview-color"
+            style={{ backgroundColor: hex }}
+          />
+        </div>
+        <input
+          type="text"
+          className="tokenpanel-color-picker-hex-input"
+          value={hexInput}
+          onChange={(e: Event) =>
+            handleHexChange((e.target as HTMLInputElement).value)
+          }
+          spellcheck={false}
+          aria-label="Hex color value"
+        />
+      </div>
+
+      {/* Preset grid ─────────────────────────────────────────────────────── */}
+      <div
+        className="tokenpanel-color-picker-grid"
+        role="grid"
+        aria-label="Color presets"
+      >
+        {PRESET_L_ROWS.map((_, rowIdx) =>
+          presetHCols.map((_h, colIdx) => {
+            const cell = presetOklchForCell(rowIdx, colIdx, oklch.a, presetHCols);
+            const inGamut = isInSrgbGamut(cell);
+            const safeCss = oklchaToCss(clampToSrgbGamut(cell));
+            const isSelected =
+              Math.abs(selectedOklch.l - cell.l) < 2 &&
+              Math.abs(((selectedOklch.h - cell.h + 360) % 360)) < 5 &&
+              Math.abs(selectedOklch.c - cell.c) < 0.05;
+            return (
+              <div
+                key={`${rowIdx}-${colIdx}`}
+                role="gridcell"
+                data-grid-row={rowIdx}
+                data-grid-col={colIdx}
+                data-oog={inGamut ? 'false' : 'true'}
+                aria-selected={isSelected}
+                aria-label={`Preset L ${cell.l}% H ${cell.h}°`}
+                className="tokenpanel-color-picker-grid-cell"
+                style={{ background: safeCss }}
+                tabIndex={rowIdx === 0 && colIdx === 0 ? 0 : -1}
+                onClick={() => handlePresetClick(rowIdx, colIdx)}
+                onKeyDown={(e: KeyboardEvent) =>
+                  handleGridKeyDown(e, rowIdx, colIdx)
+                }
+              />
+            );
+          }),
+        )}
+      </div>
+
+      {/* Sliders ────────────────────────────────────────────────────────── */}
+      <div className="tokenpanel-color-picker-sliders">
+        {mode === 'oklch'
+          ? oklchConfigs.map((cfg) => (
+              <CustomSlider
+                key={cfg.key}
+                config={cfg}
+                value={
+                  (oklch as unknown as Record<string, number>)[cfg.key] ?? 0
+                }
+                gradient={
+                  (sliderGradients as unknown as Record<string, string>)[
+                    cfg.key
+                  ] ?? ''
+                }
+                onChange={(v) => commitOklch({ [cfg.key]: v } as Partial<Oklcha>)}
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+              />
+            ))
+          : hslConfigs.map((cfg) => (
+              <CustomSlider
+                key={cfg.key}
+                config={cfg}
+                value={
+                  (hsla as unknown as Record<string, number>)[cfg.key] ?? 0
+                }
+                gradient={
+                  (sliderGradients as unknown as Record<string, string>)[
+                    cfg.key
+                  ] ?? ''
+                }
+                onChange={(v) => commitHsl({ [cfg.key]: v })}
+                onDragStart={onDragStart}
+                onDragEnd={onDragEnd}
+              />
+            ))}
+      </div>
+
+      {/* Readout (expanded shell only) ───────────────────────────────────── */}
+      {shell === 'expanded' && (
+        <div className="tokenpanel-color-picker-readout" aria-live="polite">
+          L {Math.round(oklch.l)}% · C {oklch.c.toFixed(3)} · H{' '}
+          {Math.round(oklch.h)}°
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ColorPicker;

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
@@ -76,6 +76,12 @@ const PRESET_H_COLS_MINI = [0, 60, 120, 180, 240, 300];
 const PRESET_H_COLS_EXPANDED = [0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330];
 const PRESET_C_FIXED = 0.18;
 
+// Popover size constants (spec-mandated dimensions).
+const MINI_POPOVER_W = 320;
+const MINI_POPOVER_H = 400;
+const EXPANDED_POPOVER_W = 520;
+const EXPANDED_POPOVER_H = 440;
+
 /* ── Local helpers ──────────────────────────────────────────────────────── */
 
 function oklchSliderConfigs(): SliderConfig[] {
@@ -329,7 +335,21 @@ export function ColorPicker({
   const [shell, setShell] = useState<'mini' | 'expanded'>('mini');
 
   const [hexInput, setHexInput] = useState(hex);
-  useEffect(() => setHexInput(hex), [hex]);
+  useEffect(() => {
+    // Only clobber hexInput when it holds a fully-committed valid hex. If the
+    // user has started typing a partial string (e.g. "#33"), leave it alone so
+    // an external prop change does not erase the in-progress edit.
+    if (
+      /^#[0-9a-fA-F]{6}$/.test(hexInput) ||
+      /^#[0-9a-fA-F]{8}$/.test(hexInput)
+    ) {
+      setHexInput(hex);
+    }
+  // hexInput intentionally excluded from deps: we only want to re-run when hex
+  // changes. Reading hexInput inside the effect is safe — we only write when the
+  // current value is a valid committed hex.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hex]);
 
   usePopoverClose(containerRef, onClose);
 
@@ -340,9 +360,10 @@ export function ColorPicker({
 
   const commit = useCallback(
     (next: string) => {
-      setHex(next);
-      setHexInput(next);
-      onChange(next);
+      const normalized = next.toLowerCase();
+      setHex(normalized);
+      setHexInput(normalized);
+      onChange(normalized);
     },
     [setHex, onChange],
   );
@@ -463,10 +484,14 @@ export function ColorPicker({
       setAutoStyle({ position: 'fixed', visibility: 'hidden' });
       return;
     }
-    setAutoStyle(getFixedPopoverStyle(anchor, shell === 'mini' ? 320 : 520, 400));
+    setAutoStyle(
+      getFixedPopoverStyle(
+        anchor,
+        shell === 'mini' ? MINI_POPOVER_W : EXPANDED_POPOVER_W,
+        shell === 'mini' ? MINI_POPOVER_H : EXPANDED_POPOVER_H,
+      ),
+    );
   }, [anchorRef, shell]);
-
-  const selectedOklch = useMemo(() => hexToOklcha(hex), [hex]);
 
   // Checkerboard is only needed when the color has a non-opaque alpha byte.
   const hasAlpha = /^#[0-9a-fA-F]{8}$/.test(hex);
@@ -577,35 +602,39 @@ export function ColorPicker({
         role="grid"
         aria-label="Color presets"
       >
-        {PRESET_L_ROWS.map((_, rowIdx) =>
-          presetHCols.map((_h, colIdx) => {
-            const cell = presetOklchForCell(rowIdx, colIdx, oklch.a, presetHCols);
-            const inGamut = isInSrgbGamut(cell);
-            const safeCss = oklchaToCss(clampToSrgbGamut(cell));
-            const isSelected =
-              Math.abs(selectedOklch.l - cell.l) < 2 &&
-              Math.abs(((selectedOklch.h - cell.h + 360) % 360)) < 5 &&
-              Math.abs(selectedOklch.c - cell.c) < 0.05;
-            return (
-              <div
-                key={`${rowIdx}-${colIdx}`}
-                role="gridcell"
-                data-grid-row={rowIdx}
-                data-grid-col={colIdx}
-                data-oog={inGamut ? 'false' : 'true'}
-                aria-selected={isSelected}
-                aria-label={`Preset L ${cell.l}% H ${cell.h}°`}
-                className="tokenpanel-color-picker-grid-cell"
-                style={{ background: safeCss }}
-                tabIndex={rowIdx === 0 && colIdx === 0 ? 0 : -1}
-                onClick={() => handlePresetClick(rowIdx, colIdx)}
-                onKeyDown={(e: KeyboardEvent) =>
-                  handleGridKeyDown(e, rowIdx, colIdx)
-                }
-              />
-            );
-          }),
-        )}
+        {PRESET_L_ROWS.map((_, rowIdx) => (
+          <div role="row" key={`row-${rowIdx}`}>
+            {presetHCols.map((_h, colIdx) => {
+              const cell = presetOklchForCell(rowIdx, colIdx, oklch.a, presetHCols);
+              const inGamut = isInSrgbGamut(cell);
+              const safeCss = oklchaToCss(clampToSrgbGamut(cell));
+              const hueDelta = Math.abs(oklch.h - cell.h) % 360;
+              const hueDistance = Math.min(hueDelta, 360 - hueDelta);
+              const isSelected =
+                Math.abs(oklch.l - cell.l) < 2 &&
+                hueDistance < 5 &&
+                Math.abs(oklch.c - cell.c) < 0.05;
+              return (
+                <div
+                  key={`${rowIdx}-${colIdx}`}
+                  role="gridcell"
+                  data-grid-row={rowIdx}
+                  data-grid-col={colIdx}
+                  data-oog={inGamut ? 'false' : 'true'}
+                  aria-selected={isSelected}
+                  aria-label={`Preset L ${cell.l}% H ${cell.h}°`}
+                  className="tokenpanel-color-picker-grid-cell"
+                  style={{ background: safeCss }}
+                  tabIndex={rowIdx === 0 && colIdx === 0 ? 0 : -1}
+                  onClick={() => handlePresetClick(rowIdx, colIdx)}
+                  onKeyDown={(e: KeyboardEvent) =>
+                    handleGridKeyDown(e, rowIdx, colIdx)
+                  }
+                />
+              );
+            })}
+          </div>
+        ))}
       </div>
 
       {/* Sliders ────────────────────────────────────────────────────────── */}

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
@@ -10,7 +10,8 @@
  *
  * Design rules (see packages/zudo-design-token-panel/CLAUDE.md):
  *   - All interactive elements use <div role="button" tabIndex={0}> with
- *     explicit Enter/Space onKeyDown handlers. No <button> or <h*> allowed.
+ *     explicit Enter/Space onKeyDown handlers. Native button and heading tags
+ *     are not used (hostile-host policy).
  *   - BEM class names: tokenpanel-color-picker-* (locked external contract).
  *   - usePopoverClose: pointerdown + Escape only — NO scroll listener.
  *   - Mode persisted to localStorage under key tokenpanel.colorPicker.mode.

--- a/packages/zudo-design-token-panel/src/components/color-picker/custom-slider.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/custom-slider.tsx
@@ -41,6 +41,16 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+// Snap a continuous value to the nearest step boundary relative to min.
+// Without this, pointer interaction emits off-grid floats (e.g. 0.317 on a
+// step:1 slider) while keyboard input stays snapped — the same control
+// would round-trip differently depending on input method.
+function snapToStep(value: number, min: number, step: number): number {
+  if (step <= 0) return value;
+  const steps = Math.round((value - min) / step);
+  return min + steps * step;
+}
+
 // ---------------------------------------------------------------------------
 // CustomSlider
 //
@@ -66,6 +76,8 @@ export function CustomSlider({
   onDragEnd,
 }: CustomSliderProps): JSX.Element {
   const { label, ariaLabel, min, max, step, format } = config;
+  const stepRef = useRef(step);
+  stepRef.current = step;
 
   const isDragging = useRef(false);
   const trackRef = useRef<HTMLDivElement>(null);
@@ -95,7 +107,10 @@ export function CustomSlider({
     const rect = el.getBoundingClientRect();
     if (rect.width === 0) return null;
     const f = clamp((clientX - rect.left) / rect.width, 0, 1);
-    return clamp(minRef.current + f * (maxRef.current - minRef.current), minRef.current, maxRef.current);
+    const raw = minRef.current + f * (maxRef.current - minRef.current);
+    // Snap to step so pointer and keyboard interaction emit the same grid.
+    const snapped = snapToStep(raw, minRef.current, stepRef.current);
+    return clamp(snapped, minRef.current, maxRef.current);
   }
 
   // ---- Pointer handlers via addEventListener --------------------------------
@@ -229,6 +244,9 @@ export function CustomSlider({
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={value}
+        // Screen readers announce aria-valuetext (with units, e.g. "180°")
+        // in preference to the raw aria-valuenow when both are present.
+        aria-valuetext={format(value)}
         onKeyDown={handleKeyDown}
       >
         {/* Gradient track — background set to the OKLCH-interpolated gradient string */}

--- a/packages/zudo-design-token-panel/src/components/color-picker/custom-slider.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/custom-slider.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useRef } from 'preact/compat';
+import type { JSX } from 'preact';
+
+// ---------------------------------------------------------------------------
+// SliderConfig / CustomSliderProps
+//
+// Used by OklchPicker for L/C/H and alpha sliders. The track div accepts a
+// CSS gradient string so the consumer can pass an OKLCH-interpolated gradient
+// as the track background — something an <input type="range"> cannot do with
+// a custom gradient without extra wrapper markup.
+// ---------------------------------------------------------------------------
+
+export interface SliderConfig {
+  key: string;
+  /** Single-character label, e.g. 'L', 'H'. */
+  label: string;
+  /** Full accessible label, e.g. 'Lightness', 'Hue'. */
+  ariaLabel: string;
+  min: number;
+  max: number;
+  step: number;
+  /** Format the numeric value for display in the value span. */
+  format: (v: number) => string;
+}
+
+export interface CustomSliderProps {
+  config: SliderConfig;
+  value: number;
+  /** CSS gradient string applied to the track div's background. */
+  gradient: string;
+  onChange: (next: number) => void;
+  onDragStart: () => void;
+  onDragEnd: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+// ---------------------------------------------------------------------------
+// CustomSlider
+//
+// Implements pointer-capture drag, click-to-jump, and keyboard navigation.
+// Rendered as a <div role="slider"> — NOT <input type="range"> — so the track
+// div can carry an arbitrary OKLCH-interpolated CSS gradient.
+//
+// BEM class names (locked external contract):
+//   tokenpanel-color-picker-slider-row    — outer wrapper
+//   tokenpanel-color-picker-slider-label  — left label span
+//   tokenpanel-color-picker-slider        — track host; role="slider"
+//   tokenpanel-color-picker-slider-track  — gradient background div
+//   tokenpanel-color-picker-slider-thumb  — draggable thumb div
+//   tokenpanel-color-picker-slider-value  — right value span
+// ---------------------------------------------------------------------------
+
+export function CustomSlider({
+  config,
+  value,
+  gradient,
+  onChange,
+  onDragStart,
+  onDragEnd,
+}: CustomSliderProps): JSX.Element {
+  const { label, ariaLabel, min, max, step, format } = config;
+
+  const isDragging = useRef(false);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  const fraction = clamp((value - min) / (max - min), 0, 1);
+
+  // Keep stable refs for callbacks so the useEffect below does not need to
+  // re-register listeners on every render when the parent re-renders.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const onDragStartRef = useRef(onDragStart);
+  onDragStartRef.current = onDragStart;
+  const onDragEndRef = useRef(onDragEnd);
+  onDragEndRef.current = onDragEnd;
+
+  // Keep min/max in refs as well so pointer handlers close over stable refs.
+  const minRef = useRef(min);
+  minRef.current = min;
+  const maxRef = useRef(max);
+  maxRef.current = max;
+
+  // Compute value from pointer x position relative to the track.
+  // Returns null when the rect has zero width (jsdom in tests).
+  function valueFromPointerX(clientX: number): number | null {
+    const el = trackRef.current;
+    if (!el) return null;
+    const rect = el.getBoundingClientRect();
+    if (rect.width === 0) return null;
+    const f = clamp((clientX - rect.left) / rect.width, 0, 1);
+    return clamp(minRef.current + f * (maxRef.current - minRef.current), minRef.current, maxRef.current);
+  }
+
+  // ---- Pointer handlers via addEventListener --------------------------------
+  //
+  // Preact's JSX event delegation checks `lowerCaseName in dom` to decide
+  // whether to use the lowercase event name. jsdom does NOT expose
+  // `onpointerdown` / `onpointermove` / `onpointerup` on elements, so Preact
+  // falls through and registers "PointerDown" (wrong case) — tests dispatching
+  // "pointerdown" never fire the handler. Using addEventListener directly
+  // bypasses this heuristic and works correctly in both jsdom and browsers.
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+
+    function handlePointerDown(e: PointerEvent) {
+      isDragging.current = true;
+      onDragStartRef.current();
+
+      // Pointer capture keeps events flowing even if pointer leaves the element.
+      try {
+        el!.setPointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement setPointerCapture; ignore.
+      }
+
+      // Click-to-jump on pointerdown so the thumb snaps immediately.
+      const next = valueFromPointerX(e.clientX);
+      if (next !== null) onChangeRef.current(next);
+    }
+
+    function handlePointerMove(e: PointerEvent) {
+      if (!isDragging.current) return;
+      const next = valueFromPointerX(e.clientX);
+      if (next !== null) onChangeRef.current(next);
+    }
+
+    function handlePointerUp(e: PointerEvent) {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+
+      try {
+        el!.releasePointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement releasePointerCapture; ignore.
+      }
+
+      onDragEndRef.current();
+    }
+
+    function handlePointerCancel(e: PointerEvent) {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+
+      try {
+        el!.releasePointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement releasePointerCapture; ignore.
+      }
+
+      onDragEndRef.current();
+    }
+
+    el.addEventListener('pointerdown', handlePointerDown);
+    el.addEventListener('pointermove', handlePointerMove);
+    el.addEventListener('pointerup', handlePointerUp);
+    el.addEventListener('pointercancel', handlePointerCancel);
+
+    return () => {
+      el.removeEventListener('pointerdown', handlePointerDown);
+      el.removeEventListener('pointermove', handlePointerMove);
+      el.removeEventListener('pointerup', handlePointerUp);
+      el.removeEventListener('pointercancel', handlePointerCancel);
+    };
+    // Empty dependency array: handlers are stable (use refs for callbacks).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ---- Keyboard handler -------------------------------------------------------
+  // ArrowRight / ArrowUp  → +step (or +coarse with Shift)
+  // ArrowLeft  / ArrowDown → -step (or -coarse with Shift)
+  // Home → min; End → max
+  // Coarse multiplier: step * 10 (handles both integer and sub-1 steps uniformly)
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const coarse = step * 10;
+      let delta = 0;
+
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowUp':
+          delta = e.shiftKey ? coarse : step;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          delta = e.shiftKey ? -coarse : -step;
+          break;
+        case 'Home':
+          onChange(min);
+          e.preventDefault();
+          return;
+        case 'End':
+          onChange(max);
+          e.preventDefault();
+          return;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      onChange(clamp(value + delta, min, max));
+    },
+    [value, min, max, step, onChange],
+  );
+
+  // ---- Render ---------------------------------------------------------------
+
+  return (
+    <div className="tokenpanel-color-picker-slider-row">
+      <span className="tokenpanel-color-picker-slider-label">{label}</span>
+
+      {/* Slider host: role=slider carries ARIA semantics; pointer events wired
+          via addEventListener in useEffect (jsdom compatibility); keyboard here */}
+      <div
+        ref={trackRef}
+        role="slider"
+        tabIndex={0}
+        className="tokenpanel-color-picker-slider"
+        aria-label={ariaLabel}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Gradient track — background set to the OKLCH-interpolated gradient string */}
+        <div
+          className="tokenpanel-color-picker-slider-track"
+          style={{ background: gradient }}
+        />
+
+        {/* Thumb — absolutely positioned at the current fraction */}
+        <div
+          className="tokenpanel-color-picker-slider-thumb"
+          style={{ left: `${fraction * 100}%` }}
+        />
+      </div>
+
+      <span className="tokenpanel-color-picker-slider-value">{format(value)}</span>
+    </div>
+  );
+}
+
+export default CustomSlider;

--- a/packages/zudo-design-token-panel/src/components/color-picker/index.ts
+++ b/packages/zudo-design-token-panel/src/components/color-picker/index.ts
@@ -1,0 +1,9 @@
+export {
+  ColorPicker,
+  type ColorPickerMode,
+  type ColorPickerProps,
+  LOCAL_STORAGE_KEY,
+  getFixedPopoverStyle,
+  usePopoverClose,
+} from './color-picker';
+export { default } from './color-picker';

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -597,14 +597,24 @@ function _canvasCtxSupported(): boolean {
 }
 const _canvasAvailable = _canvasCtxSupported();
 
-/** Parse an rgb()/rgba() string to a hex colour, or return null on failure. */
+/** Parse an rgb()/rgba() string to a hex colour, or return null on failure.
+ * Returns 8-digit hex when an explicit alpha < 1 is present; 6-digit otherwise.
+ */
 function _rgbStringToHex(color: string): string | null {
-  const match = color.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  const match = color.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?/);
   if (!match) return null;
   const r = parseInt(match[1], 10);
   const g = parseInt(match[2], 10);
   const b = parseInt(match[3], 10);
-  return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+  const base6 = `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1)}`;
+  if (match[4] !== undefined) {
+    const a = parseFloat(match[4]);
+    if (a < 1) {
+      const aa = Math.round(a * 255).toString(16).padStart(2, '0');
+      return `${base6}${aa}`;
+    }
+  }
+  return base6;
 }
 
 /** Convert any CSS color to hex using a canvas (cached context). */
@@ -613,8 +623,12 @@ export function cssColorToHex(color: string): string {
   if (!color || color === 'initial' || color === 'inherit') return '#000000';
   const trimmed = color.trim();
   if (/^#[0-9a-fA-F]{6}$/.test(trimmed)) return trimmed;
+  if (/^#[0-9a-fA-F]{8}$/.test(trimmed)) return trimmed;
   if (/^#[0-9a-fA-F]{3}$/.test(trimmed)) {
     return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
+  }
+  if (/^#[0-9a-fA-F]{4}$/.test(trimmed)) {
+    return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}${trimmed[4]}${trimmed[4]}`;
   }
   // Manual rgb()/rgba() fallback — handles the most common non-hex CSS form
   // and is always available (including JSDOM where the canvas path is broken).
@@ -671,13 +685,16 @@ export function colorRefToIndex(
   return bestIdx;
 }
 
-/** Parse a hex color string to RGB components. */
-function hexToRgb(hex: string): { r: number; g: number; b: number } {
+/** Parse a hex color string to RGB(A) components. When the hex is 8 digits,
+ * `aa` is the parsed alpha byte (0–255); otherwise `aa` defaults to 255.
+ */
+function hexToRgb(hex: string): { r: number; g: number; b: number; aa: number } {
   const h = hex.replace('#', '');
   return {
     r: parseInt(h.substring(0, 2), 16) || 0,
     g: parseInt(h.substring(2, 4), 16) || 0,
     b: parseInt(h.substring(4, 6), 16) || 0,
+    aa: h.length >= 8 ? (parseInt(h.substring(6, 8), 16) || 0) : 255,
   };
 }
 

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -665,17 +665,29 @@ export function colorRefToIndex(
 ): number {
   if (ref === undefined) return fallback;
   if (typeof ref === 'number') return ref;
-  // String: try exact match in palette.
-  const idx = palette.indexOf(ref);
-  if (idx >= 0) return idx;
-  // No exact match — find nearest palette color by RGB distance.
+  // Normalize the ref and every palette entry to a canonical hex form before
+  // exact-match lookup. Without this, equivalent notations miss each other
+  // (e.g. ref `rgba(255,0,0,0.5)` vs palette `#ff000080`) and fall through to
+  // the distance fallback below, which intentionally ignores alpha — that
+  // would silently bind to the wrong slot when the palette holds multiple
+  // entries with the same RGB but different alpha.
   const refHex = cssColorToHex(ref);
+  const normalized: string[] = palette.map((p) => cssColorToHex(p));
+  // First try the raw string for backwards compatibility (palette refs are
+  // usually already canonical), then the normalized form.
+  const rawIdx = palette.indexOf(ref);
+  if (rawIdx >= 0) return rawIdx;
+  const normIdx = normalized.indexOf(refHex);
+  if (normIdx >= 0) return normIdx;
+  // No exact match — find nearest palette color by RGB distance.
+  // Alpha is intentionally dropped here (distance is base-RGB only) so it is
+  // the caller's responsibility to ensure exact-match succeeds first when
+  // alpha-precision matters.
   const refRgb = hexToRgb(refHex);
   let bestIdx = fallback;
   let bestDist = Infinity;
-  for (let i = 0; i < palette.length; i++) {
-    const pHex = cssColorToHex(palette[i]);
-    const pRgb = hexToRgb(pHex);
+  for (let i = 0; i < normalized.length; i++) {
+    const pRgb = hexToRgb(normalized[i]);
     const dist = (refRgb.r - pRgb.r) ** 2 + (refRgb.g - pRgb.g) ** 2 + (refRgb.b - pRgb.b) ** 2;
     if (dist < bestDist) {
       bestDist = dist;

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -428,7 +428,7 @@
 }
 
 /* ===========================================================================
- * Popover (HslPicker host, PaletteSelector listbox)
+ * Popover (ColorPicker host, PaletteSelector listbox)
  * ========================================================================= */
 
 .tokenpanel-popover {
@@ -437,63 +437,6 @@
   padding: 12px;
   border-radius: var(--radius-tokentweak);
   box-shadow: 0 4px 12px rgb(0 0 0 / 0.3);
-}
-
-/* HslPicker layout */
-
-.tokenpanel-hsl-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 10px;
-}
-
-.tokenpanel-hsl-preview {
-  flex-shrink: 0;
-  border: 1px solid var(--tokentweak-color-muted);
-  width: 3.5rem;
-  height: 3.5rem;
-  border-radius: var(--radius-tokentweak);
-}
-
-.tokenpanel-hsl-hex-input {
-  background-color: var(--tokentweak-color-surface);
-  color: var(--tokentweak-color-fg);
-  border: 1px solid var(--tokentweak-color-muted);
-  padding-inline: 6px;
-  padding-block: 4px;
-  font-family: var(--tokentweak-font-mono);
-  font-size: 1rem;
-  width: 8rem;
-  border-radius: var(--radius-tokentweak);
-}
-
-.tokenpanel-hsl-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
-}
-
-.tokenpanel-hsl-row-label {
-  color: var(--tokentweak-color-muted);
-  flex-shrink: 0;
-  font-size: 0.875rem;
-  width: 1rem;
-}
-
-.tokenpanel-hsl-row-slider {
-  flex: 1;
-  height: 1.5rem;
-  accent-color: var(--tokentweak-color-accent);
-}
-
-.tokenpanel-hsl-row-value {
-  color: var(--tokentweak-color-fg);
-  flex-shrink: 0;
-  text-align: right;
-  font-size: 0.875rem;
-  width: 2.5rem;
 }
 
 /* ===========================================================================

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -34,6 +34,7 @@
  */
 
 @import './panel-tokens.css';
+@import '../components/color-picker/color-picker.css';
 
 /* ===========================================================================
  * Shell

--- a/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
@@ -34,7 +34,7 @@
 
 import { memo, useState, useEffect, useCallback, useMemo, useRef } from 'preact/compat';
 import type { ColorScheme } from '../config/color-schemes';
-import { hexToHsl, hslToHex } from '../utils/color-convert';
+import ColorPicker from '../components/color-picker';
 import {
   type ColorTweakState,
   applyShikiTheme,
@@ -135,96 +135,6 @@ function getFixedPopoverStyle(
 
 // --- UI Components ---
 
-function HslPicker({
-  color,
-  onChange,
-  onClose,
-  anchorRef,
-}: {
-  color: string;
-  onChange: (hex: string) => void;
-  onClose: () => void;
-  anchorRef: React.RefObject<HTMLElement | null>;
-}) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [hsl, setHsl] = useState(() => hexToHsl(color));
-  const [hexInput, setHexInput] = useState(color);
-
-  useEffect(() => {
-    setHsl(hexToHsl(color));
-    setHexInput(color);
-  }, [color]);
-
-  usePopoverClose(containerRef, onClose, true);
-
-  function updateFromHsl(newHsl: { h: number; s: number; l: number }) {
-    setHsl(newHsl);
-    const hex = hslToHex(newHsl.h, newHsl.s, newHsl.l);
-    setHexInput(hex);
-    onChange(hex);
-  }
-
-  function handleHexChange(value: string) {
-    setHexInput(value);
-    if (/^#[0-9a-fA-F]{6}$/.test(value)) {
-      setHsl(hexToHsl(value));
-      onChange(value);
-    }
-  }
-
-  const sliders = [
-    { label: 'H', value: hsl.h, max: 360, key: 'h' as const },
-    { label: 'S', value: hsl.s, max: 100, key: 's' as const },
-    { label: 'L', value: hsl.l, max: 100, key: 'l' as const },
-  ];
-
-  return (
-    <div
-      ref={containerRef}
-      className="tokenpanel-popover"
-      style={getFixedPopoverStyle(anchorRef.current, 380, 280, { width: 380 })}
-    >
-      <div className="tokenpanel-hsl-header">
-        <div
-          className="tokenpanel-hsl-preview"
-          style={{ backgroundColor: hslToHex(hsl.h, hsl.s, hsl.l) }}
-        />
-        <input
-          type="text"
-          value={hexInput}
-          onChange={(e) => handleHexChange((e.target as HTMLInputElement).value)}
-          className="tokenpanel-hsl-hex-input"
-          spellcheck={false}
-          aria-label="Hex color value"
-        />
-      </div>
-      {sliders.map(({ label, value, max, key }) => (
-        <div key={key} className="tokenpanel-hsl-row">
-          <span className="tokenpanel-hsl-row-label">{label}</span>
-          <input
-            type="range"
-            min={0}
-            max={max}
-            value={value}
-            onChange={(e) =>
-              updateFromHsl({
-                ...hsl,
-                [key]: parseInt((e.target as HTMLInputElement).value, 10),
-              })
-            }
-            className="tokenpanel-hsl-row-slider"
-            aria-label={`${label === 'H' ? 'Hue' : label === 'S' ? 'Saturation' : 'Lightness'}`}
-          />
-          <span className="tokenpanel-hsl-row-value">
-            {value}
-            {key === 'h' ? '' : '%'}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 /**
  * Single palette swatch with HSL popover.
  *
@@ -275,7 +185,7 @@ const ColorSwatch = memo(function ColorSwatch({
         aria-expanded={isOpen}
       />
       {isOpen && (
-        <HslPicker
+        <ColorPicker
           color={color}
           onChange={handleHexChange}
           onClose={handleClose}

--- a/packages/zudo-design-token-panel/src/utils/__tests__/color-hsla.test.ts
+++ b/packages/zudo-design-token-panel/src/utils/__tests__/color-hsla.test.ts
@@ -150,4 +150,15 @@ describe('hslaToHex', () => {
       expect(parsed.a).toBe(a);
     }
   });
+
+  it('clamps out-of-range s, l, a to nearest valid value', () => {
+    // s > 100 is treated as 100
+    expect(hslaToHex(0, 200, 50, 100)).toBe(hslaToHex(0, 100, 50, 100));
+    // l > 100 is treated as 100 (white)
+    expect(hslaToHex(0, 100, 200, 100)).toBe('#ffffff');
+    // a > 100 is treated as 100 (opaque, no alpha byte)
+    expect(hslaToHex(0, 100, 50, 120)).toBe('#ff0000');
+    // a < 0 is treated as 0 (transparent)
+    expect(hslaToHex(0, 100, 50, -10)).toBe('#ff000000');
+  });
 });

--- a/packages/zudo-design-token-panel/src/utils/__tests__/color-hsla.test.ts
+++ b/packages/zudo-design-token-panel/src/utils/__tests__/color-hsla.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { hexToHsla, hslaToHex } from '../color-hsla';
+
+describe('hexToHsla', () => {
+  it('parses 6-digit opaque hex — acceptance criterion', () => {
+    const result = hexToHsla('#ff0000');
+    expect(result.h).toBe(0);
+    expect(result.s).toBe(100);
+    expect(result.l).toBe(50);
+    expect(result.a).toBe(100);
+  });
+
+  it('parses 8-digit hex with alpha — acceptance criterion', () => {
+    const result = hexToHsla('#ff000080');
+    expect(result.h).toBe(0);
+    expect(result.s).toBe(100);
+    expect(result.l).toBe(50);
+    // 0x80 = 128; 128/255*100 ≈ 50.196 → rounds to 50
+    expect(result.a).toBe(50);
+  });
+
+  it('parses fully transparent 8-digit hex', () => {
+    const result = hexToHsla('#ff000000');
+    expect(result.a).toBe(0);
+  });
+
+  it('parses fully opaque 8-digit hex (ff alpha)', () => {
+    const result = hexToHsla('#ff0000ff');
+    expect(result.a).toBe(100);
+  });
+
+  it('parses 3-char shorthand #rgb the same as #rrggbb', () => {
+    const short = hexToHsla('#f00');
+    const long = hexToHsla('#ff0000');
+    expect(short).toEqual(long);
+  });
+
+  it('parses 4-char shorthand #rgba the same as #rrggbbaa', () => {
+    const short = hexToHsla('#f008');
+    const long = hexToHsla('#ff000088');
+    expect(short).toEqual(long);
+  });
+
+  it('returns saturation 0 for grays', () => {
+    expect(hexToHsla('#888888').s).toBe(0);
+  });
+
+  it('returns INVALID_HSLA default for empty string', () => {
+    expect(hexToHsla('')).toEqual({ h: 0, s: 0, l: 0, a: 100 });
+  });
+
+  it('returns INVALID_HSLA default for wrong-length hex', () => {
+    // 5 hex digits (#fffff) — not a valid 3/4/6/8 digit form
+    expect(hexToHsla('#fffff')).toEqual({ h: 0, s: 0, l: 0, a: 100 });
+  });
+
+  it('returns INVALID_HSLA default for non-hex characters', () => {
+    expect(hexToHsla('#gghhii')).toEqual({ h: 0, s: 0, l: 0, a: 100 });
+  });
+
+  it('returns INVALID_HSLA default when missing # prefix', () => {
+    expect(hexToHsla('ff0000')).toEqual({ h: 0, s: 0, l: 0, a: 100 });
+  });
+
+  it('handles blue correctly', () => {
+    const result = hexToHsla('#0000ff');
+    expect(result.h).toBe(240);
+    expect(result.s).toBe(100);
+    expect(result.l).toBe(50);
+    expect(result.a).toBe(100);
+  });
+
+  it('handles green correctly', () => {
+    const result = hexToHsla('#00ff00');
+    expect(result.h).toBe(120);
+    expect(result.s).toBe(100);
+    expect(result.l).toBe(50);
+    expect(result.a).toBe(100);
+  });
+
+  it('handles white correctly', () => {
+    const result = hexToHsla('#ffffff');
+    expect(result.l).toBe(100);
+    expect(result.s).toBe(0);
+    expect(result.a).toBe(100);
+  });
+
+  it('handles black correctly', () => {
+    const result = hexToHsla('#000000');
+    expect(result.l).toBe(0);
+    expect(result.s).toBe(0);
+    expect(result.a).toBe(100);
+  });
+});
+
+describe('hslaToHex', () => {
+  it('emits 6-digit #rrggbb when a === 100 — acceptance criterion', () => {
+    expect(hslaToHex(0, 100, 50, 100)).toBe('#ff0000');
+  });
+
+  it('emits 8-digit #rrggbbaa when a < 100 — acceptance criterion', () => {
+    // 50% alpha: Math.round(50/100*255) = Math.round(127.5) = 128 = 0x80
+    expect(hslaToHex(0, 100, 50, 50)).toBe('#ff000080');
+  });
+
+  it('emits 8-digit when a === 0', () => {
+    const result = hslaToHex(0, 100, 50, 0);
+    expect(result).toBe('#ff000000');
+  });
+
+  it('round-trips with hexToHsla for pure saturated colors', () => {
+    // Integer-rounded HSL cannot exactly represent all hex values; use primary
+    // colors whose HSL round-trip is lossless (integer h/s/l at exact values).
+    for (const hex of ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#00ffff', '#ff00ff']) {
+      const { h, s, l, a } = hexToHsla(hex);
+      expect(hslaToHex(h, s, l, a)).toBe(hex);
+    }
+  });
+
+  it('round-trips with hexToHsla for color with alpha', () => {
+    const { h, s, l, a } = hexToHsla('#ff000080');
+    const hex = hslaToHex(h, s, l, a);
+    expect(hex).toBe('#ff000080');
+  });
+
+  it('handles hue wrap-around (360 == 0)', () => {
+    expect(hslaToHex(360, 100, 50, 100)).toBe('#ff0000');
+  });
+
+  it('handles blue', () => {
+    expect(hslaToHex(240, 100, 50, 100)).toBe('#0000ff');
+  });
+
+  it('handles green', () => {
+    expect(hslaToHex(120, 100, 50, 100)).toBe('#00ff00');
+  });
+
+  it('handles white (s=0)', () => {
+    expect(hslaToHex(0, 0, 100, 100)).toBe('#ffffff');
+  });
+
+  it('handles black (s=0, l=0)', () => {
+    expect(hslaToHex(0, 0, 0, 100)).toBe('#000000');
+  });
+
+  it('various alpha round-trips: 0, 25, 75', () => {
+    for (const a of [0, 25, 75]) {
+      const hex = hslaToHex(0, 100, 50, a);
+      const parsed = hexToHsla(hex);
+      expect(parsed.a).toBe(a);
+    }
+  });
+});

--- a/packages/zudo-design-token-panel/src/utils/__tests__/color-oklch.test.ts
+++ b/packages/zudo-design-token-panel/src/utils/__tests__/color-oklch.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for the OKLCH math module.
+ *
+ * Reference colors used for OKLCH↔HSL drift tests are chosen to cover a
+ * range of hues and saturations so that any systematic conversion error is
+ * likely to be caught.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  oklchaToCss,
+  hexToOklcha,
+  oklchaToHex,
+  oklchaToHsla,
+  hslaToOklcha,
+  clampToSrgbGamut,
+  isInSrgbGamut,
+  MAX_OKLCH_CHROMA,
+  type Oklcha,
+  type Hsla,
+} from '../color-oklch';
+import { converter, inGamut, useMode, modeOklch, modeOklab, modeRgb, modeHsl, differenceEuclidean } from 'culori/fn';
+
+useMode(modeOklch);
+useMode(modeOklab);
+useMode(modeRgb);
+useMode(modeHsl);
+
+const toOklabForDiff = converter('oklab');
+const rgbInGamut = inGamut('rgb');
+
+// deltaEOK approximation: Euclidean distance in OKLab space
+// OKLab is perceptually uniform so distance ≈ ΔE-OK
+const deltaEOk = differenceEuclidean('oklab');
+
+function oklchaToOklabForDiff(o: Oklcha) {
+  return toOklabForDiff({
+    mode: 'oklch' as const,
+    l: o.l / 100,
+    c: o.c,
+    h: o.h,
+    alpha: o.a / 100,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// oklchaToCss
+// ---------------------------------------------------------------------------
+
+describe('oklchaToCss', () => {
+  it('emits oklch() without alpha when a===100', () => {
+    const css = oklchaToCss({ l: 50, c: 0.2, h: 30, a: 100 });
+    expect(css).toMatch(/^oklch\(/);
+    expect(css).not.toContain('/');
+  });
+
+  it('emits oklch() with alpha when a<100', () => {
+    const css = oklchaToCss({ l: 50, c: 0.2, h: 30, a: 50 });
+    expect(css).toContain('/');
+  });
+
+  it('correctly encodes l as a 0–1 fraction of the 0–100 input', () => {
+    const css = oklchaToCss({ l: 100, c: 0, h: 0, a: 100 });
+    expect(css).toContain('1.0000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hexToOklcha
+// ---------------------------------------------------------------------------
+
+describe('hexToOklcha — invalid input', () => {
+  it('returns fallback for empty string', () => {
+    const r = hexToOklcha('');
+    expect(r).toEqual({ l: 0, c: 0, h: 0, a: 100 });
+  });
+
+  it('returns fallback for non-hex string', () => {
+    const r = hexToOklcha('notacolor');
+    expect(r).toEqual({ l: 0, c: 0, h: 0, a: 100 });
+  });
+
+  it('returns fallback for bare hash', () => {
+    const r = hexToOklcha('#');
+    expect(r).toEqual({ l: 0, c: 0, h: 0, a: 100 });
+  });
+});
+
+describe('hexToOklcha — 3-char shorthand', () => {
+  it('#abc returns the same as #aabbcc', () => {
+    const short = hexToOklcha('#abc');
+    const long = hexToOklcha('#aabbcc');
+    expect(short.l).toBeCloseTo(long.l, 2);
+    expect(short.c).toBeCloseTo(long.c, 4);
+    expect(short.h).toBeCloseTo(long.h, 1);
+    expect(short.a).toBeCloseTo(long.a, 2);
+  });
+});
+
+describe('hexToOklcha — alpha handling', () => {
+  it('#ff000080 returns a ≈ 50 (128/255 * 100 ≈ 50.2)', () => {
+    const r = hexToOklcha('#ff000080');
+    expect(r.a).toBeCloseTo(50, 0);
+  });
+
+  it('fully opaque #ff0000 returns a === 100', () => {
+    const r = hexToOklcha('#ff0000');
+    expect(r.a).toBeCloseTo(100, 2);
+  });
+});
+
+describe('hexToOklcha — black produces zero chroma', () => {
+  it('#000000 returns c === 0', () => {
+    const r = hexToOklcha('#000000');
+    expect(r.c).toBeCloseTo(0, 4);
+    expect(r.l).toBeCloseTo(0, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// oklchaToHex
+// ---------------------------------------------------------------------------
+
+describe('oklchaToHex', () => {
+  it('returns #000000 for black (a===100)', () => {
+    expect(oklchaToHex({ l: 0, c: 0, h: 0, a: 100 })).toBe('#000000');
+  });
+
+  it('emits 8-digit hex when a<100', () => {
+    const hex = oklchaToHex({ l: 50, c: 0, h: 0, a: 50 });
+    expect(hex).toHaveLength(9); // # + 8 chars
+  });
+
+  it('emits 6-digit hex when a===100 (no alwaysAlpha)', () => {
+    const hex = oklchaToHex({ l: 50, c: 0.1, h: 180, a: 100 });
+    expect(hex).toHaveLength(7); // # + 6 chars
+  });
+
+  it('emits 8-digit hex when alwaysAlpha:true even for a===100', () => {
+    const hex = oklchaToHex({ l: 0, c: 0, h: 0, a: 100 }, { alwaysAlpha: true });
+    expect(hex).toHaveLength(9);
+  });
+
+  it('6-digit hex round-trip: #ff0000 survives hex→oklcha→hex', () => {
+    const oklcha = hexToOklcha('#ff0000');
+    const back = oklchaToHex(oklcha);
+    expect(back).toBe('#ff0000');
+  });
+
+  it('6-digit hex round-trip: #00ff00', () => {
+    const oklcha = hexToOklcha('#00ff00');
+    const back = oklchaToHex(oklcha);
+    expect(back).toBe('#00ff00');
+  });
+
+  it('6-digit hex round-trip: #0000ff', () => {
+    const oklcha = hexToOklcha('#0000ff');
+    const back = oklchaToHex(oklcha);
+    expect(back).toBe('#0000ff');
+  });
+
+  it('6-digit hex round-trip: #aabbcc', () => {
+    const oklcha = hexToOklcha('#aabbcc');
+    const back = oklchaToHex(oklcha);
+    expect(back).toBe('#aabbcc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// oklchaToHsla / hslaToOklcha — round-trip drift ≤ ΔE-OK 2
+// ---------------------------------------------------------------------------
+
+describe('OKLCH↔HSL round-trip drift', () => {
+  const referenceHexColors = [
+    '#ff0000', // red
+    '#00ff00', // green
+    '#0000ff', // blue
+    '#ffff00', // yellow
+    '#ff00ff', // magenta
+    '#00ffff', // cyan
+    '#ff8800', // orange
+    '#884400', // brown
+    '#336699', // slate blue
+    '#ffffff', // white
+    '#808080', // gray
+  ];
+
+  for (const hex of referenceHexColors) {
+    it(`${hex}: OKLCH→HSL→OKLCH drift ≤ ΔE-OK 2`, () => {
+      const original = hexToOklcha(hex);
+      const hsla = oklchaToHsla(original);
+      const roundTripped = hslaToOklcha(hsla);
+
+      const orig = oklchaToOklabForDiff(original);
+      const rt = oklchaToOklabForDiff(roundTripped);
+      if (!orig || !rt) return; // achromatic edge cases are fine
+
+      const delta = deltaEOk(orig, rt);
+      expect(delta).toBeLessThanOrEqual(2);
+    });
+  }
+
+  it('oklchaToHsla preserves alpha', () => {
+    const o: Oklcha = { l: 50, c: 0.1, h: 120, a: 75 };
+    const hsla = oklchaToHsla(o);
+    expect(hsla.a).toBeCloseTo(75, 2);
+  });
+
+  it('hslaToOklcha preserves alpha', () => {
+    const h: Hsla = { h: 120, s: 50, l: 50, a: 75 };
+    const oklcha = hslaToOklcha(h);
+    expect(oklcha.a).toBeCloseTo(75, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clampToSrgbGamut
+// ---------------------------------------------------------------------------
+
+describe('clampToSrgbGamut', () => {
+  it('preserves L and H', () => {
+    // A wide-gamut color with high chroma that exceeds sRGB
+    const o: Oklcha = { l: 70, c: MAX_OKLCH_CHROMA, h: 150, a: 100 };
+    const clamped = clampToSrgbGamut(o);
+    expect(clamped.l).toBeCloseTo(o.l, 0);
+    expect(clamped.h).toBeCloseTo(o.h, 0);
+  });
+
+  it('result is in sRGB gamut', () => {
+    const o: Oklcha = { l: 70, c: 0.5, h: 150, a: 100 };
+    const clamped = clampToSrgbGamut(o);
+    expect(isInSrgbGamut(clamped)).toBe(true);
+  });
+
+  it('in-gamut color is returned unchanged (within float tolerance)', () => {
+    const o: Oklcha = { l: 50, c: 0, h: 0, a: 100 }; // black
+    const clamped = clampToSrgbGamut(o);
+    expect(clamped.l).toBeCloseTo(50, 1);
+    expect(clamped.c).toBeCloseTo(0, 4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isInSrgbGamut
+// ---------------------------------------------------------------------------
+
+describe('isInSrgbGamut', () => {
+  it('matches culori inGamut("rgb") for black', () => {
+    const o: Oklcha = { l: 0, c: 0, h: 0, a: 100 };
+    const culoriResult = rgbInGamut({
+      mode: 'oklch' as const,
+      l: o.l / 100,
+      c: o.c,
+      h: o.h,
+    });
+    expect(isInSrgbGamut(o)).toBe(culoriResult);
+  });
+
+  it('matches culori inGamut("rgb") for red', () => {
+    const o = hexToOklcha('#ff0000');
+    const culoriResult = rgbInGamut({
+      mode: 'oklch' as const,
+      l: o.l / 100,
+      c: o.c,
+      h: o.h,
+    });
+    expect(isInSrgbGamut(o)).toBe(culoriResult);
+  });
+
+  it('out-of-gamut high-chroma color returns false', () => {
+    // Very high chroma color exceeding sRGB
+    const o: Oklcha = { l: 70, c: 0.5, h: 150, a: 100 };
+    expect(isInSrgbGamut(o)).toBe(false);
+  });
+
+  it('in-gamut gray returns true', () => {
+    const o: Oklcha = { l: 50, c: 0, h: 0, a: 100 };
+    expect(isInSrgbGamut(o)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MAX_OKLCH_CHROMA constant
+// ---------------------------------------------------------------------------
+
+describe('MAX_OKLCH_CHROMA', () => {
+  it('is 0.37', () => {
+    expect(MAX_OKLCH_CHROMA).toBe(0.37);
+  });
+});

--- a/packages/zudo-design-token-panel/src/utils/color-hsla.ts
+++ b/packages/zudo-design-token-panel/src/utils/color-hsla.ts
@@ -52,6 +52,11 @@ export function hexToHsla(hex: string): Hsla {
 }
 
 export function hslaToHex(h: number, s: number, l: number, a: number): string {
+  // Clamp inputs to valid ranges to prevent malformed hex output from out-of-range
+  // values that can arrive via slider math or user input.
+  s = Math.max(0, Math.min(100, s));
+  l = Math.max(0, Math.min(100, l));
+  a = Math.max(0, Math.min(100, a));
   h = ((h % 360) + 360) % 360;
   const sn = s / 100;
   const ln = l / 100;

--- a/packages/zudo-design-token-panel/src/utils/color-hsla.ts
+++ b/packages/zudo-design-token-panel/src/utils/color-hsla.ts
@@ -1,0 +1,97 @@
+export interface Hsla {
+  h: number;
+  s: number;
+  l: number;
+  a: number; // a ∈ [0, 100]
+}
+
+const INVALID_HSLA: Hsla = { h: 0, s: 0, l: 0, a: 100 };
+
+// Accepts #rgb, #rgba, #rrggbb, #rrggbbaa; returns '' for anything else.
+function expandHex(hex: string): string {
+  const lower = hex.toLowerCase();
+  if (/^#[0-9a-f]{6}$/.test(lower)) return lower;
+  if (/^#[0-9a-f]{8}$/.test(lower)) return lower;
+  if (/^#[0-9a-f]{3}$/.test(lower)) {
+    return `#${lower[1]}${lower[1]}${lower[2]}${lower[2]}${lower[3]}${lower[3]}`;
+  }
+  if (/^#[0-9a-f]{4}$/.test(lower)) {
+    return `#${lower[1]}${lower[1]}${lower[2]}${lower[2]}${lower[3]}${lower[3]}${lower[4]}${lower[4]}`;
+  }
+  return '';
+}
+
+export function hexToHsla(hex: string): Hsla {
+  const expanded = expandHex(hex);
+  if (!expanded) return { ...INVALID_HSLA };
+
+  const r = parseInt(expanded.slice(1, 3), 16) / 255;
+  const g = parseInt(expanded.slice(3, 5), 16) / 255;
+  const b = parseInt(expanded.slice(5, 7), 16) / 255;
+
+  // Alpha: present in 8-digit form only; default to fully opaque.
+  const a =
+    expanded.length === 9
+      ? Math.round((parseInt(expanded.slice(7, 9), 16) / 255) * 100)
+      : 100;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) return { h: 0, s: 0, l: Math.round(l * 100), a };
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+
+  return { h: Math.round(h * 360), s: Math.round(s * 100), l: Math.round(l * 100), a };
+}
+
+export function hslaToHex(h: number, s: number, l: number, a: number): string {
+  h = ((h % 360) + 360) % 360;
+  const sn = s / 100;
+  const ln = l / 100;
+  const c = (1 - Math.abs(2 * ln - 1)) * sn;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = ln - c / 2;
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0');
+
+  const rgb = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+
+  if (a === 100) return rgb;
+
+  const alphaByte = Math.round((a / 100) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  return `${rgb}${alphaByte}`;
+}

--- a/packages/zudo-design-token-panel/src/utils/color-oklch.ts
+++ b/packages/zudo-design-token-panel/src/utils/color-oklch.ts
@@ -25,17 +25,16 @@ import {
   modeHsl,
 } from 'culori/fn';
 
+import type { Hsla } from './color-hsla';
+
 useMode(modeOklch);
 useMode(modeRgb);
 useMode(modeHsl);
 
-/** All four components use the panel's 0–100 scale for alpha. */
-export interface Hsla {
-  h: number; // hue ∈ [0, 360)
-  s: number; // saturation ∈ [0, 100]
-  l: number; // lightness ∈ [0, 100]
-  a: number; // alpha ∈ [0, 100]
-}
+// Re-export the canonical Hsla shape from color-hsla.ts so the two modules
+// share a single type definition (no drift between consumers that import
+// either module).
+export type { Hsla } from './color-hsla';
 
 /** All four components use the panel's 0–100 scale for alpha. */
 export interface Oklcha {
@@ -186,7 +185,10 @@ export function clampToSrgbGamut(o: Oklcha): Oklcha {
   const culoriColor = toCuloriOklch(o);
   // clampChroma reduces C until the color is in-gamut for the target space
   const clamped = clampChroma(culoriColor, 'oklch', 'rgb');
-  if (!clamped) return o;
+  // When clampChroma cannot resolve, fall back to a fully-achromatic value
+  // at the requested L and H. Returning the original out-of-gamut input
+  // would violate the documented contract (caller expects an in-gamut color).
+  if (!clamped) return { l: o.l, c: 0, h: o.h, a: o.a };
   return {
     l: (clamped.l ?? o.l / 100) * 100,
     c: clamped.c ?? 0,

--- a/packages/zudo-design-token-panel/src/utils/color-oklch.ts
+++ b/packages/zudo-design-token-panel/src/utils/color-oklch.ts
@@ -1,0 +1,203 @@
+/**
+ * OKLCH ↔ sRGB ↔ HSL math primitives for the design-token panel.
+ *
+ * Alpha convention: all alpha values in this module are expressed on a
+ * 0–100 scale (0 = fully transparent, 100 = fully opaque). This matches
+ * the HSL convention used elsewhere in the panel and differs from culori's
+ * internal 0–1 range; conversion happens at the boundary.
+ *
+ * OKLCH CSS gradient browser baseline: Chromium 111+ / Safari 16+ / Firefox 113+.
+ * Consumers targeting older browsers should clamp to sRGB before emitting CSS.
+ */
+
+// culori/fn: tree-shake-friendly entry point. Register only the modes we use.
+// useMode must be called before any converter is invoked.
+import {
+  parse,
+  formatHex,
+  formatHex8,
+  converter,
+  clampChroma,
+  inGamut,
+  useMode,
+  modeOklch,
+  modeRgb,
+  modeHsl,
+} from 'culori/fn';
+
+useMode(modeOklch);
+useMode(modeRgb);
+useMode(modeHsl);
+
+/** All four components use the panel's 0–100 scale for alpha. */
+export interface Hsla {
+  h: number; // hue ∈ [0, 360)
+  s: number; // saturation ∈ [0, 100]
+  l: number; // lightness ∈ [0, 100]
+  a: number; // alpha ∈ [0, 100]
+}
+
+/** All four components use the panel's 0–100 scale for alpha. */
+export interface Oklcha {
+  l: number; // lightness ∈ [0, 100]
+  c: number; // chroma ∈ [0, ~0.4]; culori-native units
+  h: number; // hue ∈ [0, 360)
+  a: number; // alpha ∈ [0, 100]
+}
+
+/** Practical upper bound for chroma in the sRGB gamut. */
+export const MAX_OKLCH_CHROMA = 0.37;
+
+/** Converter factories — registered once at module load. */
+const toOklch = converter('oklch');
+const toRgb = converter('rgb');
+const toHsl = converter('hsl');
+
+const isInSrgbGamutFn = inGamut('rgb');
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Map a panel Oklcha (l∈[0,100], a∈[0,100]) to culori's oklch object. */
+function toCuloriOklch(o: Oklcha): {
+  mode: 'oklch';
+  l: number;
+  c: number;
+  h: number;
+  alpha: number;
+} {
+  return {
+    mode: 'oklch' as const,
+    l: o.l / 100,
+    c: o.c,
+    h: o.h,
+    alpha: o.a / 100,
+  };
+}
+
+/** Map a culori oklch result back to a panel Oklcha. */
+function fromCuloriOklch(raw: {
+  mode: string;
+  l?: number;
+  c?: number;
+  h?: number;
+  alpha?: number;
+}): Oklcha {
+  return {
+    l: (raw.l ?? 0) * 100,
+    c: raw.c ?? 0,
+    h: raw.h ?? 0,
+    a: (raw.alpha ?? 1) * 100,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Emit an `oklch()` CSS string.  The alpha component is omitted when a===100.
+ */
+export function oklchaToCss(o: Oklcha): string {
+  const lPct = (o.l / 100).toFixed(4);
+  const c = o.c.toFixed(4);
+  const h = o.h.toFixed(2);
+  if (o.a >= 100) {
+    return `oklch(${lPct} ${c} ${h})`;
+  }
+  const a = (o.a / 100).toFixed(4);
+  return `oklch(${lPct} ${c} ${h} / ${a})`;
+}
+
+/**
+ * Parse a hex string (#RGB / #RGBA / #RRGGBB / #RRGGBBAA) to Oklcha.
+ * Returns `{l:0, c:0, h:0, a:100}` for invalid input — never throws.
+ */
+export function hexToOklcha(hex: string): Oklcha {
+  const fallback: Oklcha = { l: 0, c: 0, h: 0, a: 100 };
+  try {
+    const parsed = parse(hex);
+    if (!parsed) return fallback;
+    const ok = toOklch(parsed);
+    if (!ok) return fallback;
+    const alpha = ok.alpha === undefined ? 1 : ok.alpha;
+    return {
+      l: (ok.l ?? 0) * 100,
+      c: ok.c ?? 0,
+      h: ok.h ?? 0,
+      a: alpha * 100,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Convert an Oklcha to a hex string.
+ * Emits 6-digit hex when a===100 (unless alwaysAlpha is set).
+ * Emits 8-digit hex when a<100 or alwaysAlpha is true.
+ */
+export function oklchaToHex(
+  o: Oklcha,
+  opts?: { alwaysAlpha?: boolean },
+): string {
+  const culoriColor = toCuloriOklch(o);
+  const rgb = toRgb(culoriColor);
+  if (!rgb) return '#000000';
+  if (opts?.alwaysAlpha || o.a < 100) {
+    return formatHex8({ ...rgb, alpha: o.a / 100 }) ?? '#000000ff';
+  }
+  return formatHex(rgb) ?? '#000000';
+}
+
+/** Convert Oklcha to Hsla.  Alpha is preserved on the 0–100 scale. */
+export function oklchaToHsla(o: Oklcha): Hsla {
+  const culoriColor = toCuloriOklch(o);
+  const hsl = toHsl(culoriColor);
+  if (!hsl) return { h: 0, s: 0, l: 0, a: o.a };
+  return {
+    h: hsl.h ?? 0,
+    s: (hsl.s ?? 0) * 100,
+    l: (hsl.l ?? 0) * 100,
+    a: o.a,
+  };
+}
+
+/** Convert Hsla to Oklcha.  Alpha is preserved on the 0–100 scale. */
+export function hslaToOklcha(h: Hsla): Oklcha {
+  const culoriHsl = {
+    mode: 'hsl' as const,
+    h: h.h,
+    s: h.s / 100,
+    l: h.l / 100,
+    alpha: h.a / 100,
+  };
+  const ok = toOklch(culoriHsl);
+  if (!ok) return { l: 0, c: 0, h: 0, a: h.a };
+  return fromCuloriOklch(ok);
+}
+
+/**
+ * Clamp an Oklcha value into the sRGB gamut while preserving L and H.
+ * Uses culori's `clampChroma` which reduces chroma until the color fits.
+ */
+export function clampToSrgbGamut(o: Oklcha): Oklcha {
+  const culoriColor = toCuloriOklch(o);
+  // clampChroma reduces C until the color is in-gamut for the target space
+  const clamped = clampChroma(culoriColor, 'oklch', 'rgb');
+  if (!clamped) return o;
+  return {
+    l: (clamped.l ?? o.l / 100) * 100,
+    c: clamped.c ?? 0,
+    h: clamped.h ?? o.h,
+    a: o.a,
+  };
+}
+
+/** Return true if the Oklcha value is within the sRGB gamut. */
+export function isInSrgbGamut(o: Oklcha): boolean {
+  const rgb = toRgb(toCuloriOklch(o));
+  if (!rgb) return false;
+  return isInSrgbGamutFn(rgb);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,7 +289,14 @@ importers:
         version: 5.9.3
 
   packages/zudo-design-token-panel:
+    dependencies:
+      culori:
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
+      '@types/culori':
+        specifier: ^4.0.1
+        version: 4.0.1
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -1733,6 +1740,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/culori@4.0.1':
+    resolution: {integrity: sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -2195,6 +2205,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  culori@4.0.2:
+    resolution: {integrity: sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cytoscape-cose-bilkent@4.1.0:
     resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
@@ -5459,6 +5473,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/culori@4.0.1': {}
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -6045,6 +6061,8 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  culori@4.0.2: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.2):
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/169

---

## Summary

Replace the panel's simple HSL-only popover picker (`HslPicker` inline in `color-tab.tsx`) with a dual-mode OKLCH | HSL color picker, ported from a reference React-based viewer project and adapted to the panel's Preact runtime and hostile-host CSS-isolation policy.

The new picker exposes:

- OKLCH | HSL mode toggle (pill with `aria-pressed`, mode persisted in localStorage `tokenpanel.colorPicker.mode`)
- Two shell sizes — mini (320×400) and expanded (520×440)
- 6×6 (mini) / 6×12 (expanded) OKLCH preset grid with `data-oog` out-of-gamut markers
- Custom pointer-capture sliders with OKLCH-interpolated gradient track backgrounds
- Hex input as source of truth — mode toggle never emits `onChange`
- `culori`-backed accurate OKLCH ↔ HSL ↔ sRGB math
- **Alpha slider in both modes**; emits 8-digit hex when alpha < 100; checkerboard preview when alpha < 100; persist + apply pipeline round-trips 8-digit hex end-to-end

**Status: epic complete (Waves 1, 2, 3, 3-confirm).** Ready for review and merge into `main`.

## Wave plan (all complete)

- ✅ **Wave 1 (5 foundation sub-issues)**:
    - #170 OKLCH math module + culori dependency
    - #171 HSLA math module (alpha-aware)
    - #172 Custom slider primitive (div role=slider, pointer-capture, keyboard, step-snapped)
    - #173 Color picker CSS (tokenpanel-* BEM, --tokentweak-* design tokens)
    - #174 Alpha-aware persist + apply pipeline (#RRGGBBAA round-trip)
- ✅ **Wave 2 (1 sub-issue)**:
    - #175 OklchPicker component (.tsx) — assembled the Wave 1 foundations; 8 deep-review fixes applied
- ✅ **Wave 3 (2 sub-issues)**:
    - #176 Swap HslPicker → ColorPicker in color-tab.tsx (94-line net delete)
    - #177 CSS cleanup — retire .tokenpanel-hsl-* rules (57-line CSS delete)
- ✅ **Wave 3 confirm**:
    - #178 Full integration verification — extended Invariant D in `manifest-cascade-verification.test.ts` to mechanically enforce the hostile-host policy on `src/components/color-picker/`

## Cumulative diff

```
packages/zudo-design-token-panel/package.json                                        |   4 +
packages/zudo-design-token-panel/src/__tests__/alpha-pipeline.test.ts               |  86 +++
packages/zudo-design-token-panel/src/__tests__/css-color-to-hex.test.ts             |   4 +-
packages/zudo-design-token-panel/src/__tests__/manifest-cascade-verification.test.ts|  39 +-
packages/zudo-design-token-panel/src/components/color-picker/__tests__/...           | 1127 ++++
packages/zudo-design-token-panel/src/components/color-picker/color-picker.css       | 338 +++
packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx       | 720 ++++
packages/zudo-design-token-panel/src/components/color-picker/custom-slider.tsx      | 270 +++
packages/zudo-design-token-panel/src/components/color-picker/index.ts               |   9 +
packages/zudo-design-token-panel/src/state/tweak-state.ts                           |  53 +-
packages/zudo-design-token-panel/src/styles/panel.css                               | -58 +
packages/zudo-design-token-panel/src/tabs/color-tab.tsx                             | -92 +
packages/zudo-design-token-panel/src/utils/__tests__/color-hsla.test.ts             | 164 ++
packages/zudo-design-token-panel/src/utils/__tests__/color-oklch.test.ts            | 289 ++++
packages/zudo-design-token-panel/src/utils/color-hsla.ts                            | 102 ++
packages/zudo-design-token-panel/src/utils/color-oklch.ts                           | 205 ++
pnpm-lock.yaml                                                                       |  18 +
```

Net: ~3,300 lines added (mostly tests + the new picker component + CSS), 150 lines removed (legacy HslPicker + .tokenpanel-hsl-* CSS).

## Verification

- **674 unit tests pass** (vitest + jsdom) — covers OKLCH/HSLA math, slider primitive, picker component (mode toggle, hex input, preset grid, drag-gate, alpha emit, hostile-host class assertions), alpha persist+apply pipeline, manifest cascade invariants A–F.
- **typecheck clean** across all 7 workspaces (panel package + 5 example apps).
- **Invariant D** in `manifest-cascade-verification.test.ts` now mechanically enforces the hostile-host policy (`<h1>`–`<h6>`, `<details>`, `<summary>`, `<button>`, `<table>` blocked) on both `src/tabs/` AND `src/components/color-picker/`.
- **CI green** on all 3 checks (Build doc site / Build, test, typecheck, lint / Deploy PR preview).
- **Deep review** across waves: 3 Claude Opus reviewers + Codex standard + Codex adversarial + GitHub Copilot CLI cheap. Wave 1 had 6 findings (all fixed). Wave 2 had 8 findings (all fixed). Wave 3 + Wave 3 confirm had 1 known Codex P2 (scroll-close behavior — intentional per Wave 2 spec to fix the drag-edge dismissal regression).

## Verification report (Wave 3 confirm)

`$HOME/cclogs/zdtp/oklch-hsl-dual-picker-verify-2026-05-17T170948.md`. Lists all 7 verification steps from #178; classifies each as automated (done) vs manual (recommended before merge — browser-based checks: alpha visual round-trip, hostile-host harness, cross-example click-test, Playwright slider-gradient screenshot).

## Known design tradeoff

The new ColorPicker deliberately omits the scroll-close behavior the legacy HslPicker had. The Wave 2 spec for #175 removed it to fix the drag-edge false-dismissal regression (closing on scroll during slider drag near scrollable viewport). The picker now stays at its initial fixed-position coordinates if the panel scrolls while open. If this surfaces as a UX problem in browser verification, a follow-up could add scroll-time **reposition** (not close) — a 5-line addition to `color-picker.tsx`.

## Recommended manual verification before merge

See `verify-2026-05-17T170948.md` for the full list. In brief:

1. Open panel in any example app, pick a swatch, set alpha ~50%, reload, reopen → confirm color persists with translucency on the rendered CSS variable.
2. Boot astro example, inject the hostile CSS from `doc/.../hostile-host.mdx`, exercise the picker; confirm no host-CSS leakage.
3. Boot each of the 5 example apps; confirm the picker opens and works.
4. (Optional) Playwright screenshot of an open picker — visually confirm OKLCH slider gradient renders.

## Notes

- The reference project name does NOT appear in any sub-issue title or PR body (the `/refer-another-project` privacy constraint is preserved).
- The bundle delta is small per the Wave 1 plan note — `culori` named imports from `culori/fn` keep it under ~30 KB minified.
- After merging this PR, the epic issue #169 can be closed.
