### PR TITLE
fix: re-render panel on programmatic show after hide (#223)

### DIFF
--- a/packages/zudo-design-token-panel/src/__tests__/show-after-hide.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/show-after-hide.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression test for issue #223 — programmatic show-after-hide.
+ *
+ * Reported symptom:
+ *
+ *   1. `showDesignTokenPanel()` — panel mounts open.
+ *   2. `hideDesignTokenPanel()` — OPEN_KEY removed, panel renders null.
+ *   3. `showDesignTokenPanel()` again — Expected: panel re-renders open.
+ *      Actual (pre-fix): nothing happens; panel stays invisible.
+ *
+ * Root cause
+ * ----------
+ * `showDesignTokenPanel()` gated its `notifyPanelOpenChanged()` call on
+ * `isPanelCurrentlyOpen() === false`. But `seedOpenStateBeforeMount(true)`
+ * runs first and writes `OPEN_KEY = '1'`, so the post-seed probe always
+ * reads "open" and the gate is never satisfied on the steady-state re-show
+ * path. The mounted panel's sync-event listener never fired, so `setOpen`
+ * never flipped back to `true`.
+ *
+ * Fix: always notify on the non-fresh-mount path, mirroring
+ * `hideDesignTokenPanel()`. The sync event is idempotent.
+ *
+ * This complements `toggle-event-after-close.test.tsx`, which only covers
+ * the header-button `toggle-design-token-panel` event path — not the
+ * programmatic `show`/`hide` API.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getOpenKey } from '../state/tweak-state';
+import { __resetPanelConfigForTests, getPanelConfig, panelRootId } from '../config/panel-config';
+
+const PANEL_ROOT_ID = panelRootId(getPanelConfig());
+const OPEN_PANEL_HEADER_TEXT = 'Design Tokens';
+
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+describe('design-token-panel — programmatic show after hide', () => {
+  beforeEach(() => {
+    __resetPanelConfigForTests();
+    localStorage.clear();
+    document.body.innerHTML = '';
+    const w = window as unknown as Record<string, unknown>;
+    delete w.__zudoDesignTokenPanelAdapter;
+    delete w.__zudoDesignTokenPanelLifecycle;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('re-renders the panel on show → hide → show, repeatable 3×', async () => {
+    const { showDesignTokenPanel, hideDesignTokenPanel } = await import('../index');
+
+    // --- Initial show: fresh mount ---
+    showDesignTokenPanel();
+    await waitForEffectFlush();
+
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root, 'panel root should mount on first show').not.toBeNull();
+    expect(root!.textContent ?? '').toContain(OPEN_PANEL_HEADER_TEXT);
+    expect(localStorage.getItem(getOpenKey())).toBe('1');
+
+    // --- Three full hide → show cycles against the already-mounted panel ---
+    for (let cycle = 1; cycle <= 3; cycle++) {
+      hideDesignTokenPanel();
+      await waitForEffectFlush();
+      expect(
+        localStorage.getItem(getOpenKey()),
+        `cycle ${cycle}: OPEN_KEY removed after hide`,
+      ).toBeNull();
+      expect(root!.textContent ?? '', `cycle ${cycle}: panel content hidden`).not.toContain(
+        OPEN_PANEL_HEADER_TEXT,
+      );
+
+      showDesignTokenPanel();
+      await waitForEffectFlush();
+      expect(localStorage.getItem(getOpenKey()), `cycle ${cycle}: OPEN_KEY back to "1"`).toBe('1');
+      expect(
+        root!.textContent ?? '',
+        `cycle ${cycle}: panel content visible after re-show`,
+      ).toContain(OPEN_PANEL_HEADER_TEXT);
+    }
+  });
+});

--- a/packages/zudo-design-token-panel/src/index.tsx
+++ b/packages/zudo-design-token-panel/src/index.tsx
@@ -348,15 +348,14 @@ export function showDesignTokenPanel(): void {
   // Fresh mount: panel.tsx's mount-effect picks up OPEN_KEY="1" and renders
   // open — no listener race because the listener doesn't run yet anyway.
   if (isFreshMount) return;
-  // Steady state: notify the mounted panel to re-read OPEN_KEY.
-  if (isPanelCurrentlyOpen() === false) {
-    // OPEN_KEY just changed; sync the panel.
-    notifyPanelOpenChanged();
-  }
-  // (If OPEN_KEY was already "1", panel is already open; nothing to do.)
-  // Note: we read `isPanelCurrentlyOpen` *after* the seed, so this only skips
-  // the notify when the panel state is already in sync — which is harmless
-  // either way because the sync event is idempotent.
+  // Steady state: always notify the mounted panel to re-read OPEN_KEY.
+  // `seedOpenStateBeforeMount(true)` already wrote OPEN_KEY='1' above, so a
+  // post-seed `isPanelCurrentlyOpen()` probe would *always* read "open" — it
+  // cannot distinguish "already open" from "just re-shown after a hide". The
+  // notify must therefore be unconditional (mirrors `hideDesignTokenPanel`).
+  // The sync event is idempotent: if the panel is genuinely already open the
+  // panel's `setOpen(true)` is a no-op via Preact's setState identity check.
+  notifyPanelOpenChanged();
 }
 
 export function hideDesignTokenPanel(): void {


### PR DESCRIPTION
## Summary

`showDesignTokenPanel()` after `hideDesignTokenPanel()` did **not** re-render the panel. A pure `show → hide → show` cycle (zero editing) left the panel invisible.

### Root cause

`showDesignTokenPanel()` gated `notifyPanelOpenChanged()` behind `if (isPanelCurrentlyOpen() === false)`. But `seedOpenStateBeforeMount(true)` runs first and writes `OPEN_KEY = '1'`, so the post-seed `isPanelCurrentlyOpen()` probe always reads `true`. The gate is therefore never satisfied on the steady-state re-show path, the mounted panel's `__zdtp:open-state-changed` listener never fires, `setOpen(true)` never happens, and the panel keeps rendering `null`.

`hideDesignTokenPanel()` already handles this correctly (always notifies); `toggleDesignPanel()` is fine because it snapshots intent *before* the seed.

### Fix

Drop the broken gate — always call `notifyPanelOpenChanged()` on the non-fresh-mount path, mirroring `hideDesignTokenPanel()`. The sync event is idempotent: the panel's `setOpen(true)` is a no-op via Preact's setState identity check when the panel is already open.

## Test plan

- [x] New `show-after-hide.test.tsx` — exercises the programmatic show/hide API across 3 repeated `hide → show` cycles. Verified RED without the fix (fails at `cycle 1: panel content visible after re-show`), GREEN with it.
- [x] `pnpm test` — all 665 tests pass.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` produces `dist/` cleanly.

Note: the existing `toggle-event-after-close.test.tsx` only covered the header-button toggle-event path, not the programmatic API — which is why this regression slipped through.

Found during a zzmod consumer audit (zudolab/zzmod#186).

Closes #223