### PR TITLE
Make ColorScheme.shikiTheme optional (#342) + document scheme-change re-seed model (#343)

### DIFF
--- a/packages/zdtp/README.md
+++ b/packages/zdtp/README.md
@@ -838,6 +838,17 @@ myapp-design-token-panel:visible
 
 The `visible` key uses a literal `:` separator, not `-`. Every other derived key uses `-`. This is intentional — see [`PORTABLE-CONTRACT.md`](./PORTABLE-CONTRACT.md) §2 for the historical reason. Don't try to "normalize" it; the unit tests assert this specific shape.
 
+### Scheme changes and the global tweak model
+
+Tweak state is **global**, not scheme-scoped: the keys above are derived only from `storagePrefix` and carry no color-scheme name. A single envelope holds every slice — the `color` slice stores **absolute** colors (palette + role/semantic indices resolved against that palette), while the `spacing` / `typography` / `size` slices store token overrides that are independent of the active scheme.
+
+Because the stored palette is absolute, it cannot simply be re-applied on top of a different scheme. So when the host dispatches a `color-scheme-changed` event (e.g. a light/dark toggle), the panel **re-seeds its live state from the newly active scheme**: it removes the inline `:root` overrides it had applied (`clearAppliedStyles`) and re-initializes the live envelope from that scheme (`freshTweakState`). Palette tweaks are therefore intentionally **not** carried across a scheme switch — the panel adopts the new scheme's palette rather than layering the previous absolute colors on top of it. This is the panel's deliberate global model; it does **not** persist a separate color slice per scheme.
+
+Two consequences worth knowing as a host integrator:
+
+- The event handler does not rewrite the `localStorage` envelope — it only re-seeds the live (in-memory) state and clears the inline overrides. The persisted envelope remains until the next in-panel edit re-persists the (re-seeded) state, or a full reload re-applies it via `loadPersistedState`.
+- Do **not** manually delete the tweak keys on a scheme toggle. The panel already re-seeds on the event, and a manual envelope delete would also discard the scheme-independent `spacing` / `typography` / `size` overrides.
+
 ---
 
 ## 10. Console API contract

--- a/packages/zdtp/src/__tests__/tweak-state.test.ts
+++ b/packages/zdtp/src/__tests__/tweak-state.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP,
+  getActivePrimaryCluster,
   getStorageKeyV1,
   getStorageKeyV2,
   getStorageKeyV3,
+  initColorFromSchemeData,
   type ColorTweakState,
   type StorageLike,
   loadPersistedState,
 } from '../state/tweak-state';
+import type { ColorScheme } from '../config/color-schemes';
 import { __resetPanelConfigForTests } from '../config/panel-config';
 import { installFixturePanelConfig } from './_test-helpers';
 
@@ -524,5 +527,36 @@ describe('loadPersistedState — typography rename map (configurable)', () => {
     expect(result!.typography['toString']).toBe('1rem');
     expect(result!.typography['constructor']).toBe('2rem');
     expect(result!.typography['text-xs']).toBe('0.9rem');
+  });
+});
+
+describe('#342 — ColorScheme.shikiTheme is optional', () => {
+  // A scheme literal that omits `shikiTheme` must type-check (this annotation
+  // would fail to compile if the field were still required) and, at runtime,
+  // fall back to the cluster's `defaultShikiTheme`. The palette cast is an
+  // unrelated concern — `ColorScheme.palette` is a 16-tuple, our fixture a
+  // plain `string[]`.
+  const schemeWithoutShiki: ColorScheme = {
+    background: 0,
+    foreground: 15,
+    cursor: 6,
+    selectionBg: 0,
+    selectionFg: 15,
+    palette: palette16 as ColorScheme['palette'],
+  };
+
+  it('falls back to the cluster defaultShikiTheme when a scheme omits it', () => {
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(schemeWithoutShiki, cluster);
+    expect(state.shikiTheme).toBe(cluster.defaultShikiTheme);
+  });
+
+  it('honors an explicit shikiTheme when the scheme provides one', () => {
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(
+      { ...schemeWithoutShiki, shikiTheme: 'vitesse-dark' },
+      cluster,
+    );
+    expect(state.shikiTheme).toBe('vitesse-dark');
   });
 });

