### PR TITLE
fix: resolve oklch() colors in cssColorToHex via pixel sampling

### DIFF
--- a/packages/zudo-design-token-panel/src/__tests__/css-color-to-hex.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/css-color-to-hex.test.ts
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 /**
- * Regression tests for cssColorToHex — specifically the JSDOM no-op fillStyle
- * case where the canvas 2D context silently ignores fillStyle assignments and
- * always returns '#000000'.
+ * Regression tests for cssColorToHex covering two distinct browser quirks:
  *
- * Finding 6: module-level cached canvas 2D context was broken in JSDOM because
- * the fillStyle setter is a no-op. We now feature-detect this at module load
- * and fall back to a manual rgb()/rgba() parser when the canvas is unreliable.
+ * 1. JSDOM no-op fillStyle — the canvas 2D context silently ignores fillStyle
+ *    assignments and always returns '#000000'. We feature-detect this at
+ *    module load and fall back to a manual rgb()/rgba() parser.
+ *
+ * 2. Modern-browser oklch round-trip — Chrome serializes a CSS Color 4 input
+ *    (oklch/oklab/lab/lch/color()) back through the fillStyle *getter* in its
+ *    own syntax (e.g. `oklch(0.65 0.2 45)`), not as hex. The old code read the
+ *    getter string and collapsed every such color to '#000000'. cssColorToHex
+ *    now samples the painted pixel via getImageData, so the getter format is
+ *    irrelevant — see issue #221.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -41,6 +46,89 @@ describe('cssColorToHex', () => {
       expect(cssColorToHex('initial')).toBe('#000000');
       expect(cssColorToHex('inherit')).toBe('#000000');
       expect(cssColorToHex('')).toBe('#000000');
+    });
+  });
+
+  describe('working canvas with oklch round-trip (modern-browser simulation)', () => {
+    // This mock reproduces modern Chrome: the fillStyle getter echoes the set
+    // value verbatim (so for oklch it is deliberately NOT hex), while
+    // getImageData returns the resolved sRGB bytes the browser would paint.
+    // An unknown string models an invalid CSS color — the real setter ignores
+    // it, leaving the previously-set value in place.
+
+    // Resolved sRGB bytes per color, verified against Chromium 148.
+    const RESOLVED: Record<string, [number, number, number, number]> = {
+      '#000000': [0, 0, 0, 255],
+      '#ffffff': [255, 255, 255, 255],
+      'oklch(17% 0.005 50)': [17, 15, 13, 255],
+      'oklch(65% 0.2 45)': [236, 90, 0, 255],
+      'oklch(100% 0 0)': [255, 255, 255, 255],
+      'oklch(65% 0.2 45 / 0.5)': [236, 90, 0, 128],
+    };
+
+    let originalGetContext: typeof HTMLCanvasElement.prototype.getContext;
+
+    beforeEach(() => {
+      originalGetContext = HTMLCanvasElement.prototype.getContext;
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function (this: HTMLCanvasElement, type: string, ...args: unknown[]): any {
+          if (type !== '2d') {
+            return (originalGetContext as (...a: unknown[]) => unknown).call(this, type, ...args);
+          }
+          let fillStyle = '#000000';
+          const fakeCtx = {
+            get fillStyle() {
+              return fillStyle;
+            },
+            set fillStyle(v: string) {
+              // Only known colors are "valid"; an unknown string is ignored,
+              // mirroring the browser's silent rejection of invalid colors.
+              if (v in RESOLVED) fillStyle = v;
+            },
+            clearRect() {},
+            fillRect() {},
+            getImageData() {
+              const [r, g, b, a] = RESOLVED[fillStyle] ?? [0, 0, 0, 255];
+              return { data: new Uint8ClampedArray([r, g, b, a]) };
+            },
+          };
+          return fakeCtx as unknown as CanvasRenderingContext2D;
+        } as typeof HTMLCanvasElement.prototype.getContext,
+      );
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('resolves an oklch() color to hex via pixel sampling', async () => {
+      vi.resetModules();
+      const { cssColorToHex } = await import('../state/tweak-state');
+      expect(cssColorToHex('oklch(17% 0.005 50)')).toBe('#110f0d');
+      expect(cssColorToHex('oklch(65% 0.2 45)')).toBe('#ec5a00');
+      expect(cssColorToHex('oklch(100% 0 0)')).toBe('#ffffff');
+    });
+
+    it('preserves alpha < 1 from an oklch() color as 8-digit hex', async () => {
+      vi.resetModules();
+      const { cssColorToHex } = await import('../state/tweak-state');
+      expect(cssColorToHex('oklch(65% 0.2 45 / 0.5)')).toBe('#ec5a0080');
+    });
+
+    it('returns #000000 for an unparseable color the setter ignores', async () => {
+      vi.resetModules();
+      const { cssColorToHex } = await import('../state/tweak-state');
+      expect(cssColorToHex('definitely-not-a-color')).toBe('#000000');
+    });
+
+    it('does not depend on the fillStyle getter returning hex', async () => {
+      // Proves the mock echoes a non-hex string back — the new code path
+      // ignores the getter entirely and reads pixel data instead.
+      const ctx = document.createElement('canvas').getContext('2d')!;
+      ctx.fillStyle = 'oklch(65% 0.2 45)';
+      expect(ctx.fillStyle).toBe('oklch(65% 0.2 45)');
+      expect(ctx.fillStyle.startsWith('#')).toBe(false);
     });
   });
 

--- a/packages/zudo-design-token-panel/src/state/tweak-state.ts
+++ b/packages/zudo-design-token-panel/src/state/tweak-state.ts
@@ -617,6 +617,13 @@ function _rgbStringToHex(color: string): string | null {
   return base6;
 }
 
+/** Serialize sRGB byte channels to hex — 8 digits when alpha < 255, else 6. */
+function _rgbaBytesToHex(r: number, g: number, b: number, a: number): string {
+  const hex2 = (n: number) => n.toString(16).padStart(2, '0');
+  const base6 = `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+  return a < 255 ? `${base6}${hex2(a)}` : base6;
+}
+
 /** Convert any CSS color to hex using a canvas (cached context). */
 let _canvasCtx: CanvasRenderingContext2D | null = null;
 export function cssColorToHex(color: string): string {
@@ -640,10 +647,22 @@ export function cssColorToHex(color: string): string {
   try {
     if (!_canvasCtx) _canvasCtx = document.createElement('canvas').getContext('2d');
     if (!_canvasCtx) return '#000000';
+    // Read the resolved color from pixel data, NOT from the fillStyle string.
+    // Modern browsers round-trip CSS Color 4 inputs (oklch, oklab, lab, lch,
+    // color()) back through the fillStyle *getter* in their own syntax — e.g.
+    // `oklch(0.65 0.2 45)` — which matches neither the `#` branch nor the
+    // rgb() parser, so the old string-readback path collapsed every such
+    // color to '#000000'. Painting one pixel and sampling it via getImageData
+    // yields resolved sRGB bytes regardless of the getter's serialization.
+    // Seed fillStyle with a known value first: an invalid `trimmed` is
+    // silently ignored by the setter, so this makes invalid input resolve
+    // deterministically to black instead of leaking a prior cached color.
+    _canvasCtx.fillStyle = '#000000';
     _canvasCtx.fillStyle = trimmed;
-    const resolved = _canvasCtx.fillStyle;
-    if (resolved.startsWith('#')) return resolved;
-    return _rgbStringToHex(resolved) ?? '#000000';
+    _canvasCtx.clearRect(0, 0, 1, 1);
+    _canvasCtx.fillRect(0, 0, 1, 1);
+    const [r, g, b, a] = _canvasCtx.getImageData(0, 0, 1, 1).data;
+    return _rgbaBytesToHex(r, g, b, a);
   } catch {
     return '#000000';
   }


