### PR TITLE
fix: self-inject panel stylesheet at runtime (#219)

### DIFF
--- a/doc/src/content/docs/getting-started/install.mdx
+++ b/doc/src/content/docs/getting-started/install.mdx
@@ -87,9 +87,9 @@ The package's `package.json` declares the following peer:
   The panel's CSS is self-contained. It ships its own bundled stylesheet under the panel-private `--tokentweak-*` namespace. **Tailwind is not required in your project** to consume the panel.
 </Info>
 
-<Warning title="Don't skip the styles import">
-  After installing, you must add `import '@takazudo/zudo-design-token-panel/styles';` to your static module graph (typically next to where you mount the host component). Vite's library mode strips the package-internal CSS imports from the emitted JS, so the consumer side has to pull the bundled stylesheet in explicitly. If you forget, the panel JS still runs but every chrome rule is missing — the panel paints invisibly against the host page background.
-</Warning>
+<Info title="No styles import needed">
+  The panel injects its own stylesheet at runtime — when the panel first opens it appends a `<style>` element carrying the bundled CSS. You do **not** need to import the CSS yourself. The `@takazudo/zudo-design-token-panel/styles` (and `/styles.css`) export still resolves to the bundled stylesheet and remains available if you prefer to pull the CSS into your own stylesheet pipeline, but it is now optional.
+</Info>
 
 ## Next step
 

--- a/packages/zudo-design-token-panel/CHANGELOG.md
+++ b/packages/zudo-design-token-panel/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Fixed (panel renders unstyled without a consumer CSS import — [#219](https://github.com/Takazudo/zudo-design-token-panel/issues/219))
+
+- **Self-injected stylesheet** — the panel now injects its own bundled CSS as a
+  `<style>` element on first mount (`ensurePanelStyles()` in `src/index.tsx`).
+  Previously the panel painted unstyled unless the consumer manually added
+  `import '@takazudo/zudo-design-token-panel/styles'` to its static module
+  graph — Vite library mode strips the package-internal CSS side-effect import
+  from `dist/index.js`, so the emitted JS never loaded its own CSS. The CSS is
+  now also imported via `?inline` (a string constant that survives library-mode
+  bundling) and injected at runtime. Because injection happens in
+  `ensureMounted()`, the CSS loads exactly when the panel first opens — no eager
+  cost on pages where the panel is never used. The `./styles` / `./styles.css`
+  exports still resolve (the standalone `dist/zudo-design-token-panel.css` is
+  still emitted) and remain valid but optional; the install doc's "Don't skip
+  the styles import" warning is downgraded accordingly. Public API unchanged.
+
 ### Fixed (panel-singleton & first-toggle bugfixes — [#108](https://github.com/Takazudo/zudo-design-token-panel/issues/108), root PR [#113](https://github.com/Takazudo/zudo-design-token-panel/pull/113))
 
 - **Cross-instance singleton sharing** — configuration singletons (`configuredConfig`,

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -36,9 +36,18 @@
 
 import { render } from 'preact';
 import DesignTokenTweakPanel from './panel';
-// Side-effect import: bundles panel chrome CSS + panel-private CSS variables
-// so the package is visually self-contained for any consumer.
+// Side-effect import: kept so `vite build` keeps co-emitting
+// `dist/zudo-design-token-panel.css` and the `./styles` / `./styles.css`
+// package exports stay valid for backward compatibility. Vite library mode
+// strips this import from the emitted `dist/index.js`, so it does NOT load
+// the CSS at runtime — runtime styling comes from the `?inline` import below.
 import './styles/panel.css';
+// `?inline` import: the same stylesheet as a JS string. Unlike the side-effect
+// import above, an `?inline` import is NOT stripped by Vite library mode — it
+// survives as a string constant in `dist/index.js`. `ensurePanelStyles()`
+// injects it as a <style> element when the panel first mounts, so the package
+// is visually self-contained and consumers need no separate CSS import.
+import panelCss from './styles/panel.css?inline';
 import {
   applyFullState,
   getOpenKey,
@@ -208,6 +217,29 @@ function findRoot(): HTMLElement | null {
   return document.getElementById(getPanelId());
 }
 
+// Stable id for the injected <style> element so injection is idempotent
+// across re-mounts (astro:page-load re-materialises the shell) and across
+// multiple panel instances on one page (they share one storagePrefix-keyed
+// stylesheet — the chrome CSS is identical regardless of config).
+const PANEL_STYLE_ELEMENT_ID = 'zudo-design-token-panel-styles';
+
+/**
+ * Inject the panel's bundled stylesheet into `document.head` once.
+ *
+ * Called from `ensureMounted()` so the CSS loads exactly when the panel first
+ * opens — never on pages where the panel is never opened. The package is thus
+ * visually self-contained: consumers do not need to import `./styles`
+ * themselves (that export remains valid but is now optional).
+ */
+function ensurePanelStyles(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(PANEL_STYLE_ELEMENT_ID)) return;
+  const style = document.createElement('style');
+  style.id = PANEL_STYLE_ELEMENT_ID;
+  style.textContent = panelCss;
+  document.head.appendChild(style);
+}
+
 /**
  * Idempotently mount the Preact shell. Returns `true` only on a fresh mount.
  *
@@ -220,6 +252,7 @@ function ensureMounted(): boolean {
   if (typeof document === 'undefined') return false;
   const panelId = getPanelId();
   if (document.getElementById(panelId)) return false;
+  ensurePanelStyles();
   const root = document.createElement('div');
   root.id = panelId;
   document.body.appendChild(root);

--- a/packages/zudo-design-token-panel/src/vite-css.d.ts
+++ b/packages/zudo-design-token-panel/src/vite-css.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Ambient declaration for Vite `?inline` CSS imports so
+ * `tsc -p tsconfig.build.json` accepts `import css from './x.css?inline'`.
+ *
+ * Vite resolves the `?inline` query at build time to the fully-bundled CSS
+ * as a JS string. Unlike a bare `import './x.css'` side-effect import — which
+ * Vite library mode strips from the emitted JS — an `?inline` import survives
+ * bundling as a string constant. `src/index.tsx` uses this to self-inject the
+ * panel stylesheet at runtime.
+ */
+declare module '*.css?inline' {
+  const css: string;
+  export default css;
+}


### PR DESCRIPTION
## Summary

The panel previously rendered **unstyled** unless the consumer manually added `import '@takazudo/zudo-design-token-panel/styles'` to its static module graph. Vite library mode strips the package-internal CSS side-effect import (`import './styles/panel.css'`) from the emitted `dist/index.js`, so the JS never loaded its own CSS — it only co-emitted `dist/zudo-design-token-panel.css` as a separate file and pushed the responsibility onto every consumer.

This makes the package visually self-contained:

- `src/index.tsx` additionally imports the stylesheet via `?inline` — a JS string constant that **survives** library-mode bundling (unlike the stripped side-effect import).
- A new `ensurePanelStyles()` injects that CSS as a `<style>` element into `document.head` on first mount (called from `ensureMounted()`), idempotent via a stable element id.
- Because `ensureMounted()` runs only when the panel first opens, the CSS loads exactly then — no eager cost on pages where the panel is never used.

Backward compatible: the existing side-effect import is kept, so `dist/zudo-design-token-panel.css` is still emitted and the `./styles` / `./styles.css` exports stay valid (now optional). The install doc's "Don't skip the styles import" warning is downgraded to an informational note.

## Changes

- `src/index.tsx` — add `?inline` CSS import + `ensurePanelStyles()`, call it from `ensureMounted()`
- `src/vite-css.d.ts` — new ambient declaration for `*.css?inline` imports (so `tsc` accepts the import)
- `doc/.../getting-started/install.mdx` — downgrade the "Don't skip the styles import" warning
- `CHANGELOG.md` — Unreleased entry

## Test plan

- [x] `pnpm --filter @takazudo/zudo-design-token-panel build` — clean; `dist/index.js` now contains the inlined CSS string + injection logic; `dist/zudo-design-token-panel.css` still emitted (28.3 kB)
- [x] `pnpm --filter @takazudo/zudo-design-token-panel test` — 660 tests pass
- [x] `tsc -p tsconfig.build.json` (run by the build) — clean with the new ambient declaration

## Downstream

Filed from a zudolab/zzmod cleanup epic — see zudolab/zzmod#170. Once this merges, zzmod drops its consumer-side `@import` and bumps its `framework-pins.json` zdtp SHA.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)