--- a/packages/zdtp/src/config/color-schemes.ts
+++ b/packages/zdtp/src/config/color-schemes.ts
@@ -44,8 +44,13 @@ export interface ColorScheme {
    * in the Astro types (this package isn't an Astro app — this field is
    * preserved for symmetry with upstream presets and for any future
    * code-block tooling).
+   *
+   * Optional: this package only uses it for the (no-op) code-block preview,
+   * and `initColorFromSchemeData` falls back to `colorExtras.defaultShikiTheme`
+   * when a scheme omits it. Hosts whose schemes carry no Shiki theme can pass
+   * their scheme maps directly, without a dummy value or an `as unknown as` cast.
    */
-  shikiTheme: string;
+  shikiTheme?: string;
   /**
    * Optional semantic overrides — when omitted, defaults from
    * `SEMANTIC_DEFAULTS_ZD` (in `color-scheme-utils.ts`) are used.

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -234,7 +234,12 @@ export default function DesignTokenTweakPanel() {
     };
   }, []);
 
-  // Re-initialize when the color scheme or light/dark mode changes
+  // Re-initialize when the color scheme or light/dark mode changes.
+  // Global tweak model (see README §9): the stored palette is absolute, so on a
+  // scheme change we drop the inline overrides and re-seed the live envelope
+  // from the new scheme rather than layering the old absolute colors on top.
+  // This does not rewrite localStorage — the persisted envelope is left until
+  // the next edit re-persists or a reload re-applies it.
   useEffect(() => {
     function handleSchemeChange() {
       // Clear all inline style overrides so the new scheme's <style> tag takes effect

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -27,14 +27,17 @@
  * The secondary cluster is an opt-in field on `PanelConfig`. When the host
  * does not configure one, the secondary slice is hidden / skipped end to end.
  *
- * **shikiTheme kept (optional), applyShikiTheme stubbed**
+ * **shikiTheme kept, applyShikiTheme stubbed**
  *
  * The `shikiTheme` field stays on the state + persist envelope so JSON
  * round-tripping with external exports is seamless; the UI hides it and
  * `applyShikiTheme` is a no-op. Removing the field would churn the serde
- * format for no real benefit. It is typed optional because the runtime always
- * defaults it (init from the scheme / cluster default, hydrate backfills from
- * defaults) — so neither hosts nor persisted payloads must supply it.
+ * format for no real benefit. It stays *required* on the hydrated state —
+ * constructors and hydrators always default it (from the scheme / cluster
+ * default, or backfilled from defaults), and `TweakState` is re-exported, so
+ * keeping it required avoids widening the public `state.color.shikiTheme` type.
+ * Only the input `ColorScheme.shikiTheme` is optional (#342), so hosts may omit
+ * it on their scheme maps.
  */
 
 import type { ColorRef, ColorScheme } from '../config/color-schemes';
@@ -378,7 +381,7 @@ export function clampPosition(
  * changes. This package does not use Shiki — we keep the function for
  * API shape + persisted-state round-tripping, but the body is a no-op.
  */
-export async function applyShikiTheme(_themeName?: string): Promise<void> {
+export async function applyShikiTheme(_themeName: string): Promise<void> {
   // No Shiki integration here; preserved as a no-op for persist-envelope
   // round-trip compatibility with zudo-doc exports.
 }
@@ -440,8 +443,7 @@ export interface ColorTweakState {
   selectionBg: number;
   selectionFg: number;
   semanticMappings: Record<string, number | 'bg' | 'fg'>;
-  /** Optional — runtime always defaults it; see the file header note. */
-  shikiTheme?: string;
+  shikiTheme: string;
 }
 
 /**

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -27,12 +27,14 @@
  * The secondary cluster is an opt-in field on `PanelConfig`. When the host
  * does not configure one, the secondary slice is hidden / skipped end to end.
  *
- * **shikiTheme kept, applyShikiTheme stubbed**
+ * **shikiTheme kept (optional), applyShikiTheme stubbed**
  *
  * The `shikiTheme` field stays on the state + persist envelope so JSON
  * round-tripping with external exports is seamless; the UI hides it and
  * `applyShikiTheme` is a no-op. Removing the field would churn the serde
- * format for no real benefit.
+ * format for no real benefit. It is typed optional because the runtime always
+ * defaults it (init from the scheme / cluster default, hydrate backfills from
+ * defaults) — so neither hosts nor persisted payloads must supply it.
  */
 
 import type { ColorRef, ColorScheme } from '../config/color-schemes';
@@ -376,7 +378,7 @@ export function clampPosition(
  * changes. This package does not use Shiki — we keep the function for
  * API shape + persisted-state round-tripping, but the body is a no-op.
  */
-export async function applyShikiTheme(_themeName: string): Promise<void> {
+export async function applyShikiTheme(_themeName?: string): Promise<void> {
   // No Shiki integration here; preserved as a no-op for persist-envelope
   // round-trip compatibility with zudo-doc exports.
 }
@@ -438,7 +440,8 @@ export interface ColorTweakState {
   selectionBg: number;
   selectionFg: number;
   semanticMappings: Record<string, number | 'bg' | 'fg'>;
-  shikiTheme: string;
+  /** Optional — runtime always defaults it; see the file header note. */
+  shikiTheme?: string;
 }
 
 /**


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/342
    - https://github.com/Takazudo/zudo-design-token-panel/issues/343

---

## Summary

Two small, related improvements to the color-scheme / tweak-state public surface and its docs.

### #342 — `ColorScheme.shikiTheme` is now optional
`shikiTheme` is effectively optional at runtime: the panel only uses it for a no-op code-block preview, and `initColorFromSchemeData` already falls back to the cluster's `defaultShikiTheme`. Relaxing **`ColorScheme.shikiTheme`** to optional lets hosts pass their scheme maps without a dummy value or an `as unknown as` cast. Pure type relaxation — no runtime behavior change.

The hydrated **`ColorTweakState.shikiTheme` stays required**: `TweakState` is re-exported from the package root, so making it optional would needlessly widen the public `state.color.shikiTheme` type to `string | undefined` for consumers reading the full envelope (caught in review). Constructors/hydrators always default the field, so required is correct there.

### #343 — document the global scheme-change re-seed model
Decision: **keep the current global tweak model** (no per-scheme color slice). Added a README §9 note describing the global envelope and what `color-scheme-changed` does (drop inline overrides + re-seed the live state from the new scheme; localStorage untouched until the next edit), plus a clarifying comment at the handler. No behavior change.

## Changes
- `config/color-schemes.ts` — `ColorScheme.shikiTheme?: string` + doc comment.
- `state/tweak-state.ts` — header note clarifying state keeps `shikiTheme` required; field unchanged.
- `__tests__/tweak-state.test.ts` — contract test: a scheme omitting `shikiTheme` type-checks and falls back to `defaultShikiTheme`.
- `README.md` §9 + `panel.tsx` — re-seed model docs/comment.

## Test Plan
- `pnpm -F @takazudo/zdtp typecheck` — clean.
- `pnpm -F @takazudo/zdtp test` — 1082 tests pass (incl. new contract tests).

## Notes
- Follow-up raised during review: #347 (`color-scheme-changed` also resets non-color slices in the live state — a separate behavior decision, left out of scope here).

Closes #342
Closes #343