### PR TITLE
fix(highlight): detect easing and non-font text-kind tokens

### DIFF
--- a/packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.browser.test.ts
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.browser.test.ts
@@ -377,77 +377,204 @@ describe('number — decoy', () => {
 });
 
 // ---------------------------------------------------------------------------
-// FONT-FAMILY tokens
+// TEXT tokens (font-family / animation-name / transition-property / will-change)
 // ---------------------------------------------------------------------------
 
-describe('fontFamily — direct use', () => {
+describe('text (font-family) — direct use', () => {
   it('finds element with font-family: var(--ff)', () => {
     injectStyle(":root { --ff: Georgia, serif; }");
     injectStyle('.fx-ff { font-family: var(--ff); }');
     const el = createElement({ className: 'fx-ff' });
-    const { elements } = findElementsUsingToken('--ff', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
 
-describe('fontFamily — alias depth 1', () => {
+describe('text (font-family) — alias depth 1', () => {
   it('finds element via --ff-semantic aliasing --ff-base', () => {
     injectStyle(":root { --ff-base: Georgia, serif; --ff-semantic: var(--ff-base); }");
     injectStyle('.fx-ff-alias1 { font-family: var(--ff-semantic); }');
     const el = createElement({ className: 'fx-ff-alias1' });
-    const { elements } = findElementsUsingToken('--ff-base', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff-base', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
 
-describe('fontFamily — alias depth 2', () => {
+describe('text (font-family) — alias depth 2', () => {
   it('finds element via --heading-ff -> --ff-semantic -> --ff-base', () => {
     injectStyle(":root { --ff-base: Georgia, serif; --ff-semantic: var(--ff-base); --heading-ff: var(--ff-semantic); }");
     injectStyle('.fx-ff-alias2 { font-family: var(--heading-ff); }');
     const el = createElement({ className: 'fx-ff-alias2' });
-    const { elements } = findElementsUsingToken('--ff-base', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff-base', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
 
-describe('fontFamily — inline style', () => {
+describe('text (font-family) — inline style', () => {
   it('finds element with inline font-family: var(--ff)', () => {
     injectStyle(":root { --ff: Georgia, serif; }");
     const el = createElement({ inlineStyle: 'font-family: var(--ff)' });
-    const { elements } = findElementsUsingToken('--ff', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
 
-describe('fontFamily — multi-property rule', () => {
+describe('text (font-family) — multi-property rule', () => {
   it('finds element using font-family token (only one relevant longhand)', () => {
     injectStyle(":root { --ff: Georgia, serif; }");
     injectStyle('.fx-ff-multi { font-family: var(--ff); font-size: 16px; }');
     const el = createElement({ className: 'fx-ff-multi' });
-    const { elements } = findElementsUsingToken('--ff', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
 
-describe('fontFamily — pseudo-element consumer', () => {
+describe('text (font-family) — pseudo-element consumer', () => {
   it('finds element whose ::before uses font-family token', () => {
     injectStyle(":root { --ff: Georgia, serif; }");
     injectStyle('.fx-ff-pseudo::before { content: "x"; font-family: var(--ff); }');
     const el = createElement({ className: 'fx-ff-pseudo' });
-    const { elements } = findElementsUsingToken('--ff', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
 
-describe('fontFamily — decoy', () => {
+describe('text (font-family) — decoy', () => {
   it('does NOT find element with literal Georgia font-family', () => {
     injectStyle(":root { --ff: Georgia, serif; }");
     injectStyle('.fx-real { font-family: var(--ff); }');
     injectStyle(".fx-decoy { font-family: Georgia, serif; }");
     createElement({ className: 'fx-real' });
     const decoy = createElement({ className: 'fx-decoy' });
-    const { elements } = findElementsUsingToken('--ff', { kind: 'fontFamily' });
+    const { elements } = findElementsUsingToken('--ff', { kind: 'text' });
     expect(elements).not.toContain(decoy);
+  });
+});
+
+describe('text (animation-name) — direct use', () => {
+  it('finds element with animation-name: var(--anim)', () => {
+    injectStyle(':root { --anim: my-keyframes; }');
+    injectStyle('.fx-anim { animation-name: var(--anim); animation-duration: 1s; }');
+    const el = createElement({ className: 'fx-anim' });
+    const { elements } = findElementsUsingToken('--anim', { kind: 'text' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('text (transition-property) — direct use', () => {
+  it('finds element with transition-property: var(--prop)', () => {
+    injectStyle(':root { --prop: opacity; }');
+    injectStyle('.fx-tp { transition-property: var(--prop); transition-duration: 1s; }');
+    const el = createElement({ className: 'fx-tp' });
+    const { elements } = findElementsUsingToken('--prop', { kind: 'text' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('text (will-change) — direct use', () => {
+  it('finds element with will-change: var(--wc)', () => {
+    injectStyle(':root { --wc: transform; }');
+    injectStyle('.fx-wc { will-change: var(--wc); }');
+    const el = createElement({ className: 'fx-wc' });
+    const { elements } = findElementsUsingToken('--wc', { kind: 'text' });
+    expect(elements).toContain(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EASING tokens (transition-timing-function / animation-timing-function)
+// ---------------------------------------------------------------------------
+
+describe('easing — transition-timing-function (cubic-bezier)', () => {
+  it('finds element with transition-timing-function: var(--ease)', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    injectStyle('.fx-ease { transition-timing-function: var(--ease); transition-duration: 1s; }');
+    const el = createElement({ className: 'fx-ease' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('easing — transition-timing-function (keyword)', () => {
+  it('finds element with transition-timing-function: var(--ease) where ease=ease-in', () => {
+    injectStyle(':root { --ease: ease-in; }');
+    injectStyle('.fx-ease-kw { transition-timing-function: var(--ease); transition-duration: 1s; }');
+    const el = createElement({ className: 'fx-ease-kw' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('easing — animation-timing-function', () => {
+  it('finds element with animation-timing-function: var(--ease)', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    injectStyle('.fx-anim-ease { animation-name: x; animation-duration: 1s; animation-timing-function: var(--ease); }');
+    const el = createElement({ className: 'fx-anim-ease' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('easing — transition shorthand (longhand decomposition)', () => {
+  it('finds element using `transition: all 1s var(--ease)` shorthand', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    injectStyle('.fx-ease-short { transition: all 1s var(--ease); }');
+    const el = createElement({ className: 'fx-ease-short' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('easing — alias depth 1 (semantic)', () => {
+  it('finds element via --ease-semantic aliasing --ease-base', () => {
+    injectStyle(':root { --ease-base: cubic-bezier(0.42, 0, 1, 1); --ease-semantic: var(--ease-base); }');
+    injectStyle('.fx-ease-alias { transition-timing-function: var(--ease-semantic); transition-duration: 1s; }');
+    const el = createElement({ className: 'fx-ease-alias' });
+    const { elements } = findElementsUsingToken('--ease-base', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('easing — decoy', () => {
+  it('does NOT find element with a literal cubic-bezier value (no var())', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    injectStyle('.fx-ease-real { transition-timing-function: var(--ease); transition-duration: 1s; }');
+    injectStyle('.fx-ease-decoy { transition-timing-function: cubic-bezier(0.42, 0, 1, 1); transition-duration: 1s; }');
+    createElement({ className: 'fx-ease-real' });
+    const decoy = createElement({ className: 'fx-ease-decoy' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).not.toContain(decoy);
+  });
+});
+
+describe('easing — inline style', () => {
+  it('finds element with inline transition-timing-function: var(--ease)', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    const el = createElement({ inlineStyle: 'transition-timing-function: var(--ease); transition-duration: 1s' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// String-sentinel-rejection invariant — encodes the CSS Variables spec
+// behavior that motivated the per-property-family sentinel design (#275).
+// A string sentinel substituted into a typed property (e.g. transition-timing-
+// function) is invalid at computed-value time, so the declaration falls back
+// to its initial value. This means the `text` probe CANNOT detect easing
+// consumers — only the `easing` probe can.
+// ---------------------------------------------------------------------------
+
+describe('invariant — text probe cannot detect easing consumers (#275)', () => {
+  it('text probe finds 0 elements when easing token is consumed via transition-timing-function', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    injectStyle('.fx-ease-text { transition-timing-function: var(--ease); transition-duration: 1s; }');
+    createElement({ className: 'fx-ease-text' });
+    // Forcing the text probe: sentinel is `__zdtp_probe_text_AAA__`, which is
+    // invalid as <easing-function>; transition-timing-function falls back to
+    // `ease`. The text probe finds no consumers.
+    const { elements } = findElementsUsingToken('--ease', { kind: 'text' });
+    expect(elements).toHaveLength(0);
   });
 });
 
@@ -764,9 +891,25 @@ describe('type detection — auto-classify resolved value', () => {
     expect(elements).toContain(el);
   });
 
-  it("classifies 'Georgia, serif' as fontFamily", () => {
+  it("classifies 'Georgia, serif' as text", () => {
     injectStyle(":root { --t: Georgia, serif; }");
     injectStyle('.tc { font-family: var(--t); }');
+    const el = createElement({ className: 'tc' });
+    const { elements } = findElementsUsingToken('--t');
+    expect(elements).toContain(el);
+  });
+
+  it("classifies 'cubic-bezier(0.42, 0, 1, 1)' as easing", () => {
+    injectStyle(":root { --t: cubic-bezier(0.42, 0, 1, 1); }");
+    injectStyle('.tc { transition-timing-function: var(--t); }');
+    const el = createElement({ className: 'tc' });
+    const { elements } = findElementsUsingToken('--t');
+    expect(elements).toContain(el);
+  });
+
+  it("classifies 'ease-in' as easing", () => {
+    injectStyle(":root { --t: ease-in; }");
+    injectStyle('.tc { transition-timing-function: var(--t); }');
     const el = createElement({ className: 'tc' });
     const { elements } = findElementsUsingToken('--t');
     expect(elements).toContain(el);
@@ -782,13 +925,13 @@ describe('type detection — auto-classify resolved value', () => {
 });
 
 describe('type detection — kind hint overrides auto-detect', () => {
-  it('token with 12px value probed as fontFamily — no elements found (no font-family consumer)', () => {
+  it('token with 12px value probed as text — no elements found (no font-family consumer)', () => {
     injectStyle(':root { --t: 12px; }');
     injectStyle('.tc { padding: var(--t); }');
     const el = createElement({ className: 'tc' });
-    // Force fontFamily probe on a length token → the fontFamily sentinel
-    // (__zdtp_probe_ff_AAA__) won't match padding-top
-    const { elements } = findElementsUsingToken('--t', { kind: 'fontFamily' });
+    // Force the text probe on a length token → the text sentinel
+    // (__zdtp_probe_text_AAA__) won't match padding-top
+    const { elements } = findElementsUsingToken('--t', { kind: 'text' });
     expect(elements).not.toContain(el);
   });
 });

--- a/packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.browser.test.ts
+++ b/packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.browser.test.ts
@@ -495,12 +495,45 @@ describe('easing — transition-timing-function (cubic-bezier)', () => {
   });
 });
 
-describe('easing — transition-timing-function (keyword)', () => {
+describe('easing — transition-timing-function (keyword, explicit kind)', () => {
   it('finds element with transition-timing-function: var(--ease) where ease=ease-in', () => {
+    // Bare easing keywords collide with <custom-ident>, so auto-detect routes
+    // them to `text`. Callers that know the token is consumed via a timing-
+    // function property must pass kind: 'easing' explicitly.
     injectStyle(':root { --ease: ease-in; }');
     injectStyle('.fx-ease-kw { transition-timing-function: var(--ease); transition-duration: 1s; }');
     const el = createElement({ className: 'fx-ease-kw' });
     const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('easing — multi-value transition-timing-function list', () => {
+  it('finds element with transition-timing-function: ease, var(--ease)', () => {
+    injectStyle(':root { --ease: cubic-bezier(0.42, 0, 1, 1); }');
+    injectStyle('.fx-ease-multi { transition: opacity 1s ease, transform 1s var(--ease); }');
+    const el = createElement({ className: 'fx-ease-multi' });
+    const { elements } = findElementsUsingToken('--ease', { kind: 'easing' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('text — multi-value will-change list', () => {
+  it('finds element with will-change: opacity, var(--wc)', () => {
+    injectStyle(':root { --wc: transform; }');
+    injectStyle('.fx-wc-multi { will-change: opacity, var(--wc); }');
+    const el = createElement({ className: 'fx-wc-multi' });
+    const { elements } = findElementsUsingToken('--wc', { kind: 'text' });
+    expect(elements).toContain(el);
+  });
+});
+
+describe('text — multi-value transition-property list', () => {
+  it('finds element with transition-property: opacity, var(--prop)', () => {
+    injectStyle(':root { --prop: transform; }');
+    injectStyle('.fx-tp-multi { transition-property: opacity, var(--prop); transition-duration: 1s; }');
+    const el = createElement({ className: 'fx-tp-multi' });
+    const { elements } = findElementsUsingToken('--prop', { kind: 'text' });
     expect(elements).toContain(el);
   });
 });
@@ -907,11 +940,22 @@ describe('type detection — auto-classify resolved value', () => {
     expect(elements).toContain(el);
   });
 
-  it("classifies 'ease-in' as easing", () => {
-    injectStyle(":root { --t: ease-in; }");
+  it("classifies 'steps(3, end)' as easing", () => {
+    injectStyle(":root { --t: steps(3, end); }");
     injectStyle('.tc { transition-timing-function: var(--t); }');
     const el = createElement({ className: 'tc' });
     const { elements } = findElementsUsingToken('--t');
+    expect(elements).toContain(el);
+  });
+
+  it("does NOT classify bare keyword 'linear' as easing (custom-ident collision)", () => {
+    // A bare 'linear' value is also a valid <custom-ident>, so it could be an
+    // animation-name. Auto-detect prefers `text` for keyword values; only the
+    // unambiguous functional forms route to `easing`.
+    injectStyle(":root { --anim-name: linear; }");
+    injectStyle('.tc { animation-name: var(--anim-name); animation-duration: 1s; }');
+    const el = createElement({ className: 'tc' });
+    const { elements } = findElementsUsingToken('--anim-name');
     expect(elements).toContain(el);
   });
 

--- a/packages/zudo-design-token-panel/src/highlight/find-elements.ts
+++ b/packages/zudo-design-token-panel/src/highlight/find-elements.ts
@@ -178,13 +178,16 @@ const TOKEN_TYPES: Record<string, TokenTypeConfig> = {
     sentinelB: '__zdtp_probe_text_BBB__',
     // Properties that accept an arbitrary custom-ident (or list of idents).
     // The CSS parser preserves the sentinel string verbatim for these, so
-    // equality mode finds consumers by exact match.
+    // equality mode finds single-value consumers by exact match.
     longhands: ['font-family', 'animation-name', 'transition-property', 'will-change'],
+    // Same properties listed as compounds so the substring check catches
+    // comma-separated multi-value consumers like
+    // `transition-property: opacity, var(--prop)`, where Chrome serializes
+    // the computed value as a list containing the sentinel.
     // font / transition / animation shorthands intentionally omitted: Chrome
     // returns empty string for getComputedStyle(...).font when longhands
-    // disagree, and the shorthands' longhand decomposition above already
-    // catches every consumer.
-    compounds: [],
+    // disagree, and the longhands above already cover every consumer.
+    compounds: ['font-family', 'animation-name', 'transition-property', 'will-change'],
   },
   easing: {
     // cubic-bezier() with high-entropy coordinates that round-trip exactly
@@ -193,9 +196,13 @@ const TOKEN_TYPES: Record<string, TokenTypeConfig> = {
     sentinelA: 'cubic-bezier(0.12347, 0.67891, 0.13573, 0.24679)',
     sentinelB: 'cubic-bezier(0.98763, 0.43217, 0.86419, 0.75319)',
     longhands: ['transition-timing-function', 'animation-timing-function'],
-    // `transition` / `animation` shorthands decompose into their longhands at
-    // computed-style time, so substring match on the shorthand is not needed.
-    compounds: [],
+    // Same properties as compounds so the substring check catches
+    // comma-separated multi-value lists like
+    // `transition-timing-function: ease, var(--easing)`.
+    // `transition` / `animation` shorthands decompose into their longhands
+    // at computed-style time, so substring match on the shorthand is not
+    // needed.
+    compounds: ['transition-timing-function', 'animation-timing-function'],
   },
 };
 
@@ -232,11 +239,16 @@ const LENGTH_RE = /^-?\d+(\.\d+)?(px|rem|em|vh|vw|vmin|vmax|pt|pc|in|cm|mm|ex|ch
 const BARE_NUMBER_RE = /^-?\d+(\.\d+)?$/;
 
 /**
- * CSS <easing-function> values. Matches the cubic-bezier()/steps()/linear()
- * functional forms and the bare keywords. Anchored to the start so a stray
- * "ease" inside a longer ident doesn't false-positive.
+ * CSS <easing-function> values in their UNAMBIGUOUS functional forms
+ * (`cubic-bezier(...)`, `steps(...)`, `linear(...)`). Bare easing keywords
+ * like `ease`, `ease-in`, `linear`, `step-start` are deliberately NOT matched
+ * here: they collide with `<custom-ident>`, so a token like
+ * `--anim-name: linear` consumed via `animation-name` must auto-detect as
+ * `text`. If a token value really is a bare easing keyword consumed via
+ * `transition-timing-function`, the caller (or a future tier-kind extension)
+ * must pass `kind: 'easing'` explicitly.
  */
-const EASING_RE = /^(cubic-bezier|steps|linear)\(|^(ease|ease-in|ease-out|ease-in-out|linear|step-start|step-end)$/i;
+const EASING_RE = /^(cubic-bezier|steps|linear)\(/i;
 
 function detectKind(
   cssVar: string,

--- a/packages/zudo-design-token-panel/src/highlight/find-elements.ts
+++ b/packages/zudo-design-token-panel/src/highlight/find-elements.ts
@@ -60,7 +60,7 @@ export interface FindElementsResult {
 
 export interface FindElementsOptions {
   /** Explicit token type. Skips auto-detection when supplied. */
-  kind?: 'color' | 'length' | 'number' | 'fontFamily';
+  kind?: 'color' | 'length' | 'number' | 'text' | 'easing';
   /**
    * Probe mode.
    *   equality (default): single sentinel; fast; misses calc/min/max/clamp.
@@ -71,7 +71,21 @@ export interface FindElementsOptions {
 
 // ---------------------------------------------------------------------------
 // Token-type registry  (lifted verbatim from probe.js; font shorthand dropped
-// from fontFamily compounds per production spec)
+// from text compounds per production spec)
+//
+// Per-property-family sentinels: the CSS Variables spec causes invalid var()
+// substitutions to be treated as `unset` at the consuming property, so a
+// string sentinel never appears in computed style for typed properties like
+// `transition-timing-function`. Each kind picks a sentinel format the
+// consuming properties will accept verbatim:
+//   - color    → rgb()
+//   - length   → px
+//   - number   → bare float in (0, 1)
+//   - text     → custom-ident (font-family / animation-name / transition-property / will-change)
+//   - easing   → cubic-bezier() (transition-timing-function / animation-timing-function)
+// Strict-typed string properties (cursor, content, mask-image) and time-typed
+// properties (transition-duration, animation-duration) need their own kinds
+// and are not covered here — see #275 follow-ups.
 // ---------------------------------------------------------------------------
 
 interface TokenTypeConfig {
@@ -159,12 +173,28 @@ const TOKEN_TYPES: Record<string, TokenTypeConfig> = {
     ],
     compounds: [],
   },
-  fontFamily: {
-    sentinelA: '__zdtp_probe_ff_AAA__',
-    sentinelB: '__zdtp_probe_ff_BBB__',
-    longhands: ['font-family'],
-    // font shorthand intentionally omitted: Chrome returns empty string for
-    // getComputedStyle(...).font when longhands disagree, defeating substring match.
+  text: {
+    sentinelA: '__zdtp_probe_text_AAA__',
+    sentinelB: '__zdtp_probe_text_BBB__',
+    // Properties that accept an arbitrary custom-ident (or list of idents).
+    // The CSS parser preserves the sentinel string verbatim for these, so
+    // equality mode finds consumers by exact match.
+    longhands: ['font-family', 'animation-name', 'transition-property', 'will-change'],
+    // font / transition / animation shorthands intentionally omitted: Chrome
+    // returns empty string for getComputedStyle(...).font when longhands
+    // disagree, and the shorthands' longhand decomposition above already
+    // catches every consumer.
+    compounds: [],
+  },
+  easing: {
+    // cubic-bezier() with high-entropy coordinates that round-trip exactly
+    // through Chrome's computed-style serialization. Coordinates picked to
+    // avoid collision with common timing functions used in real code.
+    sentinelA: 'cubic-bezier(0.12347, 0.67891, 0.13573, 0.24679)',
+    sentinelB: 'cubic-bezier(0.98763, 0.43217, 0.86419, 0.75319)',
+    longhands: ['transition-timing-function', 'animation-timing-function'],
+    // `transition` / `animation` shorthands decompose into their longhands at
+    // computed-style time, so substring match on the shorthand is not needed.
     compounds: [],
   },
 };
@@ -201,10 +231,17 @@ const LENGTH_RE = /^-?\d+(\.\d+)?(px|rem|em|vh|vw|vmin|vmax|pt|pc|in|cm|mm|ex|ch
 /** Bare unitless number (including floating point). */
 const BARE_NUMBER_RE = /^-?\d+(\.\d+)?$/;
 
+/**
+ * CSS <easing-function> values. Matches the cubic-bezier()/steps()/linear()
+ * functional forms and the bare keywords. Anchored to the start so a stray
+ * "ease" inside a longer ident doesn't false-positive.
+ */
+const EASING_RE = /^(cubic-bezier|steps|linear)\(|^(ease|ease-in|ease-out|ease-in-out|linear|step-start|step-end)$/i;
+
 function detectKind(
   cssVar: string,
   warnings: string[],
-): 'color' | 'length' | 'number' | 'fontFamily' {
+): 'color' | 'length' | 'number' | 'text' | 'easing' {
   const resolved = getComputedStyle(document.documentElement)
     .getPropertyValue(cssVar)
     .trim();
@@ -225,7 +262,10 @@ function detectKind(
   if (BARE_NUMBER_RE.test(resolved)) {
     return 'number';
   }
-  return 'fontFamily';
+  if (EASING_RE.test(resolved)) {
+    return 'easing';
+  }
+  return 'text';
 }
 
 // ---------------------------------------------------------------------------
@@ -422,10 +462,14 @@ function findFirstChange(
  * @param cssVar  The full custom-property name including leading dashes,
  *   e.g. `"--brand"`. Accepts `"var(--brand)"` defensively.
  * @param options  Optional configuration:
- *   - `kind`: explicit token type (`'color' | 'length' | 'number' | 'fontFamily'`).
- *     When omitted the type is auto-detected from the resolved value on
- *     `documentElement`. If the token has no value on `:root` (empty resolved
- *     value) a warning is emitted and `color` is assumed.
+ *   - `kind`: explicit token type (`'color' | 'length' | 'number' | 'text' | 'easing'`).
+ *     `text` covers any property accepting an arbitrary custom-ident
+ *     (font-family, animation-name, transition-property, will-change).
+ *     `easing` covers timing-function properties (transition-timing-function,
+ *     animation-timing-function). When omitted the type is auto-detected from
+ *     the resolved value on `documentElement`. If the token has no value on
+ *     `:root` (empty resolved value) a warning is emitted and `color` is
+ *     assumed.
  *   - `mode`: `'equality'` (default, fast) checks whether computed longhands
  *     equal the sentinel; `'differential'` probes twice (sentinels A and B)
  *     and marks consumers where any property differs — catches `calc()`,
@@ -454,7 +498,7 @@ export function findElementsUsingToken(
   const mode = options?.mode ?? 'equality';
 
   // Phase 1: determine token type
-  const kind: 'color' | 'length' | 'number' | 'fontFamily' =
+  const kind: 'color' | 'length' | 'number' | 'text' | 'easing' =
     options?.kind ?? detectKind(normalized, warnings);
 
   const conf = TOKEN_TYPES[kind] ?? TOKEN_TYPES.color;

--- a/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
+++ b/packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx
@@ -41,7 +41,7 @@ import type { TierValueKind } from '../tokens/tier-model';
 // Kind helpers
 // ---------------------------------------------------------------------------
 
-type ProbeKind = 'color' | 'length' | 'number' | 'fontFamily';
+type ProbeKind = 'color' | 'length' | 'number' | 'text' | 'easing';
 
 function tierKindToProbeKind(t: TierValueKind | undefined): ProbeKind | undefined {
   if (!t) return undefined;
@@ -50,8 +50,9 @@ function tierKindToProbeKind(t: TierValueKind | undefined): ProbeKind | undefine
     case 'length': return 'length';
     case 'number': return 'number';
     // 'text' is a string-valued catch-all in this repo (ref-tier identifiers,
-    // easing functions, etc.) — NOT just font-family. Fall back to auto-detect
-    // so non-font text tokens aren't forced into the font-family probe.
+    // easing functions, font families, animation names, etc.). Fall back to
+    // auto-detect so the resolved value picks the right probe ('easing' for
+    // cubic-bezier/keywords, 'text' for arbitrary idents).
     case 'text': return undefined;
     case 'select': return undefined; // select can hold any type — fall back to auto-detect
   }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/275

---

## Summary

Closes #275. The probe-substitution highlight algorithm now detects text-kind tokens whose computed value is **not** a font-family — most importantly easing tokens like `cubic-bezier(0.42, 0, 1, 1)` consumed via `transition-timing-function` / `animation-timing-function`.

- Replace the `fontFamily` kind with a wider `text` kind (custom-ident sentinel; longhands: `font-family`, `animation-name`, `transition-property`, `will-change`).
- Add a new `easing` kind (high-entropy cubic-bezier sentinels; longhands: `transition-timing-function`, `animation-timing-function`).
- Auto-detect now branches on the resolved value: `cubic-bezier(` / `steps(` / `linear(` → `easing`; otherwise → `text` (default fallback changed from `fontFamily`).
- Both new kinds duplicate their longhands into `compounds` so equality mode handles comma-separated multi-value uses like `transition-property: opacity, var(--prop)`.

## Why a naive fix doesn't work

Broadening the existing `fontFamily` kind to walk `transition-timing-function` too would not detect anything. Per the CSS Variables spec, an invalid `var()` substitution at the consuming property causes the declaration to be treated as `unset`. A string sentinel like `__zdtp_probe_text_AAA__` is invalid as `<easing-function>`, so `transition-timing-function` falls back to `ease` and the sentinel never appears in computed style. **Per-property-family sentinels are required** — strings for ident-accepting properties, `cubic-bezier()` for timing functions.

The new browser-mode invariant test in `find-elements.browser.test.ts` encodes this constraint so future refactors cannot quietly regress the rationale.

## Changes

- `packages/zudo-design-token-panel/src/highlight/find-elements.ts`
    - `FindElementsOptions.kind` union: replace `fontFamily` with `text` and `easing`.
    - `TOKEN_TYPES`: drop `fontFamily`, add `text` and `easing` entries; each duplicates longhands into compounds for multi-value support.
    - `EASING_RE`: matches only the unambiguous functional forms (`cubic-bezier(`, `steps(`, `linear(`). Bare keywords (`ease`, `linear`, `step-start` …) collide with `<custom-ident>` so auto-detect routes them to `text` — callers that know the token is consumed via a timing-function property must pass `kind: 'easing'` explicitly.
    - `detectKind`: returns the widened union; default fallback changed from `fontFamily` to `text`.
- `packages/zudo-design-token-panel/src/highlight/highlight-orchestrator.tsx`
    - `ProbeKind` widened to match. Tier-kind `text` still routes to auto-detect so the resolved value picks easing-vs-text.
- `packages/zudo-design-token-panel/src/highlight/__tests__/find-elements.browser.test.ts`
    - Renamed `fontFamily — …` describes to `text (font-family) — …` and migrated `kind: 'fontFamily'` to `kind: 'text'`.
    - New tests: easing direct use (cubic-bezier + keyword + steps), animation-timing-function, transition shorthand longhand decomposition, alias depth, decoy literal cubic-bezier, inline style, multi-value easing list, text new longhands (animation-name / transition-property / will-change) and their multi-value forms, custom-ident collision case (`--anim-name: linear`), invariant test encoding the string-sentinel-rejection.

## Deferred (to be filed as follow-up `agent-found` issues)

- Strict-typed string properties `cursor`, `content`, `mask-image` — need their own per-property sentinels and are not covered here.
- Time-typed tokens like `--duration: 0.3s` consumed via `transition-duration` — need a numeric `time` kind with valid `<time>` sentinels.

These were not detectable before this PR either, so they are not regressions.

## Test Plan

- [x] `pnpm -F @takazudo/zudo-design-token-panel typecheck` — clean.
- [x] `pnpm -F @takazudo/zudo-design-token-panel test` — 933 tests pass (node + browser projects, including 85 browser-mode Playwright Chromium tests for the highlight algorithm).
- [x] Browser-mode tests cover the exact issue scenario: a cubic-bezier easing token consumed via `transition-timing-function` (also keyword form, shorthand, alias, decoy, inline style, multi-value).
- [x] Invariant test confirms the text probe genuinely finds 0 elements for an easing consumer — empirically verifying the CSS Variables spec behavior that motivated the per-property-family design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)