### PR TITLE
fix(zdtp): color tab — no density on palette, opaque token tooltip, eye toggle on base colors

### DIFF
--- a/packages/zdtp/src/styles/panel-tokens.css
+++ b/packages/zdtp/src/styles/panel-tokens.css
@@ -34,11 +34,13 @@
  * A host that wants to retheme the panel chrome assigns directly to the
  * `--tokentweak-color-*` / `--tokentweak-font-mono` names on either
  * `.tokenpanel-shell`, `[data-design-token-panel-modal]`,
- * `.tokenpanel-highlight-settings-popover`, or `.tokenpanel-color-picker`
- * (or any ancestor — `:where()` keeps specificity at 0). The two popover
- * classes are listed directly so anchored popovers rendered outside the
- * shell (siblings, NOT modals) resolve the tokens without inheriting modal
- * chrome rules. The panel deliberately
+ * `.tokenpanel-highlight-settings-popover`, `.tokenpanel-color-picker`, or
+ * `.tokenpanel-tooltip` (or any ancestor — `:where()` keeps specificity at 0).
+ * The popover/tooltip classes are listed directly because they render OUTSIDE
+ * `.tokenpanel-shell` (anchored siblings, or — for the tooltip — portaled to
+ * `document.body`); without their own entry here `var(--tokentweak-*)` would
+ * resolve to nothing and the surface would render transparent. The panel
+ * deliberately
  * does NOT read `--color-*` / `--font-mono` from the host so that
  * host-side theme changes — including theme tweaks the panel itself
  * drives in a demo — cannot bleed into the panel chrome.
@@ -47,7 +49,8 @@
   .tokenpanel-shell,
   [data-design-token-panel-modal],
   .tokenpanel-highlight-settings-popover,
-  .tokenpanel-color-picker
+  .tokenpanel-color-picker,
+  .tokenpanel-tooltip
 ) {
   /* ----------------------------------------------------------------------
    * Color palette (self-contained, dark)

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -361,16 +361,17 @@
 
 .tokenpanel-color-palette-grid {
   display: grid;
-  /* Width-based reflow: density slider drives --tokenpanel-grid-min on
-     .tokenpanel-shell; 3.5rem fallback keeps swatches square at any width. */
-  grid-template-columns: repeat(auto-fit, minmax(var(--tokenpanel-grid-min, 3.5rem), 1fr));
+  /* Palette swatches are fixed-size chips, so they reflow on their natural
+     3.5rem width and intentionally do NOT follow the density slider
+     (--tokenpanel-grid-min) — density-stretching a swatch grid looks wrong. */
+  grid-template-columns: repeat(auto-fit, minmax(3.5rem, 1fr));
   gap: var(--tokentweak-pad-sm);
 }
 
 .tokenpanel-color-palette-grid--secondary {
   display: grid;
-  /* Same width-based reflow as the primary palette grid. */
-  grid-template-columns: repeat(auto-fit, minmax(var(--tokenpanel-grid-min, 3.5rem), 1fr));
+  /* Same density-independent reflow as the primary palette grid. */
+  grid-template-columns: repeat(auto-fit, minmax(3.5rem, 1fr));
   gap: var(--tokentweak-pad-sm);
 }
 

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -626,13 +626,17 @@ export default function ColorTab({
             {primaryLabel} — Base
           </div>
           {/*
-           * `background (bg)` and `foreground (fg)` are panel-only knobs that
-           * pick which palette index seeds the rest of the UI; they do NOT
-           * correspond to real `--zd-*` cssVars in this package, so the
+           * `background (bg)` and `foreground (fg)` are palette-index knobs:
+           * the value picks which palette slot seeds that base role. The
            * labels read as plain English with the short key in parentheses
-           * (intentionally not the full `--zd-…` form). The `cursor`,
-           * `sel-bg`, `sel-fg` upstream rows are dropped here because
-           * nothing in this package references them.
+           * rather than the cssVar name. The eye toggle, however, wires to the
+           * cluster's declared base-role cssVar (`cluster.baseRoles.background`
+           * / `.foreground`) — those ARE real tokens written to the DOM by
+           * `applyColorState`, so highlighting them is just as valid as any
+           * semantic token. When a cluster declares no cssVar for a base role,
+           * `cssVar` is undefined and the eye is omitted. The `cursor`,
+           * `sel-bg`, `sel-fg` upstream rows are dropped here because nothing
+           * in this package references them.
            */}
           <div className="tokenpanel-color-base-grid">
             <PaletteSelector
@@ -642,6 +646,7 @@ export default function ColorTab({
               palette={state.palette}
               paletteCssVar={clusterPaletteCssVar}
               onChange={handleBaseIndexChange}
+              cssVar={safeCluster.baseRoles.background}
             />
             <PaletteSelector
               label="foreground (fg)"
@@ -650,6 +655,7 @@ export default function ColorTab({
               palette={state.palette}
               paletteCssVar={clusterPaletteCssVar}
               onChange={handleBaseIndexChange}
+              cssVar={safeCluster.baseRoles.foreground}
             />
           </div>
         </div>


### PR DESCRIPTION
- parent PR
    - https://github.com/Takazudo/zudo-design-token-panel/pull/310 (self)

## Summary
Fixes three UI issues in the Color tab of the `@takazudo/zdtp` design-token panel, all surfaced from screenshots.

## Changes
1. **Palette grids ignore the density slider** (`styles/panel.css`) — the palette swatch grids reflowed on `var(--tokenpanel-grid-min, 3.5rem)`, so the density slider (dense/cozy/wide → 12rem/18rem/100%) stretched the fixed-size swatch chips into oversized / single-column cells. They now reflow on a fixed `minmax(3.5rem, 1fr)`. Base/semantic rows — which density is meant to control — are unchanged.
2. **Opaque token-name tooltip** (`styles/panel-tokens.css`) — the shared tooltip portals to `document.body`, outside `.tokenpanel-shell`, so `var(--tokentweak-color-surface)`/`-fg`/`-muted` resolved to nothing and it rendered transparent. `.tokenpanel-tooltip` is now in the `:where(...)` token-scope selector (same mechanism the color-picker / highlight-settings popovers use).
3. **Eye toggle on Base color rows** (`tabs/color-tab.tsx`) — the Base section's background/foreground rows never passed a `cssVar`, so the highlight (eye) toggle was omitted, even though `cluster.baseRoles` maps those roles to real CSS vars that `applyColorState` writes to the DOM. Each Base row's eye is now wired to `cluster.baseRoles.background`/`.foreground`; the eye is omitted only when the cluster declares no cssVar for that role. The stale comment claiming base rows have no real cssVars was replaced.

## Test Plan
- `pnpm -F @takazudo/zdtp typecheck` — clean
- `pnpm -F @takazudo/zdtp test --run` — 1032 tests across 60 files pass
- Copilot review (`/gcoc-review`): no bugs, regressions, or breaking changes