### PR TITLE
feat(panel): add Element Path Copy inspect mode

### DIFF
--- a/packages/zdtp/src/element-path/__tests__/build-element-path.test.ts
+++ b/packages/zdtp/src/element-path/__tests__/build-element-path.test.ts
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  buildUniqueSelector,
+  buildBreadcrumb,
+  buildSummary,
+  resolveRole,
+  resolveText,
+  resolveAttrs,
+  buildElementPath,
+  formatElementPath,
+  buildElementPathString,
+  cssEscapeIdent,
+} from '../build-element-path';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setBody(html: string): void {
+  document.body.innerHTML = html;
+}
+
+function $(selector: string): Element {
+  const el = document.querySelector(selector);
+  if (!el) throw new Error(`fixture missing: ${selector}`);
+  return el;
+}
+
+beforeEach(() => {
+  setBody('');
+});
+
+afterEach(() => {
+  setBody('');
+});
+
+// ---------------------------------------------------------------------------
+// buildUniqueSelector
+// ---------------------------------------------------------------------------
+
+describe('buildUniqueSelector', () => {
+  it('uses a unique id when present', () => {
+    setBody('<div id="hero"><span>x</span></div>');
+    const sel = buildUniqueSelector($('#hero'));
+    expect(sel).toBe('#hero');
+  });
+
+  it('produced selector always re-selects exactly the same element', () => {
+    setBody(`
+      <main>
+        <ul>
+          <li><a href="/a">A</a></li>
+          <li><a href="/b">B</a></li>
+          <li><a href="/c">C</a></li>
+        </ul>
+      </main>
+    `);
+    const targets = document.querySelectorAll('a');
+    for (const target of Array.from(targets)) {
+      const sel = buildUniqueSelector(target);
+      const matched = document.querySelectorAll(sel);
+      expect(matched.length).toBe(1);
+      expect(matched[0]).toBe(target);
+    }
+  });
+
+  it('disambiguates same-tag siblings with :nth-of-type', () => {
+    setBody('<section><p>one</p><p>two</p><p>three</p></section>');
+    const second = document.querySelectorAll('p')[1];
+    const sel = buildUniqueSelector(second);
+    expect(sel).toContain(':nth-of-type(2)');
+    expect(document.querySelector(sel)).toBe(second);
+  });
+
+  it('anchors on an ancestor id to keep the chain short', () => {
+    setBody(`
+      <div id="card">
+        <div><div><a href="/x">link</a></div></div>
+      </div>
+    `);
+    const link = $('a');
+    const sel = buildUniqueSelector(link);
+    expect(sel.startsWith('#card')).toBe(true);
+    expect(document.querySelector(sel)).toBe(link);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBreadcrumb
+// ---------------------------------------------------------------------------
+
+describe('buildBreadcrumb', () => {
+  it('renders a readable tag/class chain without nth-* noise', () => {
+    setBody('<nav class="nav"><a class="cta" href="/x">go</a></nav>');
+    const crumb = buildBreadcrumb($('a'));
+    expect(crumb).toBe('body > nav.nav > a.cta');
+  });
+
+  it('drops hash-y / css-module class names from the chain', () => {
+    setBody('<div class="Button_root__a1b2c"><span>x</span></div>');
+    const crumb = buildBreadcrumb($('span'));
+    // The hashed class is dropped, leaving the bare tag.
+    expect(crumb).toContain('div >');
+    expect(crumb).not.toContain('Button_root');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summary / role / text / attrs
+// ---------------------------------------------------------------------------
+
+describe('buildSummary', () => {
+  it('combines tag, id, and up to two classes', () => {
+    setBody('<a id="signup" class="cta primary extra" href="/x">go</a>');
+    expect(buildSummary($('a'))).toBe('a#signup.cta.primary');
+  });
+});
+
+describe('resolveRole', () => {
+  it('prefers an explicit role attribute', () => {
+    setBody('<div role="tab">x</div>');
+    expect(resolveRole($('div'))).toBe('tab');
+  });
+
+  it('maps <a href> to link but bare <a> to null', () => {
+    setBody('<a href="/x">link</a><a>anchor</a>');
+    const anchors = document.querySelectorAll('a');
+    expect(resolveRole(anchors[0])).toBe('link');
+    expect(resolveRole(anchors[1])).toBe(null);
+  });
+
+  it('maps input types to roles', () => {
+    setBody('<input type="checkbox"><input type="text"><input type="range">');
+    const inputs = document.querySelectorAll('input');
+    expect(resolveRole(inputs[0])).toBe('checkbox');
+    expect(resolveRole(inputs[1])).toBe('textbox');
+    expect(resolveRole(inputs[2])).toBe('slider');
+  });
+
+  it('maps common landmark/heading tags', () => {
+    setBody('<nav></nav><h2>x</h2><ul></ul>');
+    expect(resolveRole($('nav'))).toBe('navigation');
+    expect(resolveRole($('h2'))).toBe('heading');
+    expect(resolveRole($('ul'))).toBe('list');
+  });
+});
+
+describe('resolveText', () => {
+  it('collapses whitespace and trims', () => {
+    setBody('<p>  hello   world  </p>');
+    expect(resolveText($('p'))).toBe('hello world');
+  });
+
+  it('returns null for empty text', () => {
+    setBody('<div></div>');
+    expect(resolveText($('div'))).toBe(null);
+  });
+
+  it('truncates long text with an ellipsis', () => {
+    const long = 'x'.repeat(200);
+    setBody(`<p>${long}</p>`);
+    const text = resolveText($('p'))!;
+    expect(text.length).toBeLessThanOrEqual(60);
+    expect(text.endsWith('…')).toBe(true);
+  });
+});
+
+describe('resolveAttrs', () => {
+  it('collects identifying attributes in priority order', () => {
+    setBody('<input id="email" name="email" type="email" placeholder="you@x.com">');
+    const attrs = resolveAttrs($('input'));
+    expect(attrs[0]).toBe('id="email"');
+    expect(attrs).toContain('name="email"');
+    expect(attrs).toContain('type="email"');
+  });
+
+  it('returns an empty array when no identifying attributes exist', () => {
+    setBody('<div></div>');
+    expect(resolveAttrs($('div'))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildElementPath + formatElementPath
+// ---------------------------------------------------------------------------
+
+describe('buildElementPath + formatElementPath', () => {
+  it('produces a full annotated block', () => {
+    setBody('<nav class="nav"><a id="cta" class="btn" href="/go">Go now</a></nav>');
+    const result = buildElementPath($('#cta'));
+    expect(result.summary).toBe('a#cta.btn');
+    expect(result.selector).toBe('#cta');
+    expect(result.breadcrumb).toBe('body > nav.nav > a.btn');
+    expect(result.role).toBe('link');
+    expect(result.text).toBe('Go now');
+    expect(result.attrs).toContain('id="cta"');
+
+    const block = formatElementPath(result);
+    expect(block).toContain('element:  a#cta.btn');
+    expect(block).toContain('selector: #cta');
+    expect(block).toContain('path:     body > nav.nav > a.btn');
+    expect(block).toContain('role:     link');
+    expect(block).toContain('text:     "Go now"');
+  });
+
+  it('omits empty optional lines', () => {
+    setBody('<div></div>');
+    const block = buildElementPathString($('div'));
+    expect(block).toContain('element:  div');
+    expect(block).not.toContain('role:');
+    expect(block).not.toContain('text:');
+    expect(block).toContain('size:');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cssEscapeIdent
+// ---------------------------------------------------------------------------
+
+describe('cssEscapeIdent', () => {
+  it('escapes characters that are invalid in CSS identifiers', () => {
+    // The exact escaping differs between CSS.escape and the fallback, but the
+    // result must always be a usable identifier (round-trips via querySelector).
+    setBody('<div id="a.b:c"></div>');
+    const escaped = cssEscapeIdent('a.b:c');
+    expect(() => document.querySelector(`#${escaped}`)).not.toThrow();
+    expect(document.querySelector(`#${escaped}`)).toBe(document.getElementById('a.b:c'));
+  });
+});

--- a/packages/zdtp/src/element-path/__tests__/build-element-path.test.ts
+++ b/packages/zdtp/src/element-path/__tests__/build-element-path.test.ts
@@ -73,6 +73,10 @@ describe('buildUniqueSelector', () => {
     expect(document.querySelector(sel)).toBe(second);
   });
 
+  it('returns "html" for the document root element', () => {
+    expect(buildUniqueSelector(document.documentElement)).toBe('html');
+  });
+
   it('anchors on an ancestor id to keep the chain short', () => {
     setBody(`
       <div id="card">

--- a/packages/zdtp/src/element-path/__tests__/build-element-path.test.ts
+++ b/packages/zdtp/src/element-path/__tests__/build-element-path.test.ts
@@ -78,12 +78,13 @@ describe('buildUniqueSelector', () => {
   });
 
   it('anchors on an ancestor id to keep the chain short', () => {
+    // Two structurally-identical subtrees mean the bare tag chain (`div > a`)
+    // is ambiguous, so uniqueness can only be reached by climbing to #card.
     setBody(`
-      <div id="card">
-        <div><div><a href="/x">link</a></div></div>
-      </div>
+      <div id="card"><div><a href="/x">link</a></div></div>
+      <div><div><a href="/y">other</a></div></div>
     `);
-    const link = $('a');
+    const link = $('#card a');
     const sel = buildUniqueSelector(link);
     expect(sel.startsWith('#card')).toBe(true);
     expect(document.querySelector(sel)).toBe(link);

--- a/packages/zdtp/src/element-path/__tests__/element-path-state.test.ts
+++ b/packages/zdtp/src/element-path/__tests__/element-path-state.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  loadElementPathEnabled,
+  saveElementPathEnabled,
+} from '../element-path-state';
+import { __resetPanelConfigForTests } from '../../config/panel-config';
+import { installFixturePanelConfig } from '../../__tests__/_test-helpers';
+
+beforeEach(() => {
+  installFixturePanelConfig();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+  localStorage.clear();
+});
+
+describe('element-path enabled persistence', () => {
+  it('defaults to false when nothing is persisted', () => {
+    expect(loadElementPathEnabled()).toBe(false);
+  });
+
+  it('round-trips true through save → load', () => {
+    saveElementPathEnabled(true);
+    expect(loadElementPathEnabled()).toBe(true);
+  });
+
+  it('round-trips false through save → load', () => {
+    saveElementPathEnabled(true);
+    saveElementPathEnabled(false);
+    expect(loadElementPathEnabled()).toBe(false);
+  });
+
+  it('writes under the storagePrefix-derived key', () => {
+    saveElementPathEnabled(true);
+    expect(localStorage.getItem('zudo-design-token-panel-elpath-enabled')).toBe('1');
+  });
+
+  it('treats any non-"1" stored value as disabled', () => {
+    localStorage.setItem('zudo-design-token-panel-elpath-enabled', 'yes');
+    expect(loadElementPathEnabled()).toBe(false);
+  });
+});

--- a/packages/zdtp/src/element-path/__tests__/inspector-overlay.test.tsx
+++ b/packages/zdtp/src/element-path/__tests__/inspector-overlay.test.tsx
@@ -91,6 +91,18 @@ describe('InspectorOverlay', () => {
     expect(document.querySelector('.tokenpanel-elpath-box')).not.toBeNull();
   });
 
+  it('highlights the element already under the cursor as soon as Alt is pressed', () => {
+    act(() => {
+      render(<InspectorOverlay enabled={true} />, container);
+    });
+    // Move first (records position) — no box yet because not armed.
+    act(() => moveOverTarget());
+    expect(document.querySelector('.tokenpanel-elpath-box')).toBeNull();
+    // Pressing Alt arms AND resolves the element under the last cursor position.
+    act(() => pressAlt());
+    expect(document.querySelector('.tokenpanel-elpath-box')).not.toBeNull();
+  });
+
   it('shows the element label with the summary descriptor', () => {
     act(() => {
       render(<InspectorOverlay enabled={true} />, container);

--- a/packages/zdtp/src/element-path/__tests__/inspector-overlay.test.tsx
+++ b/packages/zdtp/src/element-path/__tests__/inspector-overlay.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit tests for InspectorOverlay.
+ *
+ * Environment constraints (same as highlight-overlay):
+ * - jsdom's getBoundingClientRect() returns zeros — we stub it per element.
+ * - jsdom does not implement elementFromPoint — we stub it to return the
+ *   fixture target so mousemove resolves a hovered element.
+ * - clipboard.writeText is mocked so the copy path is observable.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import { InspectorOverlay } from '../inspector-overlay';
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+let target: HTMLAnchorElement;
+let writeText: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+
+  // Fixture host element to inspect.
+  target = document.createElement('a');
+  target.id = 'cta';
+  target.setAttribute('href', '/go');
+  target.textContent = 'Go';
+  document.body.appendChild(target);
+  target.getBoundingClientRect = () =>
+    ({ top: 10, left: 20, width: 100, height: 40, right: 120, bottom: 50, x: 20, y: 10, toJSON: () => ({}) }) as DOMRect;
+
+  // Stub elementFromPoint (unimplemented in jsdom).
+  document.elementFromPoint = () => target;
+
+  // Mock the modern clipboard API.
+  writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  render(null, container);
+  container.remove();
+  target.remove();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pressAlt(): void {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Alt', altKey: true, bubbles: true }));
+}
+
+function releaseAlt(): void {
+  window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Alt', altKey: false, bubbles: true }));
+}
+
+function moveOverTarget(): void {
+  document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 30, bubbles: true }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('InspectorOverlay', () => {
+  // Each state transition needs its own act() so the resulting re-render +
+  // effect (which attaches the next phase's listener) commits before the next
+  // event is dispatched. Arming attaches the mousemove/click listeners; only
+  // then does a mousemove resolve a hovered element.
+
+  it('renders no highlight box until Alt is held and the pointer moves', () => {
+    act(() => {
+      render(<InspectorOverlay enabled={true} />, container);
+    });
+    expect(document.querySelector('.tokenpanel-elpath-box')).toBeNull();
+
+    act(() => pressAlt());
+    act(() => moveOverTarget());
+    expect(document.querySelector('.tokenpanel-elpath-box')).not.toBeNull();
+  });
+
+  it('shows the element label with the summary descriptor', () => {
+    act(() => {
+      render(<InspectorOverlay enabled={true} />, container);
+    });
+    act(() => pressAlt());
+    act(() => moveOverTarget());
+    const label = document.querySelector('.tokenpanel-elpath-label-name');
+    expect(label?.textContent).toBe('a#cta');
+  });
+
+  it('does nothing while disabled, even with Alt + mousemove', () => {
+    act(() => {
+      render(<InspectorOverlay enabled={false} />, container);
+    });
+    act(() => pressAlt());
+    act(() => moveOverTarget());
+    expect(document.querySelector('.tokenpanel-elpath-box')).toBeNull();
+  });
+
+  it('clears the highlight when Alt is released', () => {
+    act(() => {
+      render(<InspectorOverlay enabled={true} />, container);
+    });
+    act(() => pressAlt());
+    act(() => moveOverTarget());
+    expect(document.querySelector('.tokenpanel-elpath-box')).not.toBeNull();
+
+    act(() => releaseAlt());
+    expect(document.querySelector('.tokenpanel-elpath-box')).toBeNull();
+  });
+
+  it('copies the annotated path and shows a toast on inspect-click', async () => {
+    act(() => {
+      render(<InspectorOverlay enabled={true} />, container);
+    });
+    act(() => pressAlt());
+    act(() => moveOverTarget());
+
+    await act(async () => {
+      document.dispatchEvent(new MouseEvent('click', { clientX: 50, clientY: 30, bubbles: true }));
+      // Flush the copyToClipboard → setToast microtask chain (writeText await +
+      // copyToClipboard await + the setToast that follows).
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('element:  a#cta');
+    expect(copied).toContain('selector: #cta');
+
+    const toast = document.querySelector('.tokenpanel-elpath-toast-text');
+    expect(toast?.textContent).toContain('Copied path: a#cta');
+  });
+
+  it('swallows the inspect-click so host handlers do not fire', () => {
+    const hostClick = vi.fn();
+    target.addEventListener('click', hostClick);
+
+    act(() => {
+      render(<InspectorOverlay enabled={true} />, container);
+    });
+    act(() => pressAlt());
+    act(() => moveOverTarget());
+    act(() => {
+      target.dispatchEvent(new MouseEvent('click', { clientX: 50, clientY: 30, bubbles: true }));
+    });
+
+    expect(hostClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zdtp/src/element-path/build-element-path.ts
+++ b/packages/zdtp/src/element-path/build-element-path.ts
@@ -1,0 +1,361 @@
+/**
+ * build-element-path — pure DOM → annotated-path generator.
+ *
+ * Produces a structured `ElementPathResult` describing a single host element,
+ * plus a `formatElementPath()` that renders it into the multi-line "annotated
+ * block" the Element Path Copy feature writes to the clipboard.
+ *
+ * Why an annotated block (not bare XPath / a single selector)?
+ * ----------------------------------------------------------
+ * The panel's whole reason to exist is better human↔AI communication about a
+ * page. A bare `/html/body/div[2]/...` (or even a terse CSS selector) tells an
+ * AI *where* an element is but nothing about *what* it is. The block bundles:
+ *
+ *   - `selector`   — a minimal, querySelector-able unique CSS selector so the
+ *                    element can be re-located programmatically.
+ *   - `breadcrumb` — a human-readable tag/class ancestor chain (no nth-* noise)
+ *                    so a reader can picture the structure at a glance.
+ *   - `role`       — explicit or implicit ARIA role (semantics).
+ *   - `text`       — a short trimmed text snippet (what the element *says*).
+ *   - `attrs`      — a few identifying attributes (id / data-testid / href / …).
+ *   - `size`       — rendered width × height in CSS px.
+ *
+ * Everything here is pure and DOM-only (no Preact), so it unit-tests cleanly
+ * under jsdom.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ElementPathResult {
+  /** One-line descriptor, e.g. `a.cta#signup`. */
+  summary: string;
+  /** Minimal unique CSS selector (querySelector-able). */
+  selector: string;
+  /** Readable ancestor chain with tag + first class, e.g. `body > nav.nav > a.cta`. */
+  breadcrumb: string;
+  /** Explicit or implicit ARIA role, or null when none is meaningful. */
+  role: string | null;
+  /** Trimmed, whitespace-collapsed, truncated text snippet, or null when empty. */
+  text: string | null;
+  /** A few identifying attributes rendered as `name="value"` strings. */
+  attrs: string[];
+  /** Rendered size in CSS px (0×0 when not laid out / detached). */
+  size: { width: number; height: number };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Max length of the copied text snippet before it is truncated with an ellipsis. */
+const MAX_TEXT_LENGTH = 60;
+
+/** Max number of breadcrumb segments (deepest N) to keep the chain readable. */
+const MAX_BREADCRUMB_DEPTH = 8;
+
+/**
+ * Attributes worth surfacing, in priority order. These are the ones that most
+ * help a human or AI identify an element without re-reading the DOM.
+ */
+const IDENTIFYING_ATTRS = [
+  'id',
+  'data-testid',
+  'data-test',
+  'data-test-id',
+  'name',
+  'type',
+  'href',
+  'aria-label',
+  'alt',
+  'placeholder',
+  'title',
+] as const;
+
+/** Max identifying attributes to include. */
+const MAX_ATTRS = 5;
+
+/**
+ * Implicit ARIA roles for the common HTML elements. Intentionally small — this
+ * is a hint for communication, not a spec-complete ARIA mapping. Elements whose
+ * implicit role depends on context/attributes (`a` without `href`, `input` of
+ * an exotic type, etc.) are handled in `implicitRole()`.
+ */
+const IMPLICIT_ROLE_BY_TAG: Record<string, string> = {
+  nav: 'navigation',
+  main: 'main',
+  header: 'banner',
+  footer: 'contentinfo',
+  aside: 'complementary',
+  section: 'region',
+  article: 'article',
+  button: 'button',
+  ul: 'list',
+  ol: 'list',
+  li: 'listitem',
+  table: 'table',
+  img: 'img',
+  form: 'form',
+  select: 'combobox',
+  textarea: 'textbox',
+  h1: 'heading',
+  h2: 'heading',
+  h3: 'heading',
+  h4: 'heading',
+  h5: 'heading',
+  h6: 'heading',
+};
+
+// ---------------------------------------------------------------------------
+// CSS identifier escaping
+// ---------------------------------------------------------------------------
+
+/**
+ * Escape a string for safe use as a CSS identifier (class / id segment).
+ * Prefers the native `CSS.escape`; falls back to a conservative manual escape
+ * for environments where it is unavailable (older jsdom, etc.).
+ */
+export function cssEscapeIdent(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(value);
+  }
+  // Minimal fallback: backslash-escape anything outside [A-Za-z0-9_-], and
+  // guard a leading digit (invalid as the first char of an identifier).
+  return value
+    .replace(/^[0-9]/, (d) => `\\3${d} `)
+    .replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+}
+
+// ---------------------------------------------------------------------------
+// Class helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the element's class list, filtered to "stable-looking" classes.
+ *
+ * Utility/atomic and hash-suffixed classes (e.g. Tailwind's `px-4`, CSS-module
+ * `Button_root__a1b2c`, styled-components `sc-xxxx`) make selectors brittle and
+ * breadcrumbs noisy. We drop classes that look machine-generated so the human
+ * breadcrumb stays readable. The unique-selector path does NOT rely on classes
+ * (it uses :nth-of-type), so dropping them never breaks uniqueness.
+ */
+function stableClasses(el: Element): string[] {
+  const raw = (el.getAttribute('class') ?? '').trim();
+  if (!raw) return [];
+  return raw
+    .split(/\s+/)
+    .filter((c) => c.length > 0)
+    // Drop hash-y fragments: 5+ char runs that mix letters and digits, or
+    // contain a CSS-module style double-underscore / sc- prefix.
+    .filter((c) => !/__|^sc-|^css-[a-z0-9]{4,}/i.test(c))
+    .filter((c) => !/[a-z][0-9]|[0-9][a-z]/i.test(c) || c.length <= 4);
+}
+
+// ---------------------------------------------------------------------------
+// Unique selector
+// ---------------------------------------------------------------------------
+
+function isUnique(selector: string, el: Element): boolean {
+  const doc = el.ownerDocument;
+  if (!doc) return false;
+  try {
+    const matches = doc.querySelectorAll(selector);
+    return matches.length === 1 && matches[0] === el;
+  } catch {
+    // Malformed selector (exotic tag/id) — treat as non-unique.
+    return false;
+  }
+}
+
+/** `:nth-of-type(n)` suffix when the element has same-tag siblings, else ''. */
+function nthOfTypeSuffix(el: Element): string {
+  const parent = el.parentElement;
+  if (!parent) return '';
+  const tag = el.tagName;
+  const sameTag = Array.from(parent.children).filter((c) => c.tagName === tag);
+  if (sameTag.length <= 1) return '';
+  const index = sameTag.indexOf(el) + 1;
+  return `:nth-of-type(${index})`;
+}
+
+/** Selector segment for a single element: lowercased tag + nth-of-type if needed. */
+function segmentFor(el: Element): string {
+  return el.tagName.toLowerCase() + nthOfTypeSuffix(el);
+}
+
+/**
+ * Build a minimal unique CSS selector for `el`.
+ *
+ * Strategy (closest to DevTools "Copy selector"):
+ *  1. If the element has a unique, valid id → `#id` (shortest possible).
+ *  2. Otherwise walk ancestors, prepending `tag:nth-of-type(n)` segments, and
+ *     stop as soon as the accumulated selector matches exactly one element.
+ *     An ancestor with a unique id anchors the chain early.
+ *  3. If we reach the root without uniqueness (degenerate DOM), return the
+ *     full chain anyway — it is the best available.
+ */
+export function buildUniqueSelector(el: Element): string {
+  // Fast path: unique id.
+  const id = el.getAttribute('id');
+  if (id) {
+    const idSelector = `#${cssEscapeIdent(id)}`;
+    if (isUnique(idSelector, el)) return idSelector;
+  }
+
+  const parts: string[] = [];
+  let current: Element | null = el;
+
+  while (current && current.nodeType === 1 && current.tagName !== 'HTML') {
+    // Anchor on an ancestor's unique id when available — shortens the chain.
+    const curId = current.getAttribute('id');
+    if (curId) {
+      const idSel = `#${cssEscapeIdent(curId)}`;
+      if (isUnique(idSel, current)) {
+        parts.unshift(idSel);
+        const candidate = parts.join(' > ');
+        if (isUnique(candidate, el)) return candidate;
+        // id anchored but chain still not unique — keep climbing from parent.
+        current = current.parentElement;
+        continue;
+      }
+    }
+
+    parts.unshift(segmentFor(current));
+    const candidate = parts.join(' > ');
+    if (isUnique(candidate, el)) return candidate;
+
+    current = current.parentElement;
+  }
+
+  return parts.join(' > ');
+}
+
+// ---------------------------------------------------------------------------
+// Breadcrumb
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a readable ancestor chain `tag.firstClass > … > tag.firstClass`,
+ * limited to the deepest `MAX_BREADCRUMB_DEPTH` segments. No nth-* noise — this
+ * is for humans, not querySelector.
+ */
+export function buildBreadcrumb(el: Element): string {
+  const segments: string[] = [];
+  let current: Element | null = el;
+
+  while (current && current.nodeType === 1 && current.tagName !== 'HTML') {
+    const tag = current.tagName.toLowerCase();
+    const cls = stableClasses(current)[0];
+    segments.unshift(cls ? `${tag}.${cls}` : tag);
+    current = current.parentElement;
+  }
+
+  if (segments.length > MAX_BREADCRUMB_DEPTH) {
+    return '… > ' + segments.slice(-MAX_BREADCRUMB_DEPTH).join(' > ');
+  }
+  return segments.join(' > ');
+}
+
+// ---------------------------------------------------------------------------
+// Role / text / attrs / summary
+// ---------------------------------------------------------------------------
+
+/** Resolve explicit `role` attribute, else a small implicit-role mapping. */
+export function resolveRole(el: Element): string | null {
+  const explicit = el.getAttribute('role');
+  if (explicit && explicit.trim()) return explicit.trim();
+
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'a') {
+    return el.hasAttribute('href') ? 'link' : null;
+  }
+  if (tag === 'input') {
+    const type = (el.getAttribute('type') ?? 'text').toLowerCase();
+    if (type === 'checkbox') return 'checkbox';
+    if (type === 'radio') return 'radio';
+    if (type === 'button' || type === 'submit' || type === 'reset') return 'button';
+    if (type === 'range') return 'slider';
+    if (type === 'hidden') return null;
+    return 'textbox';
+  }
+  return IMPLICIT_ROLE_BY_TAG[tag] ?? null;
+}
+
+/** Trimmed, whitespace-collapsed, truncated text snippet, or null when empty. */
+export function resolveText(el: Element): string | null {
+  const raw = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+  if (!raw) return null;
+  if (raw.length <= MAX_TEXT_LENGTH) return raw;
+  return raw.slice(0, MAX_TEXT_LENGTH - 1).trimEnd() + '…';
+}
+
+/** Collect up to `MAX_ATTRS` identifying attributes as `name="value"` strings. */
+export function resolveAttrs(el: Element): string[] {
+  const out: string[] = [];
+  for (const name of IDENTIFYING_ATTRS) {
+    if (out.length >= MAX_ATTRS) break;
+    const value = el.getAttribute(name);
+    if (value === null) continue;
+    const trimmed = value.replace(/\s+/g, ' ').trim();
+    if (!trimmed) continue;
+    const shown = trimmed.length > 40 ? trimmed.slice(0, 39) + '…' : trimmed;
+    out.push(`${name}="${shown}"`);
+  }
+  return out;
+}
+
+/** One-line descriptor: `tag#id.class1.class2` (id first, then up to 2 classes). */
+export function buildSummary(el: Element): string {
+  const tag = el.tagName.toLowerCase();
+  const id = el.getAttribute('id');
+  const classes = stableClasses(el).slice(0, 2);
+  let out = tag;
+  if (id) out += `#${id}`;
+  for (const c of classes) out += `.${c}`;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level builder + formatter
+// ---------------------------------------------------------------------------
+
+export function buildElementPath(el: Element): ElementPathResult {
+  let size = { width: 0, height: 0 };
+  if (typeof (el as HTMLElement).getBoundingClientRect === 'function') {
+    const rect = el.getBoundingClientRect();
+    size = { width: Math.round(rect.width), height: Math.round(rect.height) };
+  }
+
+  return {
+    summary: buildSummary(el),
+    selector: buildUniqueSelector(el),
+    breadcrumb: buildBreadcrumb(el),
+    role: resolveRole(el),
+    text: resolveText(el),
+    attrs: resolveAttrs(el),
+    size,
+  };
+}
+
+/**
+ * Render an `ElementPathResult` into the multi-line annotated block copied to
+ * the clipboard. Only meaningful fields are emitted (no empty `role:`/`text:`
+ * lines), so the block stays compact for small/anonymous elements.
+ */
+export function formatElementPath(result: ElementPathResult): string {
+  const lines: string[] = [];
+  lines.push(`element:  ${result.summary}`);
+  lines.push(`selector: ${result.selector}`);
+  lines.push(`path:     ${result.breadcrumb}`);
+  if (result.role) lines.push(`role:     ${result.role}`);
+  if (result.text) lines.push(`text:     "${result.text}"`);
+  if (result.attrs.length > 0) lines.push(`attrs:    ${result.attrs.join(', ')}`);
+  lines.push(`size:     ${result.size.width} × ${result.size.height}`);
+  return lines.join('\n');
+}
+
+/** Convenience: build + format in one call. */
+export function buildElementPathString(el: Element): string {
+  return formatElementPath(buildElementPath(el));
+}

--- a/packages/zdtp/src/element-path/build-element-path.ts
+++ b/packages/zdtp/src/element-path/build-element-path.ts
@@ -146,10 +146,11 @@ function stableClasses(el: Element): string[] {
   return raw
     .split(/\s+/)
     .filter((c) => c.length > 0)
-    // Drop hash-y fragments: 5+ char runs that mix letters and digits, or
-    // contain a CSS-module style double-underscore / sc- prefix.
+    // Drop machine-generated class fragments that make selectors/breadcrumbs
+    // noisy: CSS-module (`Button__root`), styled-components (`sc-xxxx`), emotion
+    // (`css-1a2b3c`), and bare hashes (6+ chars mixing letters and digits).
     .filter((c) => !/__|^sc-|^css-[a-z0-9]{4,}/i.test(c))
-    .filter((c) => !/[a-z][0-9]|[0-9][a-z]/i.test(c) || c.length <= 4);
+    .filter((c) => !(/[a-z][0-9]|[0-9][a-z]/i.test(c) && c.length >= 6));
 }
 
 // ---------------------------------------------------------------------------
@@ -179,9 +180,15 @@ function nthOfTypeSuffix(el: Element): string {
   return `:nth-of-type(${index})`;
 }
 
-/** Selector segment for a single element: lowercased tag + nth-of-type if needed. */
+/**
+ * Selector segment for a single element: tag + nth-of-type if needed.
+ *
+ * Uses `localName` (not `tagName.toLowerCase()`) so camel-cased SVG elements
+ * like `linearGradient` keep their exact case — CSS type selectors are
+ * case-sensitive for non-HTML elements, so lowercasing would break the match.
+ */
 function segmentFor(el: Element): string {
-  return el.tagName.toLowerCase() + nthOfTypeSuffix(el);
+  return el.localName + nthOfTypeSuffix(el);
 }
 
 /**
@@ -196,6 +203,9 @@ function segmentFor(el: Element): string {
  *     full chain anyway — it is the best available.
  */
 export function buildUniqueSelector(el: Element): string {
+  // Root element — `html` is always unique and has no useful ancestor chain.
+  if (el.tagName === 'HTML') return 'html';
+
   // Fast path: unique id.
   const id = el.getAttribute('id');
   if (id) {
@@ -245,7 +255,7 @@ export function buildBreadcrumb(el: Element): string {
   let current: Element | null = el;
 
   while (current && current.nodeType === 1 && current.tagName !== 'HTML') {
-    const tag = current.tagName.toLowerCase();
+    const tag = current.localName;
     const cls = stableClasses(current)[0];
     segments.unshift(cls ? `${tag}.${cls}` : tag);
     current = current.parentElement;
@@ -307,7 +317,7 @@ export function resolveAttrs(el: Element): string[] {
 
 /** One-line descriptor: `tag#id.class1.class2` (id first, then up to 2 classes). */
 export function buildSummary(el: Element): string {
-  const tag = el.tagName.toLowerCase();
+  const tag = el.localName;
   const id = el.getAttribute('id');
   const classes = stableClasses(el).slice(0, 2);
   let out = tag;

--- a/packages/zdtp/src/element-path/build-element-path.ts
+++ b/packages/zdtp/src/element-path/build-element-path.ts
@@ -120,11 +120,29 @@ export function cssEscapeIdent(value: string): string {
   if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
     return CSS.escape(value);
   }
-  // Minimal fallback: backslash-escape anything outside [A-Za-z0-9_-], and
-  // guard a leading digit (invalid as the first char of an identifier).
-  return value
-    .replace(/^[0-9]/, (d) => `\\3${d} `)
-    .replace(/[^a-zA-Z0-9_-]/g, (c) => `\\${c}`);
+  // Minimal fallback for environments without CSS.escape (older jsdom — which
+  // the test env actually hits — and very old browsers). Single pass so the
+  // escape sequences can never compound, mirroring CSS.escape for the inputs we
+  // can reach (only an element's `id` reaches this; class names never do):
+  //   - control chars (incl. newline/tab) → hex escape `\<hex> ` — a bare
+  //     backslash+newline is a CSS line-continuation, NOT a character escape;
+  //   - a leading digit → hex escape (invalid as the first char of an ident);
+  //   - other non-[A-Za-z0-9_-] symbols → backslash escape.
+  let out = '';
+  for (let i = 0; i < value.length; i++) {
+    const ch = value[i];
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || code === 0x7f) {
+      out += `\\${code.toString(16)} `;
+    } else if (i === 0 && code >= 0x30 && code <= 0x39) {
+      out += `\\${code.toString(16)} `;
+    } else if (/[a-zA-Z0-9_-]/.test(ch)) {
+      out += ch;
+    } else {
+      out += `\\${ch}`;
+    }
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/zdtp/src/element-path/element-path-context.ts
+++ b/packages/zdtp/src/element-path/element-path-context.ts
@@ -1,0 +1,21 @@
+/**
+ * ElementPathContext — shared state for the Element Path Copy feature.
+ *
+ * Provided by `ElementPathOrchestrator`; consumed by the header toggle button
+ * (`ElementPathToggleButton`) and the inspector overlay. When the context is
+ * null (component rendered outside the orchestrator — e.g. a bare unit test),
+ * consumers degrade gracefully and render nothing.
+ */
+
+import { createContext } from 'preact';
+
+export interface ElementPathContextValue {
+  /** Whether inspect mode is enabled (persisted). */
+  enabled: boolean;
+  /** Enable / disable inspect mode. */
+  setEnabled: (enabled: boolean) => void;
+  /** Toggle inspect mode. */
+  toggle: () => void;
+}
+
+export const ElementPathContext = createContext<ElementPathContextValue | null>(null);

--- a/packages/zdtp/src/element-path/element-path-orchestrator.tsx
+++ b/packages/zdtp/src/element-path/element-path-orchestrator.tsx
@@ -12,7 +12,7 @@
  * panel.tsx wraps its tree in this component.
  */
 
-import { useState, useCallback, useMemo, useEffect, useRef } from 'preact/hooks';
+import { useState, useCallback, useMemo } from 'preact/hooks';
 import type { ComponentChildren } from 'preact';
 import { createPortal } from 'preact/compat';
 import {
@@ -21,6 +21,7 @@ import {
 } from './element-path-context';
 import { loadElementPathEnabled, saveElementPathEnabled } from './element-path-state';
 import { InspectorOverlay } from './inspector-overlay';
+import { usePortalMount } from '../utils/use-portal-mount';
 
 // ---------------------------------------------------------------------------
 // Portal mount
@@ -29,51 +30,14 @@ import { InspectorOverlay } from './inspector-overlay';
 /** Must match the id added to PANEL_EXCLUSION_SELECTOR in find-elements.ts. */
 const PORTAL_MOUNT_ID = 'tokenpanel-elpath-mount';
 
-/**
- * Get or create the singleton portal mount <div> at document.body. Idempotent;
- * SSR-safe (returns null when document is unavailable).
- */
-function getOrCreateMountNode(): HTMLDivElement | null {
-  if (typeof document === 'undefined') return null;
-  const existing = document.getElementById(PORTAL_MOUNT_ID) as HTMLDivElement | null;
-  if (existing) return existing;
-  const node = document.createElement('div');
-  node.id = PORTAL_MOUNT_ID;
-  document.body.appendChild(node);
-  return node;
-}
-
 interface OverlayPortalProps {
   enabled: boolean;
 }
 
 function OverlayPortal({ enabled }: OverlayPortalProps) {
-  const mountNodeRef = useRef<HTMLDivElement | null>(null);
-  const [, setMountVersion] = useState(0);
-
-  useEffect(() => {
-    if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
-      mountNodeRef.current = getOrCreateMountNode();
-      setMountVersion((v) => v + 1);
-    }
-    function handleAfterSwap() {
-      if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
-        mountNodeRef.current = getOrCreateMountNode();
-        setMountVersion((v) => v + 1);
-      }
-    }
-    if (typeof window !== 'undefined') {
-      window.addEventListener('astro:after-swap', handleAfterSwap);
-    }
-    return () => {
-      if (typeof window !== 'undefined') {
-        window.removeEventListener('astro:after-swap', handleAfterSwap);
-      }
-    };
-  }, []);
-
-  if (!mountNodeRef.current) return null;
-  return createPortal(<InspectorOverlay enabled={enabled} />, mountNodeRef.current);
+  const mountNode = usePortalMount(PORTAL_MOUNT_ID);
+  if (!mountNode) return null;
+  return createPortal(<InspectorOverlay enabled={enabled} />, mountNode);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/zdtp/src/element-path/element-path-orchestrator.tsx
+++ b/packages/zdtp/src/element-path/element-path-orchestrator.tsx
@@ -1,0 +1,110 @@
+/**
+ * ElementPathOrchestrator — integration layer for Element Path Copy.
+ *
+ * Responsibilities (mirrors HighlightOrchestrator):
+ *   1. Lifts and persists the `enabled` flag.
+ *   2. Provides ElementPathContext to all descendants (header toggle button).
+ *   3. Mounts the InspectorOverlay in a portal at document.body so the box,
+ *      label, and toast render above host content regardless of where the panel
+ *      shell lives — and persist even while the panel is closed.
+ *   4. Recreates the portal mount on `astro:after-swap` when Astro replaces body.
+ *
+ * panel.tsx wraps its tree in this component.
+ */
+
+import { useState, useCallback, useMemo, useEffect, useRef } from 'preact/hooks';
+import type { ComponentChildren } from 'preact';
+import { createPortal } from 'preact/compat';
+import {
+  ElementPathContext,
+  type ElementPathContextValue,
+} from './element-path-context';
+import { loadElementPathEnabled, saveElementPathEnabled } from './element-path-state';
+import { InspectorOverlay } from './inspector-overlay';
+
+// ---------------------------------------------------------------------------
+// Portal mount
+// ---------------------------------------------------------------------------
+
+/** Must match the id added to PANEL_EXCLUSION_SELECTOR in find-elements.ts. */
+const PORTAL_MOUNT_ID = 'tokenpanel-elpath-mount';
+
+/**
+ * Get or create the singleton portal mount <div> at document.body. Idempotent;
+ * SSR-safe (returns null when document is unavailable).
+ */
+function getOrCreateMountNode(): HTMLDivElement | null {
+  if (typeof document === 'undefined') return null;
+  const existing = document.getElementById(PORTAL_MOUNT_ID) as HTMLDivElement | null;
+  if (existing) return existing;
+  const node = document.createElement('div');
+  node.id = PORTAL_MOUNT_ID;
+  document.body.appendChild(node);
+  return node;
+}
+
+interface OverlayPortalProps {
+  enabled: boolean;
+}
+
+function OverlayPortal({ enabled }: OverlayPortalProps) {
+  const mountNodeRef = useRef<HTMLDivElement | null>(null);
+  const [, setMountVersion] = useState(0);
+
+  useEffect(() => {
+    if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
+      mountNodeRef.current = getOrCreateMountNode();
+      setMountVersion((v) => v + 1);
+    }
+    function handleAfterSwap() {
+      if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
+        mountNodeRef.current = getOrCreateMountNode();
+        setMountVersion((v) => v + 1);
+      }
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('astro:after-swap', handleAfterSwap);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('astro:after-swap', handleAfterSwap);
+      }
+    };
+  }, []);
+
+  if (!mountNodeRef.current) return null;
+  return createPortal(<InspectorOverlay enabled={enabled} />, mountNodeRef.current);
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+export function ElementPathOrchestrator({ children }: { children: ComponentChildren }) {
+  const [enabled, setEnabledState] = useState<boolean>(loadElementPathEnabled);
+
+  const setEnabled = useCallback((next: boolean) => {
+    setEnabledState(next);
+    saveElementPathEnabled(next);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setEnabledState((prev) => {
+      const next = !prev;
+      saveElementPathEnabled(next);
+      return next;
+    });
+  }, []);
+
+  const ctxValue = useMemo<ElementPathContextValue>(
+    () => ({ enabled, setEnabled, toggle }),
+    [enabled, setEnabled, toggle],
+  );
+
+  return (
+    <>
+      <ElementPathContext.Provider value={ctxValue}>{children}</ElementPathContext.Provider>
+      <OverlayPortal enabled={enabled} />
+    </>
+  );
+}

--- a/packages/zdtp/src/element-path/element-path-state.ts
+++ b/packages/zdtp/src/element-path/element-path-state.ts
@@ -1,0 +1,47 @@
+/**
+ * Element Path Copy — persisted feature state.
+ *
+ * The feature has a single persisted bit: whether inspect mode is enabled.
+ * When enabled, holding Alt and hovering highlights the element under the
+ * cursor (DevTools-style box + label); clicking copies an annotated path block
+ * to the clipboard.
+ *
+ * Persistence mirrors the highlight subsystem: the key is derived from
+ * `panelConfig.storagePrefix` at call-time (never at module init) so a host's
+ * `configurePanel({ storagePrefix })` is respected.
+ */
+
+import { getPanelConfig } from '../config/panel-config';
+
+// ---------------------------------------------------------------------------
+// Storage key
+// ---------------------------------------------------------------------------
+
+function storageKey_elementPathEnabled(): string {
+  return `${getPanelConfig().storagePrefix}-elpath-enabled`;
+}
+
+// ---------------------------------------------------------------------------
+// Load / save
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the persisted enabled flag from localStorage. Defaults to `false`
+ * (inspect mode off) on any parse/access failure or when absent.
+ */
+export function loadElementPathEnabled(): boolean {
+  try {
+    return localStorage.getItem(storageKey_elementPathEnabled()) === '1';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the enabled flag to localStorage. Degrades silently when storage is unavailable. */
+export function saveElementPathEnabled(enabled: boolean): void {
+  try {
+    localStorage.setItem(storageKey_elementPathEnabled(), enabled ? '1' : '0');
+  } catch {
+    /* storage unavailable — degrade silently */
+  }
+}

--- a/packages/zdtp/src/element-path/element-path-toast.tsx
+++ b/packages/zdtp/src/element-path/element-path-toast.tsx
@@ -1,0 +1,53 @@
+/**
+ * ElementPathToast — transient top-center notification shown after a copy.
+ *
+ * Rendered inside the Element Path Copy portal (outside `.tokenpanel-shell`), so
+ * it carries its own `--tokentweak-*` scope via panel.css. `pointer-events:none`
+ * keeps it from intercepting hover while inspect mode is active.
+ *
+ * Stateless: the parent owns the message lifecycle (auto-dismiss timer). When
+ * `message` is null nothing renders.
+ */
+
+import type { JSX } from 'preact';
+
+export interface ElementPathToastProps {
+  /** Toast body; null hides the toast. */
+  message: string | null;
+  /** Whether the copy succeeded — drives the accent colour. */
+  ok: boolean;
+}
+
+export function ElementPathToast({ message, ok }: ElementPathToastProps): JSX.Element | null {
+  if (message === null) return null;
+  return (
+    <div
+      className={ok ? 'tokenpanel-elpath-toast' : 'tokenpanel-elpath-toast is-error'}
+      role="status"
+      aria-live="polite"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {ok ? (
+          <path d="M20 6 9 17l-5-5" />
+        ) : (
+          <>
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </>
+        )}
+      </svg>
+      <span className="tokenpanel-elpath-toast-text">{message}</span>
+    </div>
+  );
+}

--- a/packages/zdtp/src/element-path/element-path-toast.tsx
+++ b/packages/zdtp/src/element-path/element-path-toast.tsx
@@ -7,6 +7,13 @@
  *
  * Stateless: the parent owns the message lifecycle (auto-dismiss timer). When
  * `message` is null nothing renders.
+ *
+ * Purely visual — it carries no ARIA live-region semantics. InspectorOverlay
+ * renders a separate always-mounted visually-hidden live region for screen
+ * reader announcements (a region inserted already-populated is often not
+ * announced), so duplicating `role="status"` here would be redundant and
+ * unreliable. The icon is `aria-hidden` and the text is conveyed by the
+ * persistent announcer.
  */
 
 import type { JSX } from 'preact';
@@ -23,8 +30,7 @@ export function ElementPathToast({ message, ok }: ElementPathToastProps): JSX.El
   return (
     <div
       className={ok ? 'tokenpanel-elpath-toast' : 'tokenpanel-elpath-toast is-error'}
-      role="status"
-      aria-live="polite"
+      aria-hidden="true"
     >
       <svg
         width="14"

--- a/packages/zdtp/src/element-path/element-path-toggle-button.tsx
+++ b/packages/zdtp/src/element-path/element-path-toggle-button.tsx
@@ -5,13 +5,15 @@
  * highlights elements; clicking copies an annotated path block. Reads
  * ElementPathContext; renders nothing when used outside the orchestrator.
  *
- * Follows the chrome-button policy: a `div role="button"` with explicit
- * Enter/Space handlers.
+ * Follows the chrome-button policy via the shared `RoleButton` control
+ * (role="button" + tabIndex + Enter/Space wiring), exposing `aria-pressed`
+ * through its `ariaProps` bag.
  */
 
 import { useContext } from 'preact/hooks';
 import type { JSX } from 'preact';
 import { ElementPathContext } from './element-path-context';
+import { RoleButton } from '../controls/role-button';
 
 export function ElementPathToggleButton(): JSX.Element | null {
   const ctx = useContext(ElementPathContext);
@@ -24,20 +26,12 @@ export function ElementPathToggleButton(): JSX.Element | null {
     : 'Element path copy: OFF — click to enable, then hold Alt and click an element to copy its path.';
 
   return (
-    <div
-      role="button"
-      tabIndex={0}
+    <RoleButton
       className={enabled ? 'tokenpanel-elpath-toggle is-active' : 'tokenpanel-elpath-toggle'}
       aria-label="Toggle element path copy"
-      aria-pressed={enabled}
+      ariaProps={{ 'aria-pressed': enabled }}
       title={title}
       onClick={toggle}
-      onKeyDown={(e: KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          toggle();
-        }
-      }}
     >
       <svg
         width="14"
@@ -58,6 +52,6 @@ export function ElementPathToggleButton(): JSX.Element | null {
         <line x1="20" y1="12" x2="23" y2="12" />
         <circle cx="12" cy="12" r="1.5" />
       </svg>
-    </div>
+    </RoleButton>
   );
 }

--- a/packages/zdtp/src/element-path/element-path-toggle-button.tsx
+++ b/packages/zdtp/src/element-path/element-path-toggle-button.tsx
@@ -1,0 +1,63 @@
+/**
+ * ElementPathToggleButton — header button that enables/disables inspect mode.
+ *
+ * A crosshair/target icon. When active, holding Alt and hovering the page
+ * highlights elements; clicking copies an annotated path block. Reads
+ * ElementPathContext; renders nothing when used outside the orchestrator.
+ *
+ * Follows the chrome-button policy: a `div role="button"` with explicit
+ * Enter/Space handlers.
+ */
+
+import { useContext } from 'preact/hooks';
+import type { JSX } from 'preact';
+import { ElementPathContext } from './element-path-context';
+
+export function ElementPathToggleButton(): JSX.Element | null {
+  const ctx = useContext(ElementPathContext);
+  if (ctx === null) return null;
+
+  const { enabled, toggle } = ctx;
+
+  const title = enabled
+    ? 'Element path copy: ON — hold Alt and click an element to copy its path. Click to turn off.'
+    : 'Element path copy: OFF — click to enable, then hold Alt and click an element to copy its path.';
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      className={enabled ? 'tokenpanel-elpath-toggle is-active' : 'tokenpanel-elpath-toggle'}
+      aria-label="Toggle element path copy"
+      aria-pressed={enabled}
+      title={title}
+      onClick={toggle}
+      onKeyDown={(e: KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggle();
+        }
+      }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        {/* crosshair / inspect target */}
+        <circle cx="12" cy="12" r="7" />
+        <line x1="12" y1="1" x2="12" y2="4" />
+        <line x1="12" y1="20" x2="12" y2="23" />
+        <line x1="1" y1="12" x2="4" y2="12" />
+        <line x1="20" y1="12" x2="23" y2="12" />
+        <circle cx="12" cy="12" r="1.5" />
+      </svg>
+    </div>
+  );
+}

--- a/packages/zdtp/src/element-path/index.ts
+++ b/packages/zdtp/src/element-path/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Element Path Copy — public surface of the feature module.
+ *
+ * Lets a developer inspect any host element (hold Alt + hover for a
+ * DevTools-style highlight, click to copy an annotated path block to the
+ * clipboard) for precise human↔AI communication about the page.
+ */
+
+export { ElementPathOrchestrator } from './element-path-orchestrator';
+export { ElementPathToggleButton } from './element-path-toggle-button';
+export { ElementPathContext } from './element-path-context';
+export type { ElementPathContextValue } from './element-path-context';
+export {
+  buildElementPath,
+  buildElementPathString,
+  formatElementPath,
+  buildUniqueSelector,
+  buildBreadcrumb,
+} from './build-element-path';
+export type { ElementPathResult } from './build-element-path';
+export { loadElementPathEnabled, saveElementPathEnabled } from './element-path-state';

--- a/packages/zdtp/src/element-path/inspector-overlay.tsx
+++ b/packages/zdtp/src/element-path/inspector-overlay.tsx
@@ -1,0 +1,308 @@
+/**
+ * InspectorOverlay — the interactive heart of Element Path Copy.
+ *
+ * Behaviour (only while the feature is `enabled`):
+ *   1. Holding **Alt** arms the inspector. While Alt is down, the element under
+ *      the cursor is resolved via `document.elementFromPoint` (panel surfaces
+ *      excluded) and drawn with a DevTools-style box + an attached label tag
+ *      (`tag#id.class  W × H`) on its top-left edge.
+ *   2. **Clicking** while armed copies the annotated path block for that element
+ *      to the clipboard (the click is swallowed so host links/handlers don't
+ *      fire) and shows a transient top-center toast.
+ *
+ * Rendering follows the highlight-overlay convention: the box + label positions
+ * are written imperatively from a RAF loop (so they track scroll/reflow without
+ * a Preact re-render per frame). Preact only re-renders when the hovered element
+ * or armed/toast state changes.
+ *
+ * Self-contained — does NOT own its portal mount; the orchestrator decides where
+ * in the DOM this renders.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'preact/hooks';
+import type { JSX } from 'preact';
+import { PANEL_EXCLUSION_SELECTOR } from '../highlight/find-elements';
+import { buildSummary, buildElementPathString } from './build-element-path';
+import { copyToClipboard } from '../utils/copy-to-clipboard';
+import { ElementPathToast } from './element-path-toast';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Above the highlight overlay (49) and panel shell (50); below modals. */
+const BOX_Z_INDEX = 2147483000;
+/** Toast sits above everything the panel renders. */
+const TOAST_Z_INDEX = 2147483001;
+/** Auto-dismiss delay for the copy toast (ms). */
+const TOAST_DURATION = 2200;
+/** Gap between the element box and its label tag (px). */
+const LABEL_GAP = 2;
+
+// ---------------------------------------------------------------------------
+// Props / toast state
+// ---------------------------------------------------------------------------
+
+export interface InspectorOverlayProps {
+  /** Whether inspect mode is enabled. When false the overlay is fully inert. */
+  enabled: boolean;
+}
+
+interface ToastState {
+  message: string;
+  ok: boolean;
+  /** Monotonic key so re-copying the same element restarts the dismiss timer/animation. */
+  key: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** True when `el` is part of the panel's own UI (shell, modals, portal mounts). */
+function isPanelElement(el: Element): boolean {
+  try {
+    return el.closest(PANEL_EXCLUSION_SELECTOR) !== null;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Element | null {
+  const [armed, setArmed] = useState(false);
+  const [hoverEl, setHoverEl] = useState<Element | null>(null);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  // Refs mirroring state for use inside stable event handlers / the RAF loop.
+  const armedRef = useRef(false);
+  armedRef.current = armed;
+  const hoverElRef = useRef<Element | null>(null);
+  hoverElRef.current = hoverEl;
+
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const labelRef = useRef<HTMLDivElement | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const toastKeyRef = useRef(0);
+
+  // -------------------------------------------------------------------------
+  // Copy handler
+  // -------------------------------------------------------------------------
+
+  const copyPathFor = useCallback(async (el: Element) => {
+    const text = buildElementPathString(el);
+    const ok = await copyToClipboard(text);
+    toastKeyRef.current += 1;
+    setToast({
+      message: ok ? `Copied path: ${buildSummary(el)}` : 'Copy failed — clipboard unavailable',
+      ok,
+      key: toastKeyRef.current,
+    });
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    toastTimerRef.current = setTimeout(() => setToast(null), TOAST_DURATION);
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Reset everything when the feature is disabled.
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (enabled) return;
+    setArmed(false);
+    setHoverEl(null);
+  }, [enabled]);
+
+  // -------------------------------------------------------------------------
+  // Alt key arming + window-blur safety (release a "stuck" Alt).
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Alt' || e.altKey) setArmed(true);
+    }
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.key === 'Alt' || !e.altKey) {
+        setArmed(false);
+        setHoverEl(null);
+      }
+    }
+    function onBlur() {
+      setArmed(false);
+      setHoverEl(null);
+    }
+
+    window.addEventListener('keydown', onKeyDown, true);
+    window.addEventListener('keyup', onKeyUp, true);
+    window.addEventListener('blur', onBlur);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+      window.removeEventListener('keyup', onKeyUp, true);
+      window.removeEventListener('blur', onBlur);
+    };
+  }, [enabled]);
+
+  // -------------------------------------------------------------------------
+  // Pointer tracking + click-to-copy (active only while armed).
+  // Listeners are in the capture phase so the click is intercepted before any
+  // host handler (e.g. <a> navigation) can run.
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!enabled || !armed) return;
+
+    function onMouseMove(e: MouseEvent) {
+      const el = document.elementFromPoint(e.clientX, e.clientY);
+      if (!el || isPanelElement(el)) {
+        setHoverEl(null);
+        return;
+      }
+      setHoverEl(el);
+    }
+
+    function onClick(e: MouseEvent) {
+      const el = hoverElRef.current;
+      if (!el) return;
+      // Swallow the click so host links / buttons don't fire on inspect-click.
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      void copyPathFor(el);
+    }
+
+    document.addEventListener('mousemove', onMouseMove, true);
+    document.addEventListener('click', onClick, true);
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove, true);
+      document.removeEventListener('click', onClick, true);
+    };
+  }, [enabled, armed, copyPathFor]);
+
+  // -------------------------------------------------------------------------
+  // Crosshair cursor while armed (signals inspect mode is live).
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!enabled || !armed) return;
+    const prev = document.body.style.cursor;
+    document.body.style.cursor = 'crosshair';
+    return () => {
+      document.body.style.cursor = prev;
+    };
+  }, [enabled, armed]);
+
+  // -------------------------------------------------------------------------
+  // Imperative position loop — tracks scroll/reflow without re-rendering.
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!armed || !hoverEl) return;
+    let rafId = 0;
+
+    function position() {
+      const el = hoverElRef.current;
+      const box = boxRef.current;
+      if (el && box) {
+        if (!el.isConnected) {
+          setHoverEl(null);
+          return;
+        }
+        const r = el.getBoundingClientRect();
+        box.style.top = `${r.top}px`;
+        box.style.left = `${r.left}px`;
+        box.style.width = `${r.width}px`;
+        box.style.height = `${r.height}px`;
+
+        const label = labelRef.current;
+        if (label) {
+          const lh = label.offsetHeight;
+          // Prefer above the box; drop inside the top edge when there's no room.
+          let labelTop = r.top - lh - LABEL_GAP;
+          if (labelTop < 0) labelTop = r.top + LABEL_GAP;
+          label.style.left = `${Math.max(0, r.left)}px`;
+          label.style.top = `${labelTop}px`;
+        }
+      }
+      rafId = requestAnimationFrame(position);
+    }
+
+    rafId = requestAnimationFrame(position);
+    return () => cancelAnimationFrame(rafId);
+  }, [armed, hoverEl]);
+
+  // -------------------------------------------------------------------------
+  // Clean up the toast timer on unmount.
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Render
+  // -------------------------------------------------------------------------
+
+  const showBox = enabled && armed && hoverEl !== null;
+  const labelText = showBox && hoverEl ? buildSummary(hoverEl) : '';
+  const rect = showBox && hoverEl ? hoverEl.getBoundingClientRect() : null;
+
+  return (
+    <>
+      {showBox && rect && (
+        <>
+          <div
+            ref={boxRef}
+            className="tokenpanel-elpath-box"
+            aria-hidden="true"
+            style={{
+              position: 'fixed',
+              top: `${rect.top}px`,
+              left: `${rect.left}px`,
+              width: `${rect.width}px`,
+              height: `${rect.height}px`,
+              zIndex: BOX_Z_INDEX,
+            }}
+          />
+          <div
+            ref={labelRef}
+            className="tokenpanel-elpath-label"
+            aria-hidden="true"
+            style={{
+              position: 'fixed',
+              top: `${rect.top}px`,
+              left: `${rect.left}px`,
+              zIndex: BOX_Z_INDEX,
+            }}
+          >
+            <span className="tokenpanel-elpath-label-name">{labelText}</span>
+            <span className="tokenpanel-elpath-label-size">
+              {Math.round(rect.width)} × {Math.round(rect.height)}
+            </span>
+          </div>
+        </>
+      )}
+      {toast && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            zIndex: TOAST_Z_INDEX,
+            display: 'flex',
+            justifyContent: 'center',
+            pointerEvents: 'none',
+          }}
+        >
+          <ElementPathToast key={toast.key} message={toast.message} ok={toast.ok} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/zdtp/src/element-path/inspector-overlay.tsx
+++ b/packages/zdtp/src/element-path/inspector-overlay.tsx
@@ -140,7 +140,12 @@ export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Elemen
       if (armedRef.current) resolveHoverAt(e.clientX, e.clientY);
     }
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Alt' || e.altKey) {
+      // Only do the arm-transition work on the first Alt-down. Without the
+      // `!armedRef.current` guard, every Alt-modified keystroke (Alt+letter host
+      // shortcuts, Alt+Tab attempts) would re-run the layout-querying
+      // elementFromPoint for no behavioural benefit — the position is already
+      // tracked by the always-on mousemove handler.
+      if ((e.key === 'Alt' || e.altKey) && !armedRef.current) {
         setArmed(true);
         const last = lastMouseRef.current;
         if (last) resolveHoverAt(last.x, last.y);
@@ -278,6 +283,31 @@ export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Elemen
 
   return (
     <>
+      {/*
+        Persistent, always-mounted live region. Screen readers reliably announce
+        a live region only when it already exists in the DOM and its text then
+        changes — a region inserted already-populated is frequently NOT announced
+        (JAWS/NVDA/VoiceOver). So the announcer stays mounted and we only swap its
+        text; the visual ElementPathToast below is purely presentational.
+      */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'fixed',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0 0 0 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+      >
+        {toast?.message ?? ''}
+      </div>
       {showBox && rect && (
         <>
           <div

--- a/packages/zdtp/src/element-path/inspector-overlay.tsx
+++ b/packages/zdtp/src/element-path/inspector-overlay.tsx
@@ -87,6 +87,9 @@ export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Elemen
   const labelRef = useRef<HTMLDivElement | null>(null);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const toastKeyRef = useRef(0);
+  // Last known pointer position so pressing Alt highlights the element already
+  // under the cursor immediately (no need to nudge the mouse first).
+  const lastMouseRef = useRef<{ x: number; y: number } | null>(null);
 
   // -------------------------------------------------------------------------
   // Copy handler
@@ -116,14 +119,32 @@ export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Elemen
   }, [enabled]);
 
   // -------------------------------------------------------------------------
-  // Alt key arming + window-blur safety (release a "stuck" Alt).
+  // Pointer position + Alt arming (active whenever the feature is enabled).
+  //
+  // A single always-on mousemove records the cursor position; it only resolves
+  // a hovered element while armed. Pressing Alt arms AND resolves the element
+  // already under the cursor, so the highlight appears without a mouse nudge.
+  // keyup / window-blur release a "stuck" Alt.
   // -------------------------------------------------------------------------
 
   useEffect(() => {
     if (!enabled) return;
 
+    function resolveHoverAt(x: number, y: number) {
+      const el = document.elementFromPoint(x, y);
+      setHoverEl(!el || isPanelElement(el) ? null : el);
+    }
+
+    function onMouseMove(e: MouseEvent) {
+      lastMouseRef.current = { x: e.clientX, y: e.clientY };
+      if (armedRef.current) resolveHoverAt(e.clientX, e.clientY);
+    }
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Alt' || e.altKey) setArmed(true);
+      if (e.key === 'Alt' || e.altKey) {
+        setArmed(true);
+        const last = lastMouseRef.current;
+        if (last) resolveHoverAt(last.x, last.y);
+      }
     }
     function onKeyUp(e: KeyboardEvent) {
       if (e.key === 'Alt' || !e.altKey) {
@@ -136,10 +157,12 @@ export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Elemen
       setHoverEl(null);
     }
 
+    document.addEventListener('mousemove', onMouseMove, true);
     window.addEventListener('keydown', onKeyDown, true);
     window.addEventListener('keyup', onKeyUp, true);
     window.addEventListener('blur', onBlur);
     return () => {
+      document.removeEventListener('mousemove', onMouseMove, true);
       window.removeEventListener('keydown', onKeyDown, true);
       window.removeEventListener('keyup', onKeyUp, true);
       window.removeEventListener('blur', onBlur);
@@ -147,51 +170,52 @@ export function InspectorOverlay({ enabled }: InspectorOverlayProps): JSX.Elemen
   }, [enabled]);
 
   // -------------------------------------------------------------------------
-  // Pointer tracking + click-to-copy (active only while armed).
-  // Listeners are in the capture phase so the click is intercepted before any
-  // host handler (e.g. <a> navigation) can run.
+  // Click-to-copy (active only while armed). The click + mousedown listeners
+  // are in the capture phase so the interaction is intercepted before any host
+  // handler (<a> navigation, button onClick, focus, text selection) can run.
   // -------------------------------------------------------------------------
 
   useEffect(() => {
     if (!enabled || !armed) return;
 
-    function onMouseMove(e: MouseEvent) {
-      const el = document.elementFromPoint(e.clientX, e.clientY);
-      if (!el || isPanelElement(el)) {
-        setHoverEl(null);
-        return;
-      }
-      setHoverEl(el);
+    // Suppress mousedown side-effects (focus shift, text selection, drag start)
+    // so an inspect-click is purely a copy gesture.
+    function onMouseDown(e: MouseEvent) {
+      if (!hoverElRef.current) return;
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
     }
 
     function onClick(e: MouseEvent) {
       const el = hoverElRef.current;
       if (!el) return;
-      // Swallow the click so host links / buttons don't fire on inspect-click.
       e.preventDefault();
       e.stopPropagation();
       e.stopImmediatePropagation();
       void copyPathFor(el);
     }
 
-    document.addEventListener('mousemove', onMouseMove, true);
+    document.addEventListener('mousedown', onMouseDown, true);
     document.addEventListener('click', onClick, true);
     return () => {
-      document.removeEventListener('mousemove', onMouseMove, true);
+      document.removeEventListener('mousedown', onMouseDown, true);
       document.removeEventListener('click', onClick, true);
     };
   }, [enabled, armed, copyPathFor]);
 
   // -------------------------------------------------------------------------
-  // Crosshair cursor while armed (signals inspect mode is live).
+  // Crosshair cursor + selection lock while armed. A class on <html> drives a
+  // CSS rule (panel.css) so the crosshair wins over host element cursors
+  // (links, buttons) — more reliable than setting body.style.cursor.
   // -------------------------------------------------------------------------
 
   useEffect(() => {
     if (!enabled || !armed) return;
-    const prev = document.body.style.cursor;
-    document.body.style.cursor = 'crosshair';
+    const root = document.documentElement;
+    root.classList.add('tokenpanel-elpath-inspecting');
     return () => {
-      document.body.style.cursor = prev;
+      root.classList.remove('tokenpanel-elpath-inspecting');
     };
   }, [enabled, armed]);
 

--- a/packages/zdtp/src/highlight/find-elements.ts
+++ b/packages/zdtp/src/highlight/find-elements.ts
@@ -295,8 +295,14 @@ const PSEUDOS: Array<string | null> = [null, '::before', '::after'];
 // Panel exclusion selector (constant value kept from legacy implementation)
 // ---------------------------------------------------------------------------
 
-const PANEL_EXCLUSION_SELECTOR =
-  '.tokenpanel-shell, [data-design-token-panel-modal], #tokenpanel-highlight-mount';
+/**
+ * Selector matching every panel-owned surface that must NEVER be treated as a
+ * host element (the shell, modals, and the highlight/element-path portal mounts).
+ * Exported so the Element Path Copy inspector can skip the same surfaces when
+ * resolving the element under the cursor.
+ */
+export const PANEL_EXCLUSION_SELECTOR =
+  '.tokenpanel-shell, [data-design-token-panel-modal], #tokenpanel-highlight-mount, #tokenpanel-elpath-mount';
 
 // ---------------------------------------------------------------------------
 // Type detection

--- a/packages/zdtp/src/highlight/highlight-orchestrator.tsx
+++ b/packages/zdtp/src/highlight/highlight-orchestrator.tsx
@@ -36,6 +36,7 @@ import { findElementsUsingToken } from './find-elements';
 import type { FindElementsResult } from './find-elements';
 import { HighlightOverlay, type HighlightOverlayItem } from './highlight-overlay';
 import { getPanelConfig } from '../config/panel-config';
+import { usePortalMount } from '../utils/use-portal-mount';
 import type { TierValueKind } from '../tokens/tier-model';
 
 // ---------------------------------------------------------------------------
@@ -110,65 +111,20 @@ function isDifferentialEligible(tierKind: TierValueKind | undefined): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Portal mount helpers
+// Portal mount
 // ---------------------------------------------------------------------------
 
 /** ID also referenced in find-elements.ts PANEL_EXCLUSION_SELECTOR. Must match exactly. */
 const PORTAL_MOUNT_ID = 'tokenpanel-highlight-mount';
-
-/**
- * Get or create the singleton portal mount <div> at document.body.
- * Idempotent: if an element with the id already exists it is returned as-is.
- * SSR-safe: returns null when document is unavailable (server-render / prerender).
- */
-function getOrCreateMountNode(): HTMLDivElement | null {
-  if (typeof document === 'undefined') return null;
-  const existing = document.getElementById(PORTAL_MOUNT_ID) as HTMLDivElement | null;
-  if (existing) return existing;
-
-  const node = document.createElement('div');
-  node.id = PORTAL_MOUNT_ID;
-  document.body.appendChild(node);
-  return node;
-}
-
-// ---------------------------------------------------------------------------
-// OverlayPortal
-// ---------------------------------------------------------------------------
 
 interface OverlayPortalProps {
   items: ReadonlyArray<HighlightOverlayItem>;
 }
 
 function OverlayPortal({ items }: OverlayPortalProps) {
-  const mountNodeRef = useRef<HTMLDivElement | null>(null);
-  const [mountVersion, setMountVersion] = useState(0);
-
-  useEffect(() => {
-    if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
-      mountNodeRef.current = getOrCreateMountNode();
-      setMountVersion((v) => v + 1);
-    }
-    function handleAfterSwap() {
-      if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
-        mountNodeRef.current = getOrCreateMountNode();
-        setMountVersion((v) => v + 1);
-      }
-    }
-    if (typeof window !== 'undefined') {
-      window.addEventListener('astro:after-swap', handleAfterSwap);
-    }
-    return () => {
-      if (typeof window !== 'undefined') {
-        window.removeEventListener('astro:after-swap', handleAfterSwap);
-      }
-    };
-  }, []);
-
-  void mountVersion;
-
-  if (!mountNodeRef.current) return null;
-  return createPortal(<HighlightOverlay items={items} />, mountNodeRef.current);
+  const mountNode = usePortalMount(PORTAL_MOUNT_ID);
+  if (!mountNode) return null;
+  return createPortal(<HighlightOverlay items={items} />, mountNode);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -5,6 +5,8 @@ import { ApplyModal } from './apply-modal';
 import { RoleButton } from './controls/role-button';
 import { HighlightSettingsPopover } from './highlight/highlight-settings-popover';
 import { HighlightOrchestrator } from './highlight/highlight-orchestrator';
+import { ElementPathOrchestrator } from './element-path/element-path-orchestrator';
+import { ElementPathToggleButton } from './element-path/element-path-toggle-button';
 import ColorTab from './tabs/color-tab';
 import FontTab from './tabs/font-tab';
 import SizeTab from './tabs/size-tab';
@@ -474,6 +476,7 @@ export default function DesignTokenTweakPanel() {
 
   return (
     <HighlightOrchestrator>
+      <ElementPathOrchestrator>
       <TooltipProvider>
       {open && (() => {
         const {
@@ -543,6 +546,8 @@ export default function DesignTokenTweakPanel() {
             Reset
           </RoleButton>
           <div className="tokenpanel-spacer" />
+          {/* Element-path-copy toggle — enable, then Alt+click any element to copy its path */}
+          <ElementPathToggleButton />
           {/* Gear button — inline div so we can attach a ref for popover anchoring */}
           <div
             ref={gearBtnRef}
@@ -777,6 +782,7 @@ export default function DesignTokenTweakPanel() {
         );
       })()}
       </TooltipProvider>
+      </ElementPathOrchestrator>
     </HighlightOrchestrator>
   );
 }

--- a/packages/zdtp/src/styles/panel-tokens.css
+++ b/packages/zdtp/src/styles/panel-tokens.css
@@ -50,7 +50,9 @@
   [data-design-token-panel-modal],
   .tokenpanel-highlight-settings-popover,
   .tokenpanel-color-picker,
-  .tokenpanel-tooltip
+  .tokenpanel-tooltip,
+  .tokenpanel-elpath-label,
+  .tokenpanel-elpath-toast
 ) {
   /* ----------------------------------------------------------------------
    * Color palette (self-contained, dark)

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -1357,3 +1357,122 @@ select.tokenpanel-tier-ref-select:focus-visible {
   outline-offset: 2px;
   border-radius: 2px;
 }
+
+/* ===========================================================================
+ * Element Path Copy — inspect toggle, hover box, label tag, copy toast.
+ *
+ * The toggle lives in the panel header (inside .tokenpanel-shell). The box,
+ * label, and toast render in the #tokenpanel-elpath-mount portal at
+ * document.body — OUTSIDE the shell — so their geometry-bearing properties are
+ * applied as inline styles by the component, and the classes below carry only
+ * appearance + defensive hostile-host resets. The label/toast classes are also
+ * registered in panel-tokens.css's var scope so var(--tokentweak-*) resolves.
+ * ========================================================================= */
+
+/* Header toggle button — mirrors the gear button, accent when active. */
+.tokenpanel-elpath-toggle {
+  color: var(--tokentweak-color-muted);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: color 150ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.tokenpanel-elpath-toggle:hover {
+  color: var(--tokentweak-color-fg);
+}
+.tokenpanel-elpath-toggle:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+.tokenpanel-elpath-toggle.is-active {
+  color: var(--tokentweak-color-accent);
+}
+:where(.tokenpanel-shell) .tokenpanel-elpath-toggle svg {
+  fill: none;
+  stroke: currentColor;
+}
+
+/* Hover highlight box — DevTools-style. Geometry is inline; this carries the
+   visual ring + a translucent fill, plus defensive resets so host * {} rules
+   cannot shift it. */
+.tokenpanel-elpath-box {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  pointer-events: none;
+  box-sizing: border-box;
+  background: rgb(111 168 220 / 0.25);
+  outline: 1px solid rgb(111 168 220 / 0.9);
+  outline-offset: -1px;
+  /* Survive hosts that kill outline. */
+  box-shadow: inset 0 0 0 1px rgb(111 168 220 / 0.9);
+}
+
+/* Label tag attached to the box's top-left edge (tag#id.class  W × H). */
+.tokenpanel-elpath-label {
+  pointer-events: none;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  max-width: 90vw;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--tokentweak-color-surface, #1c1c1c);
+  color: var(--tokentweak-color-fg, #b8b8b8);
+  font-family: var(--tokentweak-font-mono, Menlo, Monaco, Consolas, monospace);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.4);
+}
+.tokenpanel-elpath-label-name {
+  color: var(--tokentweak-color-accent, #d69a66);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tokenpanel-elpath-label-size {
+  color: var(--tokentweak-color-muted, #888888);
+  flex-shrink: 0;
+}
+
+/* Copy toast — top-center status notification. */
+.tokenpanel-elpath-toast {
+  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px auto 0;
+  padding: 8px 14px;
+  border-radius: 6px;
+  background: var(--tokentweak-color-surface, #1c1c1c);
+  color: var(--tokentweak-color-fg, #b8b8b8);
+  font-family: var(--tokentweak-font-mono, Menlo, Monaco, Consolas, monospace);
+  font-size: 12px;
+  line-height: 1.4;
+  max-width: min(90vw, 520px);
+  box-shadow: 0 4px 16px rgb(0 0 0 / 0.45);
+  border: 1px solid rgb(255 255 255 / 0.08);
+}
+.tokenpanel-elpath-toast .tokenpanel-elpath-toast-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tokenpanel-elpath-toast svg {
+  flex-shrink: 0;
+  fill: none;
+  stroke: var(--tokentweak-color-success, #93bb77);
+  pointer-events: none;
+}
+.tokenpanel-elpath-toast.is-error svg {
+  stroke: var(--tokentweak-color-danger, #da6871);
+}

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -1398,6 +1398,16 @@ select.tokenpanel-tier-ref-select:focus-visible {
   stroke: currentColor;
 }
 
+/* While armed (Alt held in inspect mode): force a crosshair everywhere and
+   lock text selection so an inspect-click is purely a copy gesture. The class
+   is toggled on <html> by InspectorOverlay; `!important` beats host element
+   cursors (links/buttons). */
+html.tokenpanel-elpath-inspecting,
+html.tokenpanel-elpath-inspecting * {
+  cursor: crosshair !important;
+  user-select: none !important;
+}
+
 /* Hover highlight box — DevTools-style. Geometry is inline; this carries the
    visual ring + a translucent fill, plus defensive resets so host * {} rules
    cannot shift it. */

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -1482,6 +1482,12 @@ html.tokenpanel-elpath-inspecting * {
   fill: none;
   stroke: var(--tokentweak-color-success, #93bb77);
   pointer-events: none;
+  /* The toast renders in the #tokenpanel-elpath-mount portal (outside
+   * .tokenpanel-shell), so the shell-scoped defensive SVG reset never reaches
+   * it. Restate display/overflow here so a hostile host `svg { … }` rule cannot
+   * distort the icon. */
+  display: inline-block;
+  overflow: visible;
 }
 .tokenpanel-elpath-toast.is-error svg {
   stroke: var(--tokentweak-color-danger, #da6871);

--- a/packages/zdtp/src/utils/copy-to-clipboard.ts
+++ b/packages/zdtp/src/utils/copy-to-clipboard.ts
@@ -1,0 +1,49 @@
+/**
+ * copyToClipboard — robust copy with a legacy fallback.
+ *
+ * Primary path: `navigator.clipboard.writeText` (modern, async, requires a
+ * secure context + document focus). Fallback: an offscreen `<textarea>` +
+ * `document.execCommand('copy')` for browsers / contexts that reject the
+ * modern API (insecure context, denied permission, focus-trapped dialogs, …).
+ *
+ * Returns `true` when either path succeeds, `false` when both fail. Never
+ * throws — callers can surface a "Copied" / "Failed" state from the boolean.
+ *
+ * `container` lets the caller append the fallback textarea inside a specific
+ * element (e.g. an open `<dialog>`) so a focus trap does not block `select()`.
+ * Defaults to `document.body`.
+ */
+export async function copyToClipboard(
+  text: string,
+  container?: HTMLElement | null,
+): Promise<boolean> {
+  // Primary: modern async Clipboard API.
+  try {
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return true;
+    }
+  } catch {
+    // Fall through to the legacy path.
+  }
+
+  // Fallback: offscreen textarea + execCommand.
+  if (typeof document === 'undefined') return false;
+  const host = container ?? document.body;
+  if (!host) return false;
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.cssText = 'position:fixed;opacity:0;left:-9999px;top:0';
+    textarea.tabIndex = -1;
+    textarea.setAttribute('aria-hidden', 'true');
+    host.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const ok = document.execCommand('copy');
+    host.removeChild(textarea);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/zdtp/src/utils/use-portal-mount.ts
+++ b/packages/zdtp/src/utils/use-portal-mount.ts
@@ -1,0 +1,58 @@
+/**
+ * usePortalMount — shared singleton portal-mount lifecycle for body-level portals.
+ *
+ * Both the highlight overlay and the element-path inspector render into a
+ * singleton `<div id="…">` appended to `document.body` (so they sit above host
+ * content and persist while the panel is closed). This hook owns that lifecycle
+ * in one place:
+ *
+ *   1. Get-or-create the mount node by id (idempotent, SSR-safe).
+ *   2. Re-create it on `astro:after-swap` when Astro replaces `document.body`.
+ *   3. Force a re-render once the node exists so `createPortal` can attach.
+ *
+ * Returns the mount node, or `null` until it is available (SSR / before the
+ * first effect run) — callers should early-return `null` in that case.
+ *
+ * The `mountId` MUST also appear in `find-elements.ts` PANEL_EXCLUSION_SELECTOR
+ * so the panel's own portal surface is never treated as a host element.
+ */
+
+import { useState, useEffect, useRef } from 'preact/hooks';
+
+export function usePortalMount(mountId: string): HTMLDivElement | null {
+  const mountNodeRef = useRef<HTMLDivElement | null>(null);
+  const [, setMountVersion] = useState(0);
+
+  useEffect(() => {
+    function getOrCreateMountNode(): HTMLDivElement | null {
+      if (typeof document === 'undefined') return null;
+      const existing = document.getElementById(mountId) as HTMLDivElement | null;
+      if (existing) return existing;
+      const node = document.createElement('div');
+      node.id = mountId;
+      document.body.appendChild(node);
+      return node;
+    }
+
+    if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
+      mountNodeRef.current = getOrCreateMountNode();
+      setMountVersion((v) => v + 1);
+    }
+    function handleAfterSwap() {
+      if (!mountNodeRef.current || !mountNodeRef.current.isConnected) {
+        mountNodeRef.current = getOrCreateMountNode();
+        setMountVersion((v) => v + 1);
+      }
+    }
+    if (typeof window !== 'undefined') {
+      window.addEventListener('astro:after-swap', handleAfterSwap);
+    }
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('astro:after-swap', handleAfterSwap);
+      }
+    };
+  }, [mountId]);
+
+  return mountNodeRef.current;
+}


### PR DESCRIPTION
Add a developer-tool inspector for pointing an AI (or a human) at a
specific element on the page without relying on every element having an id.

When the new crosshair toggle in the panel header is ON, holding Alt and
hovering shows a Chrome-DevTools-style highlight box with an attached
label tag (tag#id.class + W × H). Clicking the element copies an
annotated path block to the clipboard and shows a top-center toast.

The copied block is the "richest-for-AI" format:
  element:  a#cta.btn
  selector: main > .card:nth-of-type(3) > a   (unique, querySelector-able)
  path:     body > main.content > nav.nav > a.btn   (readable breadcrumb)
  role:     link
  text:     "Go now"
  attrs:    id="cta", href="/go"
  size:     142 × 24

Implementation notes:
- New self-contained module packages/zdtp/src/element-path/:
  pure path generator (build-element-path), persisted enabled flag,
  context + orchestrator (portal mount, Astro-swap-safe), inspector
  overlay (Alt-armed pointer tracking + capture-phase click swallowing),
  label, toast, and header toggle button.
- Reuses the highlight subsystem's portal/Astro conventions and exports
  PANEL_EXCLUSION_SELECTOR so the inspector never targets panel UI.
- Extracts a shared copy-to-clipboard util (modern API + execCommand
  fallback).
- Enabled state persists across reloads (localStorage, storagePrefix-keyed).
- Follows panel DOM-hygiene rules (no host-stylable semantic tags;
  div role="button" with Enter/Space; scoped SVG resets).

Tests: unit coverage for the path generator and persistence, plus a
jsdom component test for the Alt-hover / click-to-copy flow.

https://claude.ai/code/session_01PjgemjRa2QwTPRzEyxYuNL