### PR TITLE
ci: bump checkout/setup-node/pnpm-setup off deprecated Node 20 (#338)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -20,13 +20,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,13 +20,13 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -22,13 +22,13 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/338

---

## Summary

- Bumps the three SHA-pinned GitHub Actions that still run on the deprecated **Node 20** runtime to their minimal **Node-24-capable** major (**v5**), across all 5 workflows.
- GitHub forces Node 20 actions onto Node 24 on **2026-06-16** and removes the Node 20 runtime from runners on **2026-09-16**; this clears the deprecation annotations for these actions ahead of the deadline.
- v5 is the smallest single-major jump that fully satisfies Node 24 (every v5.x of these actions runs node24), minimizing behavior-change surface — latest (v6/v7) is intentionally out of scope.

## Changes

Across `ci.yml`, `main-deploy.yml`, `pr-checks.yml`, `preview-deploy.yml`, `release.yml` (SHA-pin + version-comment convention preserved, re-pinned to exact commit SHAs):

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `11bd719 # v4.2.2` | `93cb6ef # v5.0.1` |
| `actions/setup-node` | `49933ea # v4.4.0` | `a0853c2 # v5.0.0` |
| `pnpm/action-setup` | `a7487c7 # v4.1.0` | `fc06bc1 # v5.0.0` |

Notes:
- `pnpm/action-setup` needs no behavior change: the workflows pass **no `version:` input**, so pnpm is resolved from `packageManager: pnpm@11.3.0` in `package.json`, which v5 supports identically.
- The issue's suggested "latest **v4.x** on Node 24" for pnpm isn't achievable — no v4.x runs Node 24; **v5.0.0** is the minimal Node-24 release.
- `actions/setup-node` keeps `node-version: 22` and (in `release.yml`) `cache: pnpm` with pnpm set up first — both supported by v5.

## Out of scope (deferred to #340)

`actions/upload-artifact@v4.6.2` and `actions/download-artifact@v4.1.8` are **also** on Node 20, but require a larger **v4→v7** matched-major jump (upload v5 and download v5/v6 are still node20) with upload↔download format-compatibility coupling and deploy-round-trip validation. Tracked separately in #340 for its own validated PR. `actions/github-script@v8.0.0` is already node24 — no change needed.

## Test Plan

- `ci.yml` ("Build, test, typecheck, lint") runs on this PR and exercises all three bumped actions — **passed** on Node 24.
- `pr-checks.yml` ("Build doc site" + "Deploy PR preview") also passed (still emits expected Node-20 deprecation warnings for the deferred artifact actions — not a regression).

Closes #338