### PR TITLE
Highlight Token Users: outline host-page elements using a selected token

### DIFF
--- a/doc/src/content/docs/reference/highlight-token-users.mdx
+++ b/doc/src/content/docs/reference/highlight-token-users.mdx
@@ -1,0 +1,99 @@
+---
+title: Highlight Token Users
+sidebar_position: 7
+description: Inspect which DOM elements consume a token by toggling its eye icon
+---
+
+The Highlight Token Users feature lets you visually inspect which DOM elements in the host page are consuming any given design token. Toggle the eye icon next to a token row and every matching element gets an outline; open the gear settings to customise each highlight slot's color and outline width.
+
+## Overview
+
+**Eye icon** — toggle button next to each token row. Clicking it activates an inspection highlight for that token: every element whose computed style is influenced by that CSS custom property receives a colored outline overlay in the host page. Clicking the icon a second time removes the highlight.
+
+**Gear icon** — opens the settings popover in the panel header. From there you can change the color and outline width of each of the 10 available highlight slots, and reset all slot colors to the vivid default palette.
+
+**Visual outcome** — active highlights appear as colored outlines overlaid on top of the host page's content. The overlays sit at `z-index: 49` (below the panel at `z-index: 50`, but above typical host content). Up to 10 tokens can be highlighted at the same time.
+
+<Note>
+Up to 10 simultaneous highlights are supported. Click the eye icon again to disable a highlight.
+</Note>
+
+## Quick start
+
+1. Open the panel.
+2. Navigate to the tab containing the token you want to inspect.
+3. Click the eye icon next to a token row.
+4. Observe the colored outlines that appear on elements in the host page.
+5. Click the eye icon again to remove the highlight.
+
+## Reservation-sheet semantics
+
+Highlights are allocated from a fixed 10-slot "reservation sheet". Each slot has an index (0–9), a color, and an outline width. The lowest available index is always claimed first; releasing a slot in the middle leaves higher-index slots at their current positions.
+
+**Slot allocation rules:**
+
+1. When you activate a token, the highlight system finds the lowest free slot index and claims it.
+2. That slot's color and outline width are applied to the token's outlines.
+3. When you deactivate a token, its slot is freed; all other slots stay put.
+4. The next activation claims the lowest free slot again (which may be a previously-freed lower index).
+
+**Worked example:**
+
+- Toggle token A → claims slot 0.
+- Toggle token B → claims slot 1.
+- Toggle token C → claims slot 2.
+- Disable A → slot 0 is freed. B stays at slot 1, C stays at slot 2.
+- Toggle token D → claims slot 0 (the lowest free index).
+
+Result: D is at slot 0, B is at slot 1, C is at slot 2.
+
+## Settings popover
+
+Click the **gear icon** in the panel header to open the highlight settings popover. It lists all 10 slots in a 4-column grid:
+
+| Column | What it shows |
+| --- | --- |
+| Index | Slot number (0–9) |
+| Ring swatch | A ring whose border is a live preview of the slot's current outline color |
+| Token label | The CSS variable name of the token currently using this slot, or "available" if the slot is free |
+| Slider + readout | Outline width control from 1–10 px; the readout shows the current value (e.g. `4px`) |
+
+**Changing the color:** click the ring swatch to open a color picker for that slot. The outline on any currently-highlighted element updates live.
+
+**Changing the width:** drag the slider to change the outline width. The ring swatch's border and the outline on any highlighted element update live.
+
+## Reset to defaults
+
+The **Reset to defaults** button in the settings popover footer restores all 10 slot colors to the vivid built-in default palette (red, pink, skyblue, and so on).
+
+<Tip>
+Reset to defaults only restores slot colors and widths. It does NOT clear the active inspection set — any tokens you currently have highlighted stay highlighted, with their slots now showing the default colors.
+</Tip>
+
+## Persistence model
+
+The feature uses two distinct storage layers:
+
+<Info>
+**Slot configuration (colors + widths)** — stored in `localStorage`. Persists across browser sessions. These are your personalised settings and should survive a page reload or a new browser tab.
+
+**Active inspection set (which tokens are highlighted)** — stored in `sessionStorage`. Cleared on a full page reload (`Ctrl+Shift+R` / `Cmd+Shift+R`). Each debug session starts fresh with no outlines active.
+</Info>
+
+This split means you can set up your preferred slot colors once and keep them permanently, while the list of things you are currently inspecting resets automatically when you reload — preventing leftover debug state from a previous session from polluting a fresh page load.
+
+## Documented limitations
+
+The following limitations are expected in v1 of this feature.
+
+**Cross-origin stylesheets** — stylesheets loaded from a different origin are skipped. The browser raises a `SecurityError` when the panel tries to read their rules; those stylesheets are silently ignored.
+
+**Shadow DOM** — `querySelectorAll` does not pierce shadow roots. Elements inside open or closed Shadow Roots will not receive overlays.
+
+**Constructable / adopted stylesheets** — stylesheets attached to Shadow Roots via the `adoptedStyleSheets` API are not visible to the stylesheet walker.
+
+**Selector-scoped custom-property aliases** — rules like `.scoped { --brand: blue }` that define a custom-property alias on a scoped selector are treated as global (the alias is over-approximated as if it were on `:root`). In unusual cascade scenarios this can produce false positives — overlays appearing on elements that do not actually consume the token at runtime.
+
+**Very-high host z-index** — overlays sit at `z-index: 49`. Modals or other elements at extremely high `z-index` values (e.g. `z-index: 99999`) will visually cover the outlines. The panel itself sits at `z-index: 50`, so overlays appear below the panel but above typical page content.
+
+**No auto-update for newly inserted DOM elements** — if a DOM element matching an existing stylesheet rule is inserted dynamically after the highlight is activated, it will not automatically receive an overlay (there is no body-level `MutationObserver` in v1). However, new `<style>` or `<link>` elements added to `<head>` after activation ARE picked up by the stylesheet observer.

--- a/doc/src/content/docs/reference/highlight-token-users.mdx
+++ b/doc/src/content/docs/reference/highlight-token-users.mdx
@@ -94,6 +94,8 @@ The following limitations are expected in v1 of this feature.
 
 **Selector-scoped custom-property aliases** — rules like `.scoped { --brand: blue }` that define a custom-property alias on a scoped selector are treated as global (the alias is over-approximated as if it were on `:root`). In unusual cascade scenarios this can produce false positives — overlays appearing on elements that do not actually consume the token at runtime.
 
