### PR TITLE
[Token Outline Tweak] Wave 1 — popover bg fix + Disable-all button + prose-page throw fix

### DIFF
--- a/doc/src/content/docs/reference/highlight-token-users.mdx
+++ b/doc/src/content/docs/reference/highlight-token-users.mdx
@@ -70,6 +70,10 @@ The **Reset to defaults** button in the settings popover footer restores all 10 
 Reset to defaults only restores slot colors and widths. It does NOT clear the active inspection set — any tokens you currently have highlighted stay highlighted, with their slots now showing the default colors.
 </Tip>
 
+## Disable all highlights
+
+The **Disable all highlights** button in the settings popover footer clears the entire active inspection set in one click — all outline overlays are removed immediately. Slot colors and outline widths are preserved; only the active map is cleared. There is no confirmation dialog. If you change your mind, you can re-enable individual tokens by clicking their eye icons again.
+
 ## Persistence model
 
 The feature uses two distinct storage layers:

--- a/packages/zudo-design-token-panel/src/__tests__/panel-config-ref-tier-kind.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/panel-config-ref-tier-kind.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Regression coverage for #245 — the strict inter-tier kind-compatibility
+ * rule in `assertValidTab` used to throw whenever a tier with
+ * `referencesTier` had a `kind` different from its referenced tier. That
+ * rule was over-strict and broke every demo's Font tab at host-adapter
+ * bootstrap time, because:
+ *
+ *   - The tier resolver (`apply/tier-resolver.ts`) does NOT read
+ *     `TierItem.type.kind` for ref-tier items. Resolution is a pure id
+ *     lookup that emits `var(--targetCssVar)`.
+ *   - The panel UI (`tabs/generic-tab.tsx`, `tabs/font-tab.tsx`,
+ *     `tabs/spacing-tab.tsx`, `tabs/size-tab.tsx`) routes any item whose
+ *     tier has `referencesTier` to `TierRefSelector` unconditionally —
+ *     the item's `kind` is ignored for editor selection.
+ *
+ * So a ref-tier item's `kind` field has no runtime effect; demos legitimately
+ * encode it as `kind: 'text'` to communicate "the stored value is a string
+ * identifier". The validator must therefore allow any kind on a ref-tier
+ * item regardless of the referenced tier's kind.
+ *
+ * The intra-tier rule ("all items in one tier share a kind") and the
+ * "referenced tier must exist" rule are still enforced — both catch real
+ * encoding bugs and remain backed by runtime behaviour.
+ */
+import { describe, expect, it } from 'vitest';
+import { assertValidPanelConfig } from '../config/panel-config';
+
+const baseHostFields = {
+  storagePrefix: 'astro',
+  consoleNamespace: 'astro',
+  modalClassPrefix: 'tokenpanel-modal',
+  schemaId: 'astro/v1',
+  exportFilenameBase: 'astro-tokens',
+} as const;
+
+describe('panel-config — ref-tier item kind compatibility (issue #245)', () => {
+  it('accepts the astro Font-tab shape: semantic(kind:text) referencesTier raw(kind:length)', () => {
+    // Exact shape lifted from the astro demo manifest. All 5 demos use this
+    // pattern in the Font tab. Previously threw "kind mismatch — tier
+    // 'semantic' has kind 'text' but referenced tier 'raw' has kind 'length'".
+    const fontTab = {
+      id: 'font',
+      label: 'Font',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Font scale',
+          items: [
+            {
+              id: 'astro-scale-base',
+              cssVar: '--astro-scale-base',
+              label: 'Scale Base',
+              default: '1rem',
+              type: { kind: 'length', min: 0.5, max: 2, step: 0.0625, unit: 'rem' },
+            },
+            {
+              id: 'astro-scale-lg',
+              cssVar: '--astro-scale-lg',
+              label: 'Scale LG',
+              default: '1.25rem',
+              type: { kind: 'length', min: 0.5, max: 2, step: 0.0625, unit: 'rem' },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Font role',
+          referencesTier: 'raw',
+          items: [
+            {
+              id: 'astro-text-body',
+              cssVar: '--astro-text-body',
+              label: 'Body',
+              default: 'astro-scale-base',
+              type: { kind: 'text' },
+            },
+            {
+              id: 'astro-text-title',
+              cssVar: '--astro-text-title',
+              label: 'Title',
+              default: 'astro-scale-lg',
+              type: { kind: 'text' },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() =>
+      assertValidPanelConfig({ ...baseHostFields, tabs: [fontTab] }),
+    ).not.toThrow();
+  });
+
+  it('accepts color(kind:color) referencesTier palette(kind:color) — the color-tab pattern', () => {
+    const colorTab = {
+      id: 'color',
+      label: 'Color',
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'palette-0',
+              cssVar: '--color-palette-0',
+              label: 'P0',
+              default: '#1e1e1e',
+              type: { kind: 'color' },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'palette',
+          items: [
+            {
+              id: 'primary',
+              cssVar: '--color-primary',
+              label: 'Primary',
+              default: 'palette-0',
+              type: { kind: 'color' },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() =>
+      assertValidPanelConfig({ ...baseHostFields, tabs: [colorTab] }),
+    ).not.toThrow();
+  });
+
+  it('still rejects a ref to a non-existent tier (referenced-tier-exists rule preserved)', () => {
+    const badRefTab = {
+      id: 'broken',
+      label: 'Broken',
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'nonexistent',
+          items: [
+            {
+              id: 'role-a',
+              cssVar: '--broken-role-a',
+              label: 'Role A',
+              default: 'whatever',
+              type: { kind: 'text' },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() =>
+      assertValidPanelConfig({ ...baseHostFields, tabs: [badRefTab] }),
+    ).toThrow(/tier "nonexistent" does not exist/);
+  });
+
+  it('still rejects mixed item kinds within a single tier (intra-tier rule preserved)', () => {
+    const mixedTab = {
+      id: 'mixed',
+      label: 'Mixed',
+      tiers: [
+        {
+          id: 'jumble',
+          label: 'Jumble',
+          items: [
+            {
+              id: 'a',
+              cssVar: '--mixed-a',
+              label: 'A',
+              default: '#fff',
+              type: { kind: 'color' },
+            },
+            {
+              id: 'b',
+              cssVar: '--mixed-b',
+              label: 'B',
+              default: '4px',
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              type: { kind: 'length', min: 0, max: 10, step: 1, unit: 'px' } as any,
+            },
+          ],
+        },
+      ],
+    };
+    expect(() =>
+      assertValidPanelConfig({ ...baseHostFields, tabs: [mixedTab] }),
+    ).toThrow(/mixed item kinds/);
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/panel-config.test.ts
@@ -545,9 +545,19 @@ describe('panel-config — assertValidPanelConfig host-tabs validation', () => {
   });
 
   // Rule: referencesTier kind compatibility ----------------------------------
+  //
+  // The inter-tier kind-compat check was removed in issue #245. Ref-tier
+  // items are id-string references; the resolver does not inspect kind and
+  // the UI routes them to TierRefSelector regardless. See
+  // panel-config-ref-tier-kind.test.ts for the rationale and the
+  // accepts-this-pattern coverage.
 
-  it('rejects referencesTier when kinds are incompatible (color vs length)', () => {
-    const tabKindMismatch: TabConfig = {
+  it('accepts referencesTier when kinds DIFFER (semantic kind:color references raw kind:length)', () => {
+    // Previously threw "kind mismatch". The rule was over-strict — runtime
+    // ignores ref-tier item kinds. Demos legitimately encode font.semantic
+    // items as `kind: 'text'` while referencing font.raw items of
+    // `kind: 'length'` (the stored value is an id string, which is textual).
+    const tabKindDiffer: TabConfig = {
       id: 'mismatch-tab',
       label: 'Mismatch Tab',
       tiers: [
@@ -567,7 +577,7 @@ describe('panel-config — assertValidPanelConfig host-tabs validation', () => {
         {
           id: 'semantic-colors',
           label: 'Semantic colors',
-          referencesTier: 'raw-lengths', // kind mismatch: color vs length
+          referencesTier: 'raw-lengths',
           items: [
             {
               id: 'primary',
@@ -581,8 +591,8 @@ describe('panel-config — assertValidPanelConfig host-tabs validation', () => {
       ],
     };
     expect(() =>
-      assertValidPanelConfig(makeBaseConfig({ tabs: [tabKindMismatch] })),
-    ).toThrow(/kind mismatch/);
+      assertValidPanelConfig(makeBaseConfig({ tabs: [tabKindDiffer] })),
+    ).not.toThrow();
   });
 
   it('accepts referencesTier when kinds are compatible (text-to-text)', () => {

--- a/packages/zudo-design-token-panel/src/bin/__tests__/server.integration.test.ts
+++ b/packages/zudo-design-token-panel/src/bin/__tests__/server.integration.test.ts
@@ -13,7 +13,14 @@
  * fixed port to provoke the collision.
  */
 import { spawn, type ChildProcessByStdio } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -312,6 +319,72 @@ describe('design-token-panel-server bin (integration)', () => {
     expect(typeof body.writeRoot).toBe('string');
     expect(typeof body.routing).toBe('string');
     expect(typeof body.port).toBe('number');
+  }, 10_000);
+
+  /**
+   * Regression test for #257: pnpm symlinks the panel package into
+   * `node_modules/@takazudo/zudo-design-token-panel/` (pointing to a
+   * `.pnpm/...` real path), so `process.argv[1]` is the symlink path while
+   * `import.meta.url` is the resolved real path. Without realpathSync on the
+   * argv side, the `invokedDirectly` URL comparison was always false and
+   * `main()` never ran — the bin exited cleanly with code 0 and no output.
+   */
+  it('invoked via a symlink (pnpm .bin shape) still binds and serves', async () => {
+    const fix = makeTmpFixture();
+    cleanupTasks.push(() => rmSync(fix.dir, { recursive: true, force: true }));
+
+    const linkPath = join(fix.dir, 'server-link.js');
+    symlinkSync(BIN_PATH, linkPath);
+
+    const child = spawn(
+      'node',
+      [
+        linkPath,
+        '--root',
+        fix.dir,
+        '--write-root',
+        fix.dir,
+        '--routing',
+        fix.routingPath,
+        '--port',
+        '0',
+        '--allow-origin',
+        'http://localhost:9999',
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    cleanupTasks.push(() => killBin(child));
+
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let exited = false;
+    child.stdout!.setEncoding('utf-8');
+    child.stderr!.setEncoding('utf-8');
+    child.stdout!.on('data', (chunk: string) => stdout.push(chunk));
+    child.stderr!.on('data', (chunk: string) => stderr.push(chunk));
+    child.on('exit', () => {
+      exited = true;
+    });
+
+    let port = -1;
+    await waitFor(
+      () => {
+        if (exited) return true;
+        const match = stdout.join('').match(STARTUP_LINE_RE);
+        if (match) {
+          port = Number(match[1]);
+          return true;
+        }
+        return false;
+      },
+      { timeout: 5000, label: 'symlink-invoked bin startup' },
+    );
+
+    expect(child.exitCode, `bin exited prematurely. stdout: ${stdout.join('')} stderr: ${stderr.join('')}`).toBeNull();
+    expect(port).toBeGreaterThan(0);
+
+    const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+    expect(response.status).toBe(200);
   }, 10_000);
 
   it('a second bin on the same fixed port exits 1 with EADDRINUSE on stderr', async () => {

--- a/packages/zudo-design-token-panel/src/bin/server.ts
+++ b/packages/zudo-design-token-panel/src/bin/server.ts
@@ -20,6 +20,7 @@
  *   - shuts down gracefully on SIGINT/SIGTERM
  */
 
+import { realpathSync } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { resolve } from 'node:path';
 import { createApplyHandler, loadRoutingFromFile } from '../server';
@@ -330,7 +331,11 @@ const invokedDirectly = (() => {
   if (typeof process.argv[1] !== 'string') return false;
   try {
     // Node ESM doesn't expose `require.main === module`; compare resolved URLs.
-    const argvUrl = new URL(`file://${resolve(process.argv[1])}`).href;
+    // realpathSync de-references the pnpm `.bin/...` symlink so the comparison
+    // against `import.meta.url` (which is the real path) matches when the bin
+    // is invoked through `node_modules/.bin/design-token-panel-server`.
+    const real = realpathSync(process.argv[1]);
+    const argvUrl = new URL(`file://${resolve(real)}`).href;
     const metaUrl = import.meta.url;
     return argvUrl === metaUrl;
   } catch {

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -587,7 +587,23 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
     }
   }
 
-  // Rule: referencesTier integrity — named tier exists and kinds are compatible
+  // Rule: referencesTier integrity — the named tier must exist in the same tab.
+  //
+  // Note: we deliberately do NOT enforce inter-tier kind compatibility between a
+  // referencing tier and its referenced tier (issue #245). At runtime the
+  // referencing tier's items are id-string references; the tier resolver
+  // (`apply/tier-resolver.ts`) does not inspect `TierItem.type.kind` for them,
+  // and the panel UI (`tabs/generic-tab.tsx`, `tabs/font-tab.tsx`, etc.) routes
+  // every ref-tier item to `TierRefSelector` regardless of `kind`. Demos
+  // therefore legitimately encode ref-tier items as `kind: 'text'` even when
+  // the referenced tier holds (say) `kind: 'length'` values — the stored value
+  // is an identifier string, which is textual. Enforcing a strict kind match
+  // here used to crash host-adapter bootstrap on every demo's Font tab even
+  // though the runtime would have rendered the page correctly.
+  //
+  // The intra-tier rule above ("all items in one tier share a kind") still
+  // catches real encoding bugs and is backed by editor-dispatch behaviour.
+  void tierKindMap; // kept for future use; intra-tier check populates it
   for (const tier of tab.tiers) {
     const ti = tier as Record<string, unknown>;
     const tierId = ti.id as string;
@@ -602,18 +618,6 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
       if (!tierIds.has(refId)) {
         throw new Error(
           `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesTier: tier "${refId}" does not exist in this tab`,
-        );
-      }
-      // Rule: kind compatibility — the referencing tier's items' kind must match the referenced tier's items' kind
-      const referencingKind = tierKindMap.get(tierId);
-      const referencedKind = tierKindMap.get(refId);
-      if (
-        referencingKind !== undefined &&
-        referencedKind !== undefined &&
-        referencingKind !== referencedKind
-      ) {
-        throw new Error(
-          `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesTier: kind mismatch — tier "${tierId}" has kind "${referencingKind}" but referenced tier "${refId}" has kind "${referencedKind}"`,
         );
       }
     }

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -497,9 +497,6 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
 
   // Rule: every tier.id is unique within a tab
   const tierIds = new Set<string>();
-  // Collect tier kind for referencesTier compatibility check
-  // Maps tier id → the kind string of its first item (or undefined if empty)
-  const tierKindMap = new Map<string, string | undefined>();
 
   for (const tier of tab.tiers) {
     if (tier === null || typeof tier !== 'object' || Array.isArray(tier)) {
@@ -526,9 +523,12 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
       );
     }
 
-    // Determine the representative kind for this tier and validate consistency.
-    // All items in a tier must share the same kind — mixed kinds in a tier are
-    // invalid because referencesTier compatibility is defined at the tier level.
+    // Validate intra-tier kind consistency. All items in a tier must share the
+    // same kind — mixed kinds in one tier are invalid because the editor
+    // dispatch in `tabs/generic-tab.tsx` and friends keys off a single kind
+    // per tier section. Only the consistency check matters here; the
+    // representative kind itself is not stored (inter-tier kind compatibility
+    // was dropped in issue #245 — see the `referencesTier` block below).
     let tierKind: string | undefined = undefined;
     for (const rawItem of ti.items as unknown[]) {
       if (rawItem === null || typeof rawItem !== 'object' || Array.isArray(rawItem)) continue;
@@ -545,7 +545,6 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
         );
       }
     }
-    tierKindMap.set(ti.id, tierKind);
   }
 
   // Rule: every item.id is unique within a tab (across all tiers)
@@ -603,7 +602,6 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
   //
   // The intra-tier rule above ("all items in one tier share a kind") still
   // catches real encoding bugs and is backed by editor-dispatch behaviour.
-  void tierKindMap; // kept for future use; intra-tier check populates it
   for (const tier of tab.tiers) {
     const ti = tier as Record<string, unknown>;
     const tierId = ti.id as string;

--- a/packages/zudo-design-token-panel/src/config/panel-config.ts
+++ b/packages/zudo-design-token-panel/src/config/panel-config.ts
@@ -486,7 +486,11 @@ function assertValidTabs(tabs: unknown): void {
 /**
  * Validate a single tab entry within `PanelConfig.tabs`.
  * Checks tier-id uniqueness, item-id uniqueness across all tiers, cssVar
- * format, and referencesTier integrity (existence + kind compatibility).
+ * format, and referencesTier existence (the referenced tier id must exist).
+ * Cross-tier kind compatibility is deliberately NOT checked — the runtime
+ * resolver does pure id lookup and the UI routes ref-tier items via
+ * TierRefSelector regardless of kind. See #245 / #255 for the design notes
+ * and the follow-up issue about a narrower compatibility guard.
  */
 function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
   if (!Array.isArray(tab.tiers)) {

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-orchestrator.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-orchestrator.test.tsx
@@ -421,11 +421,63 @@ describe('matchCounts', () => {
 });
 
 // ---------------------------------------------------------------------------
+// disableAll — clear active map + persist
+// ---------------------------------------------------------------------------
+
+describe('disableAll', () => {
+  it('clears the active map and preserves slots', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    // Activate 3 tokens
+    act(() => { ctx!.toggle('--brand'); });
+    act(() => { ctx!.toggle('--secondary'); });
+    act(() => { ctx!.toggle('--accent'); });
+    expect(Object.keys(ctx!.state.active)).toHaveLength(3);
+
+    const slotsBefore = ctx!.state.slots.map((s) => ({ ...s }));
+
+    act(() => { ctx!.disableAll!(); });
+
+    expect(ctx!.state.active).toEqual({});
+    expect(ctx!.state.slots).toEqual(slotsBefore);
+  });
+
+  it('persists empty active to sessionStorage after disableAll so reload does not resurrect highlights', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    act(() => { ctx!.toggle('--brand'); });
+    act(() => { ctx!.toggle('--secondary'); });
+
+    // Confirm active map has entries before disable
+    expect(Object.keys(ctx!.state.active)).toHaveLength(2);
+
+    act(() => { ctx!.disableAll!(); });
+
+    // After disableAll, sessionStorage must contain empty active map so a reload
+    // does not resurrect previously-active highlights.
+    // The key is derived from the default storagePrefix: 'zudo-design-token-panel'.
+    const activeKey = 'zudo-design-token-panel-highlight-active';
+    const stored = sessionStorage.getItem(activeKey);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual({});
+  });
+
+  it('provides disableAll in context', () => {
+    let ctx: HighlightContextValue | null = null;
+    renderOrchestrator((c) => { ctx = c; });
+
+    expect(typeof ctx!.disableAll).toBe('function');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Context shape tests
 // ---------------------------------------------------------------------------
 
 describe('context value shape', () => {
-  it('provides state, toggle, setSlot, reset, matchCounts in context', () => {
+  it('provides state, toggle, setSlot, reset, disableAll, matchCounts in context', () => {
     let ctx: HighlightContextValue | null = null;
     renderOrchestrator((c) => { ctx = c; });
 
@@ -434,6 +486,7 @@ describe('context value shape', () => {
     expect(typeof ctx!.toggle).toBe('function');
     expect(typeof ctx!.setSlot).toBe('function');
     expect(typeof ctx!.reset).toBe('function');
+    expect(typeof ctx!.disableAll).toBe('function');
     expect(typeof ctx!.matchCounts).toBe('object');
   });
 

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
@@ -140,14 +140,19 @@ describe('HighlightSettingsPopover', () => {
       expect(nativeDialogs).toHaveLength(0);
     });
 
-    it('popover root carries data-design-token-panel-modal so --tokentweak-* vars resolve', () => {
-      // The popover renders outside .tokenpanel-shell; without this attribute
-      // the :where(.tokenpanel-shell, [data-design-token-panel-modal]) token
-      // scope never matches and background/color vars fall back to nothing.
+    it('popover root carries .tokenpanel-highlight-settings-popover so --tokentweak-* vars resolve', () => {
+      // The popover renders outside .tokenpanel-shell; the :where() selector
+      // in panel-tokens.css lists .tokenpanel-highlight-settings-popover
+      // directly so the --tokentweak-* tokens resolve without pulling in
+      // the modal-chrome rules (which would apply translate(-50%, -50%) and
+      // break the gear-anchored fixed-position layout).
       renderPopover(makeCtx(), container);
       const dialog = container.querySelector('[role="dialog"]') as HTMLElement;
       expect(dialog).not.toBeNull();
-      expect(dialog.hasAttribute('data-design-token-panel-modal')).toBe(true);
+      expect(dialog.classList.contains('tokenpanel-highlight-settings-popover')).toBe(true);
+      // Negative assertion: do NOT carry the modal attribute (would force
+      // modal chrome and shift the popover off-anchor).
+      expect(dialog.hasAttribute('data-design-token-panel-modal')).toBe(false);
     });
 
     it('does not render any <button> elements (hostile-host policy)', () => {

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
@@ -63,6 +63,7 @@ function makeCtx(overrides: Partial<HighlightContextValue> = {}): HighlightConte
     toggle: vi.fn(),
     setSlot: vi.fn(),
     reset: vi.fn(),
+    disableAll: vi.fn(),
     matchCounts: {},
     ...overrides,
   };
@@ -385,14 +386,15 @@ describe('HighlightSettingsPopover', () => {
   describe('reset button', () => {
     it('renders a "Reset to defaults" button', () => {
       renderPopover(makeCtx(), container);
-      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn');
+      const resetBtns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn'));
+      const resetBtn = resetBtns.find((el) => el.textContent?.trim() === 'Reset to defaults');
       expect(resetBtn).not.toBeNull();
-      expect(resetBtn?.textContent?.trim()).toBe('Reset to defaults');
     });
 
     it('reset button has role="button"', () => {
       renderPopover(makeCtx(), container);
-      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn');
+      const resetBtns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn'));
+      const resetBtn = resetBtns.find((el) => el.textContent?.trim() === 'Reset to defaults');
       expect(resetBtn?.getAttribute('role')).toBe('button');
     });
 
@@ -401,24 +403,90 @@ describe('HighlightSettingsPopover', () => {
       const ctx = makeCtx({ reset });
       renderPopover(ctx, container);
 
-      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn') as HTMLElement;
+      const resetBtns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn')) as HTMLElement[];
+      const resetBtn = resetBtns.find((el) => el.textContent?.trim() === 'Reset to defaults')!;
       act(() => { resetBtn.click(); });
 
       expect(reset).toHaveBeenCalledTimes(1);
     });
 
-    it('reset button does NOT call toggle or setSlot', () => {
+    it('reset button does NOT call toggle, setSlot, or disableAll', () => {
       const toggle = vi.fn();
       const setSlot = vi.fn();
       const reset = vi.fn();
-      const ctx = makeCtx({ toggle, setSlot, reset });
+      const disableAll = vi.fn();
+      const ctx = makeCtx({ toggle, setSlot, reset, disableAll });
       renderPopover(ctx, container);
 
-      const resetBtn = container.querySelector('.tokenpanel-highlight-settings-reset-btn') as HTMLElement;
+      const resetBtns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn')) as HTMLElement[];
+      const resetBtn = resetBtns.find((el) => el.textContent?.trim() === 'Reset to defaults')!;
       act(() => { resetBtn.click(); });
 
       expect(toggle).not.toHaveBeenCalled();
       expect(setSlot).not.toHaveBeenCalled();
+      expect(disableAll).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disable all highlights button', () => {
+    it('renders a "Disable all highlights" button', () => {
+      renderPopover(makeCtx(), container);
+      const btns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn'));
+      const disableBtn = btns.find((el) => el.textContent?.trim() === 'Disable all highlights');
+      expect(disableBtn).not.toBeNull();
+    });
+
+    it('disable button has role="button"', () => {
+      renderPopover(makeCtx(), container);
+      const btns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn'));
+      const disableBtn = btns.find((el) => el.textContent?.trim() === 'Disable all highlights');
+      expect(disableBtn?.getAttribute('role')).toBe('button');
+    });
+
+    it('clicking "Disable all highlights" calls context.disableAll()', () => {
+      const disableAll = vi.fn();
+      const ctx = makeCtx({ disableAll });
+      renderPopover(ctx, container);
+
+      const btns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn')) as HTMLElement[];
+      const disableBtn = btns.find((el) => el.textContent?.trim() === 'Disable all highlights')!;
+      act(() => { disableBtn.click(); });
+
+      expect(disableAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('clicking "Disable all highlights" with 3 active entries invokes disableAll', () => {
+      const disableAll = vi.fn();
+      const ctx = makeCtx({
+        disableAll,
+        state: makeState({
+          active: { '--color-brand': 0, '--text-sm': 2, '--spacing-md': 5 },
+        }),
+      });
+      renderPopover(ctx, container);
+
+      const btns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn')) as HTMLElement[];
+      const disableBtn = btns.find((el) => el.textContent?.trim() === 'Disable all highlights')!;
+      act(() => { disableBtn.click(); });
+
+      expect(disableAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('disable button does NOT call toggle, setSlot, or reset', () => {
+      const toggle = vi.fn();
+      const setSlot = vi.fn();
+      const reset = vi.fn();
+      const disableAll = vi.fn();
+      const ctx = makeCtx({ toggle, setSlot, reset, disableAll });
+      renderPopover(ctx, container);
+
+      const btns = Array.from(container.querySelectorAll('.tokenpanel-highlight-settings-reset-btn')) as HTMLElement[];
+      const disableBtn = btns.find((el) => el.textContent?.trim() === 'Disable all highlights')!;
+      act(() => { disableBtn.click(); });
+
+      expect(toggle).not.toHaveBeenCalled();
+      expect(setSlot).not.toHaveBeenCalled();
+      expect(reset).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-settings-popover.test.tsx
@@ -139,6 +139,16 @@ describe('HighlightSettingsPopover', () => {
       expect(nativeDialogs).toHaveLength(0);
     });
 
+    it('popover root carries data-design-token-panel-modal so --tokentweak-* vars resolve', () => {
+      // The popover renders outside .tokenpanel-shell; without this attribute
+      // the :where(.tokenpanel-shell, [data-design-token-panel-modal]) token
+      // scope never matches and background/color vars fall back to nothing.
+      renderPopover(makeCtx(), container);
+      const dialog = container.querySelector('[role="dialog"]') as HTMLElement;
+      expect(dialog).not.toBeNull();
+      expect(dialog.hasAttribute('data-design-token-panel-modal')).toBe(true);
+    });
+
     it('does not render any <button> elements (hostile-host policy)', () => {
       renderPopover(makeCtx(), container);
       const buttons = container.querySelectorAll('button');

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-state.test.ts
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/highlight-state.test.ts
@@ -5,6 +5,7 @@ import {
   allocateSlot,
   toggleHighlight,
   resetSlots,
+  clearAllActive,
   setSlot,
   loadHighlightState,
   saveHighlightState,
@@ -187,6 +188,52 @@ describe('resetSlots', () => {
     const next = resetSlots(state);
     expect(next).not.toBe(state);
     expect(next.slots).not.toBe(state.slots);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearAllActive
+// ---------------------------------------------------------------------------
+
+describe('clearAllActive', () => {
+  it('returns state with empty active map', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: { '--color-brand': 0, '--text-sm': 2, '--spacing-md': 5 },
+    };
+    const next = clearAllActive(state);
+    expect(next.active).toEqual({});
+  });
+
+  it('preserves slots unchanged', () => {
+    const customSlots = DEFAULT_HIGHLIGHT_SLOTS.map((s, i) =>
+      i === 0 ? { color: '#aabbcc', outlineWidth: 4 } : { ...s },
+    );
+    const state: HighlightState = {
+      slots: customSlots,
+      active: { '--token-x': 0, '--token-y': 3 },
+    };
+    const next = clearAllActive(state);
+    expect(next.slots).toEqual(customSlots);
+  });
+
+  it('returns a new state object (immutable)', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: { '--a': 0 },
+    };
+    const next = clearAllActive(state);
+    expect(next).not.toBe(state);
+    expect(next.active).not.toBe(state.active);
+  });
+
+  it('returns state with empty active when already empty', () => {
+    const state: HighlightState = {
+      slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+      active: {},
+    };
+    const next = clearAllActive(state);
+    expect(next.active).toEqual({});
   });
 });
 

--- a/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
@@ -27,6 +27,7 @@ import {
   toggleHighlight,
   setSlot as setSlotHelper,
   resetSlots,
+  clearAllActive,
   type HighlightState,
   type HighlightSlotSpec,
 } from './highlight-state';
@@ -133,6 +134,14 @@ export function HighlightOrchestrator({ children }: { children: ComponentChildre
     });
   }, []);
 
+  const disableAll = useCallback(() => {
+    setState((s) => {
+      const next = clearAllActive(s);
+      saveHighlightState(next);
+      return next;
+    });
+  }, []);
+
   // -------------------------------------------------------------------------
   // Stylesheet MutationObserver — bumps stylesheetVersion when <style> or
   // <link rel="stylesheet"> nodes are added/removed from document.head.
@@ -226,8 +235,8 @@ export function HighlightOrchestrator({ children }: { children: ComponentChildre
   // -------------------------------------------------------------------------
 
   const ctxValue = useMemo<HighlightContextValue>(
-    () => ({ state, toggle, setSlot, reset, matchCounts }),
-    [state, toggle, setSlot, reset, matchCounts],
+    () => ({ state, toggle, setSlot, reset, disableAll, matchCounts }),
+    [state, toggle, setSlot, reset, disableAll, matchCounts],
   );
 
   return (

--- a/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
@@ -55,7 +55,7 @@ export function HighlightSettingsPopover({
   // Graceful null guard: no context = no popover.
   if (!ctx) return null;
 
-  const { state, setSlot, reset } = ctx;
+  const { state, setSlot, reset, disableAll } = ctx;
 
   // Build reverse map: slotIndex → cssVar (first match wins).
   const slotToCssVar: Record<number, string> = {};
@@ -161,6 +161,12 @@ export function HighlightSettingsPopover({
 
       {/* Footer */}
       <div className="tokenpanel-highlight-settings-footer">
+        <RoleButton
+          onClick={() => disableAll && disableAll()}
+          className="tokenpanel-highlight-settings-reset-btn"
+        >
+          Disable all highlights
+        </RoleButton>
         <RoleButton
           onClick={() => reset && reset()}
           className="tokenpanel-highlight-settings-reset-btn"

--- a/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
@@ -81,7 +81,6 @@ export function HighlightSettingsPopover({
       aria-label="Highlight outline settings"
       className="tokenpanel-highlight-settings-popover"
       style={{ ...popoverStyle, zIndex: 65 }}
-      data-design-token-panel-modal=""
     >
       {/* Header */}
       <div className="tokenpanel-highlight-settings-header">

--- a/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-settings-popover.tsx
@@ -81,6 +81,7 @@ export function HighlightSettingsPopover({
       aria-label="Highlight outline settings"
       className="tokenpanel-highlight-settings-popover"
       style={{ ...popoverStyle, zIndex: 65 }}
+      data-design-token-panel-modal=""
     >
       {/* Header */}
       <div className="tokenpanel-highlight-settings-header">

--- a/packages/zudo-design-token-panel/src/highlight/highlight-state.ts
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-state.ts
@@ -113,6 +113,14 @@ export function resetSlots(state: HighlightState): HighlightState {
 }
 
 /**
+ * Clear all active highlights. Returns a new state with an empty `active` map;
+ * `slots` (colors + outline widths) are left untouched.
+ */
+export function clearAllActive(state: HighlightState): HighlightState {
+  return { ...state, active: {} };
+}
+
+/**
  * Merge `partial` into the slot at `index`. Out-of-range index returns
  * `state` unchanged.
  */

--- a/packages/zudo-design-token-panel/src/highlight/highlight-toggle-button.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-toggle-button.tsx
@@ -29,6 +29,8 @@ export interface HighlightContextValue {
   setSlot?: (index: number, partial: Partial<HighlightSlotSpec>) => void;
   /** Optional — orchestrator may expose reset to clear all active highlights. */
   reset?: () => void;
+  /** Optional — orchestrator may expose disableAll to clear the active map while preserving slot colours. */
+  disableAll?: () => void;
 }
 
 export const HighlightContext = createContext<HighlightContextValue | null>(null);

--- a/packages/zudo-design-token-panel/src/styles/panel-tokens.css
+++ b/packages/zudo-design-token-panel/src/styles/panel-tokens.css
@@ -33,13 +33,22 @@
  * ---------------------
  * A host that wants to retheme the panel chrome assigns directly to the
  * `--tokentweak-color-*` / `--tokentweak-font-mono` names on either
- * `.tokenpanel-shell` or `[data-design-token-panel-modal]` (or any
- * ancestor — `:where()` keeps specificity at 0). The panel deliberately
+ * `.tokenpanel-shell`, `[data-design-token-panel-modal]`,
+ * `.tokenpanel-highlight-settings-popover`, or `.tokenpanel-color-picker`
+ * (or any ancestor — `:where()` keeps specificity at 0). The two popover
+ * classes are listed directly so anchored popovers rendered outside the
+ * shell (siblings, NOT modals) resolve the tokens without inheriting modal
+ * chrome rules. The panel deliberately
  * does NOT read `--color-*` / `--font-mono` from the host so that
  * host-side theme changes — including theme tweaks the panel itself
  * drives in a demo — cannot bleed into the panel chrome.
  */
-:where(.tokenpanel-shell, [data-design-token-panel-modal]) {
+:where(
+  .tokenpanel-shell,
+  [data-design-token-panel-modal],
+  .tokenpanel-highlight-settings-popover,
+  .tokenpanel-color-picker
+) {
   /* ----------------------------------------------------------------------
    * Color palette (self-contained, dark)
    *

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1423,7 +1423,7 @@
   border-top: 1px solid var(--tokentweak-color-muted);
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: var(--tokentweak-pad-sm);
 }
 
 .tokenpanel-highlight-settings-reset-btn {

--- a/packages/zudo-design-token-panel/src/styles/panel.css
+++ b/packages/zudo-design-token-panel/src/styles/panel.css
@@ -1423,6 +1423,7 @@
   border-top: 1px solid var(--tokentweak-color-muted);
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
 }
 
 .tokenpanel-highlight-settings-reset-btn {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/242

---

## Summary

Wave 1 of the token-outline-tweak epic (#242). Three panel-repo sub-issues land in one accumulating PR. The base branch will keep accumulating Wave 2 (#247 sibling-clone sync + verify-ui sweep), Wave 3 (#248-#252 cross-repo demo e2e specs), and Wave 4 (#253 cross-repo SHA bump) before merging into main.

- **#243** — fix highlight-settings popover bg-missing regression (anchored popover now scopes `--tokentweak-*` via its own class instead of borrowing the modal-chrome attribute)
- **#244** — add "Disable all highlights" footer button to the settings popover (clears active map, preserves slot colors and outline widths, persisted to sessionStorage)
- **#245** — drop the over-strict inter-tier kind-compat check that threw on every page of every demo at host-adapter bootstrap (Font tab pattern: kind=length raw + kind=text semantic with referencesTier='raw' is legitimate); resolver does pure id lookup
- **Deferred** — #246 (Next.js overlay-not-rendering) deferred to Wave 2 W1-D verification. Sonnet probe ruled out Families 2 and 3 (overlay invisible / cross-origin detection) and could not localize Family 1 (mount missing) from source alone. PR #234's SSR-safety fix (already in main) appears to address the Family 1 hypothesis; W1-D will verify on a live Next.js demo and, if FAIL, a follow-up panel-repo PR will branch off this base.

## Changes

### Highlight popover bg fix (#243)

- `packages/zudo-design-token-panel/src/styles/panel-tokens.css` — extend the `:where()` selector to list the two anchored-popover classes directly (`.tokenpanel-highlight-settings-popover`, `.tokenpanel-color-picker`). Keeps specificity at zero so host overrides still win; the modal-chrome rules at panel.css:741 no longer apply to anchored popovers.
- Deep-review fix in `a9abe01`: corrects the initial sub-#243 approach (which had added `data-design-token-panel-modal` to the popover). The modal attribute also brought in `transform: translate(-50%, -50%)` and modal sizing, which would have shifted the popover off its gear-button anchor.

### Disable-all highlights button (#244)

- `highlight-state.ts` — new `clearAllActive` pure helper; clears the active map while preserving slot definitions
- `highlight-orchestrator.tsx` — new `disableAll` callback exposed via `HighlightContextValue`; same setState + saveHighlightState pattern as the existing reset callback
- `highlight-toggle-button.tsx` — `HighlightContextValue` gains optional `disableAll`
- `highlight-settings-popover.tsx` — second `RoleButton` in the popover footer next to "Reset to defaults"
- `panel.css` — footer now uses `gap: var(--tokentweak-pad-sm)` (was hard-coded `8px`; deep-review nit)
- Tests: `clearAllActive` pure helper, popover click handler, sessionStorage persistence
- Doc page: `highlight-token-users.mdx` updated with the new button

### Prose-page tier-resolver throw fix (#245)

- `config/panel-config.ts` — drop the strict inter-tier kind-compat check; the resolver and UI both ignore `TierItem.type.kind` for ref-tier items, so the check was rejecting configs the runtime would have rendered. The cross-tier consistency check (every `referencesTier` id must exist) is preserved.
- Removed unused `tierKindMap` construction (the only consumer was the removed check)
- New regression test `panel-config-ref-tier-kind.test.ts` exercises the four demo shapes (color/length/text/raw cross-kind references)
- Existing `panel-config.test.ts` case for "rejects when kinds incompatible" flipped to `not.toThrow`
- Follow-up #255 raised (agent-found) for a narrower compatibility guard that permits the Font tab pattern but rejects clearly-incompatible cross-kind refs (e.g. color → length)

### Review pass (a9abe01)

Deep-review across 6 reviewers (3 Claude Opus code-reviewer subagents + codex standard + codex adversarial + gcoc copilot). P1 finding (3 reviewers concurred): the initial sub-#243 fix attached `data-design-token-panel-modal` to the popover, pulling in modal chrome rules that would shift it off-anchor. Corrected in this PR. Also folded in: stale JSDoc fix, hard-coded gap → token.

## Test plan

- [x] `pnpm -F @takazudo/zudo-design-token-panel test --run` — 839 passing across 56 files (12 new tests added across the 3 sub-issues)
- [x] `pnpm -F @takazudo/zudo-design-token-panel typecheck` — 0 errors
- [x] `pnpm -F @takazudo/zudo-design-token-panel build` — clean
- [ ] Wave 2 #247's W1-A through W1-D verify-ui sweep across the 5 demos (deferred to next wave). W1-D doubles as the #246 deferred-verification gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)