### PR TITLE
Token Tooltip: shared TokenLabel tooltip across all token-name display sites (#330)

### DIFF
--- a/packages/zdtp/src/controls/__tests__/token-label.test.tsx
+++ b/packages/zdtp/src/controls/__tests__/token-label.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for the TokenLabel component.
+ *
+ * Acceptance criteria:
+ *  1. Renders cssVar text.
+ *  2. Attaches useTooltip: mouseenter → .tokenpanel-tooltip shows the cssVar text.
+ *  3. Renders sub-label only when label !== cssVar.
+ *  4. Uses default className 'tokenpanel-row-label' when className omitted.
+ *  5. Accepts a custom className override.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { TooltipProvider } from '../tooltip';
+import TokenLabel from '../token-label';
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => render(null, container));
+  document.body.removeChild(container);
+});
+
+function renderLabel(
+  cssVar: string,
+  label?: string,
+  className?: string,
+): void {
+  act(() => {
+    render(
+      <TooltipProvider>
+        <TokenLabel cssVar={cssVar} label={label} className={className} />
+      </TooltipProvider>,
+      container,
+    );
+  });
+}
+
+function getTooltip(): HTMLElement {
+  return document.querySelector('.tokenpanel-tooltip') as HTMLElement;
+}
+
+function getLabel(): HTMLElement {
+  return container.querySelector('.tokenpanel-row-label') as HTMLElement;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Renders cssVar text
+// ---------------------------------------------------------------------------
+
+describe('TokenLabel — renders cssVar text', () => {
+  it('renders the cssVar as visible text', () => {
+    renderLabel('--my-token');
+    expect(container.textContent).toContain('--my-token');
+  });
+
+  it('uses default class tokenpanel-row-label', () => {
+    renderLabel('--my-token');
+    const span = getLabel();
+    expect(span).not.toBeNull();
+    expect(span.className).toBe('tokenpanel-row-label');
+  });
+
+  it('accepts a custom className', () => {
+    act(() => {
+      render(
+        <TooltipProvider>
+          <TokenLabel cssVar="--my-token" className="custom-class" />
+        </TooltipProvider>,
+        container,
+      );
+    });
+    const span = container.querySelector('.custom-class') as HTMLElement;
+    expect(span).not.toBeNull();
+    expect(span.textContent).toContain('--my-token');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Tooltip via useTooltip — mouseenter shows the cssVar text
+// ---------------------------------------------------------------------------
+
+describe('TokenLabel — useTooltip integration', () => {
+  it('tooltip element is present after render', () => {
+    renderLabel('--test-tooltip');
+    expect(getTooltip()).not.toBeNull();
+  });
+
+  it('tooltip starts hidden (data-show=false)', () => {
+    renderLabel('--test-tooltip');
+    expect(getTooltip().getAttribute('data-show')).toBe('false');
+  });
+
+  it('tooltip shows on mouseenter and contains cssVar text', () => {
+    renderLabel('--test-tooltip');
+    act(() => {
+      getLabel().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+    const tooltip = getTooltip();
+    expect(tooltip.getAttribute('data-show')).toBe('true');
+    expect(tooltip.textContent).toBe('--test-tooltip');
+  });
+
+  it('tooltip hides on mouseleave', () => {
+    renderLabel('--test-tooltip');
+    act(() => {
+      getLabel().dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+    act(() => {
+      getLabel().dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    });
+    expect(getTooltip().getAttribute('data-show')).toBe('false');
+  });
+
+  it('no native title attribute on the span', () => {
+    renderLabel('--test-tooltip');
+    expect(getLabel().hasAttribute('title')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Sub-label rendered only when label !== cssVar
+// ---------------------------------------------------------------------------
+
+describe('TokenLabel — sub-label visibility', () => {
+  it('renders sub-label when label differs from cssVar', () => {
+    renderLabel('--my-token', 'My Token Label');
+    const sub = container.querySelector('.tokenpanel-row-label-sub');
+    expect(sub).not.toBeNull();
+    expect(sub?.textContent).toBe('My Token Label');
+  });
+
+  it('does NOT render sub-label when label equals cssVar', () => {
+    renderLabel('--my-token', '--my-token');
+    const sub = container.querySelector('.tokenpanel-row-label-sub');
+    expect(sub).toBeNull();
+  });
+
+  it('does NOT render sub-label when label is omitted', () => {
+    renderLabel('--my-token');
+    const sub = container.querySelector('.tokenpanel-row-label-sub');
+    expect(sub).toBeNull();
+  });
+
+  it('does NOT render sub-label when label is empty string', () => {
+    renderLabel('--my-token', '');
+    const sub = container.querySelector('.tokenpanel-row-label-sub');
+    expect(sub).toBeNull();
+  });
+});

--- a/packages/zdtp/src/controls/select-row.tsx
+++ b/packages/zdtp/src/controls/select-row.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback } from 'preact/compat';
 import type { TokenDef } from '../tokens/manifest';
+import TokenLabel from './token-label';
 
 /**
  * One manifest-driven token row backed by a native `<select>`.
@@ -39,9 +40,7 @@ function SelectRow({ token, value, onChange }: SelectRowProps) {
 
   return (
     <div className="tokenpanel-row">
-      <span className="tokenpanel-row-label" title={token.cssVar}>
-        {token.cssVar}
-      </span>
+      <TokenLabel cssVar={token.cssVar} />
       <select
         value={value}
         onChange={handleChange}

--- a/packages/zdtp/src/controls/slider-row.tsx
+++ b/packages/zdtp/src/controls/slider-row.tsx
@@ -1,5 +1,6 @@
 import { memo, useState, useEffect, useCallback } from 'preact/compat';
 import { type TokenDef, formatValue, parseNumericValue } from '../tokens/manifest';
+import TokenLabel from './token-label';
 
 /**
  * One manifest-driven token row:
@@ -75,9 +76,7 @@ function SliderRow({ token, value, onChange }: SliderRowProps) {
     <div className="tokenpanel-row--stacked">
       {/* Top row: label + number input */}
       <div className="tokenpanel-row-head">
-        <span className="tokenpanel-row-label" title={token.cssVar}>
-          {token.cssVar}
-        </span>
+        <TokenLabel cssVar={token.cssVar} />
         <div className="tokenpanel-row-input-group">
           <input
             type="text"

--- a/packages/zdtp/src/controls/text-row.tsx
+++ b/packages/zdtp/src/controls/text-row.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useState } from 'preact/compat';
 import type { TokenDef } from '../tokens/manifest';
 import { sanitizeCssValue } from './sanitize-css-value';
+import TokenLabel from './token-label';
 
 /**
  * One manifest-driven token row backed by a free-form text input.
@@ -48,9 +49,7 @@ function TextRow({ token, value, onChange }: TextRowProps) {
 
   return (
     <div className="tokenpanel-row">
-      <span className="tokenpanel-row-label" title={token.cssVar}>
-        {token.cssVar}
-      </span>
+      <TokenLabel cssVar={token.cssVar} />
       <input
         type="text"
         value={draft}

--- a/packages/zdtp/src/controls/token-label.tsx
+++ b/packages/zdtp/src/controls/token-label.tsx
@@ -1,0 +1,31 @@
+import { memo } from 'preact/compat';
+import { useTooltip } from './tooltip';
+
+export interface TokenLabelProps {
+  cssVar: string;
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Renders a token-name label with the shared rich tooltip.
+ * Replaces bare `<span title={cssVar}>` usages across all tabs so every
+ * token-name display site uses the same `.tokenpanel-tooltip` primitive.
+ *
+ * The optional `label` sub-label is shown only when it differs from `cssVar`
+ * (avoids redundant repetition for tokens whose label IS the cssVar).
+ */
+function TokenLabelInner({ cssVar, label, className }: TokenLabelProps) {
+  const tooltipProps = useTooltip(cssVar);
+  return (
+    <span className={className ?? 'tokenpanel-row-label'} {...tooltipProps}>
+      {cssVar}
+      {label && label !== cssVar && (
+        <span className="tokenpanel-row-label-sub">{label}</span>
+      )}
+    </span>
+  );
+}
+
+export const TokenLabel = memo(TokenLabelInner);
+export default TokenLabel;

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -10,6 +10,7 @@ import FontTab from './tabs/font-tab';
 import SizeTab from './tabs/size-tab';
 import SpacingTab from './tabs/spacing-tab';
 import GenericTab from './tabs/generic-tab';
+import { TooltipProvider } from './controls/tooltip';
 import { getPanelConfig, storageKey_visible } from './config/panel-config';
 import type { TabConfig } from './tokens/tier-model';
 import { usePersist } from './state/persist';
@@ -473,6 +474,7 @@ export default function DesignTokenTweakPanel() {
 
   return (
     <HighlightOrchestrator>
+      <TooltipProvider>
       {open && (() => {
         const {
           width: panelW,
@@ -774,6 +776,7 @@ export default function DesignTokenTweakPanel() {
           </>
         );
       })()}
+      </TooltipProvider>
     </HighlightOrchestrator>
   );
 }

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../highlight/highlight-toggle-button';
 import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../../highlight/highlight-state';
 import ColorTab from '../color-tab';
+import { TooltipProvider } from '../../controls/tooltip';
 import type { TabConfig } from '../../tokens/tier-model';
 import type { ColorTweakState } from '../../state/tweak-state';
 import {
@@ -151,7 +152,7 @@ function makeCtx(
 
 function noop() {}
 
-/** Render ColorTab wrapped in a HighlightContext provider */
+/** Render ColorTab wrapped in TooltipProvider and HighlightContext provider */
 function renderColorTab(
   ctx: HighlightContextValue,
   opts: {
@@ -169,16 +170,18 @@ function renderColorTab(
   } = opts;
   act(() => {
     render(
-      <HighlightContext.Provider value={ctx}>
-        <ColorTab
-          tab={tab}
-          state={colorState}
-          persistColor={noop}
-          secondaryTab={secondaryTab}
-          secondaryState={secondaryState}
-          persistSecondary={noop}
-        />
-      </HighlightContext.Provider>,
+      <TooltipProvider>
+        <HighlightContext.Provider value={ctx}>
+          <ColorTab
+            tab={tab}
+            state={colorState}
+            persistColor={noop}
+            secondaryTab={secondaryTab}
+            secondaryState={secondaryState}
+            persistSecondary={noop}
+          />
+        </HighlightContext.Provider>
+      </TooltipProvider>,
       container,
     );
   });
@@ -282,17 +285,19 @@ describe('ColorTab — no <button> elements (hostile-host policy)', () => {
   });
 
   it('renders no <button> elements without HighlightContext (null context)', () => {
-    // Render without provider — toggles should silently not render
+    // Render with TooltipProvider but without HighlightContext — toggles should silently not render
     act(() => {
       render(
-        <ColorTab
-          tab={PRIMARY_COLOR_TAB}
-          state={makeColorState()}
-          persistColor={noop}
-          secondaryTab={null}
-          secondaryState={null}
-          persistSecondary={noop}
-        />,
+        <TooltipProvider>
+          <ColorTab
+            tab={PRIMARY_COLOR_TAB}
+            state={makeColorState()}
+            persistColor={noop}
+            secondaryTab={null}
+            secondaryState={null}
+            persistSecondary={noop}
+          />
+        </TooltipProvider>,
         container,
       );
     });

--- a/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
@@ -22,6 +22,7 @@ import { act } from 'preact/test-utils';
 import GenericTab from '../generic-tab';
 import type { TabConfig } from '../../tokens/tier-model';
 import type { TabOverrides } from '../../apply/tier-resolver';
+import { TooltipProvider } from '../../controls/tooltip';
 
 // ---------------------------------------------------------------------------
 // Synthetic TabConfig fixtures
@@ -151,6 +152,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Unmount the Preact tree to clean up portals (e.g. TooltipProvider's
+  // .tokenpanel-tooltip div rendered into document.body).
+  act(() => {
+    render(null, container);
+  });
   document.body.removeChild(container);
 });
 
@@ -158,10 +164,12 @@ async function renderGenericTab(
   tab: TabConfig,
   overrides: TabOverrides = {},
   onChange: (tierId: string, itemId: string, next: string) => void = () => undefined,
+  withTooltipProvider = false,
 ): Promise<void> {
   await act(() => {
+    const content = <GenericTab tab={tab} overrides={overrides} onChange={onChange} />;
     render(
-      <GenericTab tab={tab} overrides={overrides} onChange={onChange} />,
+      withTooltipProvider ? <TooltipProvider>{content}</TooltipProvider> : content,
       container,
     );
   });
@@ -492,5 +500,82 @@ describe('GenericItemEditor — free numeric input, no clamping (#326)', () => {
     const numberCalls = onChange.mock.calls.filter(([, itemId]) => itemId === 'number-item');
     expect(numberCalls).toHaveLength(1);
     expect(numberCalls[0]).toEqual(['values', 'number-item', '5']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rich tooltip on token-name labels
+// ---------------------------------------------------------------------------
+
+describe('GenericTab — rich tooltip on token-name labels', () => {
+  it('renders a tokenpanel-tooltip element when wrapped in TooltipProvider', async () => {
+    await renderGenericTab(EASING_TAB, {}, () => undefined, true);
+
+    const tooltip = document.querySelector('.tokenpanel-tooltip');
+    expect(tooltip).not.toBeNull();
+  });
+
+  it('tooltip starts hidden (data-show=false)', async () => {
+    await renderGenericTab(EASING_TAB, {}, () => undefined, true);
+
+    const tooltip = document.querySelector('.tokenpanel-tooltip');
+    expect(tooltip?.getAttribute('data-show')).toBe('false');
+  });
+
+  it('mouseenter on label shows tooltip with the full cssVar text', async () => {
+    await renderGenericTab(EASING_TAB, {}, () => undefined, true);
+
+    // Get the label for the first item in the literal tier (raw → ease-in)
+    const label = container.querySelector('.tokenpanel-row-label') as HTMLElement;
+    expect(label).not.toBeNull();
+
+    act(() => {
+      label.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    const tooltip = document.querySelector('.tokenpanel-tooltip');
+    expect(tooltip?.getAttribute('data-show')).toBe('true');
+    // Tooltip text should be the full cssVar, not truncated
+    expect(tooltip?.textContent).toBe('--test-easing-ease-in');
+  });
+
+  it('mouseleave on label hides the tooltip', async () => {
+    await renderGenericTab(EASING_TAB, {}, () => undefined, true);
+
+    const label = container.querySelector('.tokenpanel-row-label') as HTMLElement;
+    act(() => {
+      label.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+    act(() => {
+      label.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+    });
+
+    const tooltip = document.querySelector('.tokenpanel-tooltip');
+    expect(tooltip?.getAttribute('data-show')).toBe('false');
+  });
+
+  it('label has no native title attribute', async () => {
+    await renderGenericTab(EASING_TAB, {}, () => undefined, true);
+
+    const label = container.querySelector('.tokenpanel-row-label') as HTMLElement;
+    expect(label.hasAttribute('title')).toBe(false);
+  });
+
+  it('ref-tier row label also has rich tooltip with correct cssVar', async () => {
+    await renderGenericTab(EASING_TAB, {}, () => undefined, true);
+
+    // The semantic tier has referencesTier — its label should also use TokenLabel
+    const refRow = container.querySelector('[data-testid="tier-ref-row-tab-open"]') as HTMLElement;
+    expect(refRow).not.toBeNull();
+    const label = refRow.querySelector('.tokenpanel-row-label') as HTMLElement;
+    expect(label).not.toBeNull();
+
+    act(() => {
+      label.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    const tooltip = document.querySelector('.tokenpanel-tooltip');
+    expect(tooltip?.getAttribute('data-show')).toBe('true');
+    expect(tooltip?.textContent).toBe('--test-easing-tab-open');
   });
 });

--- a/packages/zdtp/src/tabs/_generic-item-editor.tsx
+++ b/packages/zdtp/src/tabs/_generic-item-editor.tsx
@@ -12,6 +12,7 @@
 import { memo, useCallback, useEffect, useRef, useState } from 'preact/compat';
 import type { TierItem, TierValueKind } from '../tokens/tier-model';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
+import TokenLabel from '../controls/token-label';
 
 export interface GenericItemEditorProps {
   item: TierItem;
@@ -89,12 +90,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       const numberRow = (
         <div className="tokenpanel-row--stacked" data-testid={`tier-item-${item.id}`}>
           <div className="tokenpanel-row-head">
-            <span className="tokenpanel-row-label" title={item.cssVar}>
-              {item.cssVar}
-              {item.label !== item.cssVar && (
-                <span className="tokenpanel-row-label-sub">{item.label}</span>
-              )}
-            </span>
+            <TokenLabel cssVar={item.cssVar} label={item.label} />
             <div className="tokenpanel-row-input-group">
               <input
                 type="text"
@@ -143,12 +139,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.cssVar}
-            {item.label !== item.cssVar && (
-              <span className="tokenpanel-row-label-sub">{item.label}</span>
-            )}
-          </span>
+          <TokenLabel cssVar={item.cssVar} label={item.label} />
           <select
             value={selectDraft}
             onChange={handleChange}
@@ -176,12 +167,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.cssVar}
-            {item.label !== item.cssVar && (
-              <span className="tokenpanel-row-label-sub">{item.label}</span>
-            )}
-          </span>
+          <TokenLabel cssVar={item.cssVar} label={item.label} />
           <input
             type="text"
             value={value}
@@ -205,12 +191,7 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.cssVar}
-            {item.label !== item.cssVar && (
-              <span className="tokenpanel-row-label-sub">{item.label}</span>
-            )}
-          </span>
+          <TokenLabel cssVar={item.cssVar} label={item.label} />
           <input
             type="color"
             value={value}

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -46,7 +46,7 @@ import { resolveColorClusterFromTab } from '../config/cluster-config';
 import type { TabConfig } from '../tokens/tier-model';
 import type { PersistColor, PersistSecondary } from '../state/persist';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
-import { TooltipProvider, useTooltip } from '../controls/tooltip';
+import { useTooltip } from '../controls/tooltip';
 
 // The bundled scheme registry now lives on
 // `panelConfig.colorCluster.colorSchemes`, not on a global import. Read it
@@ -557,7 +557,6 @@ export default function ColorTab({
   );
 
   return (
-    <TooltipProvider>
     <div className="tokenpanel-tab-content">
       {/* Preset loader — tab-scoped so the outer header row stays general */}
       <div className="tokenpanel-tab-actions">
@@ -755,6 +754,5 @@ export default function ColorTab({
          */}
       </div>
     </div>
-    </TooltipProvider>
   );
 }

--- a/packages/zdtp/src/tabs/font-tab.tsx
+++ b/packages/zdtp/src/tabs/font-tab.tsx
@@ -7,6 +7,7 @@ import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { resolveTierItemValue } from '../apply/tier-resolver';
+import TokenLabel from '../controls/token-label';
 
 interface FontTabProps {
   tab: TabConfig;
@@ -111,12 +112,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                 className="tokenpanel-row"
                 data-testid={`tier-ref-row-${item.id}`}
               >
-                <span className="tokenpanel-row-label" title={item.cssVar}>
-                  {item.cssVar}
-                  {item.label !== item.cssVar && (
-                    <span className="tokenpanel-row-label-sub">{item.label}</span>
-                  )}
-                </span>
+                <TokenLabel cssVar={item.cssVar} label={item.label} />
                 <TierRefSelector
                   tab={tab}
                   tierId={tier.id}

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -21,6 +21,7 @@ import type { TabConfig, TierConfig, TierItem, TierValueKind } from '../tokens/t
 import { type TabOverrides, resolveTierItemValue } from '../apply/tier-resolver';
 import TierRefSelector from '../controls/tier-ref-selector';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
+import TokenLabel from '../controls/token-label';
 
 // ---------------------------------------------------------------------------
 // Item editor dispatch
@@ -46,12 +47,7 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
     const refTierId = tier.referencesTier;
     return (
       <div className="tokenpanel-row" data-testid={`tier-ref-row-${item.id}`}>
-        <span className="tokenpanel-row-label" title={item.cssVar}>
-          {item.cssVar}
-          {item.label !== item.cssVar && (
-            <span className="tokenpanel-row-label-sub">{item.label}</span>
-          )}
-        </span>
+        <TokenLabel cssVar={item.cssVar} label={item.label} />
         <TierRefSelector
           tab={tab}
           tierId={tier.id}
@@ -110,12 +106,7 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
       return (
         <div className="tokenpanel-row--stacked" data-testid={`tier-item-${item.id}`}>
           <div className="tokenpanel-row-head">
-            <span className="tokenpanel-row-label" title={item.cssVar}>
-              {item.cssVar}
-              {item.label !== item.cssVar && (
-                <span className="tokenpanel-row-label-sub">{item.label}</span>
-              )}
-            </span>
+            <TokenLabel cssVar={item.cssVar} label={item.label} />
             <div className="tokenpanel-row-input-group">
               <input
                 type="text"
@@ -142,12 +133,7 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.cssVar}
-            {item.label !== item.cssVar && (
-              <span className="tokenpanel-row-label-sub">{item.label}</span>
-            )}
-          </span>
+          <TokenLabel cssVar={item.cssVar} label={item.label} />
           <select
             value={value}
             onChange={handleChange}
@@ -175,12 +161,7 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.cssVar}
-            {item.label !== item.cssVar && (
-              <span className="tokenpanel-row-label-sub">{item.label}</span>
-            )}
-          </span>
+          <TokenLabel cssVar={item.cssVar} label={item.label} />
           <input
             type="text"
             value={value}
@@ -204,12 +185,7 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
       };
       return (
         <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
-          <span className="tokenpanel-row-label" title={item.cssVar}>
-            {item.cssVar}
-            {item.label !== item.cssVar && (
-              <span className="tokenpanel-row-label-sub">{item.label}</span>
-            )}
-          </span>
+          <TokenLabel cssVar={item.cssVar} label={item.label} />
           <input
             type="color"
             value={value}

--- a/packages/zdtp/src/tabs/size-tab.tsx
+++ b/packages/zdtp/src/tabs/size-tab.tsx
@@ -7,6 +7,7 @@ import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { resolveTierItemValue } from '../apply/tier-resolver';
+import TokenLabel from '../controls/token-label';
 
 interface SizeTabProps {
   tab: TabConfig;
@@ -109,12 +110,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                 className="tokenpanel-row"
                 data-testid={`tier-ref-row-${item.id}`}
               >
-                <span className="tokenpanel-row-label" title={item.cssVar}>
-                  {item.cssVar}
-                  {item.label !== item.cssVar && (
-                    <span className="tokenpanel-row-label-sub">{item.label}</span>
-                  )}
-                </span>
+                <TokenLabel cssVar={item.cssVar} label={item.label} />
                 <TierRefSelector
                   tab={tab}
                   tierId={tier.id}

--- a/packages/zdtp/src/tabs/spacing-tab.tsx
+++ b/packages/zdtp/src/tabs/spacing-tab.tsx
@@ -7,6 +7,7 @@ import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { resolveTierItemValue } from '../apply/tier-resolver';
+import TokenLabel from '../controls/token-label';
 
 interface SpacingTabProps {
   tab: TabConfig;
@@ -114,12 +115,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                 className="tokenpanel-row"
                 data-testid={`tier-ref-row-${item.id}`}
               >
-                <span className="tokenpanel-row-label" title={item.cssVar}>
-                  {item.cssVar}
-                  {item.label !== item.cssVar && (
-                    <span className="tokenpanel-row-label-sub">{item.label}</span>
-                  )}
-                </span>
+                <TokenLabel cssVar={item.cssVar} label={item.label} />
                 <TierRefSelector
                   tab={tab}
                   tierId={tier.id}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/329
    - https://github.com/Takazudo/zudo-design-token-panel/issues/330

---

## Summary

Wave 1 of the Token Tooltip epic (#329). Closes #330.

The Color tab already shows a rich custom tooltip via `useTooltip` + `TooltipProvider`. Other tabs (Size, Font, Spacing, Easing, GenericTab) used the slow native HTML `title` attribute on truncated labels. This PR ships tooltip parity: every token-name display site uses the same rich `.tokenpanel-tooltip` primitive.

### Changes

- **NEW `packages/zdtp/src/controls/token-label.tsx`** — tiny memo'd component with props `{ cssVar, label?, className? }`. Renders a `<span>` carrying `useTooltip(cssVar)`, the `cssVar` text, and an optional sub-label only when `label !== cssVar`. No native `title` attribute — the custom tooltip is the single source.
- **Lifted `TooltipProvider` from `color-tab.tsx` to `panel.tsx`** so all tabs share a single provider. `color-tab.tsx` no longer wraps its content with its own `TooltipProvider`; existing `useTooltip(...)` calls on `ColorSwatch` / `PaletteSelector` resolve through the panel-level provider.
- **Applied `<TokenLabel>` at every token-name display site**:
    - `packages/zdtp/src/tabs/_generic-item-editor.tsx` (4 cases)
    - `packages/zdtp/src/tabs/generic-tab.tsx` (5 occurrences)
    - `packages/zdtp/src/tabs/size-tab.tsx`, `font-tab.tsx`, `spacing-tab.tsx`, `color-tab.tsx`
    - `packages/zdtp/src/controls/text-row.tsx`, `slider-row.tsx`, `select-row.tsx`

### Tests

- NEW `packages/zdtp/src/controls/__tests__/token-label.test.tsx` — verifies TokenLabel renders cssVar text, attaches useTooltip, renders the sub-label only when `label !== cssVar`.
- `color-tab.test.tsx` — fixture wrapped with `TooltipProvider` to keep tests passing after dropping the inner provider.
- `generic-tab.test.tsx` — extended to assert truncated label gets rich tooltip on hover.

### Verification

- `pnpm -F @takazudo/zdtp test --run` — 1048 tests pass (62 files).
- `pnpm typecheck` — clean across the workspace.
- `pnpm -F @takazudo/zdtp build` — succeeds.
- `grep -rn 'title={item.cssVar}' packages/zdtp/src/tabs packages/zdtp/src/controls` — zero matches (scope-narrow check: other `title=...` usages like resize handle, density label are out of scope and untouched).
- Panel DOM hygiene preserved: `TokenLabel` uses `<span>` only.
- Reviews (codex-review + gcoc-review): no actionable findings. Codex's standalone-render concerns don't apply — internal tabs/rows are not in the package's public exports map (`./`, `./astro`, `./server`, `./testing`, `./styles` only).

### Wave plan reminder

This PR is **Wave 1** of 3 (sub-issue #330). Once merged, Wave 2 (#331) cuts the `@takazudo/zdtp@0.2.0-next.2` prerelease, and Wave 3 (#332-#336) bumps + verifies the dep in the 5 external example repos.