### PR TITLE
Examples Polish: a11y + dev-server hygiene + doc comments

### DIFF
--- a/examples/zfb-tailwind/components/widgets/accordion.tsx
+++ b/examples/zfb-tailwind/components/widgets/accordion.tsx
@@ -63,7 +63,7 @@ export function AccordionDemo() {
         <details key={item.id} class="widgets-accordion rounded-md overflow-hidden">
           <summary class="flex items-center justify-between px-hsp-md py-vsp-md bg-surface rounded-md text-body cursor-pointer list-none">
             <span>{item.summary}</span>
-            <span class="text-muted text-helper select-none">▾</span>
+            <span class="text-muted text-helper select-none" aria-hidden="true">▾</span>
           </summary>
           <div class="px-hsp-md py-vsp-md border border-muted rounded-md text-body text-fg mt-vsp-xs">
             <p>{item.body}</p>

--- a/examples/zfb-tailwind/components/widgets/tabs.tsx
+++ b/examples/zfb-tailwind/components/widgets/tabs.tsx
@@ -10,9 +10,12 @@
  *   transform: translateX(...)  driven by var(--zfbtw-easing-tab-open)
  *   width = 100%/tabCount via inline style (reason: dynamic from runtime tab count —
  *   no static Tailwind utility can express a fraction of parent from a variable count)
+ *
+ * Accessibility: WAI-ARIA Tabs APG pattern with automatic activation.
+ *   https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useId, useRef } from 'preact/hooks';
 import { Island, type IslandProps } from '@takazudo/zfb';
 
 const TABS = ['Overview', 'Details', 'Settings'] as const;
