### PR TITLE
ci: bump artifact actions off deprecated Node 20 (matched v7 / node24)

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -40,7 +40,7 @@ jobs:
         run: bash scripts/stage-deploy.sh
 
       - name: Upload deploy artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deploy
           path: deploy/
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Download deploy artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: deploy
           path: deploy/

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
         run: bash scripts/stage-deploy.sh
 
       - name: Upload deploy artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: deploy
           path: deploy/
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Download deploy artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.1.8
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: deploy
           path: deploy/


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/340

---

## Summary

`actions/upload-artifact` and `actions/download-artifact` were the last two SHA-pinned CI actions still running on **Node 20** (they emitted the deprecation annotation). This bumps both off Node 20 to a matched **v7** (node24), re-pinned to exact commit SHAs and preserving the SHA-pin + version-comment convention.

Closes #340.

## Changes

| Action | Before | After (node24) |
|---|---|---|
| `actions/upload-artifact` | `ea165f8` # v4.6.2 | `043fb46` # v7.0.1 |
| `actions/download-artifact` | `d3f86a1` # v4.1.8 | `37930b1` # v7.0.0 |

Applied to both `.github/workflows/main-deploy.yml` and `.github/workflows/pr-checks.yml` (upload in the `build` job, download in the deploy/preview job).

**Matched-major rationale:** upload-artifact reaches node24 at v6, download-artifact at v7; v7 is the only common major where both are node24, so a matched v7 keeps the upload→download round-trip on a single major. (download-artifact now has a v8 that post-dates issue #340, but matched-v7 is the documented round-trip-safe choice and the v4+ artifact backend is shared regardless.) All `with:` inputs used (`name`, `path`, `retention-days`, `if-no-files-found`; `name`, `path`) remain valid in v7.

## Test Plan

- ✅ Both v7 pins confirmed `runs.using: node24` via `action.yml` at the pinned SHA.
- ✅ `pr-checks.yml` **Deploy PR preview** check is green — its step 2 *Download deploy artifact* (v7.0.0) ran `success`, exercising the upload (v7.0.1) → download (v7.0.0) round-trip on this PR.
- ✅ Post-merge `main-deploy.yml` exercises the production upload→download→Cloudflare deploy round-trip.