### PR DESCRIPTION
## Summary

`cssColorToHex()` (`src/state/tweak-state.ts`) converted CSS colors to hex by assigning them to a canvas `fillStyle` and reading the value back as a **string** — handling only `#hex` and `rgb()`/`rgba()` readback.

Modern Chrome round-trips CSS Color 4 inputs (`oklch`, `oklab`, `lab`, `lch`, `color()`) back through the `fillStyle` *getter* in their own syntax — verified in Chromium 148:

```
fillStyle = "oklch(17% 0.005 50)"  =>  readback "oklch(0.17 0.005 50)"
fillStyle = "#ea580c"              =>  readback "#ea580c"
fillStyle = "rgb(255,128,0)"       =>  readback "#ff8000"
```

The `oklch(...)` readback matched neither the `#` branch nor `_rgbStringToHex` (regex `^rgba?\(`), so `cssColorToHex` fell through to `#000000`.

### Impact

Any consumer whose color cluster uses `oklch()` got a **fully black Color tab**:
- `initColorFromSchemeData` → `scheme.palette.map(cssColorToHex)` — every swatch becomes `#000000`.
- `colorRefToIndex` normalizes refs/palette via `cssColorToHex` — entries collapse together, so Base / Semantic rows bind to the wrong palette index.

Hit in production by the zzmod consumer (takazudomodular.com), whose design-system palette is entirely `oklch()`.

## Fix

Sample the painted pixel via `fillRect` + `getImageData` instead of reading the `fillStyle` string. The canvas already parses any valid CSS color; pixel data yields resolved sRGB bytes regardless of the getter's serialization format.

- Hex passthrough, the manual `rgb()`/`rgba()` parser, and the JSDOM `_canvasAvailable` feature-detection are **unchanged** — only the canvas branch switched from string-readback to `getImageData`.
- `fillStyle` is seeded with `#000000` before the input is assigned, so an invalid color (silently ignored by the setter) resolves deterministically to black instead of leaking a prior cached color.

Verified in Chromium 148 — `getImageData` resolves every `oklch()` test color to correct sRGB (`oklch(65% 0.2 45)` → `#ec5a00`, etc.).

## Test plan

- [x] New regression tests in `css-color-to-hex.test.ts` — a modern-browser mock where the `fillStyle` getter echoes `oklch(...)` verbatim while `getImageData` returns resolved bytes; covers oklch→hex, alpha preservation, and invalid-input → black.
- [x] `pnpm test` — 664 passed (47 files).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm build` (package) — clean.

Closes #221