@@ -22,18 +25,42 @@ function TabsInner() {
   const tabCount = TABS.length;
   const indicatorPct = 100 / tabCount;
 
+  const baseId = useId();
+  const tabIds = TABS.map((_, i) => `${baseId}-tab-${i}`);
+  const panelIds = TABS.map((_, i) => `${baseId}-panel-${i}`);
+  // ref array for programmatic focus on keyboard navigation
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    let next = -1;
+    if (e.key === 'ArrowRight') next = (activeIndex + 1) % tabCount;
+    else if (e.key === 'ArrowLeft') next = (activeIndex - 1 + tabCount) % tabCount;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = tabCount - 1;
+    if (next === -1) return;
+    e.preventDefault(); // prevent page scroll on arrow/home/end keys
+    setActiveIndex(next);
+    tabRefs.current[next]?.focus();
+  };
+
   return (
     <div>
       {/* Tab list */}
-      <div class="relative flex gap-hsp-md border-b border-muted">
+      <div class="relative flex gap-hsp-md border-b border-muted" role="tablist" onKeyDown={onKeyDown}>
         {TABS.map((tab, i) => (
           <button
             key={tab}
             type="button"
+            role="tab"
+            id={tabIds[i]}
+            aria-selected={activeIndex === i}
+            aria-controls={panelIds[i]}
+            tabIndex={activeIndex === i ? 0 : -1}
             onClick={() => setActiveIndex(i)}
             class={`px-hsp-md py-vsp-sm text-body cursor-pointer border-none bg-transparent ${
               activeIndex === i ? 'text-accent font-semibold' : 'text-muted'
             }`}
+            ref={(el) => { tabRefs.current[i] = el; }}
           >
             {tab}
           </button>
@@ -46,6 +73,7 @@ function TabsInner() {
         */}
         <span
           class="absolute bottom-0 h-[2px] bg-accent"
+          aria-hidden="true"
           // reason: width is 1/N of container from runtime tab count; transition
           // timing references semantic easing token not expressible as a Tailwind utility
           style={{
@@ -56,28 +84,44 @@ function TabsInner() {
         />
       </div>
 
-      {/* Tab panels */}
-      <div class="px-hsp-md py-vsp-md text-body text-fg">
-        {activeIndex === 0 && (
-          <p>
-            <strong>Overview panel.</strong> Indicator slides on{' '}
-            <code>easing-tab-open</code>{' '}
-            (→&nbsp;<code>--zfbtw-easing-tab-open</code>).
-          </p>
-        )}
-        {activeIndex === 1 && (
-          <p>
-            <strong>Details panel.</strong> Change the{' '}
-            <em>Tab Open</em> easing in the panel to see the indicator motion update.
-          </p>
-        )}
-        {activeIndex === 2 && (
-          <p>
-            <strong>Settings panel.</strong> Active label uses{' '}
-            <code>text-accent</code>{' '}
-            (→&nbsp;<code>--zfbtw-color-accent</code>).
-          </p>
-        )}
+      {/* Tab panels — all rendered, toggled via hidden attribute */}
+      <div
+        role="tabpanel"
+        id={panelIds[0]}
+        aria-labelledby={tabIds[0]}
+        hidden={activeIndex !== 0}
+        class="px-hsp-md py-vsp-md text-body text-fg"
+      >
+        <p>
+          <strong>Overview panel.</strong> Indicator slides on{' '}
+          <code>easing-tab-open</code>{' '}
+          (→&nbsp;<code>--zfbtw-easing-tab-open</code>).
+        </p>
+      </div>
+      <div
+        role="tabpanel"
+        id={panelIds[1]}
+        aria-labelledby={tabIds[1]}
+        hidden={activeIndex !== 1}
+        class="px-hsp-md py-vsp-md text-body text-fg"
+      >
+        <p>
+          <strong>Details panel.</strong> Change the{' '}
+          <em>Tab Open</em> easing in the panel to see the indicator motion update.
+        </p>
+      </div>
+      <div
+        role="tabpanel"
+        id={panelIds[2]}
+        aria-labelledby={tabIds[2]}
+        hidden={activeIndex !== 2}
+        class="px-hsp-md py-vsp-md text-body text-fg"
+      >
+        <p>
+          <strong>Settings panel.</strong> Active label uses{' '}
+          <code>text-accent</code>{' '}
+          (→&nbsp;<code>--zfbtw-color-accent</code>).
+        </p>
       </div>
     </div>
   );

--- a/examples/zfb-tailwind/package.json
+++ b/examples/zfb-tailwind/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "description": "zfb (zudo-front-builder) + Tailwind v4 example demonstrating @takazudo/zudo-design-token-panel — tokens registered via @theme block into Tailwind v4's design-system namespaces, showcase and prose pages styled with utility classes.",
   "scripts": {
+    "predev": "rm -rf dist .zfb .zfb-build",
     "dev": "lsof -ti:44328 | xargs kill -9 2>/dev/null || true; lsof -ti:24686 | xargs kill -9 2>/dev/null || true; concurrently -k -n zfb,tokens-bin -c blue,green \"pnpm run _dev:zfb\" \"pnpm run _dev:tokens-bin\"",
-    "_dev:zfb": "zfb dev",
+    "_dev:zfb": "zfb dev --port 44328",
     "_dev:tokens-bin": "design-token-panel-server --write-root . --routing scaffold.routing.json --port 24686 --allow-origin http://localhost:44328",
     "build": "zfb build",
     "preview": "zfb preview",

--- a/examples/zfb/components/widgets/tabs.tsx
+++ b/examples/zfb/components/widgets/tabs.tsx
@@ -8,9 +8,12 @@
  *   .zfb-tabs__tab       → px: spacing-md, py: spacing-sm, text-body, color-muted (resting)
  *   .zfb-tabs__tab.is-active → color-accent
  *   .zfb-tabs__indicator → easing-tab-open (transition via inline style)
+ *
+ * Accessibility: WAI-ARIA Tabs APG pattern with automatic activation.
+ *   https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
  */
 
-import { useState } from 'preact/hooks';
+import { useState, useId, useRef } from 'preact/hooks';
 import { Island, type IslandProps } from '@takazudo/zfb';
 
 const TABS = ['Overview', 'Details', 'Settings'] as const;
@@ -20,16 +23,40 @@ function TabsInner() {
   const tabCount = TABS.length;
   const indicatorPct = 100 / tabCount;
 
+  const baseId = useId();
+  const tabIds = TABS.map((_, i) => `${baseId}-tab-${i}`);
+  const panelIds = TABS.map((_, i) => `${baseId}-panel-${i}`);
+  // ref array for programmatic focus on keyboard navigation
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    let next = -1;
+    if (e.key === 'ArrowRight') next = (activeIndex + 1) % tabCount;
+    else if (e.key === 'ArrowLeft') next = (activeIndex - 1 + tabCount) % tabCount;
+    else if (e.key === 'Home') next = 0;
+    else if (e.key === 'End') next = tabCount - 1;
+    if (next === -1) return;
+    e.preventDefault(); // prevent page scroll on arrow/home/end keys
+    setActiveIndex(next);
+    tabRefs.current[next]?.focus();
+  };
+
   return (
     <div class="zfb-tabs">
       {/* Tab list */}
-      <div class="zfb-tabs__list">
+      <div class="zfb-tabs__list" role="tablist" onKeyDown={onKeyDown}>
         {TABS.map((tab, i) => (
           <button
             key={tab}
             type="button"
+            role="tab"
+            id={tabIds[i]}
+            aria-selected={activeIndex === i}
+            aria-controls={panelIds[i]}
+            tabIndex={activeIndex === i ? 0 : -1}
             onClick={() => setActiveIndex(i)}
             class={`zfb-tabs__tab${activeIndex === i ? ' is-active' : ''}`}
+            ref={(el) => { tabRefs.current[i] = el; }}
           >
             {tab}
           </button>
@@ -42,6 +69,7 @@ function TabsInner() {
         */}
         <span
           class="zfb-tabs__indicator"
+          aria-hidden="true"
           // reason: width is 1/N of container from runtime tab count; transition
           // timing references semantic easing token not expressible without inline style
           style={{
@@ -52,28 +80,44 @@ function TabsInner() {
         />
       </div>
 
-      {/* Tab panels */}
-      <div class="zfb-tabs__panel">
-        {activeIndex === 0 && (
-          <p>
-            <strong>Overview panel.</strong> Indicator slides on{' '}
-            <code>easing-tab-open</code>{' '}
-            (→&nbsp;<code>--zfb-easing-tab-open</code>).
-          </p>
-        )}
-        {activeIndex === 1 && (
-          <p>
-            <strong>Details panel.</strong> Change the{' '}
-            <em>Tab Open</em> easing in the panel to see the indicator motion update.
-          </p>
-        )}
-        {activeIndex === 2 && (
-          <p>
-            <strong>Settings panel.</strong> Active label uses{' '}
-            <code>color-accent</code>{' '}
-            (→&nbsp;<code>--zfb-color-accent</code>).
-          </p>
-        )}
+      {/* Tab panels — all rendered, toggled via hidden attribute */}
+      <div
+        role="tabpanel"
+        id={panelIds[0]}
+        aria-labelledby={tabIds[0]}
+        hidden={activeIndex !== 0}
+        class="zfb-tabs__panel"
+      >
+        <p>
+          <strong>Overview panel.</strong> Indicator slides on{' '}
+          <code>easing-tab-open</code>{' '}
+          (→&nbsp;<code>--zfb-easing-tab-open</code>).
+        </p>
+      </div>
+      <div
+        role="tabpanel"
+        id={panelIds[1]}
+        aria-labelledby={tabIds[1]}
+        hidden={activeIndex !== 1}
+        class="zfb-tabs__panel"
+      >
+        <p>
+          <strong>Details panel.</strong> Change the{' '}
+          <em>Tab Open</em> easing in the panel to see the indicator motion update.
+        </p>
+      </div>
+      <div
+        role="tabpanel"
+        id={panelIds[2]}
+        aria-labelledby={tabIds[2]}
+        hidden={activeIndex !== 2}
+        class="zfb-tabs__panel"
+      >
+        <p>
+          <strong>Settings panel.</strong> Active label uses{' '}
+          <code>color-accent</code>{' '}
+          (→&nbsp;<code>--zfb-color-accent</code>).
+        </p>
       </div>
     </div>
   );

--- a/examples/zfb/config/default-cluster.ts
+++ b/examples/zfb/config/default-cluster.ts
@@ -2,7 +2,7 @@
  * Demo color cluster for the zfb example.
  *
  * The cluster's CSS-var family is `--zfb-*` (palette + base roles +
- * semantic names), declared on `:root` by `styles/tokens.css`. Tweaks in
+ * semantic names), declared on `:root` by `styles/global.css`. Tweaks in
  * the panel write through these names; the apply pipeline (when wired through
  * the bin sidecar) rewrites the same names on disk.
  *

--- a/examples/zfb/package.json
+++ b/examples/zfb/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "description": "zfb (zudo-front-builder) example app demonstrating @takazudo/zudo-design-token-panel — host-config-driven panel mounted as a Preact island via zfb's Island component, plus apply-pipeline round-trip via a devMiddleware plugin that proxies to the bin sidecar.",
   "scripts": {
+    "predev": "rm -rf dist .zfb .zfb-build zfb-tailwind-entry-*.css",
     "dev": "lsof -ti:44327 | xargs kill -9 2>/dev/null || true; lsof -ti:24685 | xargs kill -9 2>/dev/null || true; concurrently -k -n zfb,tokens-bin -c blue,green \"pnpm run _dev:zfb\" \"pnpm run _dev:tokens-bin\"",
-    "_dev:zfb": "zfb dev",
+    "_dev:zfb": "zfb dev --port 44327",
     "_dev:tokens-bin": "design-token-panel-server --write-root . --routing scaffold.routing.json --port 24685 --allow-origin http://localhost:44327",
     "build": "zfb build",
     "preview": "zfb preview",


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/197

---

## Summary

Implements **Examples Polish** epic (#197): three independent fixes across `examples/zfb` and `examples/zfb-tailwind`. All sub-tasks merged into `base/examples-polish` via local merges.

### Sub-issues closed

- **Closes #198** — A11y polish for Tabs (WAI-ARIA APG pattern with automatic activation) in both example apps, plus `aria-hidden` parity fix on the `zfb-tailwind` accordion chevron. Native `<details>/<summary>` accordion pattern preserved as-is.
- **Closes #199** — `zfb dev` now binds explicit ports (`44327` for zfb, `44328` for zfb-tailwind) via `--port`. Adds a `predev` script that cleans `dist/`, `.zfb/`, `.zfb-build/` (plus stray `zfb-tailwind-entry-*.css` in `examples/zfb/`) before each dev session.
- **Closes #200** — Tiny doc-comment fix in `examples/zfb/config/default-cluster.ts`: `styles/tokens.css` → `styles/global.css` to match the current file layout.

## Topic merges (local-only; topic PRs not created because already merged)

| Sub-issue | Topic branch | Commits |
|---|---|---|
| #198 | `examples-polish/a11y-tabs` | 9db7452, ebd050d, 0258b44 |
| #199 | `examples-polish/dev-server` | ac7069c, 380f700 |
| #200 | `examples-polish/config-comments` | b874992 |

## Investigation outcome (sub-issue #199)

Per #123, investigated whether `zfb dev` (without `--port`) serves stale `dist/` assets. **Confirmed**: upstream `zfb-server` routes `GET /assets/*` via `tower_http ServeDir` rooted at `dist/assets/` with no HMR proxy, and `DevAssetPipeline` is constructed with `run_css: None` — CSS bundles are not regenerated on watcher ticks. Stale `dist/` content from a prior `zfb build` is served as-is. The `predev` clean is therefore both hygiene **and** a workaround for the missing dev-mode CSS rebuild. Upstream issue tracking deferred (sibling upstream fix is out of scope for this sweep).

## Verification (local, on merged base)

- `pnpm typecheck` — passes for all workspace projects (vite-react, next, astro, zfb, zfb-tailwind, doc, @takazudo/zudo-design-token-panel).
- `pnpm -F zfb-example build` — 6 pages built successfully.
- `pnpm -F zfb-tailwind-example build` — 6 pages built successfully.
- `/gcoc-review` (Copilot CLI cheap mode, gpt-4.1) — no issues found, all changes correct and scoped.

## Out-of-scope guard rails (verified)

- `modal.tsx` files unchanged in both example apps.
- `examples/zfb/config/default-manifest.ts` unchanged (already references `styles/global.css`).
- `examples/zfb-tailwind` untouched for sub-issue #200.
- `examples/vite-react`, `examples/astro`, `examples/next` unchanged.