### PR TITLE
ci(release): drop stale npm `next` dist-tag on stable releases (#345)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@
 #   All other v* tags                           → npm dist-tag "latest"
 # Prerelease consumers opt in with `pnpm add @takazudo/zdtp@next`.
 #
+# Stale-`next` cleanup (#345): the package does not currently maintain a
+# prerelease line, so a leftover `next` tag can silently lag `latest` (a host
+# resolving `@next` would get an older build). On every stable publish, the
+# "Drop stale next dist-tag" step below removes `next` IF it points behind the
+# just-published `latest` — a legitimately-ahead prerelease `next` is preserved.
+#
 # The pre-publish test gate lives upstream in ci.yml / pr-checks.yml (the panel's
 # test suite needs Playwright Chromium for browser tests). `prepublishOnly` here
 # runs `pnpm build` only — it freshens dist/ but does not re-run browser tests.
@@ -106,5 +112,31 @@ jobs:
       - name: Publish to npm
         if: ${{ inputs.dry_run != true && startsWith(github.ref, 'refs/tags/v') }}
         run: pnpm -r publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Drop a stale `next` dist-tag on stable releases (#345). Only removes
+      # `next` when it lags the just-published `latest`; a legitimately-ahead
+      # prerelease `next` is left intact. semver-sort decides "behind": if the
+      # greater of {next, latest} is latest, next is stale. Idempotent — a no-op
+      # when there is no `next` tag.
+      - name: Drop stale next dist-tag (stable releases)
+        if: ${{ inputs.dry_run != true && startsWith(github.ref, 'refs/tags/v') && env.DIST_TAG == 'latest' }}
+        shell: bash
+        run: |
+          PKG="@takazudo/zdtp"
+          NEXT_VER=$(npm dist-tag ls "$PKG" | awk -F': ' '/^next:/{print $2}')
+          if [ -z "$NEXT_VER" ]; then
+            echo "No 'next' dist-tag on $PKG — nothing to drop."
+            exit 0
+          fi
+          LATEST_VER=$(npm dist-tag ls "$PKG" | awk -F': ' '/^latest:/{print $2}')
+          GREATEST=$(npx --yes semver "$NEXT_VER" "$LATEST_VER" | tail -1)
+          if [ "$NEXT_VER" != "$LATEST_VER" ] && [ "$GREATEST" = "$LATEST_VER" ]; then
+            echo "Dropping stale '$PKG@next' ($NEXT_VER < latest $LATEST_VER)…"
+            npm dist-tag rm "$PKG" next
+          else
+            echo "Keeping '$PKG@next' ($NEXT_VER) — not behind latest ($LATEST_VER)."
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/345

---

## Summary

The npm `next` dist-tag is stale: `next: 0.2.0-next.2` lags `latest: 0.2.2`, so anyone resolving `@takazudo/zdtp@next` silently gets an old prerelease. The package no longer maintains a prerelease line (maintainer: *"we don't need 'next' … purge is proper"*).

Stable `v*` tags already publish only to `latest` (the `next` tag is only ever set by `*-next.*` / `*-beta.*` / `*-rc.*` tags), so the fix is release-time hygiene: after a stable publish, drop `next` **if it points behind the just-published `latest`**.

## Changes

- `.github/workflows/release.yml`: new post-publish step **"Drop stale next dist-tag (stable releases)"**, gated on `DIST_TAG == 'latest'`. It removes `next` only when semver-sort says it lags `latest`; a legitimately-ahead prerelease `next` is left intact. Idempotent (no-op when no `next` exists).

## How the stale tag gets dropped

Takes effect on the next stable release. A patch release (0.2.3, also shipping #342/#343) is cut right after this merges; its `v0.2.3` workflow run executes the new step and removes the stale `next`.

Closes #345