+**Inherited-property consumers** — when a token is set on an ancestor through an inheritable property (e.g. `body { color: var(--brand) }`), only the directly-matching element is outlined. Descendants whose computed style inherits the value are NOT outlined, even though they effectively "use" the token via inheritance. The walker matches rule selectors, not computed styles.
+
 **Very-high host z-index** — overlays sit at `z-index: 49`. Modals or other elements at extremely high `z-index` values (e.g. `z-index: 99999`) will visually cover the outlines. The panel itself sits at `z-index: 50`, so overlays appear below the panel but above typical page content.
 
 **No auto-update for newly inserted DOM elements** — if a DOM element matching an existing stylesheet rule is inserted dynamically after the highlight is activated, it will not automatically receive an overlay (there is no body-level `MutationObserver` in v1). However, new `<style>` or `<link>` elements added to `<head>` after activation ARE picked up by the stylesheet observer.

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.test.ts
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.test.ts
@@ -1,0 +1,405 @@
+// @vitest-environment jsdom
+/**
+ * Unit tests for findElementsUsingToken.
+ *
+ * Each test runs in JSDOM. Stylesheets are injected via <style> elements and
+ * DOM nodes via document.body. Both are cleaned up in afterEach so tests are
+ * fully isolated.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findElementsUsingToken } from '../find-elements';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let injectedStyles: HTMLStyleElement[] = [];
+let injectedElements: Element[] = [];
+
+/**
+ * Inject a <style> element into document.head with the given CSS text.
+ * Returns the sheet for further manipulation if needed.
+ */
+function injectStyle(css: string): CSSStyleSheet {
+  const el = document.createElement('style');
+  el.textContent = css;
+  document.head.appendChild(el);
+  injectedStyles.push(el);
+  return el.sheet as CSSStyleSheet;
+}
+
+/**
+ * Create a DOM element in document.body and return it.
+ * Optionally set a class and/or inline style.
+ */
+function createElement(opts: {
+  tag?: string;
+  className?: string;
+  inlineStyle?: string;
+  id?: string;
+  parent?: Element;
+}): HTMLElement {
+  const el = document.createElement(opts.tag ?? 'div');
+  if (opts.className) el.className = opts.className;
+  if (opts.inlineStyle) el.setAttribute('style', opts.inlineStyle);
+  if (opts.id) el.id = opts.id;
+  (opts.parent ?? document.body).appendChild(el);
+  injectedElements.push(el);
+  return el;
+}
+
+beforeEach(() => {
+  injectedStyles = [];
+  injectedElements = [];
+});
+
+afterEach(() => {
+  for (const el of injectedStyles) el.remove();
+  for (const el of injectedElements) el.remove();
+  injectedStyles = [];
+  injectedElements = [];
+});
+
+// ---------------------------------------------------------------------------
+// Empty case
+// ---------------------------------------------------------------------------
+
+describe('empty case', () => {
+  it('returns empty arrays when no stylesheets reference the token', () => {
+    const result = findElementsUsingToken('--brand');
+    expect(result.elements).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Direct match
+// ---------------------------------------------------------------------------
+
+describe('direct match', () => {
+  it('returns the matching element when a rule references the token', () => {
+    const el = createElement({ className: 'foo' });
+    injectStyle('.foo { color: var(--brand); }');
+    const { elements, warnings } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+    expect(warnings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Right-boundary: --brand must NOT match --brand-fg
+// ---------------------------------------------------------------------------
+
+describe('right-boundary guard', () => {
+  it('does not return elements that only reference a token with a longer name', () => {
+    const el = createElement({ className: 'bar' });
+    injectStyle('.bar { color: var(--brand-fg); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).not.toContain(el);
+  });
+
+  it('still returns an element that references --brand directly alongside a longer-named token', () => {
+    const elA = createElement({ className: 'direct-brand' });
+    const elB = createElement({ className: 'only-brand-fg' });
+    injectStyle('.direct-brand { color: var(--brand); }');
+    injectStyle('.only-brand-fg { color: var(--brand-fg); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(elA);
+    expect(elements).not.toContain(elB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Alias expansion
+// ---------------------------------------------------------------------------
+
+describe('alias expansion', () => {
+  it('returns elements using an alias of the target token', () => {
+    // :root { --brand-fg: var(--brand); }  =>  --brand aliases to --brand-fg
+    injectStyle(':root { --brand-fg: var(--brand); }');
+    const el = createElement({ className: 'x' });
+    injectStyle('.x { color: var(--brand-fg); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('does not traverse beyond depth 5', () => {
+    // Chain: --a -> --b -> --c -> --d -> --e -> --f -> --g (7 hops, exceeds limit)
+    injectStyle(`
+      :root {
+        --b: var(--a);
+        --c: var(--b);
+        --d: var(--c);
+        --e: var(--d);
+        --f: var(--e);
+        --g: var(--f);
+      }
+    `);
+    const el = createElement({ className: 'deep' });
+    injectStyle('.deep { color: var(--g); }');
+    // --g is 6 hops from --a, which exceeds MAX_ALIAS_DEPTH=5
+    const { elements } = findElementsUsingToken('--a');
+    expect(elements).not.toContain(el);
+  });
+
+  it('stops exactly at depth 5 (the 5th hop is included)', () => {
+    // Chain: --a -> --b -> --c -> --d -> --e -> --f (5 hops)
+    injectStyle(`
+      :root {
+        --b: var(--a);
+        --c: var(--b);
+        --d: var(--c);
+        --e: var(--d);
+        --f: var(--e);
+      }
+    `);
+    const el = createElement({ className: 'depth5' });
+    injectStyle('.depth5 { color: var(--f); }');
+    // --f is 5 hops from --a (a→b→c→d→e→f), depth cap is 5, so --f IS included
+    const { elements } = findElementsUsingToken('--a');
+    expect(elements).toContain(el);
+  });
+
+  it('handles alias cycles without infinite looping', () => {
+    injectStyle(':root { --a: var(--b); --b: var(--a); }');
+    const el = createElement({ className: 'cycle' });
+    injectStyle('.cycle { color: var(--b); }');
+    // Should not throw/hang; --b is reachable from --a in 1 hop
+    const { elements } = findElementsUsingToken('--a');
+    expect(elements).toContain(el);
+  });
+
+  it('recognises html selector as a theme selector for aliases', () => {
+    injectStyle('html { --x-alias: var(--x); }');
+    const el = createElement({ className: 'html-alias' });
+    injectStyle('.html-alias { color: var(--x-alias); }');
+    const { elements } = findElementsUsingToken('--x');
+    expect(elements).toContain(el);
+  });
+
+  it('recognises [data-theme="dark"] selector for aliases', () => {
+    injectStyle('[data-theme="dark"] { --t-alias: var(--t); }');
+    const el = createElement({ className: 'theme-alias' });
+    injectStyle('.theme-alias { color: var(--t-alias); }');
+    const { elements } = findElementsUsingToken('--t');
+    expect(elements).toContain(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inline-style hybrid
+// ---------------------------------------------------------------------------
+
+describe('inline-style hybrid', () => {
+  it('returns an element with a matching inline var()', () => {
+    const el = createElement({ inlineStyle: 'color: var(--brand)' });
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('does not return an inline-style element using a longer-named token', () => {
+    const el = createElement({ inlineStyle: 'color: var(--brand-fg)' });
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).not.toContain(el);
+  });
+
+  it('returns an alias element that uses inline var()', () => {
+    injectStyle(':root { --brand-alias: var(--brand); }');
+    const el = createElement({ inlineStyle: 'color: var(--brand-alias)' });
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-origin stylesheet skipping
+// ---------------------------------------------------------------------------
+
+describe('cross-origin stylesheet', () => {
+  it('skips a sheet that throws SecurityError and records a warning', () => {
+    // Inject the real style and DOM element BEFORE overriding styleSheets so
+    // the real sheet is included in the snapshot we'll inject the fake into.
+    const el = createElement({ className: 'after-xorigin' });
+    injectStyle('.after-xorigin { color: var(--brand); }');
+
+    // Create a fake CSSStyleSheet that throws on .cssRules access
+    const fakeSheet = {
+      href: 'https://cross-origin.example/styles.css',
+      get cssRules(): CSSRuleList {
+        throw new DOMException('Blocked by CORS', 'SecurityError');
+      },
+    } as unknown as CSSStyleSheet;
+
+    // Temporarily prepend the fake sheet by overriding document.styleSheets.
+    // Capture the live list NOW (after the injectStyle above) so real sheets
+    // are included.
+    const realSheetArray = Array.from(document.styleSheets);
+    const fakeList = [fakeSheet, ...realSheetArray];
+
+    // Save the prototype descriptor so we can restore it cleanly.
+    const docProto = Object.getPrototypeOf(document) as typeof Document.prototype;
+    const originalDesc = Object.getOwnPropertyDescriptor(docProto, 'styleSheets');
+
+    Object.defineProperty(document, 'styleSheets', {
+      value: fakeList,
+      configurable: true,
+      writable: false,
+    });
+
+    try {
+      const { elements, warnings } = findElementsUsingToken('--brand');
+      expect(warnings.some((w) => w.includes('cross-origin.example'))).toBe(true);
+      // The real sheet still gets scanned
+      expect(elements).toContain(el);
+    } finally {
+      // Remove the own-property override so the prototype getter takes back control.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (document as any).styleSheets;
+      // If there was a custom descriptor on the prototype (unusual), put it back.
+      if (originalDesc) {
+        Object.defineProperty(docProto, 'styleSheets', originalDesc);
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// @media / nested rule recursion
+// ---------------------------------------------------------------------------
+
+describe('@media recursion', () => {
+  it('finds elements referenced inside @media rules', () => {
+    const el = createElement({ className: 'media-rule' });
+    injectStyle('@media (min-width: 1px) { .media-rule { color: var(--brand); } }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('finds elements referenced inside nested @supports rules', () => {
+    const el = createElement({ className: 'supports-rule' });
+    injectStyle('@supports (display: grid) { .supports-rule { background: var(--brand); } }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selector cleanup
+// ---------------------------------------------------------------------------
+
+describe('selector cleanup', () => {
+  it('matches .btn element from a .btn:hover rule', () => {
+    const el = createElement({ className: 'btn' });
+    injectStyle('.btn:hover { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('matches .btn element from a .btn::before rule', () => {
+    const el = createElement({ className: 'btn' });
+    injectStyle('.btn::before { content: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('matches .btn from a .btn:hover:focus rule (multi-strip)', () => {
+    const el = createElement({ className: 'btn-multi' });
+    injectStyle('.btn-multi:hover:focus { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('preserves :not() and returns the base element', () => {
+    const el = createElement({ className: 'btn-not' });
+    injectStyle('.btn-not:not(:hover) { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    // :not(:hover) ends with ')' so the state pseudo strip regex does NOT match
+    expect(elements).toContain(el);
+  });
+
+  it('strips outer :hover from .btn:is(.a, .b):hover, leaves :is(...) intact', () => {
+    // Create a div that matches .btn-is.a
+    const el = createElement({ className: 'btn-is a' });
+    injectStyle('.btn-is:is(.a, .b):hover { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+
+  it('handles comma-separated selectors and skips empty fragments', () => {
+    const elA = createElement({ className: 'comma-a' });
+    const elB = createElement({ className: 'comma-b' });
+    injectStyle('.comma-a, .comma-b { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(elA);
+    expect(elements).toContain(elB);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Panel exclusion
+// ---------------------------------------------------------------------------
+
+describe('panel exclusion', () => {
+  it('excludes elements inside .tokenpanel-shell', () => {
+    const shell = createElement({ className: 'tokenpanel-shell' });
+    const inner = createElement({ className: 'inner-panel', parent: shell });
+    injectStyle('.inner-panel { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).not.toContain(inner);
+  });
+
+  it('excludes elements inside [data-design-token-panel-modal]', () => {
+    const modal = createElement({});
+    modal.setAttribute('data-design-token-panel-modal', '');
+    const inner = createElement({ className: 'inside-modal', parent: modal });
+    injectStyle('.inside-modal { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).not.toContain(inner);
+  });
+
+  it('excludes elements inside #tokenpanel-highlight-mount', () => {
+    const mount = createElement({ id: 'tokenpanel-highlight-mount' });
+    const inner = createElement({ className: 'inside-mount', parent: mount });
+    injectStyle('.inside-mount { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).not.toContain(inner);
+  });
+
+  it('keeps elements that are NOT inside any panel shell', () => {
+    const el = createElement({ className: 'outside-panel' });
+    injectStyle('.outside-panel { color: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    expect(elements).toContain(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe('deduplication', () => {
+  it('returns each element only once even if matched by multiple rules', () => {
+    const el = createElement({ className: 'dedup' });
+    injectStyle('.dedup { color: var(--brand); }');
+    injectStyle('.dedup { background: var(--brand); }');
+    const { elements } = findElementsUsingToken('--brand');
+    const count = elements.filter((e) => e === el).length;
+    expect(count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Normalization: var() wrapper stripping
+// ---------------------------------------------------------------------------
+
+describe('normalization', () => {
+  it('accepts "var(--brand)" as input and behaves identically to "--brand"', () => {
+    const el = createElement({ className: 'norm' });
+    injectStyle('.norm { color: var(--brand); }');
+    const withWrapper = findElementsUsingToken('var(--brand)');
+    const withoutWrapper = findElementsUsingToken('--brand');
+    expect(withWrapper.elements).toContain(el);
+    expect(withoutWrapper.elements).toContain(el);
+  });
+});

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-orchestrator.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-orchestrator.test.tsx
@@ -1,0 +1,459 @@
+// @vitest-environment jsdom
+
+/**
+ * Integration tests for HighlightOrchestrator.
+ *
+ * Strategy:
+ * - Most tests render <HighlightOrchestrator> in a real jsdom environment.
+ * - findElementsUsingToken is mocked via vi.mock to give deterministic returns.
+ * - A subset of tests inject real <style> rules to exercise the stylesheet
+ *   observer path (stylesheetVersion bump + re-resolve).
+ * - The HighlightOverlay uses a RAF loop; we replace requestAnimationFrame with
+ *   a manual queue (same pattern as highlight-overlay.test.tsx) so we can
+ *   flush exactly one tick and assert overlay positions.
+ *
+ * Acceptance criteria covered:
+ * 1. Toggling adds overlay divs for matching elements.
+ * 2. Toggling off removes overlays.
+ * 3. Multiple tokens → distinct slot colors per reservation-sheet rules.
+ * 4. Editing a slot color (setSlot) instantly recolors active overlays.
+ * 5. Appending a <style> to <head> triggers re-resolve.
+ * 6. Closing the panel (open===false parent gate) does NOT clear overlays.
+ * 7. astro:after-swap recreates the portal mount if detached.
+ * 8. matchCounts are populated in context.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, h } from 'preact';
+import { act } from 'preact/test-utils';
+import { useContext } from 'preact/hooks';
+import { HighlightOrchestrator } from '../highlight-orchestrator';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from '../highlight-toggle-button';
+
+// ---------------------------------------------------------------------------
+// Mock findElementsUsingToken
+// ---------------------------------------------------------------------------
+
+const mockFindElements = vi.fn();
+
+vi.mock('../find-elements', () => ({
+  findElementsUsingToken: (cssVar: string) => mockFindElements(cssVar),
+}));
+
+// ---------------------------------------------------------------------------
+// Manual RAF queue
+// ---------------------------------------------------------------------------
+
+type RafCallback = (time: number) => void;
+let rafQueue: RafCallback[] = [];
+let rafTime = 0;
+
+function flushRaf(): void {
+  const toRun = rafQueue.slice();
+  rafQueue = [];
+  for (const cb of toRun) cb(rafTime++);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  rafQueue = [];
+  rafTime = 0;
+  window.requestAnimationFrame = (cb: RafCallback): number => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  };
+  window.cancelAnimationFrame = vi.fn();
+
+  // Clear storage to prevent state bleeding between tests
+  sessionStorage.clear();
+  localStorage.clear();
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+
+  // Default mock: no elements found for any token
+  mockFindElements.mockReturnValue({ elements: [], warnings: [] });
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+  // Clear storage between tests
+  sessionStorage.clear();
+  localStorage.clear();
+  // Clean up portal mount if created
+  const mount = document.getElementById('tokenpanel-highlight-mount');
+  if (mount) mount.remove();
+  // Clean up any injected style sheets from tests
+  for (const s of Array.from(document.head.querySelectorAll('style[data-test]'))) {
+    s.remove();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeElement(): HTMLDivElement {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () =>
+    ({
+      top: 10,
+      left: 20,
+      width: 100,
+      height: 50,
+      right: 120,
+      bottom: 60,
+      x: 20,
+      y: 10,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  document.body.appendChild(el);
+  return el;
+}
+
+/** Consumer component that reads context and exposes it via a ref. */
+function ContextCapture({
+  onCtx,
+}: {
+  onCtx: (ctx: HighlightContextValue | null) => void;
+}) {
+  const ctx = useContext(HighlightContext);
+  onCtx(ctx);
+  return null;
+}
+
+function renderOrchestrator(
+  onCtx: (ctx: HighlightContextValue | null) => void,
+): void {
+  act(() => {
+    render(
+      h(HighlightOrchestrator, null,
+        h(ContextCapture, { onCtx }),
+      ),
+      container,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Toggling adds overlay divs
+// ---------------------------------------------------------------------------
+
+describe('toggle adds overlay', () => {
+  it('overlay div appears in portal mount after toggle', () => {
+    const el = makeElement();
+    mockFindElements.mockReturnValue({ elements: [el], warnings: [] });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--brand'); });
+    act(() => { flushRaf(); });
+
+    const mount = document.getElementById('tokenpanel-highlight-mount');
+    expect(mount).not.toBeNull();
+    const overlays = mount!.querySelectorAll('.tokenpanel-highlight-overlay');
+    expect(overlays.length).toBeGreaterThanOrEqual(1);
+
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Toggling off removes overlays
+// ---------------------------------------------------------------------------
+
+describe('toggle off removes overlay', () => {
+  it('overlay disappears after toggling the same token off', () => {
+    const el = makeElement();
+    mockFindElements.mockReturnValue({ elements: [el], warnings: [] });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    // Toggle on
+    act(() => { ctx!.toggle('--brand'); });
+    // Flush RAF to let the RAF loop render overlay positions
+    act(() => { flushRaf(); flushRaf(); });
+
+    const mount = document.getElementById('tokenpanel-highlight-mount');
+    expect(mount!.querySelectorAll('.tokenpanel-highlight-overlay').length).toBeGreaterThanOrEqual(1);
+
+    // Toggle off
+    mockFindElements.mockReturnValue({ elements: [], warnings: [] });
+    act(() => { ctx!.toggle('--brand'); });
+    act(() => { flushRaf(); flushRaf(); });
+
+    expect(mount!.querySelectorAll('.tokenpanel-highlight-overlay').length).toBe(0);
+
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Multiple tokens → distinct slot colors
+// ---------------------------------------------------------------------------
+
+describe('multiple tokens get distinct slot colors', () => {
+  it('two toggled tokens get overlays with different slot colors', () => {
+    const el1 = makeElement();
+    const el2 = makeElement();
+
+    mockFindElements.mockImplementation((cssVar: string) => {
+      if (cssVar === '--brand') return { elements: [el1], warnings: [] };
+      if (cssVar === '--secondary') return { elements: [el2], warnings: [] };
+      return { elements: [], warnings: [] };
+    });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--brand'); });
+    act(() => { ctx!.toggle('--secondary'); });
+    act(() => { flushRaf(); });
+
+    // Verify context has both tokens active in distinct slots
+    const state = ctx!.state;
+    const slot1 = state.active['--brand'];
+    const slot2 = state.active['--secondary'];
+    expect(slot1).not.toBe(slot2);
+
+    // slot colors should differ (different reservation slots)
+    const color1 = state.slots[slot1].color;
+    const color2 = state.slots[slot2].color;
+    expect(color1).not.toBe(color2);
+
+    el1.remove();
+    el2.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. setSlot recolors active overlays
+// ---------------------------------------------------------------------------
+
+describe('setSlot recolors overlays', () => {
+  it('calling setSlot updates context state immediately', () => {
+    const el = makeElement();
+    mockFindElements.mockReturnValue({ elements: [el], warnings: [] });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--brand'); });
+
+    const slotIdx = ctx!.state.active['--brand'];
+    expect(slotIdx).toBe(0); // first slot
+
+    act(() => { ctx!.setSlot!(0, { color: '#00ff00' }); });
+
+    expect(ctx!.state.slots[0].color).toBe('#00ff00');
+
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Appending a <style> bumps stylesheetVersion
+// ---------------------------------------------------------------------------
+
+describe('stylesheet observer', () => {
+  it('appending a <style> to <head> triggers re-resolve for active tokens', async () => {
+    const el1 = makeElement();
+    const el2 = makeElement();
+
+    // Phase 1: return 1 element
+    mockFindElements.mockReturnValue({ elements: [el1], warnings: [] });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--brand'); });
+
+    // matchCounts should reflect 1 element now
+    expect(ctx!.matchCounts?.['--brand']).toBe(1);
+
+    // Phase 2: after style injection, return 2 elements
+    mockFindElements.mockReturnValue({ elements: [el1, el2], warnings: [] });
+
+    // Inject a style node — this triggers the MutationObserver
+    const style = document.createElement('style');
+    style.setAttribute('data-test', 'true');
+    style.textContent = ':root { --brand: blue; }';
+
+    await act(async () => {
+      document.head.appendChild(style);
+      // Wait for the MutationObserver to fire (microtask-async in jsdom)
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // stylesheetVersion should have bumped → useMemo recomputes → matchCounts = 2
+    expect(ctx!.matchCounts?.['--brand']).toBe(2);
+
+    el1.remove();
+    el2.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Panel closed does NOT clear overlays
+// ---------------------------------------------------------------------------
+
+describe('panel closed keeps overlays', () => {
+  it('overlay portal persists when parent renders without the panel JSX', () => {
+    const el = makeElement();
+    mockFindElements.mockReturnValue({ elements: [el], warnings: [] });
+
+    let ctx: HighlightContextValue | null = null;
+
+    function App({ show }: { show: boolean }) {
+      return h(HighlightOrchestrator, null,
+        show
+          ? h(ContextCapture, { onCtx: (c) => { ctx = c; } })
+          : null,
+      );
+    }
+
+    act(() => { render(h(App, { show: true }), container); });
+
+    act(() => { ctx!.toggle('--brand'); });
+    act(() => { flushRaf(); });
+
+    const mount = document.getElementById('tokenpanel-highlight-mount');
+    expect(mount!.querySelectorAll('.tokenpanel-highlight-overlay').length).toBeGreaterThanOrEqual(1);
+
+    // Simulate panel close — no longer rendering children inside orchestrator
+    act(() => { render(h(App, { show: false }), container); });
+    act(() => { flushRaf(); });
+
+    // The orchestrator itself still renders the OverlayPortal
+    // Overlay content depends on state being preserved — the mount should still exist
+    expect(document.getElementById('tokenpanel-highlight-mount')).not.toBeNull();
+
+    el.remove();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. astro:after-swap recreates portal mount if detached
+// ---------------------------------------------------------------------------
+
+describe('astro:after-swap', () => {
+  it('recreates the portal mount node when it was removed from DOM', async () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    // Ensure mount exists
+    expect(document.getElementById('tokenpanel-highlight-mount')).not.toBeNull();
+
+    // Simulate Astro view transition removing the old body content
+    const oldMount = document.getElementById('tokenpanel-highlight-mount')!;
+    oldMount.remove();
+    expect(document.getElementById('tokenpanel-highlight-mount')).toBeNull();
+
+    // Fire the after-swap event
+    await act(async () => {
+      window.dispatchEvent(new Event('astro:after-swap'));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The mount should be recreated
+    expect(document.getElementById('tokenpanel-highlight-mount')).not.toBeNull();
+
+    void ctx; // ctx is captured but not asserted here
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. matchCounts populated
+// ---------------------------------------------------------------------------
+
+describe('matchCounts', () => {
+  it('matchCounts reflects number of elements for each active token', () => {
+    const el1 = makeElement();
+    const el2 = makeElement();
+    const el3 = makeElement();
+
+    mockFindElements.mockImplementation((cssVar: string) => {
+      if (cssVar === '--brand') return { elements: [el1, el2, el3], warnings: [] };
+      return { elements: [], warnings: [] };
+    });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--brand'); });
+
+    expect(ctx!.matchCounts?.['--brand']).toBe(3);
+
+    el1.remove();
+    el2.remove();
+    el3.remove();
+  });
+
+  it('matchCounts is 0 when no elements match', () => {
+    mockFindElements.mockReturnValue({ elements: [], warnings: [] });
+
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--noop'); });
+
+    expect(ctx!.matchCounts?.['--noop']).toBe(0);
+  });
+
+  it('matchCounts is absent for inactive tokens', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    expect(ctx!.matchCounts?.['--not-active']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Context shape tests
+// ---------------------------------------------------------------------------
+
+describe('context value shape', () => {
+  it('provides state, toggle, setSlot, reset, matchCounts in context', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    expect(ctx).not.toBeNull();
+    expect(typeof ctx!.state).toBe('object');
+    expect(typeof ctx!.toggle).toBe('function');
+    expect(typeof ctx!.setSlot).toBe('function');
+    expect(typeof ctx!.reset).toBe('function');
+    expect(typeof ctx!.matchCounts).toBe('object');
+  });
+
+  it('initial state has 10 slots and empty active map', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    expect(ctx!.state.slots).toHaveLength(10);
+    expect(Object.keys(ctx!.state.active)).toHaveLength(0);
+  });
+
+  it('reset restores default slot colors', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.setSlot!(0, { color: '#123456' }); });
+    expect(ctx!.state.slots[0].color).toBe('#123456');
+
+    act(() => { ctx!.reset!(); });
+    // Default slot 0 color
+    expect(ctx!.state.slots[0].color).toBe('#ff2d2d');
+  });
+});

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-overlay.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-overlay.test.tsx
@@ -1,0 +1,332 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for HighlightOverlay.
+ *
+ * Key test-environment constraints:
+ * - jsdom's getBoundingClientRect() returns all-zeros for unlayouted elements.
+ *   We stub it per element.
+ * - jsdom's requestAnimationFrame is non-deterministic; we replace it with a
+ *   manual flush queue so we can advance exactly one tick between assertions.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { HighlightOverlay, type HighlightOverlayItem } from '../highlight-overlay';
+
+// ---------------------------------------------------------------------------
+// Manual RAF queue — deterministic single-tick advance
+// ---------------------------------------------------------------------------
+
+type RafCallback = (time: number) => void;
+let rafQueue: RafCallback[] = [];
+let rafTime = 0;
+
+function flushRaf(): void {
+  const toRun = rafQueue.slice();
+  rafQueue = [];
+  for (const cb of toRun) {
+    cb(rafTime++);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  rafQueue = [];
+  rafTime = 0;
+
+  // Install deterministic RAF
+  window.requestAnimationFrame = (cb: RafCallback): number => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  };
+  window.cancelAnimationFrame = vi.fn((_id: number) => {
+    // For simplicity, cancellation is not modelled in these tests because we
+    // assert state after deliberate flushes only.
+  });
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeElement(rect: { top: number; left: number; width: number; height: number }): Element {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () =>
+    ({
+      top: rect.top,
+      left: rect.left,
+      width: rect.width,
+      height: rect.height,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    } as DOMRect);
+  return el;
+}
+
+function makeItem(
+  rect: { top: number; left: number; width: number; height: number },
+  color: string,
+  outlineWidth: number,
+): HighlightOverlayItem {
+  return {
+    element: makeElement(rect),
+    slot: { color, outlineWidth },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HighlightOverlay', () => {
+  it('renders nothing when items array is empty', () => {
+    act(() => {
+      render(<HighlightOverlay items={[]} />, container);
+    });
+    const overlays = container.querySelectorAll('.tokenpanel-highlight-overlay');
+    expect(overlays).toHaveLength(0);
+  });
+
+  it('renders 1 overlay div for 1 item', () => {
+    const item = makeItem({ top: 10, left: 20, width: 100, height: 30 }, '#ff0000', 2);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlays = container.querySelectorAll('.tokenpanel-highlight-overlay');
+    expect(overlays).toHaveLength(1);
+  });
+
+  it('sets correct initial rect on the overlay', () => {
+    const item = makeItem({ top: 10, left: 20, width: 100, height: 30 }, '#ff0000', 2);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.top).toBe('10px');
+    expect(overlay.style.left).toBe('20px');
+    expect(overlay.style.width).toBe('100px');
+    expect(overlay.style.height).toBe('30px');
+  });
+
+  it('uses position:fixed on overlay divs', () => {
+    const item = makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#00ff00', 1);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.position).toBe('fixed');
+  });
+
+  it('applies z-index 49', () => {
+    const item = makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#00ff00', 1);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.zIndex).toBe('49');
+  });
+
+  it('sets outline using slot color and outlineWidth', () => {
+    const item = makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#abcdef', 3);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.outline).toBe('3px solid #abcdef');
+  });
+
+  it('sets box-shadow inset fallback with slot color and outlineWidth', () => {
+    const item = makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#ff0000', 2);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.boxShadow).toBe('inset 0 0 0 2px #ff0000');
+  });
+
+  it('renders 3 overlays with their respective slot colors and widths', () => {
+    const items = [
+      makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#ff0000', 2),
+      makeItem({ top: 100, left: 100, width: 80, height: 40 }, '#00ff00', 3),
+      makeItem({ top: 200, left: 200, width: 60, height: 60 }, '#0000ff', 1),
+    ];
+
+    act(() => {
+      render(<HighlightOverlay items={items} />, container);
+    });
+
+    const overlays = container.querySelectorAll(
+      '.tokenpanel-highlight-overlay',
+    ) as NodeListOf<HTMLElement>;
+    expect(overlays).toHaveLength(3);
+
+    expect(overlays[0].style.outline).toBe('2px solid #ff0000');
+    expect(overlays[1].style.outline).toBe('3px solid #00ff00');
+    expect(overlays[2].style.outline).toBe('1px solid #0000ff');
+
+    expect(overlays[0].style.boxShadow).toBe('inset 0 0 0 2px #ff0000');
+    expect(overlays[1].style.boxShadow).toBe('inset 0 0 0 3px #00ff00');
+    expect(overlays[2].style.boxShadow).toBe('inset 0 0 0 1px #0000ff');
+  });
+
+  it('RAF tick updates overlay position when element rect changes (simulates scroll)', async () => {
+    let top = 10;
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () =>
+      ({
+        top,
+        left: 0,
+        width: 100,
+        height: 50,
+        right: 100,
+        bottom: top + 50,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+    const item: HighlightOverlayItem = { element: el, slot: { color: '#ff0000', outlineWidth: 2 } };
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.top).toBe('10px');
+
+    // Simulate scroll: element's rect.top changes
+    top = 200;
+
+    // Advance one RAF tick — the loop should update the overlay style
+    act(() => {
+      flushRaf();
+    });
+
+    expect(overlay.style.top).toBe('200px');
+  });
+
+  it('RAF tick updates overlay position when element rect changes (simulates resize)', async () => {
+    let width = 100;
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        left: 0,
+        width,
+        height: 50,
+        right: width,
+        bottom: 50,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+
+    const item: HighlightOverlayItem = { element: el, slot: { color: '#00ff00', outlineWidth: 1 } };
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.width).toBe('100px');
+
+    // Simulate resize: element's rect.width changes
+    width = 300;
+
+    act(() => {
+      flushRaf();
+    });
+
+    expect(overlay.style.width).toBe('300px');
+  });
+
+  it('warns once and renders only 200 items when given more than 200', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const items: HighlightOverlayItem[] = Array.from({ length: 205 }, (_, i) =>
+      makeItem({ top: i, left: 0, width: 10, height: 10 }, '#ff0000', 2),
+    );
+
+    act(() => {
+      render(<HighlightOverlay items={items} />, container);
+    });
+
+    const overlays = container.querySelectorAll('.tokenpanel-highlight-overlay');
+    expect(overlays).toHaveLength(200);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('205 items'),
+    );
+  });
+
+  it('does not warn again on re-render when still over 200', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const items: HighlightOverlayItem[] = Array.from({ length: 205 }, (_, i) =>
+      makeItem({ top: i, left: 0, width: 10, height: 10 }, '#ff0000', 2),
+    );
+
+    act(() => {
+      render(<HighlightOverlay items={items} />, container);
+    });
+    act(() => {
+      render(<HighlightOverlay items={items} />, container);
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets pointer-events none on overlays', () => {
+    const item = makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#ff0000', 2);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.style.pointerEvents).toBe('none');
+  });
+
+  it('sets aria-hidden on overlays (purely visual, skip screen readers)', () => {
+    const item = makeItem({ top: 0, left: 0, width: 50, height: 50 }, '#ff0000', 2);
+
+    act(() => {
+      render(<HighlightOverlay items={[item]} />, container);
+    });
+
+    const overlay = container.querySelector('.tokenpanel-highlight-overlay') as HTMLElement;
+    expect(overlay.getAttribute('aria-hidden')).toBe('true');
+  });
+});

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
@@ -1,0 +1,456 @@
+// @vitest-environment jsdom
+/**
+ * Tests for HighlightSettingsPopover and the gear button in panel.tsx.
+ *
+ * Isolation strategy:
+ * - HighlightContext is imported from ../highlight-context (this worktree's
+ *   canonical location) and provided as a stub value.
+ * - No actual HighlightOrchestrator or storage is exercised here.
+ * - The ColorPicker positioning (useLayoutEffect + getBoundingClientRect)
+ *   is stubbed to avoid jsdom layout issues.
+ *
+ * See also: packages/zudo-design-token-panel/CLAUDE.md for hostile-host policy.
+ */
+
+// jsdom does not polyfill PointerEvent. Provide a minimal shim (mirrors color-picker.test.tsx).
+if (typeof PointerEvent === 'undefined') {
+  class PointerEventShim extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).PointerEvent = PointerEventShim;
+}
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { h } from 'preact';
+import { HighlightSettingsPopover } from '../highlight-settings-popover';
+import { HighlightContext, type HighlightContextValue } from '../highlight-context';
+import type { HighlightState } from '../highlight-state';
+import { DEFAULT_HIGHLIGHT_SLOTS } from '../highlight-state';
+
+// ---------------------------------------------------------------------------
+// Stub getFixedPopoverStyle — jsdom has no real layout
+// ---------------------------------------------------------------------------
+vi.mock('../../components/color-picker/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../components/color-picker/index')>();
+  return {
+    ...actual,
+    getFixedPopoverStyle: () => ({ position: 'fixed' as const, left: 0, top: 0 }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(overrides: Partial<HighlightState> = {}): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    active: {},
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<HighlightContextValue> = {}): HighlightContextValue {
+  return {
+    state: makeState(),
+    toggle: vi.fn(),
+    setSlot: vi.fn(),
+    reset: vi.fn(),
+    matchCounts: {},
+    ...overrides,
+  };
+}
+
+const anchorRef = { current: document.createElement('div') };
+
+// Render the popover wrapped in a HighlightContext.Provider.
+function renderPopover(
+  ctx: HighlightContextValue,
+  container: HTMLDivElement,
+  onClose = vi.fn(),
+) {
+  act(() => {
+    render(
+      h(HighlightContext.Provider, { value: ctx },
+        h(HighlightSettingsPopover, { anchorRef, onClose }),
+      ),
+      container,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HighlightSettingsPopover', () => {
+  describe('render basics', () => {
+    it('renders a dialog element with aria-label "Highlight outline settings"', () => {
+      renderPopover(makeCtx(), container);
+      const dialog = container.querySelector('[role="dialog"]');
+      expect(dialog).not.toBeNull();
+      expect(dialog?.getAttribute('aria-label')).toBe('Highlight outline settings');
+    });
+
+    it('renders header text "Highlight outline settings"', () => {
+      renderPopover(makeCtx(), container);
+      const header = container.querySelector('.tokenpanel-highlight-settings-header');
+      expect(header?.textContent?.trim()).toBe('Highlight outline settings');
+    });
+
+    it('returns null when HighlightContext is not provided', () => {
+      act(() => {
+        render(
+          h(HighlightSettingsPopover, { anchorRef, onClose: vi.fn() }),
+          container,
+        );
+      });
+      const dialog = container.querySelector('[role="dialog"]');
+      expect(dialog).toBeNull();
+    });
+
+    it('does not render a native <dialog> element', () => {
+      renderPopover(makeCtx(), container);
+      const nativeDialogs = container.querySelectorAll('dialog');
+      expect(nativeDialogs).toHaveLength(0);
+    });
+
+    it('does not render any <button> elements (hostile-host policy)', () => {
+      renderPopover(makeCtx(), container);
+      const buttons = container.querySelectorAll('button');
+      expect(buttons).toHaveLength(0);
+    });
+  });
+
+  describe('10 slot rows', () => {
+    it('renders 10 rows', () => {
+      renderPopover(makeCtx(), container);
+      const rows = container.querySelectorAll('.tokenpanel-highlight-settings-row');
+      expect(rows).toHaveLength(10);
+    });
+
+    it('renders 10 ring swatches', () => {
+      renderPopover(makeCtx(), container);
+      const rings = container.querySelectorAll('.tokenpanel-highlight-settings-ring');
+      expect(rings).toHaveLength(10);
+    });
+
+    it('renders 10 name cells', () => {
+      renderPopover(makeCtx(), container);
+      const names = container.querySelectorAll('.tokenpanel-highlight-settings-name');
+      expect(names).toHaveLength(10);
+    });
+
+    it('renders 10 sliders', () => {
+      renderPopover(makeCtx(), container);
+      const sliders = container.querySelectorAll('input[type="range"]');
+      // 10 slot sliders (ColorPicker is not open)
+      expect(sliders.length).toBeGreaterThanOrEqual(10);
+    });
+
+    it('renders 10 px readouts with "px" suffix', () => {
+      renderPopover(makeCtx(), container);
+      const readouts = container.querySelectorAll('.tokenpanel-highlight-settings-px');
+      expect(readouts).toHaveLength(10);
+      for (const readout of readouts) {
+        expect(readout.textContent).toMatch(/\d+px/);
+      }
+    });
+
+    it('shows slot numbers 1–10', () => {
+      renderPopover(makeCtx(), container);
+      const nums = container.querySelectorAll('.tokenpanel-highlight-settings-num');
+      expect(nums).toHaveLength(10);
+      for (let i = 0; i < 10; i++) {
+        expect(nums[i].textContent?.trim()).toBe(String(i + 1));
+      }
+    });
+  });
+
+  describe('ring swatch border', () => {
+    it('ring 0 has border reflecting slot 0 outlineWidth (2px solid)', () => {
+      const ctx = makeCtx();
+      renderPopover(ctx, container);
+      const ring = container.querySelector('.tokenpanel-highlight-settings-ring') as HTMLElement;
+      // jsdom may normalize hex color to rgb, so only assert outlineWidth and "solid"
+      expect(ring.style.border).toContain('2px solid');
+    });
+
+    it('ring reflects custom outlineWidth in border-width', () => {
+      const ctx = makeCtx({
+        state: makeState({
+          slots: DEFAULT_HIGHLIGHT_SLOTS.map((s, i) =>
+            i === 0 ? { ...s, outlineWidth: 5 } : { ...s },
+          ),
+        }),
+      });
+      renderPopover(ctx, container);
+      const ring = container.querySelector('.tokenpanel-highlight-settings-ring') as HTMLElement;
+      expect(ring.style.border).toContain('5px solid');
+    });
+
+    it('ring reflects default outlineWidth of 2px', () => {
+      renderPopover(makeCtx(), container);
+      const rings = container.querySelectorAll('.tokenpanel-highlight-settings-ring') as NodeListOf<HTMLElement>;
+      expect(rings[0].style.border).toContain('2px solid');
+    });
+  });
+
+  describe('width readout text', () => {
+    it('renders "${N}px" for slot 0 with outlineWidth 2', () => {
+      renderPopover(makeCtx(), container);
+      const readout = container.querySelector('.tokenpanel-highlight-settings-px');
+      expect(readout?.textContent?.trim()).toBe('2px');
+    });
+
+    it('renders correct px string when outlineWidth is 4', () => {
+      const ctx = makeCtx({
+        state: makeState({
+          slots: DEFAULT_HIGHLIGHT_SLOTS.map((s, i) =>
+            i === 0 ? { ...s, outlineWidth: 4 } : { ...s },
+          ),
+        }),
+      });
+      renderPopover(ctx, container);
+      const readouts = container.querySelectorAll('.tokenpanel-highlight-settings-px');
+      expect(readouts[0].textContent?.trim()).toBe('4px');
+    });
+  });
+
+  describe('active vs available labels', () => {
+    it('shows "available" for all slots when active map is empty', () => {
+      renderPopover(makeCtx(), container);
+      const names = container.querySelectorAll('.tokenpanel-highlight-settings-name');
+      for (const name of names) {
+        expect(name.textContent?.trim()).toBe('available');
+      }
+    });
+
+    it('shows cssVar for slot assigned in active map, in default text color (is-active class)', () => {
+      const ctx = makeCtx({
+        state: makeState({
+          active: { '--color-brand': 0 },
+        }),
+      });
+      renderPopover(ctx, container);
+      const names = container.querySelectorAll('.tokenpanel-highlight-settings-name');
+      expect(names[0].textContent?.trim()).toBe('--color-brand');
+      expect(names[0].classList.contains('is-active')).toBe(true);
+    });
+
+    it('shows "available" for inactive slots (no is-active class)', () => {
+      const ctx = makeCtx({
+        state: makeState({
+          active: { '--color-brand': 0 },
+        }),
+      });
+      renderPopover(ctx, container);
+      const names = container.querySelectorAll('.tokenpanel-highlight-settings-name');
+      for (let i = 1; i < 10; i++) {
+        expect(names[i].textContent?.trim()).toBe('available');
+        expect(names[i].classList.contains('is-active')).toBe(false);
+      }
+    });
+
+    it('shows multiple active cssVars in correct slot positions', () => {
+      const ctx = makeCtx({
+        state: makeState({
+          active: { '--color-brand': 0, '--text-sm': 2 },
+        }),
+      });
+      renderPopover(ctx, container);
+      const names = container.querySelectorAll('.tokenpanel-highlight-settings-name');
+      expect(names[0].textContent?.trim()).toBe('--color-brand');
+      expect(names[1].textContent?.trim()).toBe('available');
+      expect(names[2].textContent?.trim()).toBe('--text-sm');
+    });
+  });
+
+  describe('slider onInput dispatches setSlot', () => {
+    it('calls setSlot with new outlineWidth when slider fires onInput', () => {
+      const setSlot = vi.fn();
+      const ctx = makeCtx({ setSlot });
+      renderPopover(ctx, container);
+
+      const slider = container.querySelector('input[type="range"]') as HTMLInputElement;
+      expect(slider).not.toBeNull();
+
+      act(() => {
+        // Simulate range input event with value 5
+        Object.defineProperty(slider, 'value', { value: '5', writable: true });
+        slider.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      expect(setSlot).toHaveBeenCalledWith(0, { outlineWidth: 5 });
+    });
+
+    it('calls setSlot for the correct slot index', () => {
+      const setSlot = vi.fn();
+      const ctx = makeCtx({ setSlot });
+      renderPopover(ctx, container);
+
+      const sliders = container.querySelectorAll('input[type="range"]') as NodeListOf<HTMLInputElement>;
+      // fire slot 2 (index 2) slider
+      const slider2 = sliders[2];
+      act(() => {
+        Object.defineProperty(slider2, 'value', { value: '7', writable: true });
+        slider2.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      expect(setSlot).toHaveBeenCalledWith(2, { outlineWidth: 7 });
+    });
+  });
+
+  describe('ring click opens ColorPicker', () => {
+    it('clicking ring 0 makes a ColorPicker dialog appear in the DOM', () => {
+      renderPopover(makeCtx(), container);
+      const ring = container.querySelector('.tokenpanel-highlight-settings-ring') as HTMLElement;
+
+      // No picker open initially (the color-picker uses role="dialog")
+      const pickersBefore = container.querySelectorAll('.tokenpanel-color-picker');
+      expect(pickersBefore).toHaveLength(0);
+
+      act(() => {
+        ring.click();
+      });
+
+      const pickersAfter = container.querySelectorAll('.tokenpanel-color-picker');
+      expect(pickersAfter).toHaveLength(1);
+    });
+
+    it('ColorPicker onChange calls setSlot with new hex for the opened ring', () => {
+      const setSlot = vi.fn();
+      const ctx = makeCtx({ setSlot });
+      renderPopover(ctx, container);
+
+      const ring = container.querySelector('.tokenpanel-highlight-settings-ring') as HTMLElement;
+      act(() => {
+        ring.click();
+      });
+
+      // Find the hex input inside the color picker and fire the 'input' event
+      // (ColorPicker uses Preact's onChange which maps to 'input', not 'change').
+      const hexInput = container.querySelector('.tokenpanel-color-picker-hex-input') as HTMLInputElement;
+      expect(hexInput).not.toBeNull();
+
+      act(() => {
+        Object.defineProperty(hexInput, 'value', {
+          value: '#aabbcc',
+          writable: true,
+          configurable: true,
+        });
+        hexInput.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      // setSlot should have been called with slot 0 and the new hex
+      expect(setSlot).toHaveBeenCalledWith(0, { color: '#aabbcc' });
+    });
+
+    it('clicking the same ring again closes the ColorPicker', () => {
+      renderPopover(makeCtx(), container);
+      const ring = container.querySelector('.tokenpanel-highlight-settings-ring') as HTMLElement;
+
+      act(() => { ring.click(); });
+      expect(container.querySelectorAll('.tokenpanel-color-picker')).toHaveLength(1);
+
+      act(() => { ring.click(); });
+      expect(container.querySelectorAll('.tokenpanel-color-picker')).toHaveLength(0);
+    });
+  });
+
+  describe('reset button', () => {
+    it('renders a "Reset to defaults" button', () => {
+      renderPopover(makeCtx(), container);
+      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn');
+      expect(resetBtn).not.toBeNull();
+      expect(resetBtn?.textContent?.trim()).toBe('Reset to defaults');
+    });
+
+    it('reset button has role="button"', () => {
+      renderPopover(makeCtx(), container);
+      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn');
+      expect(resetBtn?.getAttribute('role')).toBe('button');
+    });
+
+    it('clicking reset calls context.reset()', () => {
+      const reset = vi.fn();
+      const ctx = makeCtx({ reset });
+      renderPopover(ctx, container);
+
+      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn') as HTMLElement;
+      act(() => { resetBtn.click(); });
+
+      expect(reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('reset button does NOT call toggle or setSlot', () => {
+      const toggle = vi.fn();
+      const setSlot = vi.fn();
+      const reset = vi.fn();
+      const ctx = makeCtx({ toggle, setSlot, reset });
+      renderPopover(ctx, container);
+
+      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn') as HTMLElement;
+      act(() => { resetBtn.click(); });
+
+      expect(toggle).not.toHaveBeenCalled();
+      expect(setSlot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close via outside click and Escape', () => {
+    it('calls onClose on outside pointerdown', () => {
+      const onClose = vi.fn();
+      renderPopover(makeCtx(), container, onClose);
+
+      act(() => {
+        document.body.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose on Escape keydown', () => {
+      const onClose = vi.fn();
+      renderPopover(makeCtx(), container, onClose);
+
+      act(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('footer rendered correctly', () => {
+    it('renders a footer element', () => {
+      renderPopover(makeCtx(), container);
+      const footer = container.querySelector('.tokenpanel-highlight-settings-footer');
+      expect(footer).not.toBeNull();
+    });
+  });
+});

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-state.test.ts
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-state.test.ts
@@ -1,0 +1,331 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  DEFAULT_HIGHLIGHT_SLOTS,
+  allocateSlot,
+  toggleHighlight,
+  resetSlots,
+  setSlot,
+  loadHighlightState,
+  saveHighlightState,
+  type HighlightState,
+} from '../highlight-state';
+import {
+  __resetPanelConfigForTests,
+  getPanelConfig,
+} from '../../config/panel-config';
+import { installFixturePanelConfig } from '../../__tests__/_test-helpers';
+
+// ---------------------------------------------------------------------------
+// Shared setup / teardown
+// ---------------------------------------------------------------------------
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  installFixturePanelConfig();
+  localStorage.clear();
+  sessionStorage.clear();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+  localStorage.clear();
+  sessionStorage.clear();
+  warnSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_HIGHLIGHT_SLOTS
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_HIGHLIGHT_SLOTS', () => {
+  it('exports exactly 10 slots', () => {
+    expect(DEFAULT_HIGHLIGHT_SLOTS).toHaveLength(10);
+  });
+
+  it('all slots have outlineWidth 2', () => {
+    for (const slot of DEFAULT_HIGHLIGHT_SLOTS) {
+      expect(slot.outlineWidth).toBe(2);
+    }
+  });
+
+  it('first slot is red #ff2d2d', () => {
+    expect(DEFAULT_HIGHLIGHT_SLOTS[0].color).toBe('#ff2d2d');
+  });
+
+  it('last slot is blue #2d6eff', () => {
+    expect(DEFAULT_HIGHLIGHT_SLOTS[9].color).toBe('#2d6eff');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// allocateSlot
+// ---------------------------------------------------------------------------
+
+describe('allocateSlot', () => {
+  it('returns 0 when active is empty', () => {
+    expect(allocateSlot({})).toBe(0);
+  });
+
+  it('returns the lowest unused index', () => {
+    expect(allocateSlot({ a: 0, b: 2 })).toBe(1);
+  });
+
+  it('returns -1 when all 10 slots are taken', () => {
+    const active: Record<string, number> = {};
+    for (let i = 0; i < 10; i++) {
+      active[`--var-${i}`] = i;
+    }
+    expect(allocateSlot(active)).toBe(-1);
+  });
+
+  it('returns 0 when only slot 0 is available', () => {
+    const active: Record<string, number> = {};
+    for (let i = 1; i < 10; i++) {
+      active[`--var-${i}`] = i;
+    }
+    expect(allocateSlot(active)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleHighlight
+// ---------------------------------------------------------------------------
+
+describe('toggleHighlight', () => {
+  const base: HighlightState = {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    active: {},
+  };
+
+  it('first toggle on --a assigns slot 0', () => {
+    const next = toggleHighlight(base, '--a');
+    expect(next.active).toEqual({ '--a': 0 });
+  });
+
+  it('sequential toggles --a, --b, --c assign slots 0, 1, 2', () => {
+    let state = toggleHighlight(base, '--a');
+    state = toggleHighlight(state, '--b');
+    state = toggleHighlight(state, '--c');
+    expect(state.active).toEqual({ '--a': 0, '--b': 1, '--c': 2 });
+  });
+
+  it('reservation-sheet: toggling off --a and --b leaves --c at slot 2', () => {
+    let state = toggleHighlight(base, '--a');
+    state = toggleHighlight(state, '--b');
+    state = toggleHighlight(state, '--c');
+    // Release --a and --b
+    state = toggleHighlight(state, '--a');
+    state = toggleHighlight(state, '--b');
+    expect(state.active).toEqual({ '--c': 2 });
+  });
+
+  it('reservation-sheet: after releasing --a and --b, --d claims slot 0', () => {
+    let state = toggleHighlight(base, '--a');
+    state = toggleHighlight(state, '--b');
+    state = toggleHighlight(state, '--c');
+    state = toggleHighlight(state, '--a');
+    state = toggleHighlight(state, '--b');
+    state = toggleHighlight(state, '--d');
+    expect(state.active).toEqual({ '--c': 2, '--d': 0 });
+  });
+
+  it('toggle on active var removes the mapping', () => {
+    const withA: HighlightState = { ...base, active: { '--a': 0 } };
+    const next = toggleHighlight(withA, '--a');
+    expect(next.active).toEqual({});
+  });
+
+  it('returns new state objects (immutable)', () => {
+    const next = toggleHighlight(base, '--a');
+    expect(next).not.toBe(base);
+    expect(next.active).not.toBe(base.active);
+  });
+
+  it('all-taken: returns same state reference and warns', () => {
+    const active: Record<string, number> = {};
+    for (let i = 0; i < 10; i++) {
+      active[`--var-${i}`] = i;
+    }
+    const fullState: HighlightState = { ...base, active };
+    const result = toggleHighlight(fullState, '--new');
+    expect(result).toBe(fullState);
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resetSlots
+// ---------------------------------------------------------------------------
+
+describe('resetSlots', () => {
+  it('restores slot colors to defaults', () => {
+    const modified: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s, color: '#000000' })),
+      active: { '--x': 3 },
+    };
+    const next = resetSlots(modified);
+    expect(next.slots).toEqual(DEFAULT_HIGHLIGHT_SLOTS);
+  });
+
+  it('preserves the active map', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s, color: '#000000' })),
+      active: { '--x': 3, '--y': 7 },
+    };
+    const next = resetSlots(state);
+    expect(next.active).toEqual({ '--x': 3, '--y': 7 });
+  });
+
+  it('returns a new state object (immutable)', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: {},
+    };
+    const next = resetSlots(state);
+    expect(next).not.toBe(state);
+    expect(next.slots).not.toBe(state.slots);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setSlot
+// ---------------------------------------------------------------------------
+
+describe('setSlot', () => {
+  const base: HighlightState = {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    active: {},
+  };
+
+  it('merges partial into the specified slot', () => {
+    const next = setSlot(base, 0, { color: '#aabbcc' });
+    expect(next.slots[0]).toEqual({ color: '#aabbcc', outlineWidth: 2 });
+  });
+
+  it('leaves other slots unchanged', () => {
+    const next = setSlot(base, 0, { color: '#aabbcc' });
+    for (let i = 1; i < 10; i++) {
+      expect(next.slots[i]).toEqual(DEFAULT_HIGHLIGHT_SLOTS[i]);
+    }
+  });
+
+  it('returns state unchanged for out-of-range index (negative)', () => {
+    const next = setSlot(base, -1, { color: '#aabbcc' });
+    expect(next).toBe(base);
+  });
+
+  it('returns state unchanged for out-of-range index (≥ 10)', () => {
+    const next = setSlot(base, 10, { color: '#aabbcc' });
+    expect(next).toBe(base);
+  });
+
+  it('returns a new state object (immutable)', () => {
+    const next = setSlot(base, 0, { color: '#aabbcc' });
+    expect(next).not.toBe(base);
+    expect(next.slots).not.toBe(base.slots);
+  });
+
+  it('can update outlineWidth independently', () => {
+    const next = setSlot(base, 3, { outlineWidth: 4 });
+    expect(next.slots[3]).toEqual({ color: DEFAULT_HIGHLIGHT_SLOTS[3].color, outlineWidth: 4 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence — loadHighlightState / saveHighlightState
+// ---------------------------------------------------------------------------
+
+describe('loadHighlightState — default (empty storage)', () => {
+  it('returns DEFAULT_HIGHLIGHT_SLOTS and empty active when storage is empty', () => {
+    const state = loadHighlightState();
+    expect(state.slots).toEqual(DEFAULT_HIGHLIGHT_SLOTS);
+    expect(state.active).toEqual({});
+  });
+});
+
+describe('saveHighlightState / loadHighlightState — round-trip', () => {
+  it('round-trips slots and active correctly', () => {
+    const original: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s, i) =>
+        i === 0 ? { color: '#112233', outlineWidth: 3 } : { ...s },
+      ),
+      active: { '--token-a': 0, '--token-b': 5 },
+    };
+
+    saveHighlightState(original);
+    const loaded = loadHighlightState();
+
+    expect(loaded.slots).toEqual(original.slots);
+    expect(loaded.active).toEqual(original.active);
+  });
+
+  it('slots are stored in localStorage (not sessionStorage)', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: {},
+    };
+    saveHighlightState(state);
+
+    const prefix = getPanelConfig().storagePrefix;
+    const slotsKey = `${prefix}-highlight-slots`;
+    const activeKey = `${prefix}-highlight-active`;
+
+    // slots must be in localStorage
+    expect(localStorage.getItem(slotsKey)).not.toBeNull();
+    // active must NOT be in localStorage
+    expect(localStorage.getItem(activeKey)).toBeNull();
+  });
+
+  it('active is stored in sessionStorage (not localStorage)', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: { '--token-x': 2 },
+    };
+    saveHighlightState(state);
+
+    const prefix = getPanelConfig().storagePrefix;
+    const slotsKey = `${prefix}-highlight-slots`;
+    const activeKey = `${prefix}-highlight-active`;
+
+    // active must be in sessionStorage
+    expect(sessionStorage.getItem(activeKey)).not.toBeNull();
+    // slots must NOT be in sessionStorage
+    expect(sessionStorage.getItem(slotsKey)).toBeNull();
+  });
+});
+
+describe('loadHighlightState — storage key contains storagePrefix', () => {
+  it('uses the storagePrefix from getPanelConfig() in the key', () => {
+    const prefix = getPanelConfig().storagePrefix;
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: { '--token-a': 1 },
+    };
+    saveHighlightState(state);
+
+    expect(localStorage.getItem(`${prefix}-highlight-slots`)).not.toBeNull();
+    expect(sessionStorage.getItem(`${prefix}-highlight-active`)).not.toBeNull();
+  });
+});
+
+describe('loadHighlightState — corrupt storage degrades gracefully', () => {
+  it('returns defaults when localStorage contains invalid JSON for slots', () => {
+    const prefix = getPanelConfig().storagePrefix;
+    localStorage.setItem(`${prefix}-highlight-slots`, 'not-json{{{');
+    const state = loadHighlightState();
+    expect(state.slots).toEqual(DEFAULT_HIGHLIGHT_SLOTS);
+    expect(state.active).toEqual({});
+  });
+
+  it('returns empty active when sessionStorage contains invalid JSON', () => {
+    const prefix = getPanelConfig().storagePrefix;
+    // Put valid slots so we can verify active independently
+    saveHighlightState({ slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })), active: {} });
+    sessionStorage.setItem(`${prefix}-highlight-active`, 'not-json{{{');
+    const state = loadHighlightState();
+    expect(state.active).toEqual({});
+  });
+});

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-toggle-button.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-toggle-button.test.tsx
@@ -1,0 +1,501 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for HighlightToggleButton and HighlightContext.
+ *
+ * Tests cover:
+ * - Renders nothing when HighlightContext is null (no provider).
+ * - Renders the eye icon when context is provided.
+ * - No <button> elements (hostile-host policy: use div role="button" instead).
+ * - Clicking calls context.toggle(cssVar).
+ * - Enter and Space keyboard events trigger toggle.
+ * - tabIndex={0} for keyboard accessibility.
+ * - Active state: icon colored with slot color via inline style.
+ * - Inactive state: no inline color style.
+ * - Title attribute content for active vs inactive.
+ * - matchCounts included in title when provided.
+ * - GenericTab rows expose the eye button.
+ * - _generic-item-editor (used by spacing/font/size tabs) rows expose the button.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import {
+  HighlightToggleButton,
+  HighlightContext,
+  type HighlightContextValue,
+} from '../highlight-toggle-button';
+import type { HighlightState } from '../highlight-state';
+import { DEFAULT_HIGHLIGHT_SLOTS } from '../highlight-state';
+import GenericTab from '../../tabs/generic-tab';
+import type { TabConfig } from '../../tokens/tier-model';
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeState(overrides: Partial<HighlightState> = {}): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    active: {},
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  state: HighlightState,
+  toggle: (cssVar: string) => void,
+  extra: Partial<HighlightContextValue> = {},
+): HighlightContextValue {
+  return { state, toggle, ...extra };
+}
+
+function renderWithCtx(
+  cssVar: string,
+  ctx: HighlightContextValue,
+): void {
+  act(() => {
+    render(
+      <HighlightContext.Provider value={ctx}>
+        <HighlightToggleButton cssVar={cssVar} />
+      </HighlightContext.Provider>,
+      container,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Null context — renders nothing
+// ---------------------------------------------------------------------------
+
+describe('HighlightToggleButton — null context', () => {
+  it('renders nothing when HighlightContext is null (no provider)', () => {
+    act(() => {
+      render(<HighlightToggleButton cssVar="--my-token" />, container);
+    });
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// With context — basic rendering
+// ---------------------------------------------------------------------------
+
+describe('HighlightToggleButton — with context', () => {
+  it('renders a div with role="button" when context is provided', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('[role="button"]');
+    expect(btn).not.toBeNull();
+  });
+
+  it('does NOT render a <button> element (hostile-host policy)', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('the div has tabIndex 0 for keyboard accessibility', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('[role="button"]') as HTMLElement;
+    expect(btn.tabIndex).toBe(0);
+  });
+
+  it('renders an SVG inside the button', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inactive state
+// ---------------------------------------------------------------------------
+
+describe('HighlightToggleButton — inactive', () => {
+  it('has class tokenpanel-highlight-toggle (no is-active) when inactive', () => {
+    const state = makeState({ active: {} });
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn).not.toBeNull();
+    expect(btn.classList.contains('is-active')).toBe(false);
+  });
+
+  it('has no inline color style when inactive', () => {
+    const state = makeState({ active: {} });
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn.style.color).toBe('');
+  });
+
+  it('title says "Highlight elements using …" when inactive', () => {
+    const state = makeState({ active: {} });
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn.title).toBe('Highlight elements using --my-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active state
+// ---------------------------------------------------------------------------
+
+describe('HighlightToggleButton — active', () => {
+  it('has is-active class when the cssVar is in state.active', () => {
+    const state = makeState({ active: { '--my-token': 0 } });
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn.classList.contains('is-active')).toBe(true);
+  });
+
+  it('applies inline color equal to the slot color when active', () => {
+    // slot index 0 color is '#ff2d2d'; jsdom normalizes hex to rgb
+    const state = makeState({ active: { '--my-token': 0 } });
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    // inline style has color set (non-empty)
+    expect(btn.style.color).not.toBe('');
+    // jsdom normalizes hex to rgb — verify the value matches the slot color
+    expect(btn.style.color).toBe('rgb(255, 45, 45)');
+  });
+
+  it('title says "Stop highlighting …" when active (no count)', () => {
+    const state = makeState({ active: { '--my-token': 0 } });
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn.title).toBe('Stop highlighting --my-token');
+  });
+
+  it('title includes count when matchCounts provided for active token', () => {
+    const state = makeState({ active: { '--my-token': 0 } });
+    const toggle = vi.fn();
+    renderWithCtx(
+      '--my-token',
+      makeCtx(state, toggle, { matchCounts: { '--my-token': 7 } }),
+    );
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn.title).toBe('Stop highlighting --my-token (7 elements)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Click / keyboard interaction
+// ---------------------------------------------------------------------------
+
+describe('HighlightToggleButton — interactions', () => {
+  it('click calls context.toggle with cssVar', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('[role="button"]') as HTMLElement;
+    act(() => btn.click());
+
+    expect(toggle).toHaveBeenCalledTimes(1);
+    expect(toggle).toHaveBeenCalledWith('--my-token');
+  });
+
+  it('Enter keydown calls toggle', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('[role="button"]') as HTMLElement;
+    act(() => {
+      btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    expect(toggle).toHaveBeenCalledTimes(1);
+    expect(toggle).toHaveBeenCalledWith('--my-token');
+  });
+
+  it('Space keydown calls toggle', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('[role="button"]') as HTMLElement;
+    act(() => {
+      btn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+
+    expect(toggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('other keydown (e.g. Tab) does NOT call toggle', () => {
+    const state = makeState();
+    const toggle = vi.fn();
+    renderWithCtx('--my-token', makeCtx(state, toggle));
+
+    const btn = container.querySelector('[role="button"]') as HTMLElement;
+    act(() => {
+      btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }));
+    });
+
+    expect(toggle).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GenericTab — eye button present on every row variant
+// ---------------------------------------------------------------------------
+
+const GENERIC_TAB_CONFIG: TabConfig = {
+  id: 'my-tab',
+  label: 'My Tab',
+  tiers: [
+    {
+      id: 'lengths',
+      label: 'Lengths',
+      items: [
+        {
+          id: 'gap-md',
+          cssVar: '--gap-md',
+          label: 'gap-md',
+          default: '16px',
+          type: { kind: 'length', min: 0, max: 64, step: 1, unit: 'px' },
+        },
+      ],
+    },
+    {
+      id: 'selects',
+      label: 'Selects',
+      items: [
+        {
+          id: 'display',
+          cssVar: '--display',
+          label: 'display',
+          default: 'block',
+          type: { kind: 'select', options: ['block', 'flex'] },
+        },
+      ],
+    },
+    {
+      id: 'texts',
+      label: 'Texts',
+      items: [
+        {
+          id: 'font-family',
+          cssVar: '--font-family',
+          label: 'font-family',
+          default: 'sans-serif',
+          type: { kind: 'text' },
+        },
+      ],
+    },
+    {
+      id: 'colors',
+      label: 'Colors',
+      items: [
+        {
+          id: 'brand-color',
+          cssVar: '--brand-color',
+          label: 'brand-color',
+          default: '#ff0000',
+          type: { kind: 'color' },
+        },
+      ],
+    },
+  ],
+};
+
+function noop() {}
+
+describe('GenericTab — eye button present on all row types', () => {
+  function renderGenericTab(ctx: HighlightContextValue): void {
+    act(() => {
+      render(
+        <HighlightContext.Provider value={ctx}>
+          <GenericTab
+            tab={GENERIC_TAB_CONFIG}
+            overrides={{}}
+            onChange={noop}
+          />
+        </HighlightContext.Provider>,
+        container,
+      );
+    });
+  }
+
+  it('length row has a tokenpanel-highlight-toggle button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderGenericTab(ctx);
+
+    const row = container.querySelector('[data-testid="tier-item-gap-md"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('select row has a tokenpanel-highlight-toggle button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderGenericTab(ctx);
+
+    const row = container.querySelector('[data-testid="tier-item-display"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('text row has a tokenpanel-highlight-toggle button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderGenericTab(ctx);
+
+    const row = container.querySelector('[data-testid="tier-item-font-family"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('color row has a tokenpanel-highlight-toggle button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderGenericTab(ctx);
+
+    const row = container.querySelector('[data-testid="tier-item-brand-color"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('no <button> elements in GenericTab render (hostile-host policy)', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderGenericTab(ctx);
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('clicking eye button on length row calls toggle with cssVar', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeState(), toggle);
+    renderGenericTab(ctx);
+
+    const row = container.querySelector('[data-testid="tier-item-gap-md"]') as HTMLElement;
+    const btn = row.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => btn.click());
+
+    expect(toggle).toHaveBeenCalledWith('--gap-md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _generic-item-editor (spacing/font/size tabs delegate to this)
+// ---------------------------------------------------------------------------
+
+import GenericItemEditor from '../../tabs/_generic-item-editor';
+import type { TierItem } from '../../tokens/tier-model';
+
+const SPACING_ITEM: TierItem = {
+  id: 'hsp-md',
+  cssVar: '--zd-spacing-hgap-md',
+  label: 'hsp-md',
+  default: '40px',
+  type: { kind: 'length', min: 0, max: 64, step: 1, unit: 'px' },
+};
+
+const FONT_ITEM: TierItem = {
+  id: 'text-base',
+  cssVar: '--zd-font-base-size',
+  label: 'text-base',
+  default: '1.4rem',
+  type: { kind: 'length', min: 0.5, max: 4, step: 0.05, unit: 'rem' },
+};
+
+const SIZE_ITEM: TierItem = {
+  id: 'radius-lg',
+  cssVar: '--radius-lg',
+  label: 'radius-lg',
+  default: '8px',
+  type: { kind: 'length', min: 0, max: 32, step: 1, unit: 'px' },
+};
+
+describe('_generic-item-editor — eye button present (spacing/font/size via this editor)', () => {
+  function renderEditor(item: TierItem, ctx: HighlightContextValue): void {
+    act(() => {
+      render(
+        <HighlightContext.Provider value={ctx}>
+          <GenericItemEditor item={item} value={item.default} onChange={noop} />
+        </HighlightContext.Provider>,
+        container,
+      );
+    });
+  }
+
+  it('spacing first row (length) has the eye button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderEditor(SPACING_ITEM, ctx);
+
+    expect(container.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('font first row (length) has the eye button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderEditor(FONT_ITEM, ctx);
+
+    expect(container.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('size first row (length) has the eye button', () => {
+    const ctx = makeCtx(makeState(), vi.fn());
+    renderEditor(SIZE_ITEM, ctx);
+
+    expect(container.querySelector('.tokenpanel-highlight-toggle')).not.toBeNull();
+  });
+
+  it('clicking the button in editor calls toggle with cssVar', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeState(), toggle);
+    renderEditor(SPACING_ITEM, ctx);
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => btn.click());
+
+    expect(toggle).toHaveBeenCalledWith('--zd-spacing-hgap-md');
+  });
+
+  it('active state in editor: button has is-active + inline color', () => {
+    // slot 0 color is '#ff2d2d'; jsdom normalizes hex to rgb
+    const state = makeState({ active: { '--zd-spacing-hgap-md': 0 } });
+    const ctx = makeCtx(state, vi.fn());
+    renderEditor(SPACING_ITEM, ctx);
+
+    const btn = container.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    expect(btn.classList.contains('is-active')).toBe(true);
+    expect(btn.style.color).toBe('rgb(255, 45, 45)');
+  });
+});

--- a/packages/zudo-design-token-panel/src/highlight/find-elements.ts
+++ b/packages/zudo-design-token-panel/src/highlight/find-elements.ts
@@ -1,0 +1,341 @@
+/**
+ * findElementsUsingToken — walks document.styleSheets and the DOM to find
+ * every element that uses a given CSS custom property (including via
+ * custom-property alias chains).
+ *
+ * Panel-internal elements (inside .tokenpanel-shell,
+ * [data-design-token-panel-modal], or #tokenpanel-highlight-mount) are
+ * excluded from the returned set.
+ */
+
+export interface FindElementsResult {
+  elements: Element[];
+  warnings: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a CSS custom-property name so it can be embedded literally in a
+ * RegExp. Custom-property names only legitimately contain [A-Za-z0-9_-] in
+ * practice, but we escape everything else defensively.
+ */
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build a regex that matches `var(--TOKEN_NAME` at the correct right boundary,
+ * so --brand does not match --brand-fg.
+ * Pattern: /var\(\s*--TOKEN(?![\w-])/
+ */
+function buildVarRegex(cssVarName: string): RegExp {
+  // cssVarName already includes leading dashes, e.g. "--brand"
+  return new RegExp(`var\\(\\s*${escapeForRegex(cssVarName)}(?![\\w-])`);
+}
+
+/**
+ * Paren-aware comma splitter. Only splits on commas at depth 0 so that
+ * selectors like `.a:is(.b, .c)` are not broken at the inner comma.
+ */
+function splitSelectorList(selectorText: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < selectorText.length; i++) {
+    const ch = selectorText[i];
+    if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+    } else if (ch === ',' && depth === 0) {
+      parts.push(selectorText.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(selectorText.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+/** Strip trailing pseudo-element (e.g. ::before, ::after). */
+const PSEUDO_ELEMENT_RE = /::[\w-]+(\([^)]*\))?$/;
+
+/** Trailing state pseudo-class patterns that are safe to strip. */
+const STATE_PSEUDO_RE =
+  /:(?:hover|focus|focus-visible|focus-within|active|visited|link|target)(\([^)]*\))?$/;
+
+/**
+ * Clean a single selector fragment so it can be used in querySelectorAll to
+ * match real elements rather than ephemeral states:
+ *   - remove trailing pseudo-element
+ *   - remove trailing state pseudo-classes (looping until none remain)
+ *   - leave functional pseudo-classes like :not(), :is(), :where(), :has() intact
+ */
+function cleanSelectorFragment(fragment: string): string {
+  let s = fragment;
+  // Strip trailing pseudo-element first
+  s = s.replace(PSEUDO_ELEMENT_RE, '').trimEnd();
+  // Strip trailing state pseudo-classes in a loop
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(STATE_PSEUDO_RE, '').trimEnd();
+  } while (s !== prev);
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// Alias map builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Selectors that define token aliases for the whole document.
+ * Only :root, html, or [data-theme="..."] (any value) qualify.
+ */
+function isThemeSelector(sel: string): boolean {
+  const s = sel.trim();
+  if (s === ':root' || s === 'html') return true;
+  // matches [data-theme="..."] or [data-theme='...'] or [data-theme=anything]
+  if (/^\[data-theme\s*=/.test(s)) return true;
+  return false;
+}
+
+/**
+ * Walk every CSSStyleRule in the sheet's flat rule list and collect alias
+ * declarations of the form:
+ *   --TARGET: var(--SOURCE [, fallback])
+ * on :root / html / [data-theme="..."] selectors.
+ *
+ * Returns Map<sourceVar, Set<targetVar>> where both include leading "--".
+ *
+ * Note: we pass `rules` (already extracted with a try/catch by the caller)
+ * rather than the CSSStyleSheet itself to keep recursion clean.
+ */
+function collectAliases(
+  rules: CSSRuleList | Iterable<CSSRule>,
+  out: Map<string, Set<string>>,
+): void {
+  for (const rule of rules) {
+    // Recurse into grouping rules (@media, @supports, @layer block, @container)
+    // using duck-typing: CSSLayerStatementRule (@layer foo, bar;) has no
+    // .cssRules so the duck-typed check filters it automatically.
+    if ('cssRules' in rule && rule.cssRules) {
+      collectAliases(rule.cssRules as CSSRuleList, out);
+      continue;
+    }
+
+    if (!(rule instanceof CSSStyleRule)) continue;
+
+    // Split on top-level commas; check each fragment for a theme selector.
+    const fragments = splitSelectorList(rule.selectorText);
+    const isTheme = fragments.some(isThemeSelector);
+    if (!isTheme) continue;
+
+    const { style } = rule;
+    for (let i = 0; i < style.length; i++) {
+      const prop = style[i];
+      if (!prop.startsWith('--')) continue; // only custom properties
+      const val = style.getPropertyValue(prop).trim();
+      // Match: var(--SOURCE_VAR ...)
+      const m = /^var\(\s*(--[\w-]+)/.exec(val);
+      if (!m) continue;
+      const source = m[1];
+      const target = prop;
+      if (!out.has(source)) out.set(source, new Set());
+      out.get(source)!.add(target);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BFS forward expansion
+// ---------------------------------------------------------------------------
+
+const MAX_ALIAS_DEPTH = 5;
+
+/**
+ * Starting from rootVar (e.g. "--brand"), compute all custom properties that
+ * are reachable via the alias chain within MAX_ALIAS_DEPTH hops. The root
+ * itself is always included.
+ */
+function expandForward(rootVar: string, aliasMap: Map<string, Set<string>>): Set<string> {
+  const reachable = new Set<string>([rootVar]);
+  const queue: Array<{ var: string; depth: number }> = [{ var: rootVar, depth: 0 }];
+
+  while (queue.length > 0) {
+    const { var: current, depth } = queue.shift()!;
+    if (depth >= MAX_ALIAS_DEPTH) continue;
+    const targets = aliasMap.get(current);
+    if (!targets) continue;
+    for (const t of targets) {
+      if (!reachable.has(t)) {
+        reachable.add(t);
+        queue.push({ var: t, depth: depth + 1 });
+      }
+    }
+  }
+
+  return reachable;
+}
+
+// ---------------------------------------------------------------------------
+// Rule walker
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk rules in a stylesheet, collecting DOM elements that reference any
+ * token in forwardSet. Modifies `elements` (Set) and `warnings` (Array)
+ * in-place.
+ */
+function walkRules(
+  rules: CSSRuleList | Iterable<CSSRule>,
+  forwardSet: Set<string>,
+  regexCache: Map<string, RegExp>,
+  elements: Set<Element>,
+  warnings: string[],
+): void {
+  for (const rule of rules) {
+    // Recurse into grouping rules — duck-type on cssRules to avoid depending
+    // on CSSGroupingRule being exposed in every test environment.
+    if ('cssRules' in rule && rule.cssRules) {
+      walkRules(rule.cssRules as CSSRuleList, forwardSet, regexCache, elements, warnings);
+      continue;
+    }
+
+    if (!(rule instanceof CSSStyleRule)) continue;
+
+    const { style, selectorText } = rule;
+    let ruleMatchesToken = false;
+
+    // Enumerate properties (not re-parse cssText) for accurate value access.
+    for (let i = 0; i < style.length; i++) {
+      const prop = style[i];
+      const val = style.getPropertyValue(prop);
+      for (const cssVar of forwardSet) {
+        let re = regexCache.get(cssVar);
+        if (!re) {
+          re = buildVarRegex(cssVar);
+          regexCache.set(cssVar, re);
+        }
+        if (re.test(val)) {
+          ruleMatchesToken = true;
+          break;
+        }
+      }
+      if (ruleMatchesToken) break;
+    }
+
+    if (!ruleMatchesToken) continue;
+
+    // Collect matching DOM elements via cleaned selector fragments.
+    const fragments = splitSelectorList(selectorText);
+    for (const fragment of fragments) {
+      const cleaned = cleanSelectorFragment(fragment);
+      if (!cleaned) continue;
+      try {
+        const found = document.querySelectorAll(cleaned);
+        for (const el of found) {
+          elements.add(el);
+        }
+      } catch {
+        // Invalid selector after cleaning — skip silently.
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Panel-internal selectors whose elements must be excluded from results. */
+const PANEL_EXCLUSION_SELECTOR =
+  '.tokenpanel-shell, [data-design-token-panel-modal], #tokenpanel-highlight-mount';
+
+/**
+ * Find all DOM elements that use the given CSS custom property, either
+ * directly in a stylesheet rule or via a custom-property alias chain (depth ≤ 5),
+ * or via an inline `style` attribute.
+ *
+ * @param cssVar - The full custom-property name including leading dashes,
+ *   e.g. "--brand". Accepts "var(--brand)" defensively (wrapper is stripped).
+ */
+export function findElementsUsingToken(cssVar: string): FindElementsResult {
+  // Defensive normalization: strip whitespace and the var() wrapper if present.
+  let normalized = cssVar.trim();
+  if (normalized.startsWith('var(')) {
+    // strip "var(" prefix and trailing ")"
+    normalized = normalized.replace(/^var\(\s*/, '').replace(/\s*\)$/, '').trim();
+  }
+
+  const warnings: string[] = [];
+  const aliasMap: Map<string, Set<string>> = new Map();
+
+  // Phase 1: build alias map from all accessible stylesheets.
+  for (const sheet of document.styleSheets) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      // Cross-origin — record warning and skip.
+      const href = (sheet as CSSStyleSheet).href ?? '(unknown)';
+      warnings.push(`Cross-origin stylesheet skipped: ${href}`);
+      continue;
+    }
+    collectAliases(rules, aliasMap);
+  }
+
+  // Phase 2: BFS expansion to get all aliases of the target token.
+  const forwardSet = expandForward(normalized, aliasMap);
+
+  // Phase 3: walk rules to find matching elements.
+  const regexCache = new Map<string, RegExp>();
+  const elements = new Set<Element>();
+
+  for (const sheet of document.styleSheets) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      // Already logged in phase 1; skip silently here.
+      continue;
+    }
+    walkRules(rules, forwardSet, regexCache, elements, warnings);
+  }
+
+  // Phase 4: inline-style hybrid pass — catch elements whose style attribute
+  // contains var(--TOKEN_NAME) without any stylesheet rule.
+  for (const cssVar of forwardSet) {
+    // Fast pre-filter via attribute substring, then post-filter with the
+    // right-boundary regex to avoid false positives (e.g. --brand matching
+    // --brand-fg).
+    const re = buildVarRegex(cssVar);
+    // Encode for the attribute substring selector (avoid quoting issues).
+    const attrSel = `[style*="var(${cssVar})"]`;
+    let candidates: NodeListOf<Element>;
+    try {
+      candidates = document.querySelectorAll(attrSel);
+    } catch {
+      continue;
+    }
+    for (const el of candidates) {
+      const styleVal = el.getAttribute('style') ?? '';
+      if (re.test(styleVal)) {
+        elements.add(el);
+      }
+    }
+  }
+
+  // Phase 5: panel-exclusion filter.
+  const filtered: Element[] = [];
+  for (const el of elements) {
+    const panelAncestor = el.closest(PANEL_EXCLUSION_SELECTOR);
+    if (panelAncestor !== null) continue;
+    filtered.push(el);
+  }
+
+  return { elements: filtered, warnings };
+}

--- a/packages/zudo-design-token-panel/src/highlight/highlight-context.ts
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-context.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'preact';
+import type { HighlightState, HighlightSlotSpec } from './highlight-state';
+
+export interface HighlightContextValue {
+  state: HighlightState;
+  toggle: (cssVar: string) => void;
+  setSlot?: (index: number, partial: Partial<HighlightSlotSpec>) => void;
+  reset?: () => void;
+  matchCounts?: Record<string, number>;
+}
+
+export const HighlightContext = createContext<HighlightContextValue | null>(null);

--- a/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
@@ -1,0 +1,244 @@
+/**
+ * HighlightOrchestrator — integration layer for the highlight feature.
+ *
+ * Responsibilities:
+ * 1. Lifts and persists HighlightState.
+ * 2. Provides HighlightContext to all descendants.
+ * 3. Mounts an overlay portal at document.body (above the panel-closed gate).
+ * 4. Observes document.head for stylesheet changes so newly injected CSS is
+ *    picked up by re-resolving elements.
+ * 5. Handles astro:after-swap — recreates the portal mount and re-attaches the
+ *    MutationObserver when Astro replaces the body/head.
+ *
+ * Self-contained — panel.tsx wraps its existing JSX in this component so the
+ * overlay persists even when the panel is closed.
+ */
+
+import { useState, useCallback, useMemo, useEffect, useRef } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+import { createPortal } from 'preact/compat';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from './highlight-toggle-button';
+import {
+  loadHighlightState,
+  saveHighlightState,
+  toggleHighlight,
+  setSlot as setSlotHelper,
+  resetSlots,
+  type HighlightState,
+  type HighlightSlotSpec,
+} from './highlight-state';
+import { findElementsUsingToken } from './find-elements';
+import { HighlightOverlay, type HighlightOverlayItem } from './highlight-overlay';
+
+// ---------------------------------------------------------------------------
+// Portal mount helpers
+// ---------------------------------------------------------------------------
+
+/** ID also referenced in find-elements.ts PANEL_EXCLUSION_SELECTOR. Must match exactly. */
+const PORTAL_MOUNT_ID = 'tokenpanel-highlight-mount';
+
+/**
+ * Get or create the singleton portal mount <div> at document.body.
+ * Idempotent: if an element with the id already exists it is returned as-is.
+ */
+function getOrCreateMountNode(): HTMLDivElement {
+  const existing = document.getElementById(PORTAL_MOUNT_ID) as HTMLDivElement | null;
+  if (existing) return existing;
+
+  const node = document.createElement('div');
+  node.id = PORTAL_MOUNT_ID;
+  document.body.appendChild(node);
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// OverlayPortal
+// ---------------------------------------------------------------------------
+
+interface OverlayPortalProps {
+  items: ReadonlyArray<HighlightOverlayItem>;
+}
+
+function OverlayPortal({ items }: OverlayPortalProps) {
+  // mountNodeRef persists the DOM node so we can check isConnected.
+  const mountNodeRef = useRef<HTMLDivElement | null>(null);
+  // Bump to force re-render when mountNode needs to be recreated.
+  const [mountVersion, setMountVersion] = useState(0);
+
+  // Create or retrieve the portal mount on first render.
+  if (mountNodeRef.current === null || !mountNodeRef.current.isConnected) {
+    mountNodeRef.current = getOrCreateMountNode();
+  }
+
+  // astro:after-swap — Astro replaces document.body on view transitions.
+  // After swap the mount node may be detached; recreate if needed.
+  useEffect(() => {
+    function handleAfterSwap() {
+      if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
+        mountNodeRef.current = getOrCreateMountNode();
+        setMountVersion((v) => v + 1);
+      }
+    }
+    window.addEventListener('astro:after-swap', handleAfterSwap);
+    return () => {
+      window.removeEventListener('astro:after-swap', handleAfterSwap);
+    };
+  }, []);
+
+  // Suppress the linting rule that complains about mountVersion not being used —
+  // it IS used: it's a dependency that forces this component to re-evaluate the
+  // portal target when the mountNode is recreated.
+  void mountVersion;
+
+  return createPortal(<HighlightOverlay items={items} />, mountNodeRef.current);
+}
+
+// ---------------------------------------------------------------------------
+// HighlightOrchestrator
+// ---------------------------------------------------------------------------
+
+export function HighlightOrchestrator({ children }: { children: ComponentChildren }) {
+  const [state, setState] = useState<HighlightState>(loadHighlightState);
+
+  // Track stylesheet version for cache-busting when new sheets are injected.
+  const [stylesheetVersion, setStylesheetVersion] = useState(0);
+
+  // -------------------------------------------------------------------------
+  // State mutation helpers
+  // -------------------------------------------------------------------------
+
+  const toggle = useCallback((cssVar: string) => {
+    setState((s) => {
+      const next = toggleHighlight(s, cssVar);
+      saveHighlightState(next);
+      return next;
+    });
+  }, []);
+
+  const setSlot = useCallback((index: number, partial: Partial<HighlightSlotSpec>) => {
+    setState((s) => {
+      const next = setSlotHelper(s, index, partial);
+      saveHighlightState(next);
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setState((s) => {
+      const next = resetSlots(s);
+      saveHighlightState(next);
+      return next;
+    });
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Stylesheet MutationObserver — bumps stylesheetVersion when <style> or
+  // <link rel="stylesheet"> nodes are added/removed from document.head.
+  // Re-attaches on astro:after-swap if head is replaced.
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    let observer: MutationObserver | null = null;
+
+    function attachObserver() {
+      if (observer) observer.disconnect();
+      observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          for (const node of mutation.addedNodes) {
+            if (isStylesheetNode(node)) {
+              setStylesheetVersion((v) => v + 1);
+              return;
+            }
+          }
+          for (const node of mutation.removedNodes) {
+            if (isStylesheetNode(node)) {
+              setStylesheetVersion((v) => v + 1);
+              return;
+            }
+          }
+        }
+      });
+      observer.observe(document.head, { childList: true });
+    }
+
+    attachObserver();
+
+    function handleAfterSwap() {
+      // Re-attach observer to the new head after Astro swaps the page.
+      attachObserver();
+    }
+    window.addEventListener('astro:after-swap', handleAfterSwap);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener('astro:after-swap', handleAfterSwap);
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Resolve items + matchCounts via useMemo
+  // Recomputes whenever active tokens, slot specs, or stylesheets change.
+  // -------------------------------------------------------------------------
+
+  const { items, matchCounts } = useMemo(() => {
+    // stylesheetVersion is captured to invalidate cache on new sheets.
+    void stylesheetVersion;
+
+    const resolvedItems: HighlightOverlayItem[] = [];
+    const counts: Record<string, number> = {};
+
+    for (const [cssVar, slotIdx] of Object.entries(state.active)) {
+      const result = findElementsUsingToken(cssVar);
+
+      if (result.warnings.length > 0) {
+        for (const warning of result.warnings) {
+          console.warn('[zudo-design-token-panel] highlight:', warning);
+        }
+      }
+
+      const elements = result.elements;
+      counts[cssVar] = elements.length;
+
+      const slot = state.slots[slotIdx];
+      if (!slot) continue;
+
+      for (const element of elements) {
+        resolvedItems.push({ element, slot });
+      }
+    }
+
+    return { items: resolvedItems, matchCounts: counts };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.active, state.slots, stylesheetVersion]);
+
+  // -------------------------------------------------------------------------
+  // Context value
+  // -------------------------------------------------------------------------
+
+  const ctxValue = useMemo<HighlightContextValue>(
+    () => ({ state, toggle, setSlot, reset, matchCounts }),
+    [state, toggle, setSlot, reset, matchCounts],
+  );
+
+  return (
+    <>
+      <HighlightContext.Provider value={ctxValue}>{children}</HighlightContext.Provider>
+      <OverlayPortal items={items} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isStylesheetNode(node: Node): boolean {
+  if (node.nodeType !== Node.ELEMENT_NODE) return false;
+  const el = node as Element;
+  if (el.tagName === 'STYLE') return true;
+  if (el.tagName === 'LINK' && el.getAttribute('rel') === 'stylesheet') return true;
+  return false;
+}

--- a/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
@@ -43,8 +43,10 @@ const PORTAL_MOUNT_ID = 'tokenpanel-highlight-mount';
 /**
  * Get or create the singleton portal mount <div> at document.body.
  * Idempotent: if an element with the id already exists it is returned as-is.
+ * SSR-safe: returns null when document is unavailable (server-render / prerender).
  */
-function getOrCreateMountNode(): HTMLDivElement {
+function getOrCreateMountNode(): HTMLDivElement | null {
+  if (typeof document === 'undefined') return null;
   const existing = document.getElementById(PORTAL_MOUNT_ID) as HTMLDivElement | null;
   if (existing) return existing;
 
@@ -63,36 +65,33 @@ interface OverlayPortalProps {
 }
 
 function OverlayPortal({ items }: OverlayPortalProps) {
-  // mountNodeRef persists the DOM node so we can check isConnected.
   const mountNodeRef = useRef<HTMLDivElement | null>(null);
-  // Bump to force re-render when mountNode needs to be recreated.
   const [mountVersion, setMountVersion] = useState(0);
 
-  // Create or retrieve the portal mount on first render.
-  if (mountNodeRef.current === null || !mountNodeRef.current.isConnected) {
-    mountNodeRef.current = getOrCreateMountNode();
-  }
-
-  // astro:after-swap — Astro replaces document.body on view transitions.
-  // After swap the mount node may be detached; recreate if needed.
   useEffect(() => {
+    if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
+      mountNodeRef.current = getOrCreateMountNode();
+      setMountVersion((v) => v + 1);
+    }
     function handleAfterSwap() {
       if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
         mountNodeRef.current = getOrCreateMountNode();
         setMountVersion((v) => v + 1);
       }
     }
-    window.addEventListener('astro:after-swap', handleAfterSwap);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('astro:after-swap', handleAfterSwap);
+    }
     return () => {
-      window.removeEventListener('astro:after-swap', handleAfterSwap);
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('astro:after-swap', handleAfterSwap);
+      }
     };
   }, []);
 
-  // Suppress the linting rule that complains about mountVersion not being used —
-  // it IS used: it's a dependency that forces this component to re-evaluate the
-  // portal target when the mountNode is recreated.
   void mountVersion;
 
+  if (!mountNodeRef.current) return null;
   return createPortal(<HighlightOverlay items={items} />, mountNodeRef.current);
 }
 
@@ -169,12 +168,20 @@ export function HighlightOrchestrator({ children }: { children: ComponentChildre
     function handleAfterSwap() {
       // Re-attach observer to the new head after Astro swaps the page.
       attachObserver();
+      // Bump version to invalidate the per-cssVar element cache — Astro view
+      // transitions replace document.body, so every previously matched Element
+      // reference is now detached.
+      setStylesheetVersion((v) => v + 1);
     }
-    window.addEventListener('astro:after-swap', handleAfterSwap);
+    if (typeof window !== 'undefined') {
+      window.addEventListener('astro:after-swap', handleAfterSwap);
+    }
 
     return () => {
       observer?.disconnect();
-      window.removeEventListener('astro:after-swap', handleAfterSwap);
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('astro:after-swap', handleAfterSwap);
+      }
     };
   }, []);
 

--- a/packages/zudo-design-token-panel/src/highlight/highlight-overlay.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-overlay.tsx
@@ -1,0 +1,163 @@
+/**
+ * HighlightOverlay — absolutely-positioned div rings around host elements.
+ *
+ * Renders one overlay <div> per {element, slot} item, using
+ * getBoundingClientRect() + position:fixed so the outlines track the element
+ * regardless of page scroll or layout reflow.
+ *
+ * Reposition strategy
+ * -------------------
+ * A single RAF loop runs while items.length > 0.  Each tick reads
+ * getBoundingClientRect() for every item and updates the corresponding overlay
+ * div's inline style IMPERATIVELY (direct DOM mutation — no Preact re-render
+ * per frame). This keeps animation cost O(items) DOM writes per frame rather
+ * than O(items) VDOM diffs.
+ *
+ * Hostile-host fallback
+ * ---------------------
+ * Some hosts reset `outline: none !important`.  We also apply
+ * `box-shadow: inset 0 0 0 <w>px <color>` so the visual cue survives even
+ * when outline is killed.
+ *
+ * Self-contained — does NOT manage its own portal mount.
+ * The orchestrator (#232) owns where in the DOM this component is rendered.
+ */
+
+import { useEffect, useRef } from 'preact/hooks';
+import type { JSX } from 'preact';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Inline copy of HighlightSlotSpec.  After sub-issue #227 merges, the
+ * orchestrator (#232) can import from either source — the shapes are
+ * identical so TypeScript will accept either.
+ */
+export interface HighlightSlotSpec {
+  color: string;
+  outlineWidth: number;
+}
+
+export interface HighlightOverlayItem {
+  element: Element;
+  slot: HighlightSlotSpec;
+}
+
+export interface HighlightOverlayProps {
+  items: ReadonlyArray<HighlightOverlayItem>;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Cap to avoid runaway DOM cost with huge item lists. */
+const MAX_ITEMS = 200;
+
+/** Below panel shell (z-index 50) and resize grip (60), above host content. */
+const OVERLAY_Z_INDEX = 49;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildOverlayStyle(
+  rect: DOMRect,
+  slot: HighlightSlotSpec,
+): Partial<CSSStyleDeclaration> {
+  return {
+    position: 'fixed',
+    top: `${rect.top}px`,
+    left: `${rect.left}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+    outline: `${slot.outlineWidth}px solid ${slot.color}`,
+    outlineOffset: '-1px',
+    // Hostile-host fallback: some hosts apply `outline: none !important`.
+    // box-shadow inset draws the same ring without relying on outline.
+    boxShadow: `inset 0 0 0 ${slot.outlineWidth}px ${slot.color}`,
+    pointerEvents: 'none',
+    zIndex: String(OVERLAY_Z_INDEX),
+    boxSizing: 'border-box',
+  };
+}
+
+function applyStyle(el: HTMLDivElement, style: Partial<CSSStyleDeclaration>): void {
+  for (const key of Object.keys(style) as Array<keyof CSSStyleDeclaration>) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el.style as any)[key] = style[key];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function HighlightOverlay({ items }: HighlightOverlayProps): JSX.Element | null {
+  const visibleItems = items.length > MAX_ITEMS ? items.slice(0, MAX_ITEMS) : items;
+
+  // Warn once when the list exceeds the cap.  A ref prevents the warning from
+  // firing on every parent re-render while the list stays oversized.
+  const warnedRef = useRef(false);
+  if (items.length > MAX_ITEMS && !warnedRef.current) {
+    warnedRef.current = true;
+    console.warn(
+      `HighlightOverlay: received ${items.length} items (max ${MAX_ITEMS}). ` +
+        `Only the first ${MAX_ITEMS} overlays will be rendered.`,
+    );
+  }
+  // Reset warn flag when list drops back below cap.
+  if (items.length <= MAX_ITEMS) {
+    warnedRef.current = false;
+  }
+
+  // One ref per visible item — stores the rendered overlay div.
+  const overlayRefs = useRef<Array<HTMLDivElement | null>>([]);
+
+  // RAF loop — updates overlay positions imperatively each frame.
+  useEffect(() => {
+    if (visibleItems.length === 0) return;
+
+    let rafId: number;
+
+    function tick() {
+      for (let i = 0; i < visibleItems.length; i++) {
+        const divEl = overlayRefs.current[i];
+        if (!divEl) continue;
+        const rect = visibleItems[i].element.getBoundingClientRect();
+        applyStyle(divEl, buildOverlayStyle(rect, visibleItems[i].slot));
+      }
+      rafId = requestAnimationFrame(tick);
+    }
+
+    rafId = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+    };
+  }, [visibleItems]);
+
+  if (visibleItems.length === 0) return null;
+
+  return (
+    <>
+      {visibleItems.map((item, i) => {
+        const rect = item.element.getBoundingClientRect();
+        const style = buildOverlayStyle(rect, item.slot);
+        return (
+          <div
+            key={i}
+            className="tokenpanel-highlight-overlay"
+            aria-hidden="true"
+            ref={(el) => {
+              overlayRefs.current[i] = el as HTMLDivElement | null;
+            }}
+            style={style as JSX.CSSProperties}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
@@ -1,0 +1,188 @@
+/**
+ * HighlightSettingsPopover — variation-14 design.
+ *
+ * A 4-column row grid showing 10 highlight slots:
+ *   [num] [ring swatch] [token name / "available"] [slider + Npx readout]
+ *
+ * Footer: "Reset to defaults" button.
+ *
+ * Must be rendered inside a HighlightContext.Provider. Gracefully returns
+ * null if context is absent (pre-#232 worktrees, or during merges).
+ */
+
+import { useContext, useRef, useState } from 'preact/compat';
+import type { JSX } from 'preact';
+import { RoleButton } from '../controls/role-button';
+import { ColorPicker, getFixedPopoverStyle, usePopoverClose } from '../components/color-picker/index';
+import { HighlightContext } from './highlight-context';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface HighlightSettingsPopoverProps {
+  /** The anchor element (gear button) for initial positioning. */
+  anchorRef: React.RefObject<HTMLElement | null>;
+  /** Called when the popover requests to close. */
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function HighlightSettingsPopover({
+  anchorRef,
+  onClose,
+}: HighlightSettingsPopoverProps): JSX.Element | null {
+  const ctx = useContext(HighlightContext);
+
+  // Track which slot's ring is being edited in the ColorPicker.
+  const [editingSlotIndex, setEditingSlotIndex] = useState<number | null>(null);
+
+  // Refs for each row's ring element — used as ColorPicker anchors.
+  const ringRefs = useRef<(HTMLDivElement | null)[]>(Array.from({ length: 10 }, () => null));
+
+  // Ref for the popover container (used by usePopoverClose).
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // ColorPicker anchor ref points to the currently-editing ring element.
+  // Must be declared here (before any early return) to satisfy Rules of Hooks.
+  const colorPickerAnchorRef = useRef<HTMLDivElement | null>(null);
+
+  usePopoverClose(containerRef, onClose);
+
+  // Graceful null guard: no context = no popover.
+  if (!ctx) return null;
+
+  const { state, setSlot, reset } = ctx;
+
+  // Build reverse map: slotIndex → cssVar (first match wins).
+  const slotToCssVar: Record<number, string> = {};
+  for (const [cssVar, slotIdx] of Object.entries(state.active)) {
+    if (!(slotIdx in slotToCssVar)) {
+      slotToCssVar[slotIdx] = cssVar;
+    }
+  }
+
+  // Compute the popover position anchored to the gear button.
+  // Estimated size: 440px wide, ~520px tall (10 rows × 44px + header + footer).
+  const popoverStyle = getFixedPopoverStyle(anchorRef.current ?? null, 440, 520);
+
+  // Point colorPickerAnchorRef at the active ring element (safe here — past the null guard).
+  if (editingSlotIndex !== null) {
+    colorPickerAnchorRef.current = ringRefs.current[editingSlotIndex] ?? null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-label="Highlight outline settings"
+      className="tokenpanel-highlight-settings-popover"
+      style={{ ...popoverStyle, zIndex: 65 }}
+    >
+      {/* Header */}
+      <div className="tokenpanel-highlight-settings-header">
+        Highlight outline settings
+      </div>
+
+      {/* Slot list */}
+      <div className="tokenpanel-highlight-settings-list">
+        {state.slots.map((slot, index) => {
+          const cssVar = slotToCssVar[index];
+          const isActive = cssVar !== undefined;
+          const ringBorder = `${slot.outlineWidth}px solid ${slot.color}`;
+
+          return (
+            <div
+              key={index}
+              className="tokenpanel-highlight-settings-row"
+            >
+              {/* Column 1: slot number */}
+              <div className="tokenpanel-highlight-settings-num">
+                {index + 1}
+              </div>
+
+              {/* Column 2: ring swatch — clicking opens ColorPicker */}
+              <div
+                ref={(el) => {
+                  ringRefs.current[index] = el;
+                }}
+                className="tokenpanel-highlight-settings-ring"
+                style={{ border: ringBorder }}
+                role="button"
+                tabIndex={0}
+                aria-label={`Edit color for slot ${index + 1}`}
+                onClick={() => setEditingSlotIndex(editingSlotIndex === index ? null : index)}
+                onKeyDown={(e: KeyboardEvent) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setEditingSlotIndex(editingSlotIndex === index ? null : index);
+                  }
+                }}
+              />
+
+              {/* Column 3: token name or "available" */}
+              <div
+                className={
+                  isActive
+                    ? 'tokenpanel-highlight-settings-name is-active'
+                    : 'tokenpanel-highlight-settings-name'
+                }
+              >
+                {isActive ? cssVar : 'available'}
+              </div>
+
+              {/* Column 4: width slider + readout */}
+              <div className="tokenpanel-highlight-settings-width">
+                <input
+                  type="range"
+                  min={1}
+                  max={10}
+                  step={1}
+                  value={slot.outlineWidth}
+                  aria-label={`Outline width for slot ${index + 1}`}
+                  className="tokenpanel-highlight-settings-slider"
+                  onInput={(e) => {
+                    if (setSlot) {
+                      setSlot(index, { outlineWidth: Number((e.currentTarget as HTMLInputElement).value) });
+                    }
+                  }}
+                />
+                <div className="tokenpanel-highlight-settings-px">
+                  {slot.outlineWidth}px
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="tokenpanel-highlight-settings-footer">
+        <RoleButton
+          onClick={() => reset && reset()}
+          className="tokenpanel-highlight-settings-reset-btn"
+        >
+          Reset to defaults
+        </RoleButton>
+      </div>
+
+      {/* ColorPicker for editing a slot color — renders when editingSlotIndex is set */}
+      {editingSlotIndex !== null && (
+        <ColorPicker
+          color={state.slots[editingSlotIndex]?.color ?? '#ffffff'}
+          onChange={(hex) => {
+            if (setSlot && editingSlotIndex !== null) {
+              setSlot(editingSlotIndex, { color: hex });
+            }
+          }}
+          label={`Slot ${editingSlotIndex + 1} color`}
+          anchorRef={colorPickerAnchorRef as React.RefObject<HTMLElement | null>}
+          onClose={() => setEditingSlotIndex(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/zudo-design-token-panel/src/highlight/highlight-state.ts
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-state.ts
@@ -1,0 +1,193 @@
+/**
+ * Highlight state slice — reservation-sheet model.
+ *
+ * 10 colour slots ({color, outlineWidth}) are pre-defined. A cssVar can be
+ * mapped to a slot (0..9) via toggleHighlight. The slot is reserved until
+ * the same cssVar is toggled off, giving a stable colour across inspect
+ * sessions (the "reservation-sheet" property: slot 2 always means the same
+ * colour regardless of toggle order).
+ *
+ * Persistence is split:
+ *   slots  → localStorage  (survives full page reload — user colour edits kept)
+ *   active → sessionStorage (cleared on reload — inspection set is ephemeral)
+ */
+
+import { getPanelConfig } from '../config/panel-config';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface HighlightSlotSpec {
+  color: string;
+  outlineWidth: number;
+}
+
+export interface HighlightState {
+  /** Fixed-length array of 10 slot specs. */
+  slots: HighlightSlotSpec[];
+  /** cssVar → slotIndex (0..9) for every currently-highlighted token. */
+  active: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Default slots
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_HIGHLIGHT_SLOTS: HighlightSlotSpec[] = [
+  { color: '#ff2d2d', outlineWidth: 2 }, // red
+  { color: '#ff2dcf', outlineWidth: 2 }, // pink
+  { color: '#2dd4ff', outlineWidth: 2 }, // skyblue
+  { color: '#ffa92d', outlineWidth: 2 }, // orange
+  { color: '#2dff5b', outlineWidth: 2 }, // green
+  { color: '#a92dff', outlineWidth: 2 }, // purple
+  { color: '#ff2d6e', outlineWidth: 2 }, // magenta-pink
+  { color: '#2dffd1', outlineWidth: 2 }, // mint
+  { color: '#ffe92d', outlineWidth: 2 }, // yellow
+  { color: '#2d6eff', outlineWidth: 2 }, // blue
+];
+
+// ---------------------------------------------------------------------------
+// Storage key helpers (read prefix at call-time — never at module init)
+// ---------------------------------------------------------------------------
+
+function storageKey_highlightSlots(): string {
+  return `${getPanelConfig().storagePrefix}-highlight-slots`;
+}
+
+function storageKey_highlightActive(): string {
+  return `${getPanelConfig().storagePrefix}-highlight-active`;
+}
+
+// ---------------------------------------------------------------------------
+// Pure state helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the lowest slot index (0..9) not present in `active`, or -1 if all
+ * 10 slots are already in use.
+ */
+export function allocateSlot(active: Record<string, number>): number {
+  const used = new Set(Object.values(active));
+  for (let i = 0; i < 10; i++) {
+    if (!used.has(i)) return i;
+  }
+  return -1;
+}
+
+/**
+ * Toggle highlight for `cssVar`.
+ *
+ * - If `cssVar` is already active, remove it (release the slot).
+ * - Otherwise allocate the lowest free slot and add the mapping.
+ * - If no slots are free, return `state` unchanged (referentially equal) and
+ *   emit a console.warn.
+ */
+export function toggleHighlight(state: HighlightState, cssVar: string): HighlightState {
+  if (cssVar in state.active) {
+    const { [cssVar]: _removed, ...rest } = state.active;
+    return { ...state, active: rest };
+  }
+
+  const slot = allocateSlot(state.active);
+  if (slot === -1) {
+    console.warn(
+      '[zudo-design-token-panel] highlight: all 10 slots are in use; cannot highlight',
+      cssVar,
+    );
+    return state;
+  }
+
+  return {
+    ...state,
+    active: { ...state.active, [cssVar]: slot },
+  };
+}
+
+/**
+ * Reset slot specs to the defaults. The `active` map is preserved — the user
+ * is resetting slot colours, not their inspection set.
+ */
+export function resetSlots(state: HighlightState): HighlightState {
+  return { ...state, slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })) };
+}
+
+/**
+ * Merge `partial` into the slot at `index`. Out-of-range index returns
+ * `state` unchanged.
+ */
+export function setSlot(
+  state: HighlightState,
+  index: number,
+  partial: Partial<HighlightSlotSpec>,
+): HighlightState {
+  if (index < 0 || index >= state.slots.length) return state;
+  const nextSlots = state.slots.map((s, i) => (i === index ? { ...s, ...partial } : s));
+  return { ...state, slots: nextSlots };
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Load highlight state from the split storage backends.
+ *
+ * - slots  ← localStorage  (key: `${storagePrefix}-highlight-slots`)
+ * - active ← sessionStorage (key: `${storagePrefix}-highlight-active`)
+ *
+ * On any parse / access failure the affected slice falls back to its default
+ * (`DEFAULT_HIGHLIGHT_SLOTS` / `{}`).
+ */
+export function loadHighlightState(): HighlightState {
+  let slots: HighlightSlotSpec[] = DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s }));
+  let active: Record<string, number> = {};
+
+  try {
+    const raw = localStorage.getItem(storageKey_highlightSlots());
+    if (raw !== null) {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed) && parsed.length === 10) {
+        slots = parsed as HighlightSlotSpec[];
+      }
+    }
+  } catch {
+    // Storage unavailable or parse error — use default slots.
+  }
+
+  try {
+    const raw = sessionStorage.getItem(storageKey_highlightActive());
+    if (raw !== null) {
+      const parsed = JSON.parse(raw);
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        active = parsed as Record<string, number>;
+      }
+    }
+  } catch {
+    // Storage unavailable or parse error — use empty active map.
+  }
+
+  return { slots, active };
+}
+
+/**
+ * Persist highlight state to the split storage backends.
+ *
+ * - slots  → localStorage
+ * - active → sessionStorage
+ *
+ * Gracefully handles environments where storage is unavailable.
+ */
+export function saveHighlightState(state: HighlightState): void {
+  try {
+    localStorage.setItem(storageKey_highlightSlots(), JSON.stringify(state.slots));
+  } catch {
+    // Storage unavailable — degrade silently.
+  }
+
+  try {
+    sessionStorage.setItem(storageKey_highlightActive(), JSON.stringify(state.active));
+  } catch {
+    // Storage unavailable — degrade silently.
+  }
+}

--- a/packages/zudo-design-token-panel/src/highlight/highlight-toggle-button.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-toggle-button.tsx
@@ -1,0 +1,107 @@
+/**
+ * HighlightToggleButton — eye icon that toggles CSS-variable-based highlighting.
+ *
+ * Reads HighlightContext to determine active state and slot colour.  When the
+ * context is null (component rendered outside the orchestrator's provider —
+ * e.g. in unit tests without a wrapper), the component renders nothing so
+ * rows degrade gracefully.
+ *
+ * HighlightContext is the single source of truth for the context type so both
+ * consumers (this button) and the orchestrator (#232) import from the same
+ * module.
+ */
+
+import { createContext } from 'preact';
+import { useContext, useCallback } from 'preact/hooks';
+import type { JSX } from 'preact';
+import type { HighlightState, HighlightSlotSpec } from './highlight-state';
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+export interface HighlightContextValue {
+  state: HighlightState;
+  toggle: (cssVar: string) => void;
+  /** Optional — when the orchestrator computes match counts it injects them here for title attributes. */
+  matchCounts?: Record<string, number>;
+  /** Optional — orchestrator may expose setSlot for slot colour editing. */
+  setSlot?: (index: number, partial: Partial<HighlightSlotSpec>) => void;
+  /** Optional — orchestrator may expose reset to clear all active highlights. */
+  reset?: () => void;
+}
+
+export const HighlightContext = createContext<HighlightContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// HighlightToggleButton
+// ---------------------------------------------------------------------------
+
+export interface HighlightToggleButtonProps {
+  cssVar: string;
+}
+
+export function HighlightToggleButton({ cssVar }: HighlightToggleButtonProps): JSX.Element | null {
+  const ctx = useContext(HighlightContext);
+
+  // Render nothing when used outside the orchestrator's provider.
+  if (ctx === null) return null;
+
+  const { state, toggle, matchCounts } = ctx;
+
+  const slotIdx = state.active[cssVar];
+  const isActive = slotIdx !== undefined;
+  const slotColor = isActive ? state.slots[slotIdx]?.color : undefined;
+  const count = matchCounts?.[cssVar];
+
+  const handleToggle = useCallback(() => {
+    toggle(cssVar);
+  }, [toggle, cssVar]);
+
+  const title = isActive
+    ? `Stop highlighting ${cssVar}` + (count !== undefined ? ` (${count} elements)` : '')
+    : `Highlight elements using ${cssVar}`;
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={isActive ? 'tokenpanel-highlight-toggle is-active' : 'tokenpanel-highlight-toggle'}
+      onClick={handleToggle}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleToggle();
+        }
+      }}
+      title={title}
+      style={isActive ? { color: slotColor } : undefined}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {isActive ? (
+          // eye-open: outer path + pupil circle
+          <>
+            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+            <circle cx="12" cy="12" r="3" />
+          </>
+        ) : (
+          // eye-off: slashed eye
+          <>
+            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+            <line x1="1" y1="1" x2="23" y2="23" />
+          </>
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -4,6 +4,7 @@ import { ImportModal } from './import-modal';
 import { ApplyModal } from './apply-modal';
 import { RoleButton } from './controls/role-button';
 import { HighlightSettingsPopover } from './highlight/highlight-settings-popover';
+import { HighlightOrchestrator } from './highlight/highlight-orchestrator';
 import ColorTab from './tabs/color-tab';
 import FontTab from './tabs/font-tab';
 import SizeTab from './tabs/size-tab';
@@ -470,33 +471,34 @@ export default function DesignTokenTweakPanel() {
     [activeTab, activeTabs],
   );
 
-  if (!open) return null;
-
-  const {
-    width: panelW,
-    height: panelH,
-    narrow,
-  } = computePanelSize(
-    typeof window !== 'undefined' ? window.innerWidth : 1024,
-    typeof window !== 'undefined' ? window.innerHeight : 768,
-    size,
-  );
-
-  // In narrow mode, ignore saved position — center safely near the top.
-  const panelPos =
-    narrow || isNarrow
-      ? {
-          position: 'fixed' as const,
-          top: 16,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          right: 'auto' as const,
-        }
-      : { position: 'fixed' as const, top: position.top, left: position.left };
-
   return (
-    <>
-      <div
+    <HighlightOrchestrator>
+      {open && (() => {
+        const {
+          width: panelW,
+          height: panelH,
+          narrow,
+        } = computePanelSize(
+          typeof window !== 'undefined' ? window.innerWidth : 1024,
+          typeof window !== 'undefined' ? window.innerHeight : 768,
+          size,
+        );
+
+        // In narrow mode, ignore saved position — center safely near the top.
+        const panelPos =
+          narrow || isNarrow
+            ? {
+                position: 'fixed' as const,
+                top: 16,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                right: 'auto' as const,
+              }
+            : { position: 'fixed' as const, top: position.top, left: position.left };
+
+        return (
+          <>
+            <div
         ref={panelRef}
         className="tokenpanel-shell"
         style={{
@@ -769,7 +771,10 @@ export default function DesignTokenTweakPanel() {
           onClose={() => setShowHighlightSettings(false)}
         />
       )}
-    </>
+          </>
+        );
+      })()}
+    </HighlightOrchestrator>
   );
 }
 

--- a/packages/zudo-design-token-panel/src/panel.tsx
+++ b/packages/zudo-design-token-panel/src/panel.tsx
@@ -3,6 +3,7 @@ import { ExportModal } from './export-modal';
 import { ImportModal } from './import-modal';
 import { ApplyModal } from './apply-modal';
 import { RoleButton } from './controls/role-button';
+import { HighlightSettingsPopover } from './highlight/highlight-settings-popover';
 import ColorTab from './tabs/color-tab';
 import FontTab from './tabs/font-tab';
 import SizeTab from './tabs/size-tab';
@@ -108,6 +109,8 @@ export default function DesignTokenTweakPanel() {
   const [showExport, setShowExport] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [showApply, setShowApply] = useState(false);
+  const [showHighlightSettings, setShowHighlightSettings] = useState(false);
+  const gearBtnRef = useRef<HTMLDivElement>(null);
   const [state, setState] = useState<TweakState | null>(null);
   // activeTab holds a string to support host-supplied non-reserved tab ids.
   const [activeTab, setActiveTab] = useState<string>(DEFAULT_TAB_ID);
@@ -536,6 +539,38 @@ export default function DesignTokenTweakPanel() {
             Reset
           </RoleButton>
           <div className="tokenpanel-spacer" />
+          {/* Gear button — inline div so we can attach a ref for popover anchoring */}
+          <div
+            ref={gearBtnRef}
+            role="button"
+            tabIndex={0}
+            className="tokenpanel-gear-btn"
+            aria-label="Highlight outline settings"
+            aria-expanded={showHighlightSettings}
+            aria-haspopup="dialog"
+            onClick={() => setShowHighlightSettings((v) => !v)}
+            onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                setShowHighlightSettings((v) => !v);
+              }
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="3" />
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+            </svg>
+          </div>
           <RoleButton
             onClick={() => setOpen(false)}
             className="tokenpanel-close-btn"
@@ -725,6 +760,13 @@ export default function DesignTokenTweakPanel() {
           onClose={() => setShowApply(false)}
           colorDefaults={initColorFromScheme()}
           onApplied={handleApplied}
+        />
+      )}
+
+      {showHighlightSettings && (
+        <HighlightSettingsPopover
+          anchorRef={gearBtnRef}
+          onClose={() => setShowHighlightSettings(false)}
         />
       )}
     </>

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1250,3 +1250,177 @@
   background: transparent;
   display: block;
 }
+
+/* ===========================================================================
+ * Highlight settings popover (#231)
+ *
+ * Variation-14 design: 4-column row grid for 10 highlight slots.
+ * Popover container is anchored via position:fixed inline styles computed by
+ * getFixedPopoverStyle(). z-index 65 sits above shell (50) and resize grip.
+ * ========================================================================= */
+
+.tokenpanel-highlight-settings-popover {
+  width: 440px;
+  background: var(--tokentweak-color-surface);
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: 6px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  /* z-index applied inline to keep the cascade explicit */
+}
+
+.tokenpanel-highlight-settings-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--tokentweak-color-muted);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-highlight-settings-list {
+  padding: 4px 0;
+}
+
+.tokenpanel-highlight-settings-row {
+  display: grid;
+  grid-template-columns: 22px 32px 1fr 80px;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 16px;
+}
+
+.tokenpanel-highlight-settings-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tokenpanel-highlight-settings-num {
+  color: var(--tokentweak-color-muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  font-size: 11px;
+}
+
+.tokenpanel-highlight-settings-ring {
+  width: 28px;
+  height: 28px;
+  border-radius: 3px;
+  background: transparent;
+  box-sizing: border-box;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.tokenpanel-highlight-settings-ring:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+}
+
+.tokenpanel-highlight-settings-name {
+  font-family: var(--tokentweak-font-mono);
+  font-size: 12px;
+  color: var(--tokentweak-color-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tokenpanel-highlight-settings-name.is-active {
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-highlight-settings-width {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tokenpanel-highlight-settings-slider {
+  flex: 1;
+  appearance: none;
+  -webkit-appearance: none;
+  height: 3px;
+  background: #444;
+  border-radius: 2px;
+  cursor: pointer;
+  accent-color: var(--tokentweak-color-accent);
+}
+
+.tokenpanel-highlight-settings-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--tokentweak-color-accent);
+  border: 0;
+  cursor: pointer;
+}
+
+.tokenpanel-highlight-settings-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--tokentweak-color-accent);
+  border: 0;
+  cursor: pointer;
+}
+
+.tokenpanel-highlight-settings-px {
+  color: var(--tokentweak-color-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  min-width: 24px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.tokenpanel-highlight-settings-footer {
+  padding: 12px 16px;
+  border-top: 1px solid var(--tokentweak-color-muted);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.tokenpanel-highlight-settings-reset-btn {
+  padding: 6px 12px;
+  background: #333;
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--tokentweak-color-fg);
+  transition: background 150ms ease;
+}
+
+.tokenpanel-highlight-settings-reset-btn:hover {
+  background: #404040;
+}
+
+.tokenpanel-highlight-settings-reset-btn:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+
+/* Gear icon button in panel header */
+.tokenpanel-gear-btn {
+  color: var(--tokentweak-color-muted);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tokenpanel-gear-btn:hover {
+  color: var(--tokentweak-color-fg);
+}
+
+.tokenpanel-gear-btn:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1250,3 +1250,57 @@
   background: transparent;
   display: block;
 }
+
+/* ===========================================================================
+ * Highlight toggle button (#229)
+ *
+ * Eye icon placed at the trailing end of every token row-head.  Clicking
+ * dispatches toggle(cssVar) via HighlightContext.  When active the inline
+ * color style colours the icon with the slot colour.
+ * ========================================================================= */
+
+.tokenpanel-highlight-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--tokentweak-color-muted);
+  cursor: pointer;
+  vertical-align: middle;
+  border-radius: 2px;
+  transition: background-color 150ms ease, color 150ms ease;
+}
+.tokenpanel-highlight-toggle:hover {
+  color: var(--tokentweak-color-fg);
+  background-color: rgb(from var(--tokentweak-color-fg) r g b / 0.1);
+}
+.tokenpanel-highlight-toggle:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+/* Active state: inline color style (set by the component) carries the slot
+   colour; this rule just ensures the icon's opacity/color inheritance works. */
+.tokenpanel-highlight-toggle.is-active {
+  /* color is set via inline style by the component — nothing to override here */
+  opacity: 1;
+}
+
+/* Defensive SVG reset scoped to the panel shell.
+   Ensures host icon rules (svg { fill: red; }) cannot repaint panel SVGs. */
+:where(.tokenpanel-shell) svg {
+  fill: currentColor;
+  pointer-events: none;
+  display: inline-block;
+  overflow: visible;
+}
+
+/* Override: eye icon uses stroke-based drawing, so fill must be none.
+   The svg element on HighlightToggleButton has fill="none" inline — this
+   ensures the inline attr wins over the defensive reset above. */
+:where(.tokenpanel-shell) .tokenpanel-highlight-toggle svg {
+  fill: none;
+  stroke: currentColor;
+}

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1228,3 +1228,25 @@
   outline-offset: 2px;
   border-radius: 2px;
 }
+
+/* ===========================================================================
+ * Highlight overlay (#228)
+ *
+ * One <div class="tokenpanel-highlight-overlay"> per highlighted host element.
+ * Positioned via position:fixed inline styles computed from
+ * getBoundingClientRect() — kept up-to-date by a RAF loop in the component.
+ * All load-bearing visual properties (top/left/width/height, outline,
+ * box-shadow, z-index) are applied as inline styles by the component.
+ * This class only supplies defensive hostile-host resets so host global
+ * CSS (e.g. * { margin: … }) cannot corrupt the overlay geometry.
+ * ========================================================================= */
+
+.tokenpanel-highlight-overlay {
+  /* Defensive resets — prevent host global * {} rules from adding
+     margin/padding/border that would shift the overlay off the target. */
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  display: block;
+}

--- a/packages/zudo-design-token-panel/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/__tests__/color-tab.test.tsx
@@ -1,0 +1,429 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for the HighlightToggleButton integration in ColorTab.
+ *
+ * Acceptance criteria:
+ *
+ * 1. Every cssVar-bearing row in the color tab exposes the eye toggle.
+ *    - Primary Palette swatches (e.g. --fixture-p0 … --fixture-p2)
+ *    - Primary Semantic Token rows (e.g. --fixture-semantic-accent)
+ *    - Secondary Palette swatches (when secondary cluster provided)
+ *    - Secondary Semantic Token rows (when secondary cluster provided)
+ *
+ * 2. Clicking the toggle dispatches through HighlightContext — the toggle fn
+ *    is called with the correct cssVar.
+ *
+ * 3. Base Theme rows (background / foreground) have NO eye toggle because
+ *    they are panel-internal palette indices — not real cssVars in the
+ *    document. This is the "item without a cssVar" negative case.
+ *
+ * 4. No <button> element introduced (hostile-host policy).
+ *
+ * 5. The tokenpanel/manifest-cascade-verification.test.ts Invariant D check
+ *    still passes (verified by running the suite — not re-checked here).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from '../../highlight/highlight-toggle-button';
+import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../../highlight/highlight-state';
+import ColorTab from '../color-tab';
+import type { TabConfig } from '../../tokens/tier-model';
+import type { ColorTweakState } from '../../state/tweak-state';
+import {
+  installFixturePanelConfig,
+  FIXTURE_CLUSTER,
+} from '../../__tests__/_test-helpers';
+import { __resetPanelConfigForTests } from '../../config/panel-config';
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  // getPanelConfig() is called inside ColorTab render for colorPresets.
+  // Install the fixture config so it doesn't throw on access.
+  installFixturePanelConfig();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+  __resetPanelConfigForTests();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal palette: 3 slots for speed. Template is --fixture-p{n}.
+ */
+const PALETTE_SIZE = 3;
+
+const PRIMARY_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: FIXTURE_CLUSTER.id,
+    label: FIXTURE_CLUSTER.label,
+    baseRoles: FIXTURE_CLUSTER.baseRoles,
+    baseDefaults: FIXTURE_CLUSTER.baseDefaults,
+    defaultShikiTheme: FIXTURE_CLUSTER.defaultShikiTheme,
+    colorSchemes: FIXTURE_CLUSTER.colorSchemes,
+    panelSettings: FIXTURE_CLUSTER.panelSettings,
+  },
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: Array.from({ length: PALETTE_SIZE }, (_, i) => ({
+        id: `fixture-p${i}`,
+        cssVar: `--fixture-p${i}`,
+        label: `Palette ${i}`,
+        default: '#000000',
+        type: { kind: 'color' as const },
+      })),
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        {
+          id: 'accent',
+          cssVar: '--fixture-semantic-accent',
+          label: 'Accent',
+          default: 'fixture-p1',
+          type: { kind: 'color' as const },
+        },
+        {
+          id: 'muted',
+          cssVar: '--fixture-semantic-muted',
+          label: 'Muted',
+          default: 'fixture-p2',
+          type: { kind: 'color' as const },
+        },
+      ],
+    },
+  ],
+};
+
+/** Minimal color state for PALETTE_SIZE=3 */
+function makeColorState(): ColorTweakState {
+  return {
+    palette: ['#111111', '#222222', '#333333'],
+    background: 0,
+    foreground: 2,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 2,
+    semanticMappings: { accent: 1, muted: 2, active: 0 },
+    shikiTheme: 'dracula',
+  };
+}
+
+function makeHighlightState(overrides: Partial<HighlightState> = {}): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    active: {},
+    ...overrides,
+  };
+}
+
+function makeCtx(
+  state: HighlightState,
+  toggle: (cssVar: string) => void,
+): HighlightContextValue {
+  return { state, toggle };
+}
+
+function noop() {}
+
+/** Render ColorTab wrapped in a HighlightContext provider */
+function renderColorTab(
+  ctx: HighlightContextValue,
+  opts: {
+    tab?: TabConfig;
+    colorState?: ColorTweakState;
+    secondaryTab?: TabConfig | null;
+    secondaryState?: ColorTweakState | null;
+  } = {},
+): void {
+  const {
+    tab = PRIMARY_COLOR_TAB,
+    colorState = makeColorState(),
+    secondaryTab = null,
+    secondaryState = null,
+  } = opts;
+  act(() => {
+    render(
+      <HighlightContext.Provider value={ctx}>
+        <ColorTab
+          tab={tab}
+          state={colorState}
+          persistColor={noop}
+          secondaryTab={secondaryTab}
+          secondaryState={secondaryState}
+          persistSecondary={noop}
+        />
+      </HighlightContext.Provider>,
+      container,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Palette swatch rows have the eye toggle
+// ---------------------------------------------------------------------------
+
+describe('ColorTab palette swatches — eye toggle present', () => {
+  it('primary palette swatch p0 has tokenpanel-highlight-toggle', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx);
+
+    // Find all toggles inside the primary palette grid
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    expect(paletteGrid).not.toBeNull();
+    expect(paletteGrid.querySelectorAll('.tokenpanel-highlight-toggle').length).toBeGreaterThan(0);
+  });
+
+  it('primary palette has one eye toggle per swatch (PALETTE_SIZE toggles total)', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx);
+
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    expect(paletteGrid.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(PALETTE_SIZE);
+  });
+
+  it('clicking palette swatch p0 eye toggle calls toggle with --fixture-p0', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeHighlightState(), toggle);
+    renderColorTab(ctx);
+
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    const firstToggle = paletteGrid.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => firstToggle.click());
+
+    expect(toggle).toHaveBeenCalledWith('--fixture-p0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Semantic token rows have the eye toggle
+// ---------------------------------------------------------------------------
+
+describe('ColorTab semantic token rows — eye toggle present', () => {
+  it('primary semantic rows each have a tokenpanel-highlight-toggle', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx);
+
+    // The semantic section renders inside .tokenpanel-color-base-grid
+    // (there are two: Base and Semantic). Semantic tokens appear after Base.
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    // Second base-grid is the semantic section
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    expect(semanticGrid).not.toBeNull();
+    expect(semanticGrid.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(2);
+  });
+
+  it('clicking accent semantic eye toggle calls toggle with --fixture-semantic-accent', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeHighlightState(), toggle);
+    renderColorTab(ctx);
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    const firstToggle = semanticGrid.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => firstToggle.click());
+
+    expect(toggle).toHaveBeenCalledWith('--fixture-semantic-accent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Base Theme rows (background/foreground) have NO eye toggle
+// ---------------------------------------------------------------------------
+
+describe('ColorTab Base Theme rows — no eye toggle (no real cssVar)', () => {
+  it('base grid rows have no tokenpanel-highlight-toggle', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx);
+
+    // First base-grid is the Base section (background / foreground rows)
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const baseGrid = baseGrids[0] as HTMLElement;
+    expect(baseGrid).not.toBeNull();
+    expect(baseGrid.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. No <button> element (hostile-host policy)
+// ---------------------------------------------------------------------------
+
+describe('ColorTab — no <button> elements (hostile-host policy)', () => {
+  it('renders no <button> elements when HighlightContext provided', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx);
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('renders no <button> elements without HighlightContext (null context)', () => {
+    // Render without provider — toggles should silently not render
+    act(() => {
+      render(
+        <ColorTab
+          tab={PRIMARY_COLOR_TAB}
+          state={makeColorState()}
+          persistColor={noop}
+          secondaryTab={null}
+          secondaryState={null}
+          persistSecondary={noop}
+        />,
+        container,
+      );
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Secondary palette + semantic rows get the toggle too
+// ---------------------------------------------------------------------------
+
+const SECONDARY_CLUSTER_DATA = {
+  id: 'secondary',
+  label: 'Secondary',
+  paletteSize: 2,
+  baseRoles: {},
+  paletteCssVarTemplate: '--sec-p{n}',
+  semanticDefaults: { highlight: 0 },
+  semanticCssNames: { highlight: '--sec-semantic-highlight' },
+  baseDefaults: { background: 0, foreground: 1, cursor: 0, selectionBg: 0, selectionFg: 1 },
+  defaultShikiTheme: 'dracula',
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false as const },
+};
+
+const SECONDARY_TAB: TabConfig = {
+  id: 'secondary-color',
+  label: 'Secondary Color',
+  colorExtras: {
+    id: SECONDARY_CLUSTER_DATA.id,
+    label: SECONDARY_CLUSTER_DATA.label,
+    baseRoles: SECONDARY_CLUSTER_DATA.baseRoles,
+    baseDefaults: SECONDARY_CLUSTER_DATA.baseDefaults,
+    defaultShikiTheme: SECONDARY_CLUSTER_DATA.defaultShikiTheme,
+    colorSchemes: SECONDARY_CLUSTER_DATA.colorSchemes,
+    panelSettings: SECONDARY_CLUSTER_DATA.panelSettings,
+  },
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: [
+        { id: 'sec-p0', cssVar: '--sec-p0', label: 'sec-p0', default: '#000000', type: { kind: 'color' as const } },
+        { id: 'sec-p1', cssVar: '--sec-p1', label: 'sec-p1', default: '#ffffff', type: { kind: 'color' as const } },
+      ],
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        { id: 'highlight', cssVar: '--sec-semantic-highlight', label: 'Highlight', default: 'sec-p0', type: { kind: 'color' as const } },
+      ],
+    },
+  ],
+};
+
+function makeSecondaryState(): ColorTweakState {
+  return {
+    palette: ['#000000', '#ffffff'],
+    background: 0,
+    foreground: 1,
+    cursor: 0,
+    selectionBg: 0,
+    selectionFg: 1,
+    semanticMappings: { highlight: 0 },
+    shikiTheme: 'dracula',
+  };
+}
+
+describe('ColorTab secondary cluster rows — eye toggle present', () => {
+  it('secondary palette section has toggles for each swatch', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      secondaryTab: SECONDARY_TAB,
+      secondaryState: makeSecondaryState(),
+    });
+
+    const secPaletteSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-palette-section"]',
+    ) as HTMLElement;
+    expect(secPaletteSection).not.toBeNull();
+    // 2 swatches → 2 toggles
+    expect(secPaletteSection.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(2);
+  });
+
+  it('clicking secondary palette p0 eye toggle calls toggle with --sec-p0', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeHighlightState(), toggle);
+    renderColorTab(ctx, {
+      secondaryTab: SECONDARY_TAB,
+      secondaryState: makeSecondaryState(),
+    });
+
+    const secPaletteSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-palette-section"]',
+    ) as HTMLElement;
+    const firstToggle = secPaletteSection.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => firstToggle.click());
+
+    expect(toggle).toHaveBeenCalledWith('--sec-p0');
+  });
+
+  it('secondary semantic section has a toggle for the semantic row', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      secondaryTab: SECONDARY_TAB,
+      secondaryState: makeSecondaryState(),
+    });
+
+    const secSemanticSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-semantic-section"]',
+    ) as HTMLElement;
+    expect(secSemanticSection).not.toBeNull();
+    expect(secSemanticSection.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(1);
+  });
+
+  it('clicking secondary semantic eye toggle calls toggle with --sec-semantic-highlight', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeHighlightState(), toggle);
+    renderColorTab(ctx, {
+      secondaryTab: SECONDARY_TAB,
+      secondaryState: makeSecondaryState(),
+    });
+
+    const secSemanticSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-semantic-section"]',
+    ) as HTMLElement;
+    const toggleEl = secSemanticSection.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => toggleEl.click());
+
+    expect(toggle).toHaveBeenCalledWith('--sec-semantic-highlight');
+  });
+});

--- a/packages/zudo-design-token-panel/src/tabs/_generic-item-editor.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/_generic-item-editor.tsx
@@ -11,6 +11,7 @@
 
 import { memo, useCallback, useEffect, useRef, useState } from 'preact/compat';
 import type { TierItem, TierValueKind } from '../tokens/tier-model';
+import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
 export interface GenericItemEditorProps {
   item: TierItem;
@@ -93,6 +94,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
               />
               {unit && <span className="tokenpanel-row-unit">{unit}</span>}
             </div>
+            <HighlightToggleButton cssVar={item.cssVar} />
           </div>
           <input
             type="range"
@@ -157,6 +159,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
               </option>
             ))}
           </select>
+          <HighlightToggleButton cssVar={item.cssVar} />
         </div>
       );
     }
@@ -185,6 +188,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
             autoCorrect="off"
             autoComplete="off"
           />
+          <HighlightToggleButton cssVar={item.cssVar} />
         </div>
       );
     }
@@ -209,6 +213,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
             className="tokenpanel-row-color-input"
             aria-label={`${item.cssVar} value`}
           />
+          <HighlightToggleButton cssVar={item.cssVar} />
         </div>
       );
     }

--- a/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/color-tab.tsx
@@ -45,6 +45,7 @@ import { getPanelConfig } from '../config/panel-config';
 import { resolveColorClusterFromTab } from '../config/cluster-config';
 import type { TabConfig } from '../tokens/tier-model';
 import type { PersistColor, PersistSecondary } from '../state/persist';
+import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
 // The bundled scheme registry now lives on
 // `panelConfig.colorCluster.colorSchemes`, not on a global import. Read it
@@ -149,11 +150,15 @@ const ColorSwatch = memo(function ColorSwatch({
   onChange,
   index,
   label,
+  cssVar,
 }: {
   color: string;
   onChange: (index: number, hex: string) => void;
   index: number;
   label: string;
+  /** CSS custom property name (e.g. `--zd-p3`) used to wire the eye toggle.
+   *  When present, a HighlightToggleButton appears in the swatch label row. */
+  cssVar?: string;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLDivElement>(null);
@@ -192,9 +197,12 @@ const ColorSwatch = memo(function ColorSwatch({
           anchorRef={buttonRef}
         />
       )}
-      <span className="tokenpanel-color-swatch-label" title={label}>
-        {label}
-      </span>
+      <div className="tokenpanel-color-swatch-label-row">
+        <span className="tokenpanel-color-swatch-label" title={label}>
+          {label}
+        </span>
+        {cssVar && <HighlightToggleButton cssVar={cssVar} />}
+      </div>
     </div>
   );
 });
@@ -217,6 +225,7 @@ const PaletteSelector = memo(function PaletteSelector({
   extraOptions,
   background,
   foreground,
+  cssVar,
 }: {
   label: string;
   /** Stable identifier for this row, passed back to `onChange` so the
@@ -236,6 +245,10 @@ const PaletteSelector = memo(function PaletteSelector({
   extraOptions?: ('bg' | 'fg')[];
   background?: string;
   foreground?: string;
+  /** CSS custom property this row maps to (e.g. `--fixture-semantic-accent`).
+   *  Omit for rows that have no real cssVar in the document (e.g. `background`,
+   *  `foreground` Base knobs which are panel-internal palette indices). */
+  cssVar?: string;
 }) {
   const resolvePaletteCssVar = paletteCssVar ?? ((i: number) => `--zd-p${i}`);
   const [isOpen, setIsOpen] = useState(false);
@@ -298,6 +311,8 @@ const PaletteSelector = memo(function PaletteSelector({
           <path d="M6 9l6 6 6-6" />
         </svg>
       </div>
+
+      {cssVar && <HighlightToggleButton cssVar={cssVar} />}
 
       {isOpen && (
         <div
@@ -591,6 +606,7 @@ export default function ColorTab({
               color={color}
               index={i}
               label={resolvePaletteCssVar(safeCluster, i)}
+              cssVar={resolvePaletteCssVar(safeCluster, i)}
               onChange={handlePaletteChange}
             />
           ))}
@@ -640,10 +656,11 @@ export default function ColorTab({
           </div>
           <div className="tokenpanel-color-base-grid">
             {Object.entries(safeCluster.semanticDefaults).map(([key, defaultVal]) => {
+              const semanticCssVar = safeCluster.semanticCssNames[key];
               return (
                 <PaletteSelector
                   key={key}
-                  label={safeCluster.semanticCssNames[key] ?? key}
+                  label={semanticCssVar ?? key}
                   idKey={key}
                   value={state.semanticMappings[key] ?? defaultVal}
                   palette={state.palette}
@@ -651,6 +668,7 @@ export default function ColorTab({
                   onChange={handleSemanticChange}
                   background={state.palette[state.background]}
                   foreground={state.palette[state.foreground]}
+                  cssVar={semanticCssVar}
                 />
               );
             })}
@@ -680,6 +698,7 @@ export default function ColorTab({
                     color={color}
                     index={i}
                     label={resolvePaletteCssVar(secondaryCluster, i)}
+                    cssVar={resolvePaletteCssVar(secondaryCluster, i)}
                     onChange={handleSecondaryPaletteChange}
                   />
                 ))}
@@ -696,15 +715,17 @@ export default function ColorTab({
               </div>
               <div className="tokenpanel-color-base-grid">
                 {Object.entries(secondaryCluster.semanticDefaults).map(([key, defaultVal]) => {
+                  const secondarySemanticCssVar = secondaryCluster.semanticCssNames[key];
                   return (
                     <PaletteSelector
                       key={key}
-                      label={secondaryCluster.semanticCssNames[key] ?? key}
+                      label={secondarySemanticCssVar ?? key}
                       idKey={key}
                       value={secondaryState.semanticMappings[key] ?? defaultVal}
                       palette={secondaryState.palette}
                       paletteCssVar={secondaryPaletteCssVar}
                       onChange={handleSecondarySemanticChange}
+                      cssVar={secondarySemanticCssVar}
                     />
                   );
                 })}

--- a/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/font-tab.tsx
@@ -5,6 +5,7 @@ import type { PersistFont } from '../state/persist';
 import TierRefSelector from '../controls/tier-ref-selector';
 import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
+import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
 interface FontTabProps {
   tab: TabConfig;
@@ -122,6 +123,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   value={value}
                   onChange={onChange}
                 />
+                <HighlightToggleButton cssVar={item.cssVar} />
               </div>
             );
           }

--- a/packages/zudo-design-token-panel/src/tabs/generic-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/generic-tab.tsx
@@ -20,6 +20,7 @@ import { useCallback } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem, TierValueKind } from '../tokens/tier-model';
 import type { TabOverrides } from '../apply/tier-resolver';
 import TierRefSelector from '../controls/tier-ref-selector';
+import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
 // ---------------------------------------------------------------------------
 // Item editor dispatch
@@ -56,6 +57,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
           value={value}
           onChange={onChange}
         />
+        <HighlightToggleButton cssVar={item.cssVar} />
       </div>
     );
   }
@@ -108,6 +110,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
               />
               {unit && <span className="tokenpanel-row-unit">{unit}</span>}
             </div>
+            <HighlightToggleButton cssVar={item.cssVar} />
           </div>
           <input
             type="range"
@@ -150,6 +153,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
               </option>
             ))}
           </select>
+          <HighlightToggleButton cssVar={item.cssVar} />
         </div>
       );
     }
@@ -178,6 +182,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
             autoCorrect="off"
             autoComplete="off"
           />
+          <HighlightToggleButton cssVar={item.cssVar} />
         </div>
       );
     }
@@ -202,6 +207,7 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
             className="tokenpanel-row-color-input"
             aria-label={`${item.cssVar} value`}
           />
+          <HighlightToggleButton cssVar={item.cssVar} />
         </div>
       );
     }

--- a/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/size-tab.tsx
@@ -5,6 +5,7 @@ import type { PersistSize } from '../state/persist';
 import TierRefSelector from '../controls/tier-ref-selector';
 import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
+import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
 interface SizeTabProps {
   tab: TabConfig;
@@ -120,6 +121,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   value={value}
                   onChange={onChange}
                 />
+                <HighlightToggleButton cssVar={item.cssVar} />
               </div>
             );
           }

--- a/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
+++ b/packages/zudo-design-token-panel/src/tabs/spacing-tab.tsx
@@ -5,6 +5,7 @@ import type { PersistSpacing } from '../state/persist';
 import TierRefSelector from '../controls/tier-ref-selector';
 import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
+import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
 interface SpacingTabProps {
   tab: TabConfig;
@@ -125,6 +126,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   value={value}
                   onChange={onChange}
                 />
+                <HighlightToggleButton cssVar={item.cssVar} />
               </div>
             );
           }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/225

---

## Summary

Adds the **Highlight Token Users** inspection tool to the design-token panel:

- An eye icon next to every token (across all row-based tabs AND the color tab swatch/semantic rows) outlines every DOM element in the host page that uses that token. Up to 10 simultaneous highlights.
- A gear icon in the panel header opens a 10-slot reservation-sheet settings popover (variation-14 design): per-slot color + outline width with live ring preview, slider 1–10px with the px suffix readout, and a Reset to defaults button.
- Slot colors persist via localStorage; the active highlight set is session-only (sessionStorage) — hard-reload clears active highlights but keeps custom slot colors.

## Architecture

- packages/zudo-design-token-panel/src/highlight/find-elements.ts — walks document.styleSheets to find consumers of a CSS variable. Alias-chain expansion (depth ≤ 5, cycle-safe), inline-style hybrid pass, panel-internal exclusion, safe selector cleanup, cross-origin SecurityError skip.
- packages/zudo-design-token-panel/src/highlight/highlight-state.ts — reservation-sheet model (10 slots, lowest-index-first allocation). Split persistence: localStorage for slot colors, sessionStorage for active map. Immutable helpers (allocateSlot, toggleHighlight, resetSlots, setSlot).
- packages/zudo-design-token-panel/src/highlight/highlight-overlay.tsx — Preact component rendering position:fixed overlay divs. Single RAF reposition loop updates style imperatively (no per-frame re-render). 200-element cap with one-time warn. Box-shadow inset fallback survives hostile `* { outline: none !important }` host CSS.
- packages/zudo-design-token-panel/src/highlight/highlight-toggle-button.tsx — eye icon component AND the canonical HighlightContext.
- packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx — the variation-14 popover. Reuses existing ColorPicker, RoleButton, usePopoverClose. 4-column grid: number, ring swatch (border IS the live preview), token-name label, slider + Npx readout.
- packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx — wires state + context + body-level portal mount + head MutationObserver + astro:after-swap handler. Mounts overlay portal unconditionally (highlights stay visible when panel closed). SSR-safe (typeof document/window guards; mount deferred to useEffect).

## What was implemented (8 sub-issues)

- #226 Token-usage finder (stylesheet walker + alias expansion)
- #227 Highlight state slice (10-slot reservation sheet)
- #228 Overlay renderer (positioned outlines, RAF reposition)
- #229 Eye-icon toggle in row-based token rows
- #230 Eye-icon toggle in color-tab swatch / semantic / palette rows
- #231 Gear icon + 10-slot variation-14 settings popover
- #232 Orchestrator integration (state, context, portal mount, stylesheet observer, astro:after-swap)
- #233 Documentation page: doc/src/content/docs/reference/highlight-token-users.mdx

## Review fixes applied (codex pass)

- Deferred portal mount-node creation to useEffect with typeof document/window guards — fixes SSR/prerender crashes that previously hit document.body during render.
- astro:after-swap now bumps stylesheetVersion to invalidate the per-cssVar element cache. Previously stale Element references from the prior page lingered until a stylesheet mutation or manual toggle.
- Documented inherited-property limitation in the doc page (rule selectors are matched, not computed styles — descendants inheriting body color via var(--brand) are not outlined).

## Constraints respected

- No banned semantic tags in the panel package (h1-h6, p, ul, ol, li, table, button, etc.).
- Chrome-button policy: gear / eye / reset buttons all use `<div role="button" tabIndex={0}>` with explicit onKeyDown for Enter and Space.
- Defensive svg fill/stroke reset to defend against hostile host icon rules.
- Manifest-cascade-verification Invariant D passes (no new banned tags in tabs).

## Static check status

- Tests: 822 pass on merged base (688 baseline + 134 new). Typecheck: 0 errors. Build: clean (panel + doc).
- CI: 3/3 checks green on the root PR.

## Browser verification

A full /verify-ui browser sweep against the doc-site hostile-host page and external example apps is documented in the reference page but was NOT run in this session (no -v flag passed). Manual scenarios are listed in the doc page and in #233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)