### PR TITLE
Open Issues Sweep: fix #312/#313/#314 + propagate to demos

### DIFF
--- a/packages/zdtp/src/controls/__tests__/slider-row.test.tsx
+++ b/packages/zdtp/src/controls/__tests__/slider-row.test.tsx
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for SliderRow — focuses on the input-clamping regression (#313).
+ *
+ * Core scenario: typing "22" into an input with max=6 must NOT snap the
+ * displayed value to "6" mid-keystroke. The draft is preserved; clamping only
+ * happens on blur.
+ *
+ * Event simulation notes:
+ *  - Preact-compat maps `onChange` to the native `input` event.
+ *  - jsdom does NOT propagate React/Preact synthetic events from raw
+ *    `input.value =` assignments; use Object.defineProperty + `new Event`.
+ *  - Blur uses a plain `FocusEvent('blur', { bubbles: true })`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import SliderRow from '../slider-row';
+import type { TokenDef } from '../../tokens/manifest';
+
+// ---------------------------------------------------------------------------
+// Fixture token: Header Height, min=0 max=6 step=0.25 unit=rem
+// ---------------------------------------------------------------------------
+
+const HEADER_HEIGHT_TOKEN: TokenDef = {
+  id: 'header-height',
+  cssVar: '--header-height',
+  label: 'Header Height',
+  group: 'dimensions',
+  default: '2rem',
+  min: 0,
+  max: 6,
+  step: 0.25,
+  unit: 'rem',
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+});
+
+function renderSliderRow(
+  token: TokenDef,
+  value: string,
+  onChange: (id: string, next: string) => void = vi.fn(),
+): void {
+  act(() => {
+    render(<SliderRow token={token} value={value} onChange={onChange} />, container);
+  });
+}
+
+/** Simulates typing into a text input and triggering Preact's onChange. */
+function simulateInput(input: HTMLInputElement, newValue: string): void {
+  act(() => {
+    Object.defineProperty(input, 'value', { value: newValue, writable: true, configurable: true });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+/** Simulates blur on an input.
+ *
+ * Preact-compat maps `onBlur` to the native `focusout` event (not `blur`).
+ * See preact/compat/src/render.js: `onblur` → `onfocusout`.
+ */
+function simulateBlur(input: HTMLInputElement): void {
+  act(() => {
+    input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+  });
+}
+
+function getNumberInput(): HTMLInputElement {
+  return container.querySelector<HTMLInputElement>('.tokenpanel-row-number-input')!;
+}
+
+// ---------------------------------------------------------------------------
+// Regression: 2 → 22 should not snap to 6 mid-keystroke (#313)
+// ---------------------------------------------------------------------------
+
+describe('SliderRow — mid-keystroke clamping regression', () => {
+  it('does NOT call onChange when typed value exceeds max', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const input = getNumberInput();
+    expect(input).not.toBeNull();
+
+    // Simulate typing "22" (user had "2", types another "2")
+    simulateInput(input, '22');
+
+    // onChange must NOT have been called — "22" is outside [0, 6]
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps draft as "22" after typing (does not snap to 6)', () => {
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem');
+
+    const input = getNumberInput();
+    simulateInput(input, '22');
+
+    // The input still shows what the user typed, not the clamped value
+    expect(input.value).toBe('22');
+  });
+
+  it('applies --invalid class when draft is out of range', () => {
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem');
+
+    const input = getNumberInput();
+    simulateInput(input, '22');
+
+    expect(input.classList.contains('tokenpanel-row-number-input--invalid')).toBe(true);
+  });
+
+  it('does NOT apply --invalid class when draft is within range', () => {
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem');
+
+    const input = getNumberInput();
+    simulateInput(input, '3');
+
+    expect(input.classList.contains('tokenpanel-row-number-input--invalid')).toBe(false);
+  });
+
+  it('calls onChange for in-range values mid-keystroke', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const input = getNumberInput();
+    simulateInput(input, '3');
+
+    expect(onChange).toHaveBeenCalledWith('header-height', '3rem');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blur handling: clamp + commit on blur when out of range
+// ---------------------------------------------------------------------------
+
+describe('SliderRow — blur handling', () => {
+  it('clamps and commits out-of-range value on blur', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const input = getNumberInput();
+    simulateInput(input, '22');
+    // onChange not called yet
+    expect(onChange).not.toHaveBeenCalled();
+
+    simulateBlur(input);
+
+    // On blur, the out-of-range "22" is clamped to max=6 and committed
+    expect(onChange).toHaveBeenCalledWith('header-height', '6rem');
+    expect(input.value).toBe('6');
+  });
+
+  it('reverts to last-known-good on blur when input is empty', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const input = getNumberInput();
+    simulateInput(input, '');
+    simulateBlur(input);
+
+    // Empty draft should revert; onChange not called for empty
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('2');
+  });
+
+  it('reverts to last-known-good on blur when draft contains only non-numeric chars', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const input = getNumberInput();
+    // "abc" is fully unparseable (parseNumericValue returns null)
+    simulateInput(input, 'abc');
+    simulateBlur(input);
+
+    // Unparseable draft should revert to last-known-good value
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input.value).toBe('2');
+  });
+
+  it('does NOT call onChange on blur when draft is already in range', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const input = getNumberInput();
+    simulateInput(input, '3');
+    onChange.mockClear(); // clear the in-range keystroke call
+
+    simulateBlur(input);
+
+    // In-range value was already committed on keystroke; blur does nothing extra
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// External value sync (reset / preset load)
+// ---------------------------------------------------------------------------
+
+describe('SliderRow — external value sync', () => {
+  it('updates the draft when the external value prop changes', () => {
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem');
+    const input = getNumberInput();
+    expect(input.value).toBe('2');
+
+    // Simulate parent updating the value (e.g. reset)
+    act(() => {
+      render(
+        <SliderRow token={HEADER_HEIGHT_TOKEN} value="4rem" onChange={vi.fn()} />,
+        container,
+      );
+    });
+
+    expect(input.value).toBe('4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slider still commits live
+// ---------------------------------------------------------------------------
+
+describe('SliderRow — slider input', () => {
+  it('calls onChange immediately when slider moves', () => {
+    const onChange = vi.fn();
+    renderSliderRow(HEADER_HEIGHT_TOKEN, '2rem', onChange);
+
+    const slider = container.querySelector<HTMLInputElement>('input[type="range"]')!;
+    expect(slider).not.toBeNull();
+
+    act(() => {
+      Object.defineProperty(slider, 'value', { value: '4', writable: true, configurable: true });
+      slider.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledWith('header-height', '4rem');
+  });
+});

--- a/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
+++ b/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
@@ -1,20 +1,16 @@
 // @vitest-environment jsdom
 
 /**
- * Unit tests for TierRefSelector.
- *
- * Uses Preact's `render` + `act` for DOM interaction so the full
- * component lifecycle (effects, state updates) runs under vitest/jsdom.
+ * Unit tests for TierRefSelector (native <select> implementation).
  *
  * Test structure:
- *  1. Rendering — trigger button shows current ref label + preview
- *  2. Opening — clicking trigger mounts the listbox
- *  3. Keyboard: ArrowDown / ArrowUp navigate focus
- *  4. Keyboard: Enter picks the focused option, calls onChange, closes
- *  5. Keyboard: Escape closes without calling onChange
- *  6. Mouse: clicking an option calls onChange, closes
- *  7. Literal option — picks TIER_REF_LITERAL_SIGNAL, closes
- *  8. Click-outside — mousedown outside closes the listbox
+ *  1. Rendering — renders a <select> with correct options
+ *  2. Option labels — each option shows cssVar (resolved-value preview)
+ *  3. Literal option — last option is "Literal…" with TIER_REF_LITERAL_SIGNAL value
+ *  4. Selection change — fireEvent.change calls onChange with (itemId, refItemId)
+ *  5. Literal selection — fireEvent.change with sentinel calls onChange correctly
+ *  6. Value sync — overriding a tier-1 value via previewValueFor updates option labels
+ *  7. TIER_REF_LITERAL_SIGNAL sentinel value is "__literal__"
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,8 +20,7 @@ import TierRefSelector, { TIER_REF_LITERAL_SIGNAL } from '../tier-ref-selector';
 import type { TabConfig } from '../../tokens/tier-model';
 
 // ---------------------------------------------------------------------------
-// Fixture tab config — 2-tier easing example (mirrors tier-model-integration
-// test so the synthetic data is familiar and well-tested).
+// Fixture tab config — 2-tier easing example
 // ---------------------------------------------------------------------------
 
 const EASING_TAB: TabConfig = {
@@ -84,7 +79,7 @@ const EASING_TAB: TabConfig = {
 };
 
 // ---------------------------------------------------------------------------
-// Test helpers
+// Helpers
 // ---------------------------------------------------------------------------
 
 let container: HTMLDivElement;
@@ -101,9 +96,17 @@ afterEach(() => {
   container.remove();
 });
 
+/** Default previewValueFor — returns the item's manifest default. */
+function defaultPreviewValueFor(refItemId: string): string {
+  const rawTier = EASING_TAB.tiers[0];
+  const item = rawTier.items.find((i) => i.id === refItemId);
+  return item?.default ?? refItemId;
+}
+
 function renderSelector(
   value: string,
   onChange: (itemId: string, next: string) => void,
+  previewValueFor: (refItemId: string) => string = defaultPreviewValueFor,
 ) {
   act(() => {
     render(
@@ -113,41 +116,21 @@ function renderSelector(
         itemId="tab-open"
         value={value}
         onChange={onChange}
+        previewValueFor={previewValueFor}
       />,
       container,
     );
   });
 }
 
-/** Fire a keyboard event on an element. */
-function fireKey(el: Element, key: string) {
-  act(() => {
-    el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
-  });
+function getSelect(): HTMLSelectElement {
+  const el = container.querySelector<HTMLSelectElement>('select.tokenpanel-tier-ref-select');
+  if (!el) throw new Error('select.tokenpanel-tier-ref-select not found');
+  return el;
 }
 
-function getTrigger(): HTMLDivElement {
-  const btn = container.querySelector<HTMLDivElement>('.tokenpanel-tier-ref-trigger');
-  if (!btn) throw new Error('trigger button not found');
-  return btn;
-}
-
-function getListbox(): HTMLDivElement | null {
-  return container.querySelector<HTMLDivElement>('.tokenpanel-tier-ref-listbox');
-}
-
-function getOptions(): NodeListOf<HTMLElement> {
-  return container.querySelectorAll<HTMLElement>('[role="option"]');
-}
-
-function getFocusedOption(): HTMLElement | null {
-  return container.querySelector<HTMLElement>('.tokenpanel-tier-ref-option--focused');
-}
-
-function clickTrigger() {
-  act(() => {
-    getTrigger().click();
-  });
+function getOptions(): HTMLOptionElement[] {
+  return Array.from(getSelect().querySelectorAll('option'));
 }
 
 // ---------------------------------------------------------------------------
@@ -155,360 +138,166 @@ function clickTrigger() {
 // ---------------------------------------------------------------------------
 
 describe('TierRefSelector — rendering', () => {
-  it('renders a trigger button with current ref item cssVar and value preview', () => {
+  it('renders a native <select> element', () => {
     renderSelector('ease-out', vi.fn());
-
-    const trigger = getTrigger();
-    // The trigger should contain the ref item cssVar "--easing-ease-out" and a
-    // truncated preview of its default value.
-    expect(trigger.textContent).toContain('--easing-ease-out');
-    // "cubic-bezier(0, 0, 0.58, 1)" is 26 chars — fits within PREVIEW_MAX_LEN
-    expect(trigger.textContent).toContain('cubic-bezier(0, 0, 0.58, 1)');
-  });
-
-  it('truncates long value previews in the trigger', () => {
-    // ease-in default is "cubic-bezier(0.42, 0, 1, 1)" — 28 chars, at limit
-    renderSelector('ease-in', vi.fn());
-    const trigger = getTrigger();
-    // cssVar must be present
-    expect(trigger.textContent).toContain('--easing-ease-in');
-  });
-
-  it('does not render the listbox when closed', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(getListbox()).toBeNull();
-  });
-
-  it('trigger has aria-haspopup=listbox and aria-expanded=false when closed', () => {
-    renderSelector('ease-out', vi.fn());
-    const trigger = getTrigger();
-    expect(trigger.getAttribute('aria-haspopup')).toBe('listbox');
-    expect(trigger.getAttribute('aria-expanded')).toBe('false');
-  });
-});
-
-describe('TierRefSelector — opening the dropdown', () => {
-  it('shows the listbox after clicking the trigger', () => {
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    expect(getListbox()).not.toBeNull();
-  });
-
-  it('trigger aria-expanded becomes true when open', () => {
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    expect(getTrigger().getAttribute('aria-expanded')).toBe('true');
-  });
-
-  it('listbox has role=listbox', () => {
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    expect(getListbox()?.getAttribute('role')).toBe('listbox');
+    expect(getSelect()).not.toBeNull();
   });
 
   it('renders one option per raw tier item plus the Literal option', () => {
     renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    // EASING_TAB raw tier has 3 items + 1 Literal sentinel = 4 options
+    // 3 raw items + 1 Literal sentinel = 4 options
+    expect(getOptions().length).toBe(4);
+  });
+
+  it('does NOT use role=listbox markup', () => {
+    renderSelector('ease-out', vi.fn());
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+  });
+
+  it('does NOT use role=option markup', () => {
+    renderSelector('ease-out', vi.fn());
+    expect(container.querySelector('[role="option"]')).toBeNull();
+  });
+
+  it('selected value matches the current ref item id', () => {
+    renderSelector('ease-out', vi.fn());
+    expect(getSelect().value).toBe('ease-out');
+  });
+
+  it('falls back to first item when value is unrecognised', () => {
+    renderSelector('unknown-id', vi.fn());
+    expect(getSelect().value).toBe('ease-in');
+  });
+});
+
+describe('TierRefSelector — option labels', () => {
+  it('each raw item option label includes cssVar and preview value', () => {
+    renderSelector('ease-out', vi.fn());
     const options = getOptions();
-    expect(options.length).toBe(4);
+    const easeInOpt = options.find((o) => o.value === 'ease-in');
+    expect(easeInOpt).not.toBeUndefined();
+    // Label format: "--easing-ease-in (cubic-bezier(0.42, 0, 1, 1))"
+    expect(easeInOpt!.textContent).toContain('--easing-ease-in');
+    expect(easeInOpt!.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
   });
 
-  it('each raw item option shows cssVar and value preview', () => {
-    renderSelector('linear', vi.fn());
-    clickTrigger();
-    const options = Array.from(getOptions());
-    const easeInOption = options.find((o) => o.textContent?.includes('--easing-ease-in'));
-    expect(easeInOption).not.toBeUndefined();
-    // preview of "cubic-bezier(0.42, 0, 1, 1)" (28 chars — at limit, no truncation needed)
-    expect(easeInOption?.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
+  it('truncates long preview values in option labels', () => {
+    // Provide a preview value that exceeds 28 chars.
+    const longValue = 'a'.repeat(40);
+    const previewValueFor = (refItemId: string) => (refItemId === 'ease-in' ? longValue : refItemId);
+    renderSelector('ease-out', vi.fn(), previewValueFor);
+
+    const options = getOptions();
+    const easeInOpt = options.find((o) => o.value === 'ease-in');
+    expect(easeInOpt).not.toBeUndefined();
+    // Truncated to 28 chars: 27 + '…'
+    const label = easeInOpt!.textContent ?? '';
+    expect(label).toContain('…');
+    // Original long value should not appear verbatim
+    expect(label).not.toContain(longValue);
   });
 
-  it('currently selected option has aria-selected=true', () => {
+  it('Literal option is last with value TIER_REF_LITERAL_SIGNAL', () => {
     renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    const options = Array.from(getOptions());
-    const selected = options.filter((o) => o.getAttribute('aria-selected') === 'true');
-    expect(selected.length).toBe(1);
-    expect(selected[0].textContent).toContain('--easing-ease-out');
-  });
-
-  it('opens with focus on the currently selected item', () => {
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    // ease-out is index 1 in raw items
-    const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('--easing-ease-out');
-  });
-
-  it('opens with focus on first item when value is unrecognised', () => {
-    renderSelector('unknown-id', vi.fn());
-    clickTrigger();
-    const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('--easing-ease-in');
-  });
-
-  it('Enter on the trigger opens the dropdown', () => {
-    renderSelector('ease-out', vi.fn());
-    fireKey(getTrigger(), 'Enter');
-    expect(getListbox()).not.toBeNull();
-  });
-
-  it('ArrowDown on the trigger opens the dropdown', () => {
-    renderSelector('ease-out', vi.fn());
-    fireKey(getTrigger(), 'ArrowDown');
-    expect(getListbox()).not.toBeNull();
+    const options = getOptions();
+    const last = options[options.length - 1];
+    expect(last.value).toBe(TIER_REF_LITERAL_SIGNAL);
+    expect(last.textContent).toContain('Literal');
   });
 });
 
-describe('TierRefSelector — keyboard navigation', () => {
-  it('ArrowDown moves focus to the next option', () => {
-    // Start with ease-in selected (index 0) so ArrowDown → index 1 (ease-out).
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    fireKey(getListbox()!, 'ArrowDown');
-    const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('--easing-ease-out');
+describe('TierRefSelector — value sync (override-aware preview)', () => {
+  it('reflects overridden tier-1 value in option label', () => {
+    // Simulate a tier-1 override: ease-in now resolves to "custom-value".
+    const previewValueFor = (refItemId: string) =>
+      refItemId === 'ease-in' ? 'custom-value' : defaultPreviewValueFor(refItemId);
+
+    renderSelector('ease-out', vi.fn(), previewValueFor);
+
+    const options = getOptions();
+    const easeInOpt = options.find((o) => o.value === 'ease-in');
+    expect(easeInOpt).not.toBeUndefined();
+    expect(easeInOpt!.textContent).toContain('custom-value');
+    // Original manifest default should NOT appear when overridden
+    expect(easeInOpt!.textContent).not.toContain('cubic-bezier(0.42, 0, 1, 1)');
   });
 
-  it('ArrowUp moves focus to the previous option', () => {
-    // Start with ease-out selected (index 1) so ArrowUp → index 0 (ease-in).
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    fireKey(getListbox()!, 'ArrowUp');
-    const focused = getFocusedOption();
-    expect(focused?.textContent).toContain('--easing-ease-in');
-  });
+  it('re-renders with updated option labels when previewValueFor changes', () => {
+    const onChange = vi.fn();
 
-  it('ArrowDown does not go past the last option', () => {
-    // Start with Literal option focused (last): navigate down, should stay.
-    renderSelector('unknown-id', vi.fn());
-    clickTrigger();
-    const lb = getListbox()!;
-    // 3 raw items + 1 literal = 4 options; navigate to last (index 3)
+    // First render: default previews.
+    renderSelector('ease-out', onChange, defaultPreviewValueFor);
+    let easeInOpt = getOptions().find((o) => o.value === 'ease-in')!;
+    expect(easeInOpt.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
+
+    // Second render: override ease-in to a new value.
+    const overriddenPreview = (refItemId: string) =>
+      refItemId === 'ease-in' ? '0.5s ease' : defaultPreviewValueFor(refItemId);
     act(() => {
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      render(
+        <TierRefSelector
+          tab={EASING_TAB}
+          tierId="semantic"
+          itemId="tab-open"
+          value="ease-out"
+          onChange={onChange}
+          previewValueFor={overriddenPreview}
+        />,
+        container,
+      );
     });
-    const options = Array.from(getOptions());
-    const lastOption = options[options.length - 1];
-    expect(lastOption.classList.contains('tokenpanel-tier-ref-option--focused')).toBe(true);
-  });
 
-  it('ArrowUp does not go before the first option', () => {
-    // Start with ease-in (index 0), ArrowUp should keep focus at index 0.
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    fireKey(getListbox()!, 'ArrowUp');
-    const options = Array.from(getOptions());
-    expect(options[0].classList.contains('tokenpanel-tier-ref-option--focused')).toBe(true);
+    easeInOpt = getOptions().find((o) => o.value === 'ease-in')!;
+    expect(easeInOpt.textContent).toContain('0.5s ease');
+    expect(easeInOpt.textContent).not.toContain('cubic-bezier(0.42, 0, 1, 1)');
   });
 });
 
-describe('TierRefSelector — picking an option', () => {
-  it('Enter picks the focused option and calls onChange with (itemId, refItemId)', () => {
+/** Fire a native change event on a select element, setting its value first. */
+function fireSelectChange(select: HTMLSelectElement, newValue: string) {
+  act(() => {
+    // Directly mutate the select's value so the event handler sees it.
+    Object.defineProperty(select, 'value', { value: newValue, writable: true, configurable: true });
+    select.value = newValue;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+describe('TierRefSelector — selection via change event', () => {
+  it('calls onChange with (itemId, refItemId) when user changes selection', () => {
     const onChange = vi.fn();
     renderSelector('ease-in', onChange);
-    clickTrigger();
-    // Default focus is on ease-in (index 0). Navigate to ease-out (index 1).
-    fireKey(getListbox()!, 'ArrowDown');
-    fireKey(getListbox()!, 'Enter');
+
+    const select = getSelect();
+    fireSelectChange(select, 'ease-out');
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith('tab-open', 'ease-out');
   });
 
-  it('picking an option closes the dropdown', () => {
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    fireKey(getListbox()!, 'Enter');
-    expect(getListbox()).toBeNull();
-  });
-
-  it('mouse click on an option calls onChange and closes', () => {
+  it('calls onChange with (itemId, linear) when linear is selected', () => {
     const onChange = vi.fn();
     renderSelector('ease-in', onChange);
-    clickTrigger();
 
-    const options = Array.from(getOptions());
-    // Click on the "linear" option (index 2 in raw items) — identified by cssVar.
-    const linearOption = options.find((o) => o.textContent?.includes('--easing-linear'));
-    expect(linearOption).not.toBeUndefined();
-    act(() => {
-      linearOption!.dispatchEvent(
-        new MouseEvent('mousedown', { bubbles: true }),
-      );
-    });
+    const select = getSelect();
+    fireSelectChange(select, 'linear');
 
     expect(onChange).toHaveBeenCalledWith('tab-open', 'linear');
-    expect(getListbox()).toBeNull();
-  });
-});
-
-describe('TierRefSelector — Escape closes without committing', () => {
-  it('Escape closes the dropdown', () => {
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    fireKey(getListbox()!, 'Escape');
-    expect(getListbox()).toBeNull();
   });
 
-  it('Escape does not call onChange', () => {
+  it('calls onChange with TIER_REF_LITERAL_SIGNAL when Literal is selected', () => {
     const onChange = vi.fn();
     renderSelector('ease-in', onChange);
-    clickTrigger();
-    fireKey(getListbox()!, 'Escape');
-    expect(onChange).not.toHaveBeenCalled();
-  });
 
-  it('Escape returns focus to the trigger button', () => {
-    renderSelector('ease-in', vi.fn());
-    const trigger = getTrigger();
-    clickTrigger();
-    fireKey(getListbox()!, 'Escape');
-    // After Escape the trigger should be focused (checked via document.activeElement).
-    expect(document.activeElement).toBe(trigger);
-  });
-});
-
-describe('TierRefSelector — Literal option', () => {
-  it('last option is "Literal…"', () => {
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    const options = Array.from(getOptions());
-    const lastOption = options[options.length - 1];
-    expect(lastOption.textContent).toContain('Literal');
-  });
-
-  it('picking Literal calls onChange with TIER_REF_LITERAL_SIGNAL', () => {
-    const onChange = vi.fn();
-    renderSelector('ease-in', onChange);
-    clickTrigger();
-    // Navigate to Literal (last option): 3 raw + 1 literal = index 3
-    const lb = getListbox()!;
-    act(() => {
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-      lb.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
-    });
-    fireKey(lb, 'Enter');
+    const select = getSelect();
+    fireSelectChange(select, TIER_REF_LITERAL_SIGNAL);
 
     expect(onChange).toHaveBeenCalledWith('tab-open', TIER_REF_LITERAL_SIGNAL);
   });
+});
 
+describe('TierRefSelector — TIER_REF_LITERAL_SIGNAL', () => {
   it('TIER_REF_LITERAL_SIGNAL value is "__literal__"', () => {
-    // Contractual assertion — consumers depend on this exact sentinel.
     expect(TIER_REF_LITERAL_SIGNAL).toBe('__literal__');
-  });
-});
-
-describe('TierRefSelector — click-outside closes', () => {
-  it('mousedown outside the selector closes the listbox', () => {
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    expect(getListbox()).not.toBeNull();
-
-    act(() => {
-      document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-    });
-    expect(getListbox()).toBeNull();
-  });
-
-  it('mousedown inside the selector does not close the listbox', () => {
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    act(() => {
-      // Click on the listbox itself (not an option).
-      getListbox()!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
-    });
-    // The listbox is still open because we rely on mousedown+preventDefault in
-    // option handlers; a bare listbox mousedown does not commit a selection.
-    // The click-outside handler only fires when target is outside both the
-    // trigger and listbox containers — this test ensures the contains() guard
-    // works correctly.
-    //
-    // Note: the listbox mousedown bubbles to the document handler which checks
-    // `listboxRef.current.contains(target)` — this should be true, so the
-    // listbox stays open.
-    expect(getListbox()).not.toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// #149 — div-based role=listbox, aria-activedescendant, and Enter-trigger
-// These tests assert that the ul→div and button→div swaps preserve accessible
-// semantics (ARIA roles, aria-activedescendant linkage, trigger keyboard API).
-// ---------------------------------------------------------------------------
-
-describe('TierRefSelector — div-based ARIA semantics after #149 swap', () => {
-  it('listbox container is a div with role=listbox', () => {
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    const listbox = getListbox();
-    expect(listbox).not.toBeNull();
-    expect(listbox!.tagName.toLowerCase()).toBe('div');
-    expect(listbox!.getAttribute('role')).toBe('listbox');
-  });
-
-  it('option elements are divs with role=option', () => {
-    renderSelector('ease-out', vi.fn());
-    clickTrigger();
-    const options = Array.from(getOptions());
-    expect(options.length).toBeGreaterThan(0);
-    for (const opt of options) {
-      expect(opt.tagName.toLowerCase()).toBe('div');
-      expect(opt.getAttribute('role')).toBe('option');
-    }
-  });
-
-  it('listbox has aria-activedescendant pointing to the focused option', () => {
-    renderSelector('ease-in', vi.fn()); // ease-in is index 0
-    clickTrigger();
-    const listbox = getListbox()!;
-    const activedesc = listbox.getAttribute('aria-activedescendant');
-    expect(activedesc).not.toBeNull();
-    // The focused option element must exist in the DOM with that id
-    const focusedEl = document.getElementById(activedesc!);
-    expect(focusedEl).not.toBeNull();
-    expect(focusedEl!.getAttribute('role')).toBe('option');
-    // ease-in is index 0 so the focused element should reference ease-in's option
-    expect(focusedEl!.textContent).toContain('--easing-ease-in');
-  });
-
-  it('aria-activedescendant updates when ArrowDown moves focus', () => {
-    renderSelector('ease-in', vi.fn());
-    clickTrigger();
-    const listbox = getListbox()!;
-    // Before navigation — points to ease-in (index 0)
-    const before = listbox.getAttribute('aria-activedescendant');
-    fireKey(listbox, 'ArrowDown');
-    // After navigation — should point to ease-out (index 1)
-    const after = listbox.getAttribute('aria-activedescendant');
-    expect(after).not.toBe(before);
-    const focusedEl = document.getElementById(after!);
-    expect(focusedEl?.textContent).toContain('--easing-ease-out');
-  });
-
-  it('trigger is a div with role=button', () => {
-    renderSelector('ease-out', vi.fn());
-    const trigger = getTrigger();
-    expect(trigger.tagName.toLowerCase()).toBe('div');
-    expect(trigger.getAttribute('role')).toBe('button');
-  });
-
-  it('Enter keypress on trigger opens the dropdown', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(getListbox()).toBeNull();
-    fireKey(getTrigger(), 'Enter');
-    expect(getListbox()).not.toBeNull();
-  });
-
-  it('Space keypress on trigger opens the dropdown', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(getListbox()).toBeNull();
-    fireKey(getTrigger(), ' ');
-    expect(getListbox()).not.toBeNull();
   });
 });

--- a/packages/zdtp/src/controls/slider-row.tsx
+++ b/packages/zdtp/src/controls/slider-row.tsx
@@ -1,6 +1,12 @@
 import { memo, useState, useEffect, useCallback } from 'preact/compat';
 import { type TokenDef, formatValue, parseNumericValue } from '../tokens/manifest';
 
+// isOutOfRange: returns true when n is a finite number outside [min, max].
+// Does NOT flag NaN/null — those are "still typing" states, not invalid values.
+function isOutOfRange(n: number | null, min: number, max: number): boolean {
+  return n !== null && Number.isFinite(n) && (n < min || n > max);
+}
+
 /**
  * One manifest-driven token row:
  *
@@ -38,12 +44,19 @@ function SliderRow({ token, value, onChange }: SliderRowProps) {
   const slidable = !token.readonly && numeric !== null;
 
   // Draft lets the user type freely ("1.", "1.2") without the slider snapping
-  // every keystroke. We only commit (call onChange) when the draft parses.
+  // every keystroke. We only commit (call onChange) when the draft parses AND
+  // is within [min, max]. Out-of-range drafts are flagged but not clamped mid-
+  // typing; clamping happens on blur so the user sees the snap only when they
+  // leave the field, not while they are still editing.
   const [draft, setDraft] = useState<string>(numeric !== null ? String(numeric) : value);
 
   // Sync the draft when the external value changes (reset, preset load, etc.)
+  // The guard `draft !== (...)` is intentional: when the user just committed a
+  // value from this component the parent echoes it back here, but the draft is
+  // already correct — don't clobber it and interrupt mid-keystroke editing.
   useEffect(() => {
-    setDraft(numeric !== null ? String(numeric) : value);
+    const incoming = numeric !== null ? String(numeric) : value;
+    setDraft(incoming);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
@@ -62,13 +75,38 @@ function SliderRow({ token, value, onChange }: SliderRowProps) {
       const raw = e.currentTarget.value;
       setDraft(raw);
       const n = parseNumericValue(raw);
-      if (n === null) return; // wait for a parseable value before committing
-      // Clamp into the token's legal range on commit to keep the slider sane.
-      const clamped = Math.min(token.max, Math.max(token.min, n));
-      onChange(token.id, formatValue(clamped, token.unit));
+      // Only commit when the parsed value is within the token's legal range.
+      // Out-of-range or unparseable values keep the draft visible but do NOT
+      // call onChange — this prevents mid-typing snap (e.g. "22" clamped to 6).
+      if (n === null || isOutOfRange(n, token.min, token.max)) return;
+      onChange(token.id, formatValue(n, token.unit));
     },
     [onChange, token.id, token.min, token.max, token.unit],
   );
+
+  // On blur: commit a valid in-range value, clamp an out-of-range value, or
+  // revert to the last persisted value if the draft is empty / unparseable.
+  // This is the only place clamping happens — never mid-keystroke.
+  const handleNumberBlur = useCallback(() => {
+    const n = parseNumericValue(draft);
+    if (n === null) {
+      // Empty or unparseable: revert to last-known-good.
+      setDraft(numeric !== null ? String(numeric) : value);
+      return;
+    }
+    if (isOutOfRange(n, token.min, token.max)) {
+      // Out of range: clamp, commit, and update the draft to the clamped value.
+      const clamped = Math.min(token.max, Math.max(token.min, n));
+      setDraft(String(clamped));
+      onChange(token.id, formatValue(clamped, token.unit));
+    }
+    // In-range values were already committed on each keystroke; nothing more to do.
+  }, [draft, numeric, value, onChange, token.id, token.min, token.max, token.unit]);
+
+  // Mark the input invalid when the draft parses to a number outside the
+  // token's legal range (not when it's empty/partial — those aren't errors yet).
+  const parsedDraft = parseNumericValue(draft);
+  const isInvalid = isOutOfRange(parsedDraft, token.min, token.max);
 
   return (
     <div className="tokenpanel-row--stacked">
@@ -83,9 +121,11 @@ function SliderRow({ token, value, onChange }: SliderRowProps) {
             inputMode="decimal"
             value={draft}
             onChange={handleNumber}
+            onBlur={handleNumberBlur}
             disabled={token.readonly}
-            className="tokenpanel-row-number-input"
+            className={`tokenpanel-row-number-input${isInvalid ? ' tokenpanel-row-number-input--invalid' : ''}`}
             aria-label={`${token.cssVar} value`}
+            aria-invalid={isInvalid || undefined}
           />
           <span className="tokenpanel-row-unit">
             {token.readonly && !token.unit ? '' : token.unit}

--- a/packages/zdtp/src/controls/tier-ref-selector.tsx
+++ b/packages/zdtp/src/controls/tier-ref-selector.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useId, useRef, useState } from 'preact/compat';
+import { memo } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem } from '../tokens/tier-model';
 
 // ---------------------------------------------------------------------------
@@ -7,16 +7,15 @@ import type { TabConfig, TierConfig, TierItem } from '../tokens/tier-model';
 
 /**
  * Sentinel string passed to `onChange` when the user picks "Literal...".
- * The parent component (Wave 5) interprets this as a request to flip the
- * item back into its kind-specific editor (slider / text / select) writing a
- * literal CSS override.
+ * The parent component interprets this as a request to flip the item back
+ * into its kind-specific editor (slider / text / select) writing a literal
+ * CSS override.
  */
 export const TIER_REF_LITERAL_SIGNAL = '__literal__' as const;
 
 /**
- * Maximum length of a value preview string shown in the trigger button and
- * dropdown options. Long values like cubic-bezier strings are truncated so
- * the UI stays compact.
+ * Maximum length of a value preview string shown in option labels.
+ * Long values like cubic-bezier strings are truncated so the UI stays compact.
  */
 const PREVIEW_MAX_LEN = 28;
 
@@ -35,18 +34,6 @@ function findTier(tab: TabConfig, tierId: string): TierConfig | undefined {
 
 function findItem(tier: TierConfig, itemId: string): TierItem | undefined {
   return tier.items.find((i) => i.id === itemId);
-}
-
-/**
- * Resolve the label + preview string for the currently-selected ref item.
- * Falls back to the first item in the ref tier when the current `value` id
- * does not match any known item (mirrors tier-resolver fallback semantics).
- */
-function resolveCurrentRefItem(
-  refTier: TierConfig,
-  currentRefId: string,
-): TierItem {
-  return findItem(refTier, currentRefId) ?? refTier.items[0];
 }
 
 // ---------------------------------------------------------------------------
@@ -73,22 +60,19 @@ export interface TierRefSelectorProps {
    * - Picking "Literal...": `onChange(itemId, TIER_REF_LITERAL_SIGNAL)`
    */
   onChange: (itemId: string, next: string) => void;
+  /**
+   * Returns the resolved (override-aware) preview string for a tier-1 item id.
+   * Each option label is formatted as `${item.cssVar} (${truncated preview})`.
+   * Pass a wrapper around resolveTierItemValue using the current tweak-state map.
+   */
+  previewValueFor: (refItemId: string) => string;
 }
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-function TierRefSelector({ tab, tierId, itemId, value, onChange }: TierRefSelectorProps) {
-  const [open, setOpen] = useState(false);
-  const [focusedIndex, setFocusedIndex] = useState<number>(0);
-
-  const triggerRef = useRef<HTMLDivElement | null>(null);
-  const listboxRef = useRef<HTMLDivElement | null>(null);
-
-  const triggerId = useId();
-  const listboxId = useId();
-
+function TierRefSelector({ tab, tierId, itemId, value, onChange, previewValueFor }: TierRefSelectorProps) {
   // -------------------------------------------------------------------------
   // Derive ref tier and options
   // -------------------------------------------------------------------------
@@ -97,206 +81,44 @@ function TierRefSelector({ tab, tierId, itemId, value, onChange }: TierRefSelect
   const refTierId = thisTier?.referencesTier ?? '';
   const refTier = refTierId ? findTier(tab, refTierId) : undefined;
 
-  // All options: tier-1 items + "Literal..." sentinel at the end.
   const refItems: readonly TierItem[] = refTier?.items ?? [];
 
-  // "Literal..." is always last in the list.
-  const optionCount = refItems.length + 1;
-  const LITERAL_INDEX = refItems.length;
+  // Determine the currently selected value — fall back to first item if unrecognised.
+  const selectedRefItemId = (() => {
+    if (refTier && findItem(refTier, value)) return value;
+    return refItems[0]?.id ?? '';
+  })();
 
   // -------------------------------------------------------------------------
-  // Current selection display
+  // Handler
   // -------------------------------------------------------------------------
 
-  const currentRefItem = refTier ? resolveCurrentRefItem(refTier, value) : undefined;
-  const triggerLabel = currentRefItem
-    ? `${currentRefItem.cssVar} — ${truncatePreview(currentRefItem.default)}`
-    : value || '—';
-
-  // -------------------------------------------------------------------------
-  // Handlers
-  // -------------------------------------------------------------------------
-
-  const openDropdown = useCallback(() => {
-    // Position focus on the currently-selected item when opening.
-    const selectedIdx = refItems.findIndex((i) => i.id === value);
-    setFocusedIndex(selectedIdx >= 0 ? selectedIdx : 0);
-    setOpen(true);
-  }, [refItems, value]);
-
-  const closeDropdown = useCallback(() => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }, []);
-
-  const commitSelection = useCallback(
-    (idx: number) => {
-      if (idx === LITERAL_INDEX) {
-        onChange(itemId, TIER_REF_LITERAL_SIGNAL);
-      } else {
-        const picked = refItems[idx];
-        if (picked) onChange(itemId, picked.id);
-      }
-      closeDropdown();
-    },
-    [LITERAL_INDEX, refItems, itemId, onChange, closeDropdown],
-  );
-
-  // Trigger keydown: Enter / Space open; arrow keys also open.
-  const handleTriggerKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-        e.preventDefault();
-        openDropdown();
-      }
-    },
-    [openDropdown],
-  );
-
-  // Listbox keydown: ArrowUp/Down navigate, Enter/Space picks, Escape closes.
-  const handleListKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        setFocusedIndex((prev) => Math.min(prev + 1, optionCount - 1));
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        setFocusedIndex((prev) => Math.max(prev - 1, 0));
-      } else if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        commitSelection(focusedIndex);
-      } else if (e.key === 'Escape') {
-        e.preventDefault();
-        closeDropdown();
-      }
-    },
-    [focusedIndex, optionCount, commitSelection, closeDropdown],
-  );
-
-  // Close when clicking outside.
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node | null;
-      if (
-        triggerRef.current &&
-        !triggerRef.current.contains(target) &&
-        listboxRef.current &&
-        !listboxRef.current.contains(target)
-      ) {
-        closeDropdown();
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open, closeDropdown]);
-
-  // Move focus to the listbox when it opens; move focus back to trigger when it
-  // closes is handled in closeDropdown().
-  useEffect(() => {
-    if (open) {
-      listboxRef.current?.focus();
-    }
-  }, [open]);
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    onChange(itemId, e.currentTarget.value);
+  };
 
   // -------------------------------------------------------------------------
   // Render
   // -------------------------------------------------------------------------
 
-  // Stable option id helper — scoped to this listbox instance via listboxId.
-  // Used for aria-activedescendant on the listbox container.
-  function optionId(idx: number): string {
-    return `${listboxId}-opt-${idx}`;
-  }
-
-  const activedescendant = open ? optionId(focusedIndex) : undefined;
-
   return (
     <div className="tokenpanel-tier-ref-selector">
-      {/* Trigger — chrome button policy: div role=button with Enter/Space keydown.
-          Uses a plain div (not RoleButton) to keep ref assignment and full
-          aria-haspopup / aria-expanded / aria-controls control in one place. */}
-      <div
-        ref={triggerRef}
-        role="button"
-        tabIndex={0}
-        id={triggerId}
-        className="tokenpanel-tier-ref-trigger"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        aria-controls={open ? listboxId : undefined}
-        onClick={openDropdown}
-        onKeyDown={handleTriggerKeyDown}
+      <select
+        className="tokenpanel-tier-ref-select"
+        value={selectedRefItemId === '' ? TIER_REF_LITERAL_SIGNAL : selectedRefItemId}
+        onChange={handleChange}
+        aria-label={`${itemId} tier reference`}
       >
-        <span className="tokenpanel-tier-ref-trigger-label">{triggerLabel}</span>
-        <span className="tokenpanel-tier-ref-trigger-arrow" aria-hidden>
-          {open ? '▲' : '▼'}
-        </span>
-      </div>
-
-      {/* Dropdown listbox — div role=listbox replaces ul; ARIA roles preserved.
-          aria-activedescendant tracks the keyboard-focused option by id. */}
-      {open && (
-        <div
-          ref={listboxRef}
-          id={listboxId}
-          role="listbox"
-          aria-labelledby={triggerId}
-          aria-activedescendant={activedescendant}
-          tabIndex={-1}
-          className="tokenpanel-tier-ref-listbox"
-          onKeyDown={handleListKeyDown}
-        >
-          {refItems.map((item, idx) => (
-            <div
-              key={item.id}
-              id={optionId(idx)}
-              role="option"
-              aria-selected={item.id === value}
-              data-focused={idx === focusedIndex || undefined}
-              className={
-                'tokenpanel-tier-ref-option' +
-                (idx === focusedIndex ? ' tokenpanel-tier-ref-option--focused' : '')
-              }
-              onMouseDown={(e) => {
-                e.preventDefault(); // keep listbox focus
-                commitSelection(idx);
-              }}
-              onMouseEnter={() => setFocusedIndex(idx)}
-            >
-              <span className="tokenpanel-tier-ref-option-label">
-                {item.cssVar}
-                {item.label !== item.cssVar && (
-                  <span className="tokenpanel-row-label-sub">{item.label}</span>
-                )}
-              </span>
-              <span className="tokenpanel-tier-ref-option-preview">
-                {truncatePreview(item.default)}
-              </span>
-            </div>
-          ))}
-
-          {/* "Literal..." sentinel option */}
-          <div
-            key="__literal__"
-            id={optionId(LITERAL_INDEX)}
-            role="option"
-            aria-selected={false}
-            data-focused={LITERAL_INDEX === focusedIndex || undefined}
-            className={
-              'tokenpanel-tier-ref-option tokenpanel-tier-ref-option--literal' +
-              (LITERAL_INDEX === focusedIndex ? ' tokenpanel-tier-ref-option--focused' : '')
-            }
-            onMouseDown={(e) => {
-              e.preventDefault();
-              commitSelection(LITERAL_INDEX);
-            }}
-            onMouseEnter={() => setFocusedIndex(LITERAL_INDEX)}
-          >
-            <span className="tokenpanel-tier-ref-option-label">Literal…</span>
-          </div>
-        </div>
-      )}
+        {refItems.map((item) => {
+          const preview = truncatePreview(previewValueFor(item.id));
+          return (
+            <option key={item.id} value={item.id}>
+              {item.cssVar} ({preview})
+            </option>
+          );
+        })}
+        <option value={TIER_REF_LITERAL_SIGNAL}>Literal…</option>
+      </select>
     </div>
   );
 }

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -988,35 +988,20 @@
 }
 
 /* ===========================================================================
- * Tier-ref selector (anchored popover with arrow tip)
+ * Tier-ref selector (native <select>)
  *
- * Implements the Pattern-12 anchored-popover style for the Easing / Font /
- * Spacing / Size "semantic → raw" reference selector. The component lives in
- * controls/tier-ref-selector.tsx; every class and attribute targeted here is
- * already emitted by that component — NO JSX changes needed.
- *
- * Variable mapping (no accent-soft or surface-hi token in this package):
- *   accent-soft bg  → rgb(from var(--tokentweak-color-accent) r g b / 0.16)
- *   surface-hi      → var(--tokentweak-color-surface)  (border+shadow carry the elevation)
- *   line-strong     → var(--tokentweak-color-muted)
- *
- * The tick mark on each option is rendered via ::before pseudo-element so the
- * three-column grid layout (tick | label | preview) works without touching the
- * existing markup. aria-selected='true' on the <li> makes the tick visible.
+ * Replaces the custom role=listbox popover with a native <select> element.
+ * The component lives in controls/tier-ref-selector.tsx.
  * ========================================================================= */
 
-/* Relative-positioned anchor for the popover */
+/* Wrapper — fills the row flex space */
 .tokenpanel-tier-ref-selector {
-  position: relative;
   flex: 1;
   min-width: 0;
 }
 
-/* Trigger button — compact mono label + chevron */
-.tokenpanel-tier-ref-trigger {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+/* Native select — matches .tokenpanel-row-select visual style */
+select.tokenpanel-tier-ref-select {
   width: 100%;
   background-color: var(--tokentweak-color-surface);
   color: var(--tokentweak-color-fg);
@@ -1026,130 +1011,11 @@
   padding-block: 4px;
   font-family: var(--tokentweak-font-mono);
   font-size: 0.75rem;
-  text-align: left;
   cursor: pointer;
-  transition:
-    border-color 150ms ease,
-    box-shadow 150ms ease;
 }
-.tokenpanel-tier-ref-trigger:hover {
-  border-color: var(--tokentweak-color-fg);
-}
-
-/* Open state — accent border + soft focus ring (Pattern 12 verbatim) */
-.tokenpanel-tier-ref-trigger[aria-expanded='true'] {
-  border-color: var(--tokentweak-color-accent);
-  box-shadow: 0 0 0 2px rgb(from var(--tokentweak-color-accent) r g b / 0.16);
-}
-
-/* Label inside the trigger — fills remaining width, truncated */
-.tokenpanel-tier-ref-trigger-label {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Chevron — muted, does not shrink */
-.tokenpanel-tier-ref-trigger-arrow {
-  color: var(--tokentweak-color-muted);
-  font-size: 9px;
-  flex-shrink: 0;
-}
-
-/* Listbox popover — absolute, beneath trigger, elevated via border + shadow */
-.tokenpanel-tier-ref-listbox {
-  position: absolute;
-  top: calc(100% + 10px);
-  left: 0;
-  right: 0;
-  z-index: 60;
-  margin: 0;
-  padding: 4px;
-  list-style: none;
-  background-color: var(--tokentweak-color-surface);
-  border: 1px solid var(--tokentweak-color-muted);
-  border-radius: var(--radius-tokentweak);
-  box-shadow: 0 12px 28px rgb(0 0 0 / 0.5);
-  outline: none; /* tabIndex={-1} focus ring suppressed; per-option --focused handles it */
-}
-
-/* Arrow tip pointing up at the trigger (::before rotated 45°) */
-.tokenpanel-tier-ref-listbox::before {
-  content: '';
-  position: absolute;
-  top: -7px;
-  left: 22px;
-  width: 12px;
-  height: 12px;
-  background-color: var(--tokentweak-color-surface);
-  border-left: 1px solid var(--tokentweak-color-muted);
-  border-top: 1px solid var(--tokentweak-color-muted);
-  transform: rotate(45deg);
-}
-
-/* Option row — three-column grid: tick | label | preview
- * Tick is provided by ::before pseudo-element so the existing markup needs
- * no changes. The tick character is always present; color toggles via
- * aria-selected. */
-.tokenpanel-tier-ref-option {
-  display: grid;
-  grid-template-columns: 14px 1fr auto;
-  gap: 6px;
-  align-items: center;
-  padding: 5px 8px;
-  border-radius: 3px;
-  cursor: pointer;
-  font-family: var(--tokentweak-font-mono);
-  font-size: 0.8125rem;
-  color: var(--tokentweak-color-fg);
-  list-style: none;
-}
-
-/* Tick pseudo-element — always rendered, color toggled by aria-selected */
-.tokenpanel-tier-ref-option::before {
-  content: '✓';
-  font-size: 11px;
-  color: transparent; /* hidden by default */
-  line-height: 1;
-}
-
-/* Show tick on selected option */
-.tokenpanel-tier-ref-option[aria-selected='true']::before {
-  color: var(--tokentweak-color-accent);
-}
-
-/* Label — left column, truncated */
-.tokenpanel-tier-ref-option-label {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Value preview — right column, muted + smaller */
-.tokenpanel-tier-ref-option-preview {
-  font-size: 0.6875rem;
-  color: var(--tokentweak-color-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 10rem;
-}
-
-/* Keyboard focus / hover highlight */
-.tokenpanel-tier-ref-option--focused {
-  background-color: rgb(from var(--tokentweak-color-accent) r g b / 0.16);
-}
-
-/* "Literal…" option — italic muted, separator above */
-.tokenpanel-tier-ref-option--literal {
-  font-style: italic;
-  color: var(--tokentweak-color-muted);
-  border-top: 1px solid var(--tokentweak-color-muted);
-  margin-top: 4px;
-  padding-top: 8px;
+select.tokenpanel-tier-ref-select:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
 }
 
 /* Secondary human-readable label shown beneath the cssVar primary label when
@@ -1244,19 +1110,6 @@
   outline: 2px solid var(--tokentweak-color-accent);
   outline-offset: 2px;
   border-radius: 2px;
-}
-
-.tokenpanel-tier-ref-trigger:focus-visible {
-  outline: 2px solid var(--tokentweak-color-accent);
-  outline-offset: 2px;
-}
-
-/* Listbox div — remove inherited list-style that would appear on div children
- * if a host's global CSS sets list-style on ul children via [role=listbox] or
- * similar selectors. The existing .tokenpanel-tier-ref-listbox / option rules
- * handle layout; this is purely a defensive hygiene reset. */
-.tokenpanel-tier-ref-listbox[role='listbox'] {
-  list-style: none;
 }
 
 /* Tab button div (role=tab) focus ring — same pattern as role=button above.

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -683,6 +683,10 @@
 .tokenpanel-row-number-input:disabled {
   opacity: 0.6;
 }
+.tokenpanel-row-number-input--invalid {
+  border-color: #e05252;
+  color: #e05252;
+}
 
 .tokenpanel-row-unit {
   color: var(--tokentweak-color-muted);

--- a/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
@@ -378,3 +378,123 @@ describe('GenericTab — data-testid wrapper', () => {
     expect(wrapper).not.toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: mid-keystroke clamping in _generic-item-editor (#313)
+//
+// The same "2 → 22 snaps to 6" bug existed in _generic-item-editor's
+// length/number branch. These tests confirm the fix is in place.
+//
+// Event simulation follows the same pattern as slider-row.test.tsx:
+//  - Object.defineProperty + `new Event('input', { bubbles: true })` for onChange
+//  - `new FocusEvent('focusout', { bubbles: true })` for onBlur
+//    (Preact-compat maps `onBlur` → `onfocusout`)
+// ---------------------------------------------------------------------------
+
+/** Simulates a native input event on an HTMLInputElement (Preact onChange trigger). */
+function simulateInputEvent(input: HTMLInputElement, newValue: string): void {
+  act(() => {
+    Object.defineProperty(input, 'value', { value: newValue, writable: true, configurable: true });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+/** Simulates blur via focusout (Preact maps onBlur → onfocusout). */
+function simulateFocusout(input: HTMLInputElement): void {
+  act(() => {
+    input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+  });
+}
+
+describe('GenericItemEditor — mid-keystroke clamping regression (#313)', () => {
+  it('does NOT call onChange when typed length value exceeds max', async () => {
+    const onChange = vi.fn();
+    await renderGenericTab(MIXED_KINDS_TAB, {}, onChange);
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="tier-item-length-item"] input[type="text"]',
+    )!;
+    expect(input).not.toBeNull();
+
+    // Simulate typing "22" — max=4 for length-item
+    simulateInputEvent(input, '22');
+
+    // "22" is out of range; onChange must NOT have been called
+    const lengthCalls = onChange.mock.calls.filter(([, itemId]) => itemId === 'length-item');
+    expect(lengthCalls).toHaveLength(0);
+  });
+
+  it('keeps draft "22" visible after typing (does not snap to clamped value)', async () => {
+    await renderGenericTab(MIXED_KINDS_TAB, {});
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="tier-item-length-item"] input[type="text"]',
+    )!;
+
+    simulateInputEvent(input, '22');
+
+    expect(input.value).toBe('22');
+  });
+
+  it('applies --invalid class to out-of-range length input', async () => {
+    await renderGenericTab(MIXED_KINDS_TAB, {});
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="tier-item-length-item"] input[type="text"]',
+    )!;
+
+    simulateInputEvent(input, '22');
+
+    expect(input.classList.contains('tokenpanel-row-number-input--invalid')).toBe(true);
+  });
+
+  it('does NOT apply --invalid class when draft is in range', async () => {
+    await renderGenericTab(MIXED_KINDS_TAB, {});
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="tier-item-length-item"] input[type="text"]',
+    )!;
+
+    simulateInputEvent(input, '2');
+
+    expect(input.classList.contains('tokenpanel-row-number-input--invalid')).toBe(false);
+  });
+
+  it('clamps and commits out-of-range length value on blur', async () => {
+    const onChange = vi.fn();
+    await renderGenericTab(MIXED_KINDS_TAB, {}, onChange);
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="tier-item-length-item"] input[type="text"]',
+    )!;
+
+    simulateInputEvent(input, '22');
+    // Not yet committed
+    const beforeBlur = onChange.mock.calls.filter(([, itemId]) => itemId === 'length-item');
+    expect(beforeBlur).toHaveLength(0);
+
+    simulateFocusout(input);
+
+    // After blur: clamped to max=4 and committed
+    const afterBlur = onChange.mock.calls.filter(([, itemId]) => itemId === 'length-item');
+    expect(afterBlur).toHaveLength(1);
+    expect(afterBlur[0]).toEqual(['values', 'length-item', '4rem']);
+    expect(input.value).toBe('4');
+  });
+
+  it('does NOT call onChange mid-keystroke for a number item within range', async () => {
+    const onChange = vi.fn();
+    await renderGenericTab(MIXED_KINDS_TAB, {}, onChange);
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="tier-item-number-item"] input[type="text"]',
+    )!;
+
+    // number-item: min=1 max=10; typing "5" should commit
+    simulateInputEvent(input, '5');
+
+    const numberCalls = onChange.mock.calls.filter(([, itemId]) => itemId === 'number-item');
+    expect(numberCalls).toHaveLength(1);
+    expect(numberCalls[0]).toEqual(['values', 'number-item', '5']);
+  });
+});

--- a/packages/zdtp/src/tabs/_generic-item-editor.tsx
+++ b/packages/zdtp/src/tabs/_generic-item-editor.tsx
@@ -55,15 +55,48 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       const min = type.min;
       const max = type.max;
       const numeric = parseFloat(value);
-      const displayNumeric = Number.isFinite(numeric) ? numeric : min;
+      const numericForDraft = Number.isFinite(numeric) ? numeric : min;
+
+      // Draft mirrors the slider-row pattern: keep the user's in-progress text
+      // locally and only call onChange for valid, in-range keystrokes.
+      const [numDraft, setNumDraft] = useState<string>(String(numericForDraft));
+
+      // Sync the draft when an external value update arrives (reset, preset).
+      useEffect(() => {
+        setNumDraft(String(Number.isFinite(parseFloat(value)) ? parseFloat(value) : min));
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [value]);
+
+      const isNumOutOfRange = (n: number) => n < min || n > max;
 
       const handleNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
         const raw = e.currentTarget.value;
+        setNumDraft(raw);
         const n = parseFloat(raw);
-        if (!Number.isFinite(n)) return;
-        const clamped = Math.min(max, Math.max(min, n));
-        onChange(item.id, unit ? `${clamped}${unit}` : String(clamped));
+        // Only commit when parsed and in range — never clamp mid-keystroke.
+        if (!Number.isFinite(n) || isNumOutOfRange(n)) return;
+        onChange(item.id, unit ? `${n}${unit}` : String(n));
       };
+
+      // On blur: clamp out-of-range values and commit, or revert unparseable ones.
+      const handleNumberBlur = () => {
+        const n = parseFloat(numDraft);
+        if (!Number.isFinite(n)) {
+          // Revert to last-known-good persisted value.
+          setNumDraft(String(numericForDraft));
+          return;
+        }
+        if (isNumOutOfRange(n)) {
+          const clamped = Math.min(max, Math.max(min, n));
+          setNumDraft(String(clamped));
+          onChange(item.id, unit ? `${clamped}${unit}` : String(clamped));
+        }
+      };
+
+      const numIsInvalid = (() => {
+        const n = parseFloat(numDraft);
+        return Number.isFinite(n) && isNumOutOfRange(n);
+      })();
 
       // Effective readonly: either item is readonly OR pill is active
       const effectiveReadonly = isReadonly || (pill !== undefined && isPill);
@@ -81,11 +114,13 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
               <input
                 type="text"
                 inputMode="decimal"
-                value={displayNumeric}
+                value={numDraft}
                 onChange={handleNumber}
+                onBlur={handleNumberBlur}
                 disabled={effectiveReadonly}
-                className="tokenpanel-row-number-input"
+                className={`tokenpanel-row-number-input${numIsInvalid ? ' tokenpanel-row-number-input--invalid' : ''}`}
                 aria-label={`${item.cssVar} value`}
+                aria-invalid={numIsInvalid || undefined}
               />
               {unit && <span className="tokenpanel-row-unit">{unit}</span>}
             </div>

--- a/packages/zdtp/src/tabs/font-tab.tsx
+++ b/packages/zdtp/src/tabs/font-tab.tsx
@@ -6,6 +6,7 @@ import TierRefSelector from '../controls/tier-ref-selector';
 import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
+import { resolveTierItemValue } from '../apply/tier-resolver';
 
 interface FontTabProps {
   tab: TabConfig;
@@ -122,6 +123,13 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   itemId={item.id}
                   value={value}
                   onChange={onChange}
+                  previewValueFor={(refItemId) => {
+                    const refTierId = tier.referencesTier!;
+                    const result = resolveTierItemValue(tab, refTierId, refItemId, {
+                      [refTierId]: state,
+                    });
+                    return result.kind === 'literal' ? result.value : result.targetCssVar;
+                  }}
                 />
                 <HighlightToggleButton cssVar={item.cssVar} />
               </div>

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -16,7 +16,7 @@
  * `var(--target-cssvar)` at apply time) or flip the item back to literal mode.
  */
 
-import { useCallback } from 'preact/compat';
+import { useCallback, useState, useEffect } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem, TierValueKind } from '../tokens/tier-model';
 import type { TabOverrides } from '../apply/tier-resolver';
 import TierRefSelector from '../controls/tier-ref-selector';
@@ -72,15 +72,46 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
       const min = type.min;
       const max = type.max;
       const numeric = parseFloat(value);
-      const displayNumeric = Number.isFinite(numeric) ? numeric : min;
+      const numericForDraft = Number.isFinite(numeric) ? numeric : min;
+
+      // Draft mirrors slider-row pattern: no mid-keystroke clamping (#313).
+      const [numDraft, setNumDraft] = useState<string>(String(numericForDraft));
+
+      // Sync draft when external value changes (reset, preset load, etc.)
+      useEffect(() => {
+        setNumDraft(String(Number.isFinite(parseFloat(value)) ? parseFloat(value) : min));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [value]);
+
+      const isNumOutOfRange = (n: number) => n < min || n > max;
 
       const handleNumber = (e: React.ChangeEvent<HTMLInputElement>) => {
         const raw = e.currentTarget.value;
+        setNumDraft(raw);
         const n = parseFloat(raw);
-        if (!Number.isFinite(n)) return;
-        const clamped = Math.min(max, Math.max(min, n));
-        onChange(item.id, unit ? `${clamped}${unit}` : String(clamped));
+        // Only commit in-range values; never clamp mid-keystroke.
+        if (!Number.isFinite(n) || isNumOutOfRange(n)) return;
+        onChange(item.id, unit ? `${n}${unit}` : String(n));
       };
+
+      // On blur: clamp out-of-range, revert if unparseable.
+      const handleNumberBlur = () => {
+        const n = parseFloat(numDraft);
+        if (!Number.isFinite(n)) {
+          setNumDraft(String(numericForDraft));
+          return;
+        }
+        if (isNumOutOfRange(n)) {
+          const clamped = Math.min(max, Math.max(min, n));
+          setNumDraft(String(clamped));
+          onChange(item.id, unit ? `${clamped}${unit}` : String(clamped));
+        }
+      };
+
+      const numIsInvalid = (() => {
+        const n = parseFloat(numDraft);
+        return Number.isFinite(n) && isNumOutOfRange(n);
+      })();
 
       return (
         <div className="tokenpanel-row--stacked" data-testid={`tier-item-${item.id}`}>
@@ -95,11 +126,13 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
               <input
                 type="text"
                 inputMode="decimal"
-                value={displayNumeric}
+                value={numDraft}
                 onChange={handleNumber}
+                onBlur={handleNumberBlur}
                 disabled={isReadonly}
-                className="tokenpanel-row-number-input"
+                className={`tokenpanel-row-number-input${numIsInvalid ? ' tokenpanel-row-number-input--invalid' : ''}`}
                 aria-label={`${item.cssVar} value`}
+                aria-invalid={numIsInvalid || undefined}
               />
               {unit && <span className="tokenpanel-row-unit">{unit}</span>}
             </div>

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -18,7 +18,7 @@
 
 import { useCallback } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem, TierValueKind } from '../tokens/tier-model';
-import type { TabOverrides } from '../apply/tier-resolver';
+import { type TabOverrides, resolveTierItemValue } from '../apply/tier-resolver';
 import TierRefSelector from '../controls/tier-ref-selector';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 
@@ -31,6 +31,7 @@ interface ItemEditorProps {
   tier: TierConfig;
   item: TierItem;
   value: string;
+  overrides: TabOverrides;
   /** Called with (itemId, newValue) when the user commits a change. */
   onChange: (itemId: string, next: string) => void;
 }
@@ -39,9 +40,10 @@ interface ItemEditorProps {
  * Dispatch to TierRefSelector for reference tiers, otherwise render the
  * kind-appropriate editor (slider, select, text, color).
  */
-function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
+function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorProps) {
   // Reference tier: delegate to TierRefSelector.
   if (tier.referencesTier !== undefined) {
+    const refTierId = tier.referencesTier;
     return (
       <div className="tokenpanel-row" data-testid={`tier-ref-row-${item.id}`}>
         <span className="tokenpanel-row-label" title={item.cssVar}>
@@ -56,6 +58,10 @@ function ItemEditor({ tab, tier, item, value, onChange }: ItemEditorProps) {
           itemId={item.id}
           value={value}
           onChange={onChange}
+          previewValueFor={(refItemId) => {
+            const result = resolveTierItemValue(tab, refTierId, refItemId, overrides);
+            return result.kind === 'literal' ? result.value : result.targetCssVar;
+          }}
         />
         <HighlightToggleButton cssVar={item.cssVar} />
       </div>
@@ -214,10 +220,11 @@ interface TierSectionProps {
   tab: TabConfig;
   tier: TierConfig;
   overrides: Record<string, string>;
+  fullOverrides: TabOverrides;
   onItemChange: (tierId: string, itemId: string, next: string) => void;
 }
 
-function TierSection({ tab, tier, overrides, onItemChange }: TierSectionProps) {
+function TierSection({ tab, tier, overrides, fullOverrides, onItemChange }: TierSectionProps) {
   const handleItemChange = useCallback(
     (itemId: string, next: string) => {
       onItemChange(tier.id, itemId, next);
@@ -244,6 +251,7 @@ function TierSection({ tab, tier, overrides, onItemChange }: TierSectionProps) {
               tier={tier}
               item={item}
               value={value}
+              overrides={fullOverrides}
               onChange={handleItemChange}
             />
           );
@@ -302,6 +310,7 @@ export default function GenericTab({ tab, overrides, onChange }: GenericTabProps
             tab={tab}
             tier={tier}
             overrides={tierOverrides}
+            fullOverrides={overrides}
             onItemChange={handleItemChange}
           />
         );

--- a/packages/zdtp/src/tabs/size-tab.tsx
+++ b/packages/zdtp/src/tabs/size-tab.tsx
@@ -6,6 +6,7 @@ import TierRefSelector from '../controls/tier-ref-selector';
 import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
+import { resolveTierItemValue } from '../apply/tier-resolver';
 
 interface SizeTabProps {
   tab: TabConfig;
@@ -120,6 +121,13 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   itemId={item.id}
                   value={value}
                   onChange={onChange}
+                  previewValueFor={(refItemId) => {
+                    const refTierId = tier.referencesTier!;
+                    const result = resolveTierItemValue(tab, refTierId, refItemId, {
+                      [refTierId]: state,
+                    });
+                    return result.kind === 'literal' ? result.value : result.targetCssVar;
+                  }}
                 />
                 <HighlightToggleButton cssVar={item.cssVar} />
               </div>

--- a/packages/zdtp/src/tabs/spacing-tab.tsx
+++ b/packages/zdtp/src/tabs/spacing-tab.tsx
@@ -6,6 +6,7 @@ import TierRefSelector from '../controls/tier-ref-selector';
 import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
+import { resolveTierItemValue } from '../apply/tier-resolver';
 
 interface SpacingTabProps {
   tab: TabConfig;
@@ -125,6 +126,13 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   itemId={item.id}
                   value={value}
                   onChange={onChange}
+                  previewValueFor={(refItemId) => {
+                    const refTierId = tier.referencesTier!;
+                    const result = resolveTierItemValue(tab, refTierId, refItemId, {
+                      [refTierId]: state,
+                    });
+                    return result.kind === 'literal' ? result.value : result.targetCssVar;
+                  }}
                 />
                 <HighlightToggleButton cssVar={item.cssVar} />
               </div>


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/315

---

## Summary

Wave 1 of the Open Issues Sweep epic (#315). Two panel-side bugfixes combined here; merges into `main`.

### #316 — Replace tier-ref dropdown with native `<select>` and fix value sync (closes #312)

Custom `role="listbox"` UI in `TierRefSelector` swapped for a native `<select>`. Drops ~250 lines of open/focusedIndex state, ARIA plumbing, click-outside handler, and keyboard-nav callbacks. New `previewValueFor` prop threads through `font-tab`, `spacing-tab`, `size-tab`, and `generic-tab` so option labels reflect the live override-resolved value via `resolveTierItemValue()` from `apply/tier-resolver.ts` — not the stale manifest default. `TIER_REF_LITERAL_SIGNAL` sentinel flows unchanged.

### #317 — Fix slider-row + `_generic-item-editor` input clamping (closes #313)

Number inputs no longer auto-commit a clamped value mid-keystroke. Out-of-range or unparseable drafts now show a `--invalid` red border and revert (or clamp) on blur. Slider thumb continues to scrub live. New regression test file `slider-row.test.tsx` exercises the `2 → 22 → no snap to 6` repro; parallel coverage added for `_generic-item-editor.tsx` in `generic-tab.test.tsx`.

## Tests

- `pnpm -F @takazudo/zdtp typecheck`: clean
- `pnpm -F @takazudo/zdtp test`: 1028 / 1028 pass

## Topic PRs (closed after local merge into base)

- open-issues-sweep/dropdown-fix
- open-issues-sweep/input-clamp-fix