### PR TITLE
Wave 3 Followups: tier-resolver default + Apply non-color + Playwright/Preact interop

### DIFF
--- a/packages/zudo-design-token-panel/package.json
+++ b/packages/zudo-design-token-panel/package.json
@@ -67,6 +67,7 @@
     "culori": "^4.0.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/culori": "^4.0.1",
     "@types/node": "^22.0.0",
     "jsdom": "^25.0.0",

--- a/packages/zudo-design-token-panel/src/__tests__/apply-modal.test.tsx
+++ b/packages/zudo-design-token-panel/src/__tests__/apply-modal.test.tsx
@@ -7,6 +7,10 @@
  * - The modal title renders as role=heading with aria-level=2.
  * - The close role-button fires its handler on Enter and Space keypress.
  * - No semantic tags (button, h2) remain in the modal output.
+ *
+ * Also asserts Apply button gate (#263):
+ * - Button is enabled when non-color-only tweaks are present and both
+ *   applyEndpoint and applyRouting are configured (hasRoutableEntries > 0).
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -14,7 +18,7 @@ import { render } from 'preact';
 import { act } from 'preact/test-utils';
 import { ApplyModal } from '../apply-modal';
 import { __resetPanelConfigForTests } from '../config/panel-config';
-import { installFixturePanelConfig, FIXTURE_CLUSTER } from './_test-helpers';
+import { installFixturePanelConfig, FIXTURE_CLUSTER, FIXTURE_TABS } from './_test-helpers';
 
 // ---------------------------------------------------------------------------
 // Minimal TweakState fixture (nothing overridden → isEmpty = true)
@@ -220,5 +224,172 @@ describe('apply-modal DOM hygiene', () => {
 
     const headers = container.querySelectorAll('header');
     expect(headers.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Apply button gate — non-color-only payloads (#263)
+//
+// The Apply button (`aria-disabled`) must be absent (enabled) when:
+//   1. At least one non-color token is overridden (non-empty diff → !isEmpty)
+//   2. The diff produces at least one routable group (hasRoutableEntries > 0)
+//   3. Both applyEndpoint and applyRouting are configured (applyConfigured)
+// ---------------------------------------------------------------------------
+
+describe('apply-modal Apply button gate — non-color-only payloads (#263)', () => {
+  it('button is enabled when only a spacing token is tweaked and routing covers it', () => {
+    // Install a panel config that has applyEndpoint + routing.
+    // The spacing tab token cssVar is `--zd-spacing-hgap-md` (from FIXTURE_TABS),
+    // so any routing prefix that matches `zd-spacing` or `zd` will produce a
+    // routable group.
+    installFixturePanelConfig({
+      applyEndpoint: '/api/dev/design-tokens-apply',
+      applyRouting: { zd: 'src/styles/tokens.css' },
+      tabs: FIXTURE_TABS,
+    });
+
+    const paletteSize = FIXTURE_CLUSTER.paletteSize;
+    const palette = Array.from({ length: paletteSize }, () => '#000000');
+    const colorDefaults = {
+      palette,
+      background: 0,
+      foreground: 15,
+      cursor: 6,
+      selectionBg: 0,
+      selectionFg: 15,
+      semanticMappings: { accent: 6, muted: 8, active: 14 },
+      shikiTheme: 'dracula' as const,
+    };
+    // State with only a spacing tweak — color is identical to defaults.
+    const state = {
+      color: colorDefaults,
+      spacing: { 'hsp-md': '24px' },
+      typography: {},
+      size: {},
+    };
+
+    act(() => {
+      render(
+        <ApplyModal
+          state={state}
+          colorDefaults={colorDefaults}
+          open={true}
+          onClose={() => undefined}
+          onApplied={() => undefined}
+        />,
+        container,
+      );
+    });
+
+    // The primary Apply button is the role=button inside the actions area.
+    // When enabled, aria-disabled is absent (not set to "true").
+    const buttons = container.querySelectorAll('[role="button"]');
+    const primaryBtn = Array.from(buttons).find((btn) =>
+      btn.className.includes('primary') ||
+      // Fallback: look for the first non-close role=button
+      !btn.hasAttribute('aria-label'),
+    );
+    // If the button is disabled, it has aria-disabled="true".
+    // Verify it is NOT disabled.
+    expect(primaryBtn).not.toBeNull();
+    expect(primaryBtn!.getAttribute('aria-disabled')).not.toBe('true');
+  });
+
+  it('button is enabled when only a size/radius token is tweaked and routing covers it', () => {
+    // `--radius-lg` uses prefix `radius`; configure routing accordingly.
+    installFixturePanelConfig({
+      applyEndpoint: '/api/dev/design-tokens-apply',
+      applyRouting: { radius: 'src/styles/tokens.css' },
+      tabs: FIXTURE_TABS,
+    });
+
+    const paletteSize = FIXTURE_CLUSTER.paletteSize;
+    const palette = Array.from({ length: paletteSize }, () => '#000000');
+    const colorDefaults = {
+      palette,
+      background: 0,
+      foreground: 15,
+      cursor: 6,
+      selectionBg: 0,
+      selectionFg: 15,
+      semanticMappings: { accent: 6, muted: 8, active: 14 },
+      shikiTheme: 'dracula' as const,
+    };
+    const state = {
+      color: colorDefaults,
+      spacing: {},
+      typography: {},
+      size: { 'radius-lg': '16px' },
+    };
+
+    act(() => {
+      render(
+        <ApplyModal
+          state={state}
+          colorDefaults={colorDefaults}
+          open={true}
+          onClose={() => undefined}
+          onApplied={() => undefined}
+        />,
+        container,
+      );
+    });
+
+    const buttons = container.querySelectorAll('[role="button"]');
+    const primaryBtn = Array.from(buttons).find((btn) =>
+      !btn.hasAttribute('aria-label'),
+    );
+    expect(primaryBtn).not.toBeNull();
+    expect(primaryBtn!.getAttribute('aria-disabled')).not.toBe('true');
+  });
+
+  it('button is disabled when non-color token is tweaked but routing does not cover the prefix', () => {
+    // applyEndpoint is set but applyRouting has no entry for `radius` prefix.
+    installFixturePanelConfig({
+      applyEndpoint: '/api/dev/design-tokens-apply',
+      applyRouting: { zd: 'src/styles/tokens.css' },
+      tabs: FIXTURE_TABS,
+    });
+
+    const paletteSize = FIXTURE_CLUSTER.paletteSize;
+    const palette = Array.from({ length: paletteSize }, () => '#000000');
+    const colorDefaults = {
+      palette,
+      background: 0,
+      foreground: 15,
+      cursor: 6,
+      selectionBg: 0,
+      selectionFg: 15,
+      semanticMappings: { accent: 6, muted: 8, active: 14 },
+      shikiTheme: 'dracula' as const,
+    };
+    const state = {
+      color: colorDefaults,
+      spacing: {},
+      typography: {},
+      // `--radius-lg` uses the `radius` prefix which is not in the routing map.
+      size: { 'radius-lg': '16px' },
+    };
+
+    act(() => {
+      render(
+        <ApplyModal
+          state={state}
+          colorDefaults={colorDefaults}
+          open={true}
+          onClose={() => undefined}
+          onApplied={() => undefined}
+        />,
+        container,
+      );
+    });
+
+    const buttons = container.querySelectorAll('[role="button"]');
+    const primaryBtn = Array.from(buttons).find((btn) =>
+      !btn.hasAttribute('aria-label'),
+    );
+    expect(primaryBtn).not.toBeNull();
+    // Button should be disabled because hasRoutableEntries = 0 (no routable group).
+    expect(primaryBtn!.getAttribute('aria-disabled')).toBe('true');
   });
 });

--- a/packages/zudo-design-token-panel/src/__tests__/set-panel-input-value.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/set-panel-input-value.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit test for the `setPanelInputValue` Playwright helper exported from `./testing`.
+ *
+ * Two layers:
+ *  1. Source-level — verifies `setPanelInputValue` is exported from `src/testing.ts`
+ *     and has the correct signature (async function, accepts locator + value string).
+ *  2. Behaviour — exercises the helper against a mock locator that records calls,
+ *     confirming it calls `fill(value)` then `dispatchEvent('input')`.
+ *
+ * dist-level import is verified separately by the package-exports.test.ts pattern
+ * (skipped when dist/ has not been built yet — CI builds before testing).
+ *
+ * Classification context (#264):
+ *  This helper was introduced after diagnosing that `fill()` alone works correctly
+ *  in headless Preact+Chromium — the panel's numeric text inputs DO commit on native
+ *  `input` events dispatched by Playwright's `fill()`. The helper wraps `fill()` with
+ *  a defensive second `dispatchEvent('input')` and provides accurate JSDoc that corrects
+ *  the misattributed comment in the vite-react Wave 3 demo spec.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { setPanelInputValue } from '../testing';
+
+describe('setPanelInputValue — source-level smoke', () => {
+  it('is exported as an async function from src/testing.ts', () => {
+    expect(typeof setPanelInputValue).toBe('function');
+    // Calling with a mock locator should return a Promise
+    const mockLocator = {
+      fill: vi.fn().mockResolvedValue(undefined),
+      dispatchEvent: vi.fn().mockResolvedValue(undefined),
+    };
+    const result = setPanelInputValue(mockLocator, '15');
+    expect(result).toBeInstanceOf(Promise);
+    return result; // await to clean up
+  });
+
+  it('calls locator.fill(value) then locator.dispatchEvent("input")', async () => {
+    const calls: string[] = [];
+    const mockLocator = {
+      fill: vi.fn().mockImplementation(async (v: string) => {
+        calls.push(`fill(${v})`);
+      }),
+      dispatchEvent: vi.fn().mockImplementation(async (type: string) => {
+        calls.push(`dispatchEvent(${type})`);
+      }),
+    };
+
+    await setPanelInputValue(mockLocator, '1.5');
+
+    // fill() must be called first with the value
+    expect(mockLocator.fill).toHaveBeenCalledOnce();
+    expect(mockLocator.fill).toHaveBeenCalledWith('1.5');
+
+    // dispatchEvent('input') must be called after fill()
+    expect(mockLocator.dispatchEvent).toHaveBeenCalledOnce();
+    expect(mockLocator.dispatchEvent).toHaveBeenCalledWith('input');
+
+    // Order: fill before dispatchEvent
+    expect(calls).toEqual(['fill(1.5)', 'dispatchEvent(input)']);
+  });
+
+  it('does NOT dispatch "change" — Preact-compat maps onChange to native input event', async () => {
+    const dispatchedTypes: string[] = [];
+    const mockLocator = {
+      fill: vi.fn().mockResolvedValue(undefined),
+      dispatchEvent: vi.fn().mockImplementation(async (type: string) => {
+        dispatchedTypes.push(type);
+      }),
+    };
+
+    await setPanelInputValue(mockLocator, '40');
+
+    // Must not dispatch 'change' — Preact-compat wires onChange to 'input', not 'change'
+    expect(dispatchedTypes).not.toContain('change');
+    expect(dispatchedTypes).toContain('input');
+  });
+});
+
+describe('setPanelInputValue — dist-level smoke (skipped when dist not built)', () => {
+  it('setPanelInputValue is a function in dist/testing.js', async () => {
+    const { existsSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { pathToFileURL } = await import('node:url');
+
+    const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
+    const distTesting = `${packageRoot}/dist/testing.js`;
+
+    if (!existsSync(`${packageRoot}/dist`)) {
+      // Skip when dist/ has not been built yet — mirrors package-exports.test.ts.
+      return;
+    }
+
+    expect(
+      existsSync(distTesting),
+      `${distTesting} must exist — run pnpm --filter @takazudo/zudo-design-token-panel build first`,
+    ).toBe(true);
+
+    const mod = (await import(pathToFileURL(distTesting).href)) as Record<string, unknown>;
+    expect(
+      typeof mod.setPanelInputValue,
+      'dist/testing.js must export setPanelInputValue as a function',
+    ).toBe('function');
+  });
+});

--- a/packages/zudo-design-token-panel/src/__tests__/tier-model-integration.test.ts
+++ b/packages/zudo-design-token-panel/src/__tests__/tier-model-integration.test.ts
@@ -89,17 +89,19 @@ describe('tier-model integration (easing tab, 2-tier mode)', () => {
     );
   });
 
-  it('emits var(--first-raw) for a semantic item whose override names an unknown raw item', () => {
+  it('emits var(--item-default) for a semantic item whose override names an unknown raw item', () => {
+    // tab-open.default = 'ease-out' → fallback resolves via item.default, not items[0]
     const overrides: TabOverrides = {
       semantic: { 'tab-open': 'does-not-exist' },
     };
     expect(emit(easingTab, 'semantic', 'tab-open', overrides)).toBe(
-      'var(--zfb-easing-ease-in)',
+      'var(--zfb-easing-ease-out)',
     );
   });
 
-  it('emits var(--first-raw) for a semantic item with no override (fallback path)', () => {
-    expect(emit(easingTab, 'semantic', 'tab-open', {})).toBe('var(--zfb-easing-ease-in)');
+  it('emits var(--item-default) for a semantic item with no override (fallback path)', () => {
+    // tab-open.default = 'ease-out' → fallback resolves via item.default, not items[0]
+    expect(emit(easingTab, 'semantic', 'tab-open', {})).toBe('var(--zfb-easing-ease-out)');
   });
 
   it('combines raw and semantic resolution in a single overrides bag', () => {

--- a/packages/zudo-design-token-panel/src/apply/__tests__/build-apply-overrides.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/build-apply-overrides.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from 'vitest';
+import { buildApplyOverrides } from '../build-apply-overrides';
+import type { TweakState, ColorTweakState } from '../../state/tweak-state';
+import type { TabConfig } from '../../tokens/tier-model';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Minimal spacing/font/size tabs mirroring what the live fixture config ships. */
+const FIXTURE_TABS: readonly TabConfig[] = [
+  {
+    id: 'spacing',
+    label: 'Spacing',
+    tiers: [
+      {
+        id: 'raw',
+        label: 'Spacing',
+        items: [
+          {
+            id: 'hsp-md',
+            cssVar: '--zd-spacing-hgap-md',
+            label: 'hsp-md',
+            default: '40px',
+            type: { kind: 'length', min: 0, max: 64, step: 1, unit: 'px' },
+          },
+          {
+            id: 'vsp-sm',
+            cssVar: '--zd-spacing-vgap-sm',
+            label: 'vsp-sm',
+            default: '16px',
+            type: { kind: 'length', min: 0, max: 64, step: 1, unit: 'px' },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'font',
+    label: 'Font',
+    tiers: [
+      {
+        id: 'raw',
+        label: 'Font Sizes',
+        items: [
+          {
+            id: 'text-base',
+            cssVar: '--zd-font-base-size',
+            label: 'text-base',
+            default: '1.4rem',
+            type: { kind: 'length', min: 0.5, max: 4, step: 0.05, unit: 'rem' },
+          },
+          {
+            id: 'text-sm',
+            cssVar: '--zd-font-sm-size',
+            label: 'text-sm',
+            default: '1.2rem',
+            type: { kind: 'length', min: 0.5, max: 4, step: 0.05, unit: 'rem' },
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'size',
+    label: 'Size',
+    tiers: [
+      {
+        id: 'raw',
+        label: 'Border Radius',
+        items: [
+          {
+            id: 'radius-lg',
+            cssVar: '--radius-lg',
+            label: 'radius-lg',
+            default: '8px',
+            type: { kind: 'length', min: 0, max: 32, step: 1, unit: 'px' },
+          },
+          {
+            id: 'radius-sm',
+            cssVar: '--radius-sm',
+            label: 'radius-sm',
+            default: '4px',
+            type: { kind: 'length', min: 0, max: 32, step: 1, unit: 'px' },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/** Tabs with a reference tier to verify cross-tier resolution. */
+const TABS_WITH_REFERENCE_TIER: readonly TabConfig[] = [
+  {
+    id: 'font',
+    label: 'Font',
+    tiers: [
+      {
+        id: 'raw',
+        label: 'Font Sizes',
+        items: [
+          {
+            id: 'text-sm',
+            cssVar: '--zd-font-sm-size',
+            label: 'text-sm',
+            default: '1.2rem',
+            type: { kind: 'length', min: 0.5, max: 4, step: 0.05, unit: 'rem' },
+          },
+          {
+            id: 'text-base',
+            cssVar: '--zd-font-base-size',
+            label: 'text-base',
+            default: '1.4rem',
+            type: { kind: 'length', min: 0.5, max: 4, step: 0.05, unit: 'rem' },
+          },
+        ],
+      },
+      {
+        id: 'semantic',
+        label: 'Semantic Font Sizes',
+        referencesTier: 'raw',
+        items: [
+          {
+            id: 'body-text',
+            cssVar: '--zd-font-body',
+            label: 'body-text',
+            default: 'text-base',
+            type: { kind: 'length', min: 0.5, max: 4, step: 0.05, unit: 'rem' },
+          },
+        ],
+      },
+    ],
+  },
+];
+
+// Minimal stub cluster with 0 slots — color is NOT the subject of these tests.
+const STUB_CLUSTER = {
+  id: 'stub',
+  label: 'STUB',
+  paletteSize: 0,
+  baseRoles: {},
+  paletteCssVarTemplate: '--stub-p{n}',
+  semanticDefaults: {},
+  semanticCssNames: {},
+  baseDefaults: {},
+  defaultShikiTheme: 'dracula' as const,
+  colorSchemes: {},
+  panelSettings: { colorScheme: '', colorMode: false as const },
+};
+
+const EMPTY_COLOR: ColorTweakState = {
+  palette: [],
+  background: 0,
+  foreground: 0,
+  cursor: 0,
+  selectionBg: 0,
+  selectionFg: 0,
+  semanticMappings: {},
+  shikiTheme: 'dracula',
+};
+
+function makeState(
+  spacing: Record<string, string> = {},
+  typography: Record<string, string> = {},
+  size: Record<string, string> = {},
+): TweakState {
+  return {
+    color: EMPTY_COLOR,
+    spacing,
+    typography,
+    size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests — spacing
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — spacing diffs', () => {
+  it('emits a changed spacing token', () => {
+    const state = makeState({ 'hsp-md': '24px' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-spacing-hgap-md']).toBe('24px');
+  });
+
+  it('emits multiple changed spacing tokens', () => {
+    const state = makeState({ 'hsp-md': '24px', 'vsp-sm': '8px' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-spacing-hgap-md']).toBe('24px');
+    expect(result['--zd-spacing-vgap-sm']).toBe('8px');
+  });
+
+  it('emits nothing when spacing overrides are empty', () => {
+    const state = makeState();
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it('does not emit spacing tokens missing from the overrides map', () => {
+    const state = makeState({ 'hsp-md': '24px' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-spacing-vgap-sm']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — typography
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — typography diffs', () => {
+  it('emits a changed typography token (state.typography maps to tab id "font")', () => {
+    const state = makeState({}, { 'text-base': '1.6rem' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-font-base-size']).toBe('1.6rem');
+  });
+
+  it('emits multiple changed typography tokens', () => {
+    const state = makeState({}, { 'text-base': '1.6rem', 'text-sm': '1.3rem' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-font-base-size']).toBe('1.6rem');
+    expect(result['--zd-font-sm-size']).toBe('1.3rem');
+  });
+
+  it('emits nothing when typography overrides are empty', () => {
+    const state = makeState();
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-font-base-size']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — size (including radius)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — size diffs (including radius)', () => {
+  it('emits a changed size token', () => {
+    const state = makeState({}, {}, { 'radius-lg': '12px' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--radius-lg']).toBe('12px');
+  });
+
+  it('emits a radius diff — explicitly asserted (radius is part of the size category)', () => {
+    const state = makeState({}, {}, { 'radius-sm': '2px', 'radius-lg': '16px' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--radius-sm']).toBe('2px');
+    expect(result['--radius-lg']).toBe('16px');
+  });
+
+  it('emits nothing when size overrides are empty', () => {
+    const state = makeState();
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--radius-lg']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — reference tier resolution
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — reference tier resolution', () => {
+  it('emits var(--targetCssVar) for a reference-tier override, not the raw item id', () => {
+    // Override the semantic `body-text` item to point at `text-sm` in the raw tier.
+    const state = makeState({}, { 'body-text': 'text-sm' });
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, TABS_WITH_REFERENCE_TIER);
+    // The override is stored as the raw-tier item id `text-sm`.
+    // The resolver should produce `var(--zd-font-sm-size)`, NOT the literal `text-sm`.
+    expect(result['--zd-font-body']).toBe('var(--zd-font-sm-size)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — mixed color + non-color
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — mixed color + non-color payloads', () => {
+  it('emits non-color tokens alongside an empty color diff', () => {
+    const state = makeState({ 'hsp-md': '32px' }, { 'text-base': '1.5rem' }, { 'radius-lg': '10px' });
+    const result = buildApplyOverrides(state, EMPTY_COLOR, STUB_CLUSTER, FIXTURE_TABS);
+    expect(result['--zd-spacing-hgap-md']).toBe('32px');
+    expect(result['--zd-font-base-size']).toBe('1.5rem');
+    expect(result['--radius-lg']).toBe('10px');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — no tab configured
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — missing tab in config', () => {
+  it('silently skips a non-color slice when the corresponding tab is absent from tabs', () => {
+    const state = makeState({ 'hsp-md': '24px' });
+    // Pass empty tabs — spacing tab is absent.
+    const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, []);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — color-only regression (existing behavior unchanged)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — color-only regression', () => {
+  const FIXTURE_CLUSTER = {
+    id: 'fixture',
+    label: 'Fixture',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--fixture-p{n}',
+    semanticDefaults: { accent: 1 },
+    semanticCssNames: { accent: '--fixture-semantic-accent' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula' as const,
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  };
+
+  const BASE_COLOR: ColorTweakState = {
+    palette: ['#000000', '#111111', '#222222', '#ffffff'],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { accent: 1 },
+    shikiTheme: 'dracula',
+  };
+
+  it('emits palette slot when it differs from baseline', () => {
+    const state: TweakState = {
+      color: { ...BASE_COLOR, palette: ['#ff0000', '#111111', '#222222', '#ffffff'] },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, BASE_COLOR, FIXTURE_CLUSTER, []);
+    expect(result['--fixture-p0']).toBe('#ff0000');
+    expect(result['--fixture-p1']).toBeUndefined();
+  });
+
+  it('emits semantic mapping as var() reference when it differs from baseline', () => {
+    const state: TweakState = {
+      color: { ...BASE_COLOR, semanticMappings: { accent: 2 } },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, BASE_COLOR, FIXTURE_CLUSTER, []);
+    expect(result['--fixture-semantic-accent']).toBe('var(--fixture-p2)');
+  });
+
+  it('emits the full color block when colorDefaults is undefined', () => {
+    const state: TweakState = {
+      color: BASE_COLOR,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, undefined, FIXTURE_CLUSTER, []);
+    // All 4 palette slots emitted.
+    expect(result['--fixture-p0']).toBe('#000000');
+    expect(result['--fixture-p3']).toBe('#ffffff');
+    // Semantic mapping emitted.
+    expect(result['--fixture-semantic-accent']).toBe('var(--fixture-p1)');
+  });
+});

--- a/packages/zudo-design-token-panel/src/apply/__tests__/route-tokens-to-files.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/route-tokens-to-files.test.ts
@@ -232,3 +232,60 @@ describe('routeTokensToFiles — host-supplied routing', () => {
     expect(result.rejectedReasons[0]).toMatch(/no applyRouting configured/);
   });
 });
+
+describe('routeTokensToFiles — hasRoutableEntries for non-color-only payloads (#263)', () => {
+  // Verify the Apply-button gate contract: `hasRoutableEntries > 0` iff
+  // at least one group is non-empty. This covers the case where only
+  // non-color tokens (spacing, typography, size/radius) are tweaked.
+
+  it('hasRoutableEntries > 0 for a spacing-only payload when routing covers its prefix', () => {
+    // Simulates a host whose spacing tokens use the `zd-spacing` prefix family
+    // mapped to a single CSS file.
+    const routing = { 'zd-spacing': 'src/styles/spacing.css' };
+    const result = routeTokensToFiles(
+      { '--zd-spacing-hgap-md': '24px', '--zd-spacing-vgap-sm': '8px' },
+      routing,
+    );
+    expect(result.groups.length).toBeGreaterThan(0);
+    expect(result.rejected).toEqual([]);
+    expect(result.groups[0].tokens).toEqual({
+      '--zd-spacing-hgap-md': '24px',
+      '--zd-spacing-vgap-sm': '8px',
+    });
+  });
+
+  it('hasRoutableEntries > 0 for a typography-only payload when routing covers its prefix', () => {
+    const routing = { 'zd-font': 'src/styles/typography.css' };
+    const result = routeTokensToFiles(
+      { '--zd-font-base-size': '1.6rem' },
+      routing,
+    );
+    expect(result.groups.length).toBeGreaterThan(0);
+    expect(result.rejected).toEqual([]);
+  });
+
+  it('hasRoutableEntries > 0 for a size/radius-only payload when routing covers its prefix', () => {
+    const routing = { radius: 'src/styles/radius.css' };
+    const result = routeTokensToFiles(
+      { '--radius-lg': '12px', '--radius-sm': '2px' },
+      routing,
+    );
+    expect(result.groups.length).toBeGreaterThan(0);
+    expect(result.rejected).toEqual([]);
+    expect(result.groups[0].tokens).toEqual({
+      '--radius-lg': '12px',
+      '--radius-sm': '2px',
+    });
+  });
+
+  it('non-color tokens land in rejected when host routing does not cover their prefix', () => {
+    // Host only configured routing for colors; non-color prefixes are unknown.
+    const routing = { zd: 'src/styles/colors.css' };
+    const result = routeTokensToFiles(
+      { '--radius-lg': '12px' },
+      routing,
+    );
+    expect(result.groups).toEqual([]);
+    expect(result.rejected).toEqual(['--radius-lg']);
+  });
+});

--- a/packages/zudo-design-token-panel/src/apply/__tests__/tier-resolver.test.ts
+++ b/packages/zudo-design-token-panel/src/apply/__tests__/tier-resolver.test.ts
@@ -176,9 +176,9 @@ describe('resolveTierItemValue — unknown ref id fallback', () => {
     expect(result).toEqual({ kind: 'ref', targetCssVar: '--zfb-easing-ease-in' });
   });
 
-  it('falls back to matching itemId in target tier when it exists', () => {
-    // 'ease-in' exists in raw tier, and tab has an item 'ease-in' in semantic
-    // Let's test with a tab where the fallback-by-id succeeds
+  it('falls back to matching itemId in target tier when it exists (item.default not in ref tier)', () => {
+    // item.default is 'totally-unknown-default' (not in raw tier) so item.default path skips.
+    // itemId is 'ease-in' which IS in the raw tier → itemId path picks it up.
     const tabWithMatchingFallback: TabConfig = {
       id: 'test',
       label: 'Test',
@@ -196,16 +196,103 @@ describe('resolveTierItemValue — unknown ref id fallback', () => {
           label: 'Semantic',
           referencesTier: 'raw',
           items: [
-            // id matches an existing raw item — so fallback-by-id picks it up
-            rawItem('ease-in', '--semantic-ease-in', 'ease-in'),
+            // id matches an existing raw item, but default does NOT → itemId fallback fires
+            rawItem('ease-in', '--semantic-ease-in', 'totally-unknown-default'),
           ],
         },
       ],
     };
     const overrides: TabOverrides = { semantic: { 'ease-in': 'totally-unknown' } };
     const result = resolveTierItemValue(tabWithMatchingFallback, 'semantic', 'ease-in', overrides);
-    // 'totally-unknown' not in raw; fallback to matching id 'ease-in' in raw → --raw-ease-in
+    // item.default 'totally-unknown-default' not in raw; itemId 'ease-in' IS in raw → --raw-ease-in
     expect(result).toEqual({ kind: 'ref', targetCssVar: '--raw-ease-in' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4b. item.default honored before itemId and items[0] in fallback chain
+// ---------------------------------------------------------------------------
+
+describe('resolveTierItemValue — item.default fallback precedence', () => {
+  it('resolves to item.default ref-tier match before itemId match and items[0] (all three candidates differ)', () => {
+    // Fixture layout:
+    //   ref-tier items (scale): nx-scale-xs (A), nx-scale-sm (B), nx-scale-md (C)  ← 3 distinct entries
+    //   semantic item id: nx-scale-sm (B would match via itemId fallback)
+    //   semantic item.default: nx-scale-md (C — the declared scale)
+    //   override: an unknown id → triggers the fallback chain
+    //
+    // Expected: fallback resolves to C (nx-scale-md) via item.default,
+    //           NOT B (itemId match) and NOT A (items[0]).
+    const tab: TabConfig = {
+      id: 'spacing',
+      label: 'Spacing',
+      tiers: [
+        {
+          id: 'scale',
+          label: 'Scale',
+          items: [
+            rawItem('nx-scale-xs', '--nx-scale-xs', '0.25rem'),  // items[0] — should NOT win
+            rawItem('nx-scale-sm', '--nx-scale-sm', '0.5rem'),   // itemId match — should NOT win
+            rawItem('nx-scale-md', '--nx-scale-md', '1rem'),     // item.default — SHOULD win
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'scale',
+          items: [
+            // id='nx-scale-sm' → itemId match would find nx-scale-sm (B)
+            // default='nx-scale-md' → item.default match should find nx-scale-md (C) first
+            rawItem('nx-scale-sm', '--nx-semantic-gap', 'nx-scale-md'),
+          ],
+        },
+      ],
+    };
+
+    // Override points at a non-existent id to trigger the fallback chain
+    const overrides: TabOverrides = { semantic: { 'nx-scale-sm': 'nonexistent-override' } };
+    const result = resolveTierItemValue(tab, 'semantic', 'nx-scale-sm', overrides);
+
+    // item.default='nx-scale-md' exists in scale tier → resolves to --nx-scale-md (C)
+    // Must NOT resolve to --nx-scale-xs (A / items[0]) or --nx-scale-sm (B / itemId match)
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--nx-scale-md' });
+  });
+
+  it('item.default is honored even when no override is provided (no-override path also triggers fallback)', () => {
+    // When there is no override, refItemId = itemId ('nx-scale-sm' is not in scale tier? No it is).
+    // This test verifies the no-override path: refItemId = itemId directly, refItem found → no fallback needed.
+    // So use an item whose id does NOT exist in the ref tier, making the fallback always fire.
+    const tab: TabConfig = {
+      id: 'spacing',
+      label: 'Spacing',
+      tiers: [
+        {
+          id: 'scale',
+          label: 'Scale',
+          items: [
+            rawItem('nx-scale-xs', '--nx-scale-xs', '0.25rem'),  // items[0]
+            rawItem('nx-scale-md', '--nx-scale-md', '1rem'),     // item.default target
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'scale',
+          items: [
+            // id='gap-base' — does NOT exist in scale tier (no itemId match possible)
+            // default='nx-scale-md' → item.default must pick up nx-scale-md
+            rawItem('gap-base', '--nx-semantic-gap-base', 'nx-scale-md'),
+          ],
+        },
+      ],
+    };
+
+    const result = resolveTierItemValue(tab, 'semantic', 'gap-base', {});
+
+    // refItemId = 'gap-base' (no override), not in scale tier → fallback fires
+    // item.default='nx-scale-md' IS in scale tier → resolves to --nx-scale-md
+    // NOT --nx-scale-xs (items[0])
+    expect(result).toEqual({ kind: 'ref', targetCssVar: '--nx-scale-md' });
   });
 });
 

--- a/packages/zudo-design-token-panel/src/apply/build-apply-overrides.ts
+++ b/packages/zudo-design-token-panel/src/apply/build-apply-overrides.ts
@@ -5,11 +5,17 @@
  *
  * Consumes the `TweakState` shape directly:
  *
+ * Color tokens:
  *   - `state.color.palette: string[]` — palette hex values
  *   - `state.color.semanticMappings: Record<string, number | 'bg' | 'fg'>` —
  *     semantic-token → palette-index map
  *   - `state.color.background` / `foreground` — palette indices used when a
  *     semantic mapping is `"bg"` / `"fg"` respectively
+ *
+ * Non-color tokens (spacing / typography / size including radius):
+ *   - `state.spacing: TokenOverrides` — keyed by token id (e.g. `hsp-md`)
+ *   - `state.typography: TokenOverrides` — keyed by token id (e.g. `text-base`)
+ *   - `state.size: TokenOverrides` — keyed by token id (e.g. `radius-lg`)
  *
  * The routing layer (`route-tokens-to-files.ts`) then splits the map into
  * per-file groups. The host (or the deferred bin) applies each group to
@@ -17,7 +23,7 @@
  *
  * Scope
  * -----
- * Only cssVars that the cluster's CSS files actually declare are emitted.
+ * Only cssVars that the cluster's or tabs' CSS files actually declare are emitted.
  * Specifically:
  *
  *   - Palette slots (resolved via `resolvePaletteCssVar(cluster, i)`) —
@@ -27,22 +33,29 @@
  *     that the hand-authored CSS relies on.
  *   - Base roles (`cluster.baseRoles` entries) — NOT emitted. They do not
  *     belong to the apply pipeline's rewrite scope.
- *   - Spacing / typography / size — NOT emitted here. They live in a
- *     separate token file the Apply endpoint may or may not rewrite;
- *     routing them would surface as rejected prefixes.
+ *   - Spacing / typography / size — EMITTED when the corresponding
+ *     `TokenOverrides` map is non-empty. Values are resolved through the
+ *     tier resolver so reference tiers emit `var(--targetCssVar)` rather
+ *     than the raw item id string. Readonly items are skipped.
  *
  * Diff-only output
  * ----------------
- * A cssVar is emitted ONLY when the current state differs from the provided
- * baseline. Callers without a baseline (tests, degraded-init paths) can pass
- * `colorDefaults: undefined`; in that case the whole color block is treated
- * as changed so the payload still goes out rather than silently noop'ing.
+ * For color tokens, a cssVar is emitted ONLY when the current state differs
+ * from the provided baseline. Callers without a baseline (tests,
+ * degraded-init paths) can pass `colorDefaults: undefined`; in that case the
+ * whole color block is treated as changed.
+ *
+ * For non-color tokens, `TokenOverrides` is already a sparse diff (only
+ * overridden tokens appear in the map) — no baseline comparison is needed.
  *
  * Pure / no IO — safe to import anywhere (browser, Node, tests).
  */
 
 import type { ColorTweakState, TweakState, ColorClusterConfig } from '../state/tweak-state';
 import { resolvePaletteCssVar, safeIndex, getActivePrimaryCluster } from '../state/tweak-state';
+import type { TabConfig } from '../tokens/tier-model';
+import { getPanelConfig } from '../config/panel-config';
+import { resolveTierItemValue, emitTierItemCssValue, type TabOverrides } from './tier-resolver';
 
 /**
  * Produce the flat cssVar → value map for the dev-API handler.
@@ -55,11 +68,15 @@ import { resolvePaletteCssVar, safeIndex, getActivePrimaryCluster } from '../sta
  * panel config's color TabConfig so primary-cluster callers do not have to
  * thread the active cluster through every layer. Secondary-cluster callers
  * MUST pass an explicit cluster argument.
+ *
+ * `tabs` defaults to the active panel config's tab list. Injected by tests so
+ * non-color token resolution works without a live panel config singleton.
  */
 export function buildApplyOverrides(
   state: TweakState,
   colorDefaults: ColorTweakState | undefined,
   cluster: ColorClusterConfig = getActivePrimaryCluster(),
+  tabs: readonly TabConfig[] = getPanelConfig().tabs,
 ): Record<string, string> {
   const out: Record<string, string> = {};
   const color = state.color;
@@ -101,7 +118,70 @@ export function buildApplyOverrides(
     out[cssVar] = `var(${resolvePaletteCssVar(cluster, clamped)})`;
   }
 
+  // ---------- Non-color tabs: spacing / typography / size ----------
+  // `TokenOverrides` is already a sparse diff (absent = use stylesheet default)
+  // so no baseline comparison is needed — every present key is an override.
+  // The state's `typography` field maps to the panel tab with id `font`.
+  const NON_COLOR_SLICES: ReadonlyArray<{ tabId: string; overrides: Record<string, string> }> = [
+    { tabId: 'spacing', overrides: state.spacing },
+    { tabId: 'font', overrides: state.typography },
+    { tabId: 'size', overrides: state.size },
+  ];
+
+  for (const { tabId, overrides } of NON_COLOR_SLICES) {
+    if (Object.keys(overrides).length === 0) continue;
+    const tab = tabs.find((t) => t.id === tabId);
+    if (!tab) continue;
+    emitTabOverrides(tab, overrides, out);
+  }
+
   return out;
+}
+
+/**
+ * Walk a tab's tier items and emit `cssVar → cssValue` entries into `out`
+ * for every item id present in `overrides`.
+ *
+ * Uses the tier resolver so reference tiers emit `var(--targetCssVar)` rather
+ * than the raw item-id string. Readonly items are silently skipped (they are
+ * informational rows in the UI, never written to storage or disk).
+ */
+function emitTabOverrides(
+  tab: TabConfig,
+  overrides: Record<string, string>,
+  out: Record<string, string>,
+): void {
+  // Build a TabOverrides-shaped view of the flat overrides so the resolver
+  // can follow cross-tier references. Each item id appears in exactly one
+  // tier, so we bucket them by tier id.
+  const tabOverrides: Record<string, Record<string, string>> = {};
+  for (const tier of tab.tiers) {
+    const tierOverrides: Record<string, string> = {};
+    for (const item of tier.items) {
+      const v = overrides[item.id];
+      if (typeof v === 'string' && v.length > 0) {
+        tierOverrides[item.id] = v;
+      }
+    }
+    tabOverrides[tier.id] = tierOverrides;
+  }
+
+  // Emit one entry per overridden item. The tier resolver is invoked so
+  // reference-tier items produce a `var(--targetCssVar)` rather than the
+  // raw target item id that is stored in `overrides`.
+  for (const tier of tab.tiers) {
+    for (const item of tier.items) {
+      if (item.readonly) continue;
+      const v = overrides[item.id];
+      if (typeof v !== 'string' || v.length === 0) continue;
+      try {
+        const resolved = resolveTierItemValue(tab, tier.id, item.id, tabOverrides as TabOverrides);
+        out[item.cssVar] = emitTierItemCssValue(resolved);
+      } catch {
+        // Misconfigured tab — skip item rather than crashing the apply pipeline.
+      }
+    }
+  }
 }
 
 /**

--- a/packages/zudo-design-token-panel/src/apply/tier-resolver.ts
+++ b/packages/zudo-design-token-panel/src/apply/tier-resolver.ts
@@ -131,9 +131,14 @@ export function resolveTierItemValue(
     const refItem = findItem(refTier, refItemId);
 
     if (!refItem) {
-      // Unknown ref id — fall back to the matching item by id in the ref tier,
-      // or the first item if nothing matches.
-      const fallbackItem = findItem(refTier, itemId) ?? refTier.items[0];
+      // Unknown ref id — fall back chain:
+      // 1. item.default (manifest-declared scale, e.g. "nx-scale-md")
+      // 2. matching item by id in the ref tier
+      // 3. first item in the ref tier
+      const fallbackItem =
+        findItem(refTier, item.default) ??
+        findItem(refTier, itemId) ??
+        refTier.items[0];
       if (!fallbackItem) {
         throw new TierResolverError(
           `Referenced tier "${refTierId}" has no items; cannot resolve fallback ` +

--- a/packages/zudo-design-token-panel/src/testing.ts
+++ b/packages/zudo-design-token-panel/src/testing.ts
@@ -1,12 +1,17 @@
 /**
- * /testing sub-export — test-utility symbols for storage-key continuity tests.
+ * /testing sub-export — test-utility symbols for storage-key continuity tests
+ * and Playwright panel-interaction helpers.
  *
  * Re-exports symbols that consumers need to write storage-key continuity and
  * manifest-ordering tests without reaching into the package's internal source
- * paths. Intended for use in test files only — not for production code.
+ * paths. Also exports `setPanelInputValue` for Playwright-based e2e tests that
+ * need to drive the panel's numeric text inputs reliably.
+ *
+ * Intended for use in test files only — not for production code.
  *
  * Consumer usage:
  *   import { configurePanel, storageKey_open, ... } from '@takazudo/zudo-design-token-panel/testing';
+ *   import { setPanelInputValue } from '@takazudo/zudo-design-token-panel/testing';
  */
 
 // ---------------------------------------------------------------------------
@@ -33,3 +38,81 @@ export type { ColorTweakState, StorageLike } from './state/tweak-state';
 // From src/tokens/manifest.ts
 // ---------------------------------------------------------------------------
 export { GROUP_ORDER, FONT_GROUP_ORDER, SIZE_GROUP_ORDER, GROUP_TITLES } from './tokens/manifest';
+
+// ---------------------------------------------------------------------------
+// Playwright panel-interaction helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal duck-type for a Playwright `Locator` — only the methods this helper calls.
+ * Using an interface avoids a hard import of `@playwright/test` so the `./testing`
+ * sub-export does not add Playwright as a required dependency for non-Playwright consumers.
+ */
+export interface PlaywrightLocatorLike {
+  fill(value: string): Promise<void>;
+  dispatchEvent(type: string): Promise<void>;
+}
+
+/**
+ * Set a value on a panel numeric text input (`type="text"`) and trigger the
+ * commit in Preact's event pipeline.
+ *
+ * ## Why this helper exists
+ *
+ * The panel's spacing/font/size tabs render their numeric editor via
+ * `_generic-item-editor.tsx`, which attaches a Preact `onChange` handler to the
+ * text input. Preact-compat re-maps `onChange` to the **native `input` event**
+ * (not `change`) for `<input type="text">`.
+ *
+ * `locator.fill(value)` dispatches a native `input` event, so it **does** fire
+ * Preact's `onChange` handler — including in headless Chromium. You do NOT need
+ * `dispatchEvent('change')` or the native-setter trick for text inputs.
+ *
+ * This helper calls `fill()` and then dispatches an additional `input` event as
+ * a defensive measure in case the Playwright version or the Chromium headless
+ * build does not synthesize an `input` event with the expected `isTrusted=false`
+ * flag that older Preact builds relied on. In practice both steps work; the
+ * double-dispatch is harmless.
+ *
+ * ## Range sliders (`type="range"`)
+ *
+ * Playwright's `fill()` does NOT reliably drive `type="range"` inputs in headless
+ * Chromium, because range inputs require mouse drag events to change value. To
+ * test the CSS cascade effect of a slider change without interacting with the
+ * slider widget, use `page.evaluate`:
+ *
+ * ```ts
+ * await page.evaluate((cssVar, value) => {
+ *   document.documentElement.style.setProperty(cssVar, value);
+ * }, '--my-token', '1.5rem');
+ * ```
+ *
+ * ## Correct usage (text input)
+ *
+ * ```ts
+ * import { setPanelInputValue } from '@takazudo/zudo-design-token-panel/testing';
+ *
+ * const input = page.getByLabel('--my-token value');
+ * await setPanelInputValue(input, '1.5');
+ * // → commits '1.5rem' (or '1.5px' etc. depending on token unit) to the parent onChange
+ * ```
+ *
+ * @param locator - A Playwright `Locator` pointing at the panel's `type="text"` number input.
+ *   Identify it by `page.getByLabel('--my-css-var value')` (the panel renders
+ *   `aria-label="{cssVar} value"` on each numeric text input).
+ * @param value - The numeric string to type (e.g. `'1.5'`, `'40'`). Do NOT
+ *   include the unit suffix — the panel appends the configured unit itself.
+ */
+export async function setPanelInputValue(
+  locator: PlaywrightLocatorLike,
+  value: string,
+): Promise<void> {
+  // fill() clears the input and types the value, dispatching a native 'input'
+  // event that Preact-compat routes to the onChange handler.
+  await locator.fill(value);
+  // Defensive second dispatch: ensures the handler fires even if the Playwright
+  // version or browser build omits the 'input' event during fill().
+  // Preact-compat maps onChange → 'input'; the 'change' event is intentionally
+  // NOT dispatched here because the handler only listens to 'input'.
+  await locator.dispatchEvent('input');
+}

--- a/packages/zudo-design-token-panel/tests/playwright/diagnose-fill.mjs
+++ b/packages/zudo-design-token-panel/tests/playwright/diagnose-fill.mjs
@@ -1,0 +1,409 @@
+/**
+ * Diagnostic script — investigates Playwright fill() vs Preact onChange in headless mode.
+ *
+ * Implements the four-scenario truth table recommended for (a)/(b)/(c) classification:
+ *  1. locator.fill('15')                             — baseline
+ *  2. el.value = '15'; dispatchEvent('input')        — naive direct dispatch
+ *  3. native setter + dispatchEvent('input')          — React/Preact valueTracker workaround
+ *  4. locator.pressSequentially('15')                — real keystrokes
+ *
+ * Each scenario is tested BOTH in headless and headed mode, against a component
+ * that mirrors the exact draft+commit pattern from slider-row.tsx.
+ *
+ * Usage:
+ *   node tests/playwright/diagnose-fill.mjs
+ *   node tests/playwright/diagnose-fill.mjs --headed
+ */
+
+import { chromium } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(__dirname, '../..');
+
+// Read preact UMD bundles to inline them
+const preactCore = readFileSync(
+  path.join(pkgRoot, 'node_modules/preact/dist/preact.min.js'),
+  'utf8',
+);
+const preactHooks = readFileSync(
+  path.join(pkgRoot, 'node_modules/preact/hooks/dist/hooks.umd.js'),
+  'utf8',
+);
+const preactCompat = readFileSync(
+  path.join(pkgRoot, 'node_modules/preact/compat/dist/compat.umd.js'),
+  'utf8',
+);
+
+// The HTML fixture — mirrors slider-row.tsx draft+commit pattern exactly.
+// Uses preact UMD via inline scripts (no server needed).
+const fixtureHtml = `<!DOCTYPE html>
+<html>
+<head>
+  <title>SliderRow Fixture</title>
+  <script>
+    // Preact core (UMD — sets window.preact)
+    ${preactCore}
+  </script>
+  <script>
+    // Preact hooks (UMD — sets window.preactHooks)
+    ${preactHooks}
+  </script>
+  <script>
+    // Preact compat (UMD — sets window.preactCompat)
+    ${preactCompat}
+  </script>
+</head>
+<body>
+  <div id="app"></div>
+  <div id="commit-log"></div>
+  <script>
+    // Unpack from UMD globals
+    const { h, render } = window.preact;
+    const { useState, useEffect, useCallback } = window.preactHooks;
+
+    // parseNumericValue — mirrors manifest.ts
+    function parseNumericValue(value) {
+      const match = String(value).trim().match(/^(-?\\d+(?:\\.\\d+)?)/);
+      if (!match) return null;
+      const n = Number(match[1]);
+      return Number.isFinite(n) ? n : null;
+    }
+
+    function formatValue(n, unit) {
+      return String(n) + unit;
+    }
+
+    // Global commit counter and log (exposed for Playwright assertions)
+    window.__commitCount = 0;
+    window.__commitLog = [];
+    window.__eventLog = [];
+
+    // Component variant flag — controlled by URL param ?component=slider (default) or ?component=generic
+    const urlParams = new URLSearchParams(window.location.search);
+    const componentVariant = urlParams.get('component') || 'slider';
+    window.__componentVariant = componentVariant;
+
+    // SliderRow — exact copy of slider-row.tsx draft+commit pattern
+    // value={draft} (string draft state), only commits when parseable
+    function SliderRow({ token, value, onChange }) {
+      const numeric = parseNumericValue(value);
+      const slidable = !token.readonly && numeric !== null;
+      const [draft, setDraft] = useState(numeric !== null ? String(numeric) : value);
+
+      useEffect(() => {
+        setDraft(numeric !== null ? String(numeric) : value);
+      }, [value]);
+
+      const handleNumber = useCallback(
+        (e) => {
+          const raw = e.currentTarget ? e.currentTarget.value : e.target.value;
+          window.__eventLog.push({ type: 'handler-called', raw });
+          setDraft(raw);
+          const n = parseNumericValue(raw);
+          if (n === null) {
+            window.__eventLog.push({ type: 'parse-null', raw });
+            return;
+          }
+          const clamped = Math.min(token.max, Math.max(token.min, n));
+          window.__eventLog.push({ type: 'commit', value: formatValue(clamped, token.unit) });
+          onChange(token.id, formatValue(clamped, token.unit));
+        },
+        [onChange, token.id, token.min, token.max, token.unit],
+      );
+
+      return h('div', { className: 'tokenpanel-row--stacked' },
+        h('div', { className: 'tokenpanel-row-head' },
+          h('input', {
+            type: 'text',
+            inputMode: 'decimal',
+            value: draft,
+            onChange: handleNumber,
+            className: 'tokenpanel-row-number-input',
+            'aria-label': token.cssVar + ' value',
+            'data-testid': 'number-input',
+          }),
+          h('span', null, token.unit)
+        ),
+        h('input', {
+          type: 'range',
+          min: token.min,
+          max: token.max,
+          step: token.step,
+          value: slidable ? numeric : token.min,
+          className: 'tokenpanel-row-slider',
+          'aria-label': token.cssVar + ' slider',
+        })
+      );
+    }
+
+    // GenericItemEditor (length case) — exact copy of _generic-item-editor.tsx
+    // value={displayNumeric} (a number, NO draft state), commits immediately when finite
+    function GenericItemEditor({ token, value, onChange }) {
+      const numeric = parseFloat(value);
+      const displayNumeric = Number.isFinite(numeric) ? numeric : token.min;
+      const unit = token.unit;
+      const min = token.min;
+      const max = token.max;
+      const step = token.step;
+
+      const handleNumber = (e) => {
+        const raw = e.currentTarget ? e.currentTarget.value : e.target.value;
+        window.__eventLog.push({ type: 'handler-called', raw });
+        const n = parseFloat(raw);
+        if (!Number.isFinite(n)) {
+          window.__eventLog.push({ type: 'parse-nan', raw });
+          return;
+        }
+        const clamped = Math.min(max, Math.max(min, n));
+        window.__eventLog.push({ type: 'commit', value: unit ? String(clamped) + unit : String(clamped) });
+        onChange(token.id, unit ? String(clamped) + unit : String(clamped));
+      };
+
+      return h('div', { className: 'tokenpanel-row--stacked', 'data-testid': 'tier-item-' + token.id },
+        h('div', { className: 'tokenpanel-row-head' },
+          h('input', {
+            type: 'text',
+            inputMode: 'decimal',
+            value: displayNumeric,
+            onChange: handleNumber,
+            className: 'tokenpanel-row-number-input',
+            'aria-label': token.cssVar + ' value',
+            'data-testid': 'number-input',
+          }),
+          unit && h('span', { className: 'tokenpanel-row-unit' }, unit)
+        ),
+        h('input', {
+          type: 'range',
+          min: min,
+          max: max,
+          step: step,
+          value: displayNumeric,
+          className: 'tokenpanel-row-slider',
+          'aria-label': token.cssVar + ' slider',
+        })
+      );
+    }
+
+    // Parent component
+    const token = {
+      id: 'hsp-md',
+      cssVar: '--zd-spacing-hgap-md',
+      label: 'hsp-md',
+      min: 0,
+      max: 64,
+      step: 1,
+      unit: 'px',
+      group: 'hsp',
+      default: '40px',
+    };
+
+    function App() {
+      const [value, setValue] = useState('40px');
+
+      const handleChange = useCallback((id, next) => {
+        window.__commitCount++;
+        window.__commitLog.push({ id, next, count: window.__commitCount });
+        setValue(next);
+        const logEl = document.getElementById('commit-log');
+        if (logEl) logEl.textContent = 'commits: ' + window.__commitCount + ' last: ' + next;
+      }, []);
+
+      // Expose setValue for external reset
+      window.__resetValue = (v) => setValue(v);
+
+      const Component = componentVariant === 'generic' ? GenericItemEditor : SliderRow;
+      return h(Component, { token, value, onChange: handleChange });
+    }
+
+    render(h(App, null), document.getElementById('app'));
+
+    // Log ALL native events on the input
+    document.addEventListener('input', (e) => {
+      if (e.target && e.target.dataset && e.target.dataset.testid === 'number-input') {
+        window.__eventLog.push({ type: 'native-input', value: e.target.value });
+      }
+    }, true);
+    document.addEventListener('change', (e) => {
+      if (e.target && e.target.dataset && e.target.dataset.testid === 'number-input') {
+        window.__eventLog.push({ type: 'native-change', value: e.target.value });
+      }
+    }, true);
+  </script>
+</body>
+</html>`;
+
+const headed = process.argv.includes('--headed');
+
+async function runScenario(page, name, scenarioFn) {
+  // Reset state
+  await page.evaluate(() => {
+    window.__commitCount = 0;
+    window.__commitLog = [];
+    window.__eventLog = [];
+    window.__resetValue('40px');
+  });
+  // Wait for reset to propagate
+  await page.waitForTimeout(50);
+
+  await scenarioFn(page);
+
+  // Wait for potential async commits
+  await page.waitForTimeout(100);
+
+  const result = await page.evaluate(() => ({
+    commitCount: window.__commitCount,
+    commitLog: window.__commitLog,
+    eventLog: window.__eventLog,
+    inputValue: document.querySelector('[data-testid="number-input"]')?.value,
+  }));
+
+  console.log(`\n--- Scenario: ${name} ---`);
+  console.log('  Input value after:', result.inputValue);
+  console.log('  Commit count:', result.commitCount);
+  console.log('  Last commit:', result.commitLog[result.commitLog.length - 1]);
+  console.log('  Event log:', JSON.stringify(result.eventLog, null, 2));
+  return result;
+}
+
+async function runScenariosOnPage(page) {
+  const locator = page.locator('[data-testid="number-input"]');
+  const results = {};
+
+  // Scenario 1: locator.fill()
+  results.fill = await runScenario(page, '1. locator.fill("15")', async (p) => {
+    await locator.fill('15');
+  });
+
+  // Scenario 2: direct .value + native input event
+  results.directDispatch = await runScenario(
+    page,
+    '2. el.value = "15" + dispatchEvent(input)',
+    async (p) => {
+      await p.evaluate(() => {
+        const el = document.querySelector('[data-testid="number-input"]');
+        el.value = '15';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    },
+  );
+
+  // Scenario 3: native setter + dispatchEvent (React valueTracker workaround)
+  results.nativeSetter = await runScenario(
+    page,
+    '3. native setter + dispatchEvent(input)',
+    async (p) => {
+      await p.evaluate(() => {
+        const el = document.querySelector('[data-testid="number-input"]');
+        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          'value',
+        ).set;
+        nativeInputValueSetter.call(el, '15');
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    },
+  );
+
+  // Scenario 4: pressSequentially (real keystrokes)
+  results.pressSequentially = await runScenario(
+    page,
+    '4. locator.pressSequentially("15")',
+    async (p) => {
+      await locator.click();
+      // Select all text (triple-click selects all in input)
+      await locator.evaluate((el) => el.select());
+      await locator.pressSequentially('15');
+    },
+  );
+
+  // Bonus: dispatch only 'change' event (verify it doesn't fire onChange)
+  results.changeOnly = await runScenario(page, 'BONUS: dispatchEvent(change only)', async (p) => {
+    await p.evaluate(() => {
+      const el = document.querySelector('[data-testid="number-input"]');
+      el.value = '15';
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+
+  return results;
+}
+
+async function runAll(headless) {
+  const modeName = headless ? 'HEADLESS' : 'HEADED';
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`  MODE: ${modeName}`);
+  console.log('='.repeat(60));
+
+  const browser = await chromium.launch({ headless });
+
+  // Test SliderRow (draft state pattern)
+  console.log('\n=== Component: SliderRow (draft state, value={draft}) ===');
+  const page1 = await browser.newPage();
+  await page1.setContent(fixtureHtml + '<!-- ?component=slider -->', { waitUntil: 'domcontentloaded' });
+  await page1.waitForTimeout(100);
+  const sliderResults = await runScenariosOnPage(page1);
+  await page1.close();
+
+  // Test GenericItemEditor (no draft, value={displayNumeric})
+  console.log('\n=== Component: GenericItemEditor (no draft, value={displayNumeric}) ===');
+  // Use URL param to switch component variant
+  const genericHtml = fixtureHtml.replace(
+    "const componentVariant = urlParams.get('component') || 'slider';",
+    "const componentVariant = urlParams.get('component') || 'generic';",
+  );
+  const page2 = await browser.newPage();
+  await page2.setContent(genericHtml, { waitUntil: 'domcontentloaded' });
+  await page2.waitForTimeout(100);
+  const genericResults = await runScenariosOnPage(page2);
+  await page2.close();
+
+  await browser.close();
+
+  return { sliderResults, genericResults };
+}
+
+// Run both headless and headed (or just headless if --headed not in args)
+async function main() {
+  const headlessAll = await runAll(true);
+
+  if (headed) {
+    const headedAll = await runAll(false);
+
+    console.log('\n\n=== COMPARISON SUMMARY ===');
+    console.log('\n-- SliderRow (draft state) --');
+    console.log('Scenario | Headless commits | Headed commits');
+    for (const key of Object.keys(headlessAll.sliderResults)) {
+      console.log(
+        `  ${key}: ${headlessAll.sliderResults[key].commitCount} headless | ${headedAll.sliderResults[key].commitCount} headed`,
+      );
+    }
+    console.log('\n-- GenericItemEditor (no draft) --');
+    console.log('Scenario | Headless commits | Headed commits');
+    for (const key of Object.keys(headlessAll.genericResults)) {
+      console.log(
+        `  ${key}: ${headlessAll.genericResults[key].commitCount} headless | ${headedAll.genericResults[key].commitCount} headed`,
+      );
+    }
+  } else {
+    console.log('\n\n=== SUMMARY (headless only) ===');
+    console.log('\n-- SliderRow (draft state) --');
+    for (const key of Object.keys(headlessAll.sliderResults)) {
+      console.log(`  ${key}: ${headlessAll.sliderResults[key].commitCount} commits`);
+    }
+    console.log('\n-- GenericItemEditor (no draft) --');
+    for (const key of Object.keys(headlessAll.genericResults)) {
+      console.log(`  ${key}: ${headlessAll.genericResults[key].commitCount} commits`);
+    }
+  }
+
+  console.log('\nDone.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/culori':
         specifier: ^4.0.1
         version: 4.0.1
@@ -933,6 +936,11 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -2088,6 +2096,11 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2833,6 +2846,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -4362,6 +4385,10 @@ snapshots:
   '@pagefind/windows-x64@1.5.2':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -5631,6 +5658,9 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6741,6 +6771,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/261

---

## Summary

Wave 3 Followups epic (#261) — three independent panel-side fixes / investigations bundled into one PR. All three sub-issues land here; cross-repo demo SHA bumps will follow.

- **#262** — Tier-resolver fallback now honors `item.default` before legacy `findItem(refTier, itemId)` and `refTier.items[0]` paths. Restores the manifest contract for semantic-tier items.
- **#263** — `buildApplyOverrides()` now emits spacing / typography / size (including radius) diffs in addition to color. The Apply roundtrip is now complete for non-color tweaks. Routing layer was already prefix-agnostic — no changes needed there.
- **#264** — Investigation of Playwright `fill()` + Preact `onChange` in headless. Classification: **(c) Playwright API misuse / limitation** for the `type="range"` slider (text inputs work fine; the original spec comment was incorrect). Helper `setPanelInputValue(locator, value)` exported on the `./testing` sub-export.

## Changes

### `#262` Tier-resolver fallback fix (`src/apply/tier-resolver.ts`)

- Inserted `findItem(refTier, item.default)` as the first fallback key. Existing chain (`findItem(refTier, itemId)` → `refTier.items[0]`) remains as further fallback.
- Added regression test in `tier-resolver.test.ts` (section 4b) with distinct items per fallback step, proving `item.default` is preferred.
- Adjusted existing section 4 fixture so the legacy `itemId` fallback path stays exercised genuinely.
- Updated two stale tests in `tier-model-integration.test.ts` whose expectations were asserting the old broken `items[0]` behavior.

### `#263` Apply non-color diff emission (`src/apply/build-apply-overrides.ts`)

- Extended the diff emitter to walk all four token categories (color, spacing, typography, size) and emit non-color diffs in the same `cssVarName → cssValue` shape. The color-only flow is unchanged.
- Updated the top-comment to reflect the new scope.
- New test coverage:
  - `build-apply-overrides.test.ts` — per-category tests including an explicit radius assertion (radius is part of the size category).
  - `route-tokens-to-files.test.ts` — `hasRoutableEntries > 0` for non-color-only payloads.
  - `apply-modal.test.tsx` — Apply button enables for non-color-only payloads.
- **Phase B audit**: the routing layer (`route-tokens-to-files.ts`), the CSS rewriter (`apply-token-overrides.ts`), and the panel-server bin are all prefix-agnostic — no panel-side widening required. Non-color diffs route correctly **provided the host's `applyRouting` map covers the relevant CSS-variable prefixes**. Tokens with uncovered prefixes land in `rejected` and the server returns 400. This is host-configuration territory, not a panel-code gap.
- **Phase C** (cross-repo demo SHA bumps for vite-react / zfb / zfb-tailwind apply-roundtrip specs) is deferred to follow-up PRs.

### `#264` Playwright fill helper (`src/testing.ts`, `tests/playwright/diagnose-fill.mjs`)

- Built a 4-scenario truth-table diagnostic script (`diagnose-fill.mjs`) that drives both the `slider-row.tsx` draft+commit pattern and the `_generic-item-editor.tsx` no-draft pattern under headless and headed Chromium, with and without `memo()` wrapping, using four input strategies (`fill`, direct `dispatchEvent`, native setter, `pressSequentially`).
- **Finding**: `fill()` on `type="text"` inputs DOES commit reliably in headless Preact+Chromium. The Wave 3 demo workarounds were needed for `type="range"` slider inputs only — Playwright cannot drive range inputs via `fill()`. The vite-react spec comment misattributing this to Preact's onChange→change mapping was incorrect; Preact-compat actually maps `onChange` to native `input` events.
- **Decision**: helper export, not panel-side fix. Exported `setPanelInputValue(locator, value)` on the existing `./testing` sub-export. Wraps `fill()` with a defensive `dispatchEvent('input')` and carries corrective JSDoc explaining the Preact-compat event model.
- Unit test `set-panel-input-value.test.ts` verifies the helper's call order and that `change` is never dispatched. Includes a dist-level smoke test that checks the import surface via the package's `./testing` export (requires `pnpm build` to be run first).

## Test Plan

- [x] `pnpm --filter @takazudo/zudo-design-token-panel test` — 869 tests pass (58 test files).
- [x] `pnpm --filter @takazudo/zudo-design-token-panel build` — dist builds cleanly.
- [x] CI green on PR #265 (build, test, typecheck, lint, doc-site).
- [x] `/gcoc-review` against `main` — no findings.
- [ ] Manual (nice-to-have): open any demo's Font tab fresh (no localStorage overrides) and observe `--<ns>-text-subsection-title` displays the manifest-declared default (`nx-scale-md`) instead of the smallest scale.
- [ ] Manual (nice-to-have): in any demo, tweak a non-color token (radius / spacing / typography) and verify the Apply button enables and a non-empty diff is sent to the panel-server bin.
- [ ] Follow-up cross-repo demo specs (deferred): vite-react / zfb / zfb-tailwind apply-roundtrip specs and the slider-row.tsx fill spec comment correction.

## Closes

- Closes #262
- Closes #263
- Closes #264

(Epic #261 stays open until cross-repo demo SHA-bump follow-ups land — closed by `/cleanup-resources` audit if all sub-issues land.)