### PR TITLE
feat(color-picker): add popover drag-and-move handle (PR #179 review)

### DIFF
--- a/.claude/skills/test-flow-color-picker-axis-direction/SKILL.md
+++ b/.claude/skills/test-flow-color-picker-axis-direction/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: test-flow-color-picker-axis-direction
+description: Verify the OKLCH/HSL dual-mode ColorPicker (packages/zudo-design-token-panel) renders its L (lightness), H (hue), and C/S (chroma/saturation) slider axes in the CORRECT direction — left edge = min value, right edge = max value, gradient and thumb position both aligned. Use when /verify-ui-ai dispatches a subagent for color-picker-axis-direction verification, or when a future PR changes the picker and you want to re-confirm the direction is still correct.
+---
+
+# Test flow: ColorPicker axis direction (L / H / C-S)
+
+This test produces a binary PASS / FAIL verdict on whether the ColorPicker's three primary value-axis sliders (L, H, and C in OKLCH mode; H, S, L in HSL mode) render correctly — left edge of each track corresponds to the MIN value of that channel, right edge to the MAX value, and the thumb position matches the value's fraction across the track.
+
+The verdict is per-mode, per-slider, so the report can pinpoint exactly which slider in which mode is wrong (if any) and how it is wrong (gradient flipped vs thumb position mirrored vs both).
+
+## Scenario
+
+1. cd to /home/takazudo/repos/myoss/zdtp.
+2. Confirm the example app dev server is reachable. The canonical example for this test is zfb-tailwind (the one that produced the original bug-report screenshots). Its dev URL is http://localhost:44328.
+   - If port 44328 is already responding, REUSE that server. Do NOT relaunch.
+   - If port 44328 is NOT responding, start the dev server in the background and wait for ready:
+     - `pnpm -F zfb-tailwind-example dev` (also boots a tokens-bin sidecar on 24686)
+     - Wait until http://localhost:44328 returns 200 (poll with a short until loop, max 60s).
+3. Open the page at viewport 1440x900 (a non-zoomed desktop default that matches the bug-report screenshots).
+4. The floating "Design Tokens" panel is visible by default. Switch to the Color tab.
+5. Click the first color swatch in the Palette section (label starts with `--zfbtw-palette-`) to open the ColorPicker popover.
+6. The popover header shows a mode toggle (OKLCH | HSL). Start in OKLCH mode (the default).
+
+## Verification — OKLCH mode
+
+Perform each check below. For each, capture (a) a screenshot of the picker popover for evidence and (b) record the DOM measurement.
+
+### Check OKLCH-L (lightness)
+
+- Type `#000000` into the hex input. Wait for the picker to re-render.
+- Record the L-slider thumb's `left` CSS percentage (DOM measurement). Expected: ≤ 5%.
+- Record the visual color sample at the LEFT edge of the L-slider track (capture a small swatch). Expected: very dark / near-black.
+- Type `#ffffff` into the hex input. Wait for re-render.
+- Record the L-slider thumb's `left` CSS percentage. Expected: ≥ 95%.
+- Record the visual color sample at the RIGHT edge of the L-slider track. Expected: very light / near-white.
+
+### Check OKLCH-H (hue)
+
+- Type `#ff0000` into the hex input (pure red, H ≈ 29° in OKLCH but we will use HSL hex for predictable input; the resulting OKLCH H is non-zero but predictable).
+  - Actually for unambiguous H=0° testing, use the hex `#dc143c` or any color where the OKLCH H rounds to a value near 0. If the H thumb position does not match the expected value, retry with a hex whose OKLCH H is verified externally.
+- The simpler test: use the hex input value computed from the displayed picker state — read the H-slider's aria-valuenow (DOM measurement) and the thumb's `left` CSS percentage. Verify: thumb-left-percent ≈ (aria-valuenow / 360) * 100, within ±3% tolerance.
+- Set the hex to a series of values whose OKLCH H spans the gradient. Record the thumb-left-percent at each step and confirm monotonically-increasing (or at least non-decreasing) as the H value increases.
+- Capture the gradient direction by sampling color values at LEFT edge (expected: red ~ rgb(2,55,55) — OKLCH(displayed L%, displayed C, 0)) and RIGHT edge (expected: same red after the rainbow wraps at 360°).
+- The KEY observation is monotonic mapping of value to position with left = low, right = high.
+
+### Check OKLCH-C (chroma)
+
+- Read the C-slider's current aria-valuenow and the thumb's `left` CSS percentage. Compute expected-left-percent = aria-valuenow / MAX_OKLCH_CHROMA (which is 0.37 per packages/zudo-design-token-panel/src/components/color-picker/constants).
+- Verify thumb-left-percent matches expected, within ±3%.
+- Sample the LEFT edge of the C track. Expected: grayscale (chroma 0).
+- Sample the RIGHT edge. Expected: most saturated for the current L and H.
+
+## Verification — HSL mode
+
+Click the HSL button in the mode toggle. Re-run analogous checks:
+
+### Check HSL-H (hue) — identical procedure to OKLCH-H.
+
+### Check HSL-S (saturation)
+
+- aria-valuenow span is 0..100. Expected thumb-left-percent = aria-valuenow.
+- LEFT edge of S track = gray, RIGHT edge = fully saturated.
+
+### Check HSL-L (lightness)
+
+- aria-valuenow span is 0..100. Expected thumb-left-percent = aria-valuenow.
+- LEFT edge of L track = black, RIGHT edge = white.
+
+## Measurements (mechanical — these should drive the verdict, not subjective AI judgment)
+
+For each slider in each mode, compute:
+
+- `thumbPositionError = abs(thumbLeftPercent - expectedLeftPercent)` — PASS if ≤ 3%.
+- `gradientDirection` = which color appears at the LEFT vs RIGHT edge — PASS if LEFT matches MIN-value color and RIGHT matches MAX-value color (e.g. L-slider: LEFT=dark, RIGHT=light).
+
+The AI judgment ONLY applies to (b) gradientDirection (subjective "this color region is darker than that color region" — which a small color-distance computation would also resolve mechanically if needed, but for L6 we accept AI's perceptual call).
+
+## Verdict criteria
+
+PER-SLIDER PASS if BOTH `thumbPositionError` ≤ 3% AND gradientDirection matches expected.
+PER-SLIDER FAIL otherwise — report which (gradient or thumb or both) is wrong, in which direction it is wrong.
+
+OVERALL VERDICT:
+- All 6 checks PASS (OKLCH L+H+C, HSL H+S+L) → overall PASS.
+- Any check FAIL → overall FAIL.
+
+## Output schema
+
+The verification subagent MUST return a structured result containing exactly:
+
+```
+{
+  "verdict": "PASS" | "FAIL",
+  "summary": "<one-line human-readable verdict>",
+  "modes": {
+    "oklch": {
+      "L": { "thumbPositionError": number, "gradientDirection": "correct" | "reversed" | "inconclusive", "verdict": "PASS" | "FAIL", "notes": string },
+      "H": { ... same shape ... },
+      "C": { ... same shape ... }
+    },
+    "hsl": {
+      "H": { ... },
+      "S": { ... },
+      "L": { ... }
+    }
+  },
+  "screenshots": [
+    { "label": "oklch-after-#000000", "path": "<absolute path>" },
+    { "label": "oklch-after-#ffffff", "path": "<absolute path>" },
+    ...
+  ],
+  "toolUsed": "verify-ui" | "headless-browser",
+  "devServerStartedByThisRun": boolean,
+  "devServerStopped": boolean
+}
+```
+
+The `summary` field must be one line, no markdown.
+
+## Browser-driving skill preference
+
+Use `/headless-browser` (Tier 2 Playwright CLI) — this flow requires multi-step interaction (typing hex values, switching modes, clicking swatches, capturing screenshots at multiple states), and is beyond `/verify-ui`'s deterministic computed-style-only checks.
+
+`/verify-ui` is acceptable as a fallback if `/headless-browser` is unavailable, but its single-page-read shape will require more round trips for this multi-step flow.
+
+## Cleanup
+
+If this test started the dev server (`devServerStartedByThisRun: true`), stop it on exit so it does not leak. Use `lsof -ti:44328 | xargs kill -9 2>/dev/null || true` and `lsof -ti:24686 | xargs kill -9 2>/dev/null || true`. Record `devServerStopped: true` in the output.
+
+If the test reused an already-running server, do NOT stop it (someone else may still want it). Record `devServerStartedByThisRun: false, devServerStopped: false`.
+
+## Don'ts
+
+- Don't assume the bug exists — the user has reported it but the static analysis shows the code is correct. Approach with healthy skepticism in BOTH directions.
+- Don't trust visual color-perception alone — back perceptual judgments with the mechanical thumb-position measurement (which is precise and deterministic).
+- Don't run the full test suite or any other build steps in the verification subagent — this skill is for one specific verification.
+- Don't modify any source code — verification is read-only on the application.

--- a/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker-drag.test.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker-drag.test.tsx
@@ -1,0 +1,439 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for the ColorPicker drag-handle feature (issue #180).
+ *
+ * Behaviors under test:
+ *  1. The drag handle <span> renders in the header with the correct ARIA shape
+ *     (role="presentation", aria-hidden="true") and the braille-dots glyph ⠿.
+ *  2. pointerdown on the drag handle captures the pointer and starts a drag
+ *     session — verified indirectly via subsequent pointermove producing a
+ *     position-locked container style.
+ *  3. pointermove translates the container by (clientX - startX, clientY - startY)
+ *     and applies it as `position: fixed; left; top` on the container.
+ *  4. pointerup re-clamps dragPos to the viewport (rect.left/top stays inside
+ *     [pad, viewport - pad - size]).
+ *  5. The drag handle's pointerdown does NOT propagate to the document-level
+ *     outside-click handler — usePopoverClose remains silent during drag.
+ *  6. DOM hygiene — the drag handle is a <span>, not a banned semantic tag.
+ *
+ * Test environment caveats (mirrors color-picker.test.tsx setup):
+ *  - PointerEvent shim — jsdom does not polyfill PointerEvent natively.
+ *  - setPointerCapture/releasePointerCapture are not implemented in jsdom; the
+ *    component swallows the resulting throws via try/catch.
+ *  - getBoundingClientRect on jsdom returns zero-sized rects by default. Tests
+ *    that depend on rect.width / rect.height stub the function on the relevant
+ *    element so the clamp math has meaningful numbers.
+ */
+
+// jsdom does not polyfill PointerEvent. Provide a minimal shim that carries
+// pointerId + clientX/clientY through to handlers (MouseEvent base already
+// carries clientX/clientY).
+if (typeof PointerEvent === 'undefined') {
+  class PointerEventShim extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = PointerEventShim;
+}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { useRef } from 'preact/compat';
+import type { JSX } from 'preact';
+import { ColorPicker } from '../color-picker';
+import type { ColorPickerProps } from '../color-picker';
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  try {
+    window.localStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  container.remove();
+});
+
+function PickerWrapper(
+  props: Omit<ColorPickerProps, 'anchorRef' | 'onClose'> & {
+    onClose?: () => void;
+  },
+): JSX.Element {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={anchorRef} style={{ width: 40, height: 40 }} />
+      <ColorPicker
+        {...props}
+        anchorRef={anchorRef as React.RefObject<HTMLElement | null>}
+        onClose={props.onClose ?? (() => {})}
+      />
+    </div>
+  );
+}
+
+function renderPicker(
+  partial: Partial<ColorPickerProps> & { onClose?: () => void } = {},
+): void {
+  act(() => {
+    render(
+      <PickerWrapper
+        color={partial.color ?? '#ff0000'}
+        onChange={partial.onChange ?? vi.fn()}
+        label={partial.label}
+        defaultMode={partial.defaultMode}
+        onClose={partial.onClose ?? (() => {})}
+      />,
+      container,
+    );
+  });
+}
+
+function getDialog(): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[role="dialog"]');
+  if (!el) throw new Error('dialog not found');
+  return el;
+}
+
+function getDragHandle(): HTMLElement {
+  const el = container.querySelector<HTMLElement>(
+    '.tokenpanel-color-picker-drag-handle',
+  );
+  if (!el) throw new Error('drag handle not found');
+  return el;
+}
+
+// Stub getBoundingClientRect on `el` so the container appears to have a
+// concrete viewport-relative rect. jsdom returns zeros otherwise, which
+// makes both the translate math and the clamp meaningless.
+function stubRect(
+  el: HTMLElement,
+  rect: { left: number; top: number; width: number; height: number },
+): void {
+  el.getBoundingClientRect = () =>
+    ({
+      left: rect.left,
+      top: rect.top,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      width: rect.width,
+      height: rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect);
+}
+
+function firePointer(
+  el: Element,
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  init: { clientX?: number; clientY?: number; pointerId?: number } = {},
+): void {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent(type, {
+        bubbles: true,
+        pointerId: init.pointerId ?? 1,
+        clientX: init.clientX ?? 0,
+        clientY: init.clientY ?? 0,
+      }),
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Drag handle rendering & ARIA shape
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag handle rendering', () => {
+  it('renders the drag handle as a <span> in the header', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.tagName).toBe('SPAN');
+  });
+
+  it('drag handle has role="presentation" and aria-hidden="true"', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.getAttribute('role')).toBe('presentation');
+    expect(handle.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('drag handle contains the braille-dots glyph (⠿)', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.textContent).toBe('⠿');
+  });
+
+  it('drag handle sits inside the header (before the label)', () => {
+    renderPicker();
+    const header = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-header',
+    );
+    expect(header).not.toBeNull();
+    const firstChild = header!.firstElementChild;
+    expect(firstChild).not.toBeNull();
+    expect(firstChild!.classList.contains('tokenpanel-color-picker-drag-handle'))
+      .toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Drag flow — pointerdown → pointermove → pointerup
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag flow', () => {
+  it('pointermove after pointerdown applies a fixed left/top to the container', () => {
+    renderPicker();
+    const dialog = getDialog();
+    // Container starts at (100, 100) with size 320x400.
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+    firePointer(handle, 'pointermove', { clientX: 150, clientY: 130 });
+
+    // delta = (40, 20) → newLeft = 140, newTop = 120
+    expect(dialog.style.position).toBe('fixed');
+    expect(dialog.style.left).toBe('140px');
+    expect(dialog.style.top).toBe('120px');
+  });
+
+  it('subsequent pointermove updates dragPos to the latest delta', () => {
+    renderPicker();
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 10, clientY: 10 });
+    firePointer(handle, 'pointermove', { clientX: 50, clientY: 50 });
+    firePointer(handle, 'pointermove', { clientX: 200, clientY: 150 });
+
+    // delta = (190, 140) from base (100, 100) → (290, 240)
+    expect(dialog.style.left).toBe('290px');
+    expect(dialog.style.top).toBe('240px');
+  });
+
+  it('pointermove without prior pointerdown does NOT move the popover', () => {
+    renderPicker();
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    // Snapshot whatever style was applied by the auto-positioning pass.
+    const initialLeft = dialog.style.left;
+    const initialTop = dialog.style.top;
+
+    firePointer(handle, 'pointermove', { clientX: 500, clientY: 500 });
+
+    expect(dialog.style.left).toBe(initialLeft);
+    expect(dialog.style.top).toBe(initialTop);
+  });
+
+  it('pointermove with mismatched pointerId is ignored', () => {
+    renderPicker();
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', {
+      pointerId: 7,
+      clientX: 10,
+      clientY: 10,
+    });
+    // A move event from a DIFFERENT pointer must not perturb dragPos.
+    firePointer(handle, 'pointermove', {
+      pointerId: 99,
+      clientX: 999,
+      clientY: 999,
+    });
+
+    // dragPos still null → style remains the auto-positioned one. Since auto
+    // is used pre-pointerdown effect, just verify no extreme jump happened.
+    // (left should NOT be the 999-based delta.)
+    expect(dialog.style.left).not.toBe('999px');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Pointerup re-clamps to the viewport
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — pointerup clamps to viewport', () => {
+  // jsdom defaults to window.innerWidth=1024, innerHeight=768. The clamp
+  // formula is: left ∈ [pad, vw - pad - width] (pad=8). So for w=320, the
+  // right bound is 1024 - 8 - 320 = 696. Anything past 696 should be pulled
+  // back to 696 on release.
+  it('clamps left to the right edge minus padding', () => {
+    renderPicker();
+    const dialog = getDialog();
+    // Place container far off the right edge of the viewport on release.
+    const handle = getDragHandle();
+
+    // Phase 1: stubRect at start. pointerdown captures baseLeft=100.
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    // Phase 2: simulate that the user dragged the container so its real
+    // rect.left is now 5000 (way off-screen). The pointerup handler reads
+    // getBoundingClientRect again to do its clamp math.
+    stubRect(dialog, { left: 5000, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 5010, clientY: 210 });
+
+    // Expected clamp on left: vw - pad - width = 1024 - 8 - 320 = 696
+    expect(dialog.style.left).toBe('696px');
+  });
+
+  it('clamps left to the padding when negative', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    // Pretend the container's rect ended up at left=-500 after dragging.
+    stubRect(dialog, { left: -500, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: -490, clientY: 210 });
+
+    expect(dialog.style.left).toBe('8px'); // pad
+  });
+
+  it('clamps top to the bottom edge minus padding', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    // Drag so the container's rect.top sits far below the viewport.
+    stubRect(dialog, { left: 200, top: 5000, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 210, clientY: 5010 });
+
+    // vh - pad - height = 768 - 8 - 400 = 360
+    expect(dialog.style.top).toBe('360px');
+  });
+
+  it('clamps top to the padding when negative', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    stubRect(dialog, { left: 200, top: -500, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 210, clientY: -490 });
+
+    expect(dialog.style.top).toBe('8px'); // pad
+  });
+
+  it('pointercancel ends the drag (treated like pointerup, applies clamp)', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    stubRect(dialog, { left: 5000, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointercancel', { clientX: 5010, clientY: 210 });
+
+    expect(dialog.style.left).toBe('696px');
+  });
+
+  it('after pointerup, a subsequent pointermove does NOT move the popover', () => {
+    renderPicker();
+    const dialog = getDialog();
+    const handle = getDragHandle();
+
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+    stubRect(dialog, { left: 200, top: 200, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 210, clientY: 210 });
+
+    const leftAfterUp = dialog.style.left;
+    const topAfterUp = dialog.style.top;
+
+    // Drag session is over; further moves should not change position.
+    firePointer(handle, 'pointermove', { clientX: 999, clientY: 999 });
+
+    expect(dialog.style.left).toBe(leftAfterUp);
+    expect(dialog.style.top).toBe(topAfterUp);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Drag handle does NOT trigger outside-click close
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag handle and usePopoverClose', () => {
+  it('pointerdown on the drag handle does NOT call onClose', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('a full drag (down → move → up) does NOT call onClose', () => {
+    const onClose = vi.fn();
+    renderPicker({ onClose });
+    const dialog = getDialog();
+    stubRect(dialog, { left: 100, top: 100, width: 320, height: 400 });
+    const handle = getDragHandle();
+
+    firePointer(handle, 'pointerdown', { clientX: 110, clientY: 110 });
+    firePointer(handle, 'pointermove', { clientX: 200, clientY: 150 });
+    stubRect(dialog, { left: 190, top: 140, width: 320, height: 400 });
+    firePointer(handle, 'pointerup', { clientX: 200, clientY: 150 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. DOM hygiene — drag handle does not introduce banned tags
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — drag handle DOM hygiene', () => {
+  it('drag handle is a <span>, not a banned semantic tag', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.tagName).toBe('SPAN');
+    // Smoke check: still no banned tags anywhere in the dialog.
+    const banned = container.querySelectorAll('a,button,h1,h2,h3,h4,h5,h6,p,ul,ol,li');
+    expect(banned.length).toBe(0);
+  });
+
+  it('drag handle does NOT carry role="button" or tabIndex (presentational)', () => {
+    renderPicker();
+    const handle = getDragHandle();
+    expect(handle.getAttribute('role')).not.toBe('button');
+    // No keyboard activation expected — it's a pure pointer affordance.
+    expect(handle.tabIndex).toBe(-1);
+  });
+});

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
@@ -56,6 +56,30 @@
   gap: var(--tokentweak-gap-2xs);
 }
 
+/* Drag handle — braille-dots glyph in the header's leading slot.
+ * cursor: grab → grabbing; touch-action: none lets pointer events handle
+ * the gesture (otherwise the browser's pan/scroll hijacks it on touch).
+ * aria-hidden in JSX so assistive tech skips the glyph. */
+.tokenpanel-color-picker-drag-handle {
+  flex-shrink: 0;
+  cursor: grab;
+  color: var(--tokentweak-color-muted);
+  font-size: var(--tokentweak-text-caption);
+  line-height: 1;
+  padding: var(--tokentweak-pad-2xs);
+  border-radius: var(--radius-tokentweak);
+  user-select: none;
+  touch-action: none;
+}
+
+.tokenpanel-color-picker-drag-handle:hover {
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-color-picker-drag-handle:active {
+  cursor: grabbing;
+}
+
 .tokenpanel-color-picker-label {
   flex: 1;
   min-width: 0;

--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx
@@ -327,8 +327,28 @@ export function ColorPicker({
   onClose,
 }: ColorPickerProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null);
+  const dragHandleRef = useRef<HTMLSpanElement>(null);
   const isDraggingRef = useRef(false);
   const [hex, setHex] = useSyncedHex(color, isDraggingRef);
+
+  // ── Drag-handle state ─────────────────────────────────────────────────────
+  // dragPos holds the current dragged-to position (left, top in viewport px).
+  // null means auto-positioned (normal anchor-relative behavior).
+  // Session-only: the popover unmounts when the parent closes it, so dragPos
+  // resets to null on every open.
+  const [dragPos, setDragPos] = useState<{ left: number; top: number } | null>(
+    null,
+  );
+  // Ref tracking the pointer start position and the popover's base rect for
+  // the current drag gesture. Never causes a re-render.
+  const dragSession = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    baseLeft: number;
+    baseTop: number;
+  } | null>(null);
+  const isDraggingHandle = useRef(false);
 
   const [mode, setMode] = useState<ColorPickerMode>(() =>
     readPersistedMode(defaultMode),
@@ -494,6 +514,96 @@ export function ColorPicker({
     );
   }, [anchorRef, shell]);
 
+  // ── Drag-handle pointer handlers ─────────────────────────────────────────
+  // Mirrors pgen's color-picker-oklch drag implementation. Wired via
+  // addEventListener (not Preact JSX onPointer* props) for the same reason as
+  // custom-slider.tsx — Preact's jsdom feature-detection registers PointerEvent
+  // listeners with wrong casing, so tests dispatching 'pointerdown' miss them.
+  // Pointer capture keeps move/up flowing even if the pointer leaves the handle.
+  useEffect(() => {
+    const el = dragHandleRef.current;
+    if (!el) return;
+
+    function handlePointerDown(e: PointerEvent) {
+      e.preventDefault();
+      // Stop propagation so the document-level outside-click handler can't
+      // possibly receive this pointerdown. Defensive — even though the handle
+      // sits inside containerRef, mirroring pgen's pattern keeps the contract
+      // explicit.
+      e.stopPropagation();
+      const container = containerRef.current;
+      if (!container) return;
+      // Freeze the current rendered position (absolute left/top in viewport).
+      // Use getBoundingClientRect so we always operate in `top` space regardless
+      // of whether the auto-position used `top` or `bottom` CSS.
+      const rect = container.getBoundingClientRect();
+      dragSession.current = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        baseLeft: rect.left,
+        baseTop: rect.top,
+      };
+      isDraggingHandle.current = true;
+      try {
+        el!.setPointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement setPointerCapture; ignore.
+      }
+    }
+
+    function handlePointerMove(e: PointerEvent) {
+      if (!isDraggingHandle.current || !dragSession.current) return;
+      if (e.pointerId !== dragSession.current.pointerId) return;
+      const { startX, startY, baseLeft, baseTop } = dragSession.current;
+      const newLeft = baseLeft + (e.clientX - startX);
+      const newTop = baseTop + (e.clientY - startY);
+      setDragPos({ left: newLeft, top: newTop });
+    }
+
+    function handlePointerUp(e: PointerEvent) {
+      if (!isDraggingHandle.current || !dragSession.current) return;
+      if (e.pointerId !== dragSession.current.pointerId) return;
+      isDraggingHandle.current = false;
+      dragSession.current = null;
+      try {
+        el!.releasePointerCapture(e.pointerId);
+      } catch {
+        // jsdom does not implement releasePointerCapture; ignore.
+      }
+      // Re-clamp to keep the popover fully on-screen after release.
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const pad = 8;
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const clampedLeft = Math.max(
+        pad,
+        Math.min(vw - pad - rect.width, rect.left),
+      );
+      const clampedTop = Math.max(
+        pad,
+        Math.min(vh - pad - rect.height, rect.top),
+      );
+      setDragPos({ left: clampedLeft, top: clampedTop });
+    }
+
+    el.addEventListener('pointerdown', handlePointerDown);
+    el.addEventListener('pointermove', handlePointerMove);
+    el.addEventListener('pointerup', handlePointerUp);
+    el.addEventListener('pointercancel', handlePointerUp);
+
+    return () => {
+      el.removeEventListener('pointerdown', handlePointerDown);
+      el.removeEventListener('pointermove', handlePointerMove);
+      el.removeEventListener('pointerup', handlePointerUp);
+      el.removeEventListener('pointercancel', handlePointerUp);
+    };
+    // Empty dep array — handlers close over stable refs only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Checkerboard is only needed when the color has a non-opaque alpha byte.
   const hasAlpha = /^#[0-9a-fA-F]{8}$/.test(hex);
 
@@ -504,17 +614,35 @@ export function ColorPicker({
     isDraggingRef.current = false;
   }, []);
 
+  // Final container style — dragPos takes precedence over auto-positioning
+  // once the user has grabbed the handle and moved the popover.
+  const containerStyle: JSX.CSSProperties = dragPos
+    ? { position: 'fixed', left: dragPos.left, top: dragPos.top }
+    : autoStyle;
+
   return (
     <div
       ref={containerRef}
       className="tokenpanel-color-picker"
       data-mode-shell={shell}
-      style={autoStyle}
+      style={containerStyle}
       role="dialog"
       aria-label={label ? `${label} color picker` : 'Color picker'}
     >
       {/* Header ─────────────────────────────────────────────────────────── */}
       <div className="tokenpanel-color-picker-header">
+        {/* Drag handle — braille-dots glyph (⠿, U+283F) per pgen mockup.
+            role="presentation"+aria-hidden so assistive tech skips the glyph.
+            <span> chosen over <div> per zdtp panel-DOM-hygiene policy: span is
+            not in the host-resettable tag list and matches pgen's pattern. */}
+        <span
+          ref={dragHandleRef}
+          className="tokenpanel-color-picker-drag-handle"
+          role="presentation"
+          aria-hidden="true"
+        >
+          ⠿
+        </span>
         <span className="tokenpanel-color-picker-label">{label ?? 'Color'}</span>
 
         {/* Mode toggle: OKLCH | HSL */}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/180
- parent PR
    - https://github.com/Takazudo/zudo-design-token-panel/pull/179

---

## Summary

Address review feedback from [PR #179 comment](https://github.com/Takazudo/zudo-design-token-panel/pull/179#issuecomment-4469942811). The comment raised two items; one ships, one is dropped after verification.

- **Adds** a drag-and-move handle to the ColorPicker popover header (braille-dots glyph ⠿). Ported from the pgen project's `color-picker-oklch` component.
- **Investigated and dropped**: the reported L/H slider direction bug. `/verify-ui-ai` live-browser verification confirmed PASS in both OKLCH and HSL modes (max thumb-position error <0.01%); the visible color difference in the original report was fully explained by different `oklch.h` values feeding the L-axis gradient, not an axis flip.
- **Adds** a project-scope `/verify-ui-ai` test-flow skill (`.claude/skills/test-flow-color-picker-axis-direction/`) so future PRs touching the picker can re-run the same verification.

## Changes

### `packages/zudo-design-token-panel/src/components/color-picker/color-picker.tsx` (+130 / -1)
- `dragPos` `useState<{left, top}|null>` overrides the existing `getFixedPopoverStyle` auto-positioning when set.
- `dragSession` + `isDraggingHandle` refs track the active pointer (single-pointer; mismatched `pointerId` ignored).
- Pointer handlers wired via `addEventListener` (not Preact JSX `onPointer*`) for jsdom compatibility — same pattern as `custom-slider.tsx` (lowercase `onpointerdown` is not exposed by jsdom so Preact's heuristic fails).
- `setPointerCapture` / `releasePointerCapture` wrapped in try/catch (jsdom does not implement them).
- On `pointerup` re-clamp to `[pad, viewport - pad - size]` on both axes so the popover cannot be dragged off-screen.
- Drag handle rendered as `<span class="tokenpanel-color-picker-drag-handle" role="presentation" aria-hidden="true">⠿</span>` per the panel's [DOM-hygiene policy](../tree/base/picker-orient-drag/packages/zudo-design-token-panel/CLAUDE.md) (`<span>` is permitted; `role="presentation"` makes it non-interactive to assistive tech since dragging is pointer-only).
- `stopPropagation` on `pointerdown` so the drag does not trigger the outside-click close handler.

### `packages/zudo-design-token-panel/src/components/color-picker/color-picker.css` (+24)
- `.tokenpanel-color-picker-drag-handle` — `cursor: grab` → `cursor: grabbing` on `:active`, `touch-action: none` (so touch drag does not scroll the page), `user-select: none`, plus subtle padding and color matching the panel design tokens.

### `packages/zudo-design-token-panel/src/components/color-picker/__tests__/color-picker-drag.test.tsx` (+439, new)
- 18 tests covering the drag flow: handle ARIA shape (span, role=presentation, aria-hidden, braille-dots glyph, first child of header), pointer-capture wiring, drag translation on pointermove, multi-step pointermove takes the latest, no-op when pointermove fires without pointerdown, mismatched `pointerId` ignored, viewport re-clamp on pointerup (left + top, both edges), pointercancel behaves like pointerup, pointermove after pointerup is no-op, outside-click close still works after drag, no banned semantic tags introduced, handle has neither `role=button` nor `tabIndex`.

### `.claude/skills/test-flow-color-picker-axis-direction/SKILL.md` (+138, new)
- Project-scope test-flow skill authored by `/verify-ui-ai`. Captures the procedure (which dev URL, which swatch to click, which hex inputs to type), the mechanical measurements (3% thumb-position tolerance per slider), the verdict criteria (6 checks: OKLCH L/H/C + HSL H/S/L), and the structured output schema. Re-invokable by any future PR that wants to confirm the slider-direction property still holds.

## Why topic 1 was dropped

The PR #179 review comment claimed the L and H sliders "go the wrong direction". Two-pass investigation:

1. **Static** (orient-fix child agent): code is byte-identical to pgen's `color-picker-oklch` for gradient generation, fraction-from-value math, and thumb position. Pixel-sampled the four attached screenshots — thumb positions match `(value − min) / (max − min)` for every visible value.
2. **Live browser** (`/verify-ui-ai` via headless-browser subagent): typed hex `#000000`, `#ffffff`, `#ff0000`, `#00ff00` into the picker on the astro-example app. All 6 axis-direction checks PASS, max thumb-position error <0.01% (tolerance is 3%). Gradient LEFT edge always matches MIN value, RIGHT edge always matches MAX.

The visible color-palette difference between pgen's L slider (plum→pink in the expected screenshot) and zdtp's L slider (indigo→cyan in the broken screenshot) is fully explained by the different `oklch.h` feeding each gradient (pgen at `h=315°`, zdtp at `h=261°`). The L axis correctly renders `oklch(0% Cb h=hue)` → `oklch(100% Cb h=hue)`, which is dark→light for any hue. Not an axis flip.

Evidence: [PR #179 verdict comment](https://github.com/Takazudo/zudo-design-token-panel/pull/179#issuecomment-4470275259).

## Test Plan

- [x] Unit tests pass: `pnpm -F @takazudo/zudo-design-token-panel test --run` — 692/692
- [x] New drag suite: `pnpm -F @takazudo/zudo-design-token-panel test color-picker-drag` — 18/18
- [x] Build green: `pnpm -F @takazudo/zudo-design-token-panel build`
- [x] `/gcoc-review` on merged diff — no blocking findings (one optional perf note about `setState` per `pointermove` deferred as not-observed)
- [x] Live drag verification: `dx=200` `dy=100` exact on 1440x1500 viewport (first run at 1440x900 hit the viewport-clamp at 8 px from the bottom edge — implemented feature working correctly), outside-click close still works after drag
- [x] `/verify-ui-ai` on slider direction — PASS, no bug