### PR TITLE
fix(color-picker): correct palette grid axis (hue=X, brightness=Y)

### DIFF
--- a/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
+++ b/packages/zudo-design-token-panel/src/components/color-picker/color-picker.css
@@ -222,6 +222,16 @@
   gap: 2px;
 }
 
+/* role="row" wrappers carry ARIA grid semantics but must not break the
+   CSS grid track layout — promote their cells to direct grid items so
+   hue runs across the X axis and brightness down the Y axis (matching
+   the pgen reference). Without this, the row wrappers become the grid
+   items themselves and the inner cells stack vertically, transposing
+   the axes. */
+.tokenpanel-color-picker-grid > [role='row'] {
+  display: contents;
+}
+
 .tokenpanel-color-picker[data-mode-shell='expanded'] .tokenpanel-color-picker-grid {
   grid-template-columns: repeat(12, 1fr);
 }


### PR DESCRIPTION
- parent PR
    - https://github.com/Takazudo/zudo-design-token-panel/pull/179

---

## Summary

Fix the ColorPicker preset palette grid so hue runs across the X axis and brightness down the Y axis, matching the pgen reference and the user expectation captured in the PR #179 review comment.

## Background

PR #181 attempted to address the same "hue/brightness direction wrong" feedback but the investigation only covered the L/H/C/S sliders and concluded no-op. The actual mismatch was in the **preset palette grid** above the sliders, which was untouched.

## Root cause

`color-picker.tsx:734-766` wraps each row in a `<div role="row">` between the grid container and the cells. With `.tokenpanel-color-picker-grid` set to `display: grid; grid-template-columns: repeat(12, 1fr)` (or `repeat(6, 1fr)` in mini mode), the 6 row wrappers — not the 72 (or 36) cells — became the grid items. Each wrapper had no grid display of its own, so its inner cells fell back to block flow and stacked vertically. Visible result: 6 columns (one per row wrapper = brightness) × 12 rows (cells stacked = hue) — the axes flipped vs the pgen reference (`color-picker-oklch.tsx:861-888`, which renders cells flat with no row wrappers).

## Changes

- `packages/zudo-design-token-panel/src/components/color-picker/color-picker.css` — add `display: contents` to `.tokenpanel-color-picker-grid > [role="row"]` so the cells participate directly in the parent grid track layout while preserving the ARIA `grid` / `row` / `gridcell` structure (and the existing role=row regression tests).

Total: 1 file, +10 lines (rule + multi-line rationale comment).

## Test Plan

- [x] `pnpm -F @takazudo/zudo-design-token-panel test --run` — 692/692 passing, including the 4 existing M2 tests that assert `[role="grid"] [role="row"]` count and gridcell children.
- [x] `pnpm -F @takazudo/zudo-design-token-panel typecheck` — clean.
- [x] Live browser deterministic verification (Playwright CLI on the astro example at `localhost:44324`):
    - `gridTemplateColumns` resolves to 6 tracks (mini mode) of equal width.
    - `roleRowCount = 6`, `rowDisplay = "contents"`.
    - Cells with `data-grid-row="0"` are aligned horizontally (same Y) — top row visually contains H=0°, 60°, 120°, 180°, 240°, 300° at L=95%.
    - Cells with `data-grid-col="0"` are aligned vertically (same X) — leftmost column visually contains L=95%, 78%, 61%, 44% at H=0°.
- [x] Visual screenshot of the palette popover confirms the layout matches the pgen reference: top row goes light-pink → light-orange → light-yellow-green → light-cyan → light-blue → light-lavender; each column darkens top-to-bottom in the same hue family.
- [x] `/gcoc-review`: no actionable findings (the only Medium note is a known Safari+VoiceOver edge case with `display: contents` and `role="row"`, not something this PR can resolve — gridcells retain their own role and remain announced).