### PR TITLE
ci: prune stale npm `next` via dispatch workflow (fix #345 release-step)

### DIFF
--- a/.github/workflows/prune-stale-next-dist-tag.yml
+++ b/.github/workflows/prune-stale-next-dist-tag.yml
@@ -1,0 +1,52 @@
+# prune-stale-next-dist-tag.yml
+#
+# Manually-triggered maintenance: drop a stale npm `next` dist-tag for
+# @takazudo/zdtp when it lags `latest` (#345). The package does not maintain a
+# prerelease line, so a leftover `next` tag silently serves an older build to
+# anyone resolving `@takazudo/zdtp@next`.
+#
+# Decision logic + the npm calls live in scripts/prune-stale-next-dist-tag.mjs
+# (dependency-free, unit-tested comparator). This is intentionally a separate,
+# manual workflow rather than a step in release.yml: registry dist-tag mutation
+# is kept out of the publish job so a prune hiccup never marks a successful
+# release as failed.
+#
+# Run from the Actions tab, or: `gh workflow run prune-stale-next-dist-tag.yml`.
+# Auth reuses the same Automation-type NPM_TOKEN secret as release.yml.
+
+name: Prune stale next dist-tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print the decision without mutating the registry"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-dist-tag-maintenance
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    name: Prune stale next dist-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Prune stale next dist-tag
+        run: node scripts/prune-stale-next-dist-tag.mjs ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,10 @@
 #   All other v* tags                           → npm dist-tag "latest"
 # Prerelease consumers opt in with `pnpm add @takazudo/zdtp@next`.
 #
-# Stale-`next` cleanup (#345): the package does not currently maintain a
-# prerelease line, so a leftover `next` tag can silently lag `latest` (a host
-# resolving `@next` would get an older build). On every stable publish, the
-# "Drop stale next dist-tag" step below removes `next` IF it points behind the
-# just-published `latest` — a legitimately-ahead prerelease `next` is preserved.
+# Stale-`next` cleanup (#345) is handled out-of-band by
+# .github/workflows/prune-stale-next-dist-tag.yml (manual dispatch) — registry
+# dist-tag mutation is kept OUT of this publish job so a prune hiccup can never
+# mark a successful release as failed.
 #
 # The pre-publish test gate lives upstream in ci.yml / pr-checks.yml (the panel's
 # test suite needs Playwright Chromium for browser tests). `prepublishOnly` here
@@ -112,31 +111,5 @@ jobs:
       - name: Publish to npm
         if: ${{ inputs.dry_run != true && startsWith(github.ref, 'refs/tags/v') }}
         run: pnpm -r publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # Drop a stale `next` dist-tag on stable releases (#345). Only removes
-      # `next` when it lags the just-published `latest`; a legitimately-ahead
-      # prerelease `next` is left intact. semver-sort decides "behind": if the
-      # greater of {next, latest} is latest, next is stale. Idempotent — a no-op
-      # when there is no `next` tag.
-      - name: Drop stale next dist-tag (stable releases)
-        if: ${{ inputs.dry_run != true && startsWith(github.ref, 'refs/tags/v') && env.DIST_TAG == 'latest' }}
-        shell: bash
-        run: |
-          PKG="@takazudo/zdtp"
-          NEXT_VER=$(npm dist-tag ls "$PKG" | awk -F': ' '/^next:/{print $2}')
-          if [ -z "$NEXT_VER" ]; then
-            echo "No 'next' dist-tag on $PKG — nothing to drop."
-            exit 0
-          fi
-          LATEST_VER=$(npm dist-tag ls "$PKG" | awk -F': ' '/^latest:/{print $2}')
-          GREATEST=$(npx --yes semver "$NEXT_VER" "$LATEST_VER" | tail -1)
-          if [ "$NEXT_VER" != "$LATEST_VER" ] && [ "$GREATEST" = "$LATEST_VER" ]; then
-            echo "Dropping stale '$PKG@next' ($NEXT_VER < latest $LATEST_VER)…"
-            npm dist-tag rm "$PKG" next
-          else
-            echo "Keeping '$PKG@next' ($NEXT_VER) — not behind latest ($LATEST_VER)."
-          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/prune-stale-next-dist-tag.mjs
+++ b/scripts/prune-stale-next-dist-tag.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Prune a stale npm `next` dist-tag for @takazudo/zdtp (#345).
+//
+// The package does not maintain a prerelease line, so a leftover `next` tag can
+// silently lag `latest` (a consumer resolving `@takazudo/zdtp@next` would get an
+// older build). This script drops `next` ONLY when it points behind `latest`;
+// a legitimately-ahead prerelease `next` is preserved. It is idempotent — a
+// no-op when there is no `next` tag (or no `latest`).
+//
+// Dependency-free on purpose: an earlier release-step used `npx semver`, which
+// failed in CI with "semver: not found". This uses only `npm` (bundled with
+// Node) plus a self-contained semver-precedence comparator.
+//
+// Auth: `npm dist-tag rm` needs a writable registry token. In CI that comes from
+// NODE_AUTH_TOKEN + the .npmrc that actions/setup-node writes. Pass --dry-run to
+// print the decision without mutating the registry (works without auth).
+
+import { execFileSync } from 'node:child_process';
+
+const PKG = '@takazudo/zdtp';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/**
+ * Compare two semver strings by precedence (semver.org §11).
+ * Returns <0 if a < b, 0 if equal, >0 if a > b.
+ */
+export function comparePrecedence(a, b) {
+  const parse = (v) => {
+    const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(v.trim());
+    if (!m) throw new Error(`Unparseable version: ${v}`);
+    return { main: [Number(m[1]), Number(m[2]), Number(m[3])], pre: m[4] ? m[4].split('.') : [] };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa.main[i] !== pb.main[i]) return pa.main[i] - pb.main[i];
+  }
+  // Equal core: a version with NO prerelease has higher precedence than one with.
+  if (pa.pre.length === 0 && pb.pre.length === 0) return 0;
+  if (pa.pre.length === 0) return 1;
+  if (pb.pre.length === 0) return -1;
+  // Both prerelease: compare identifiers left to right.
+  const n = Math.min(pa.pre.length, pb.pre.length);
+  for (let i = 0; i < n; i++) {
+    const x = pa.pre[i];
+    const y = pb.pre[i];
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      const d = Number(x) - Number(y);
+      if (d !== 0) return d;
+    } else if (xn !== yn) {
+      // Numeric identifiers have lower precedence than non-numeric.
+      return xn ? -1 : 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  // All shared identifiers equal: the longer prerelease has higher precedence.
+  return pa.pre.length - pb.pre.length;
+}
+
+function readDistTags() {
+  const out = execFileSync('npm', ['dist-tag', 'ls', PKG], { encoding: 'utf8' });
+  const tags = {};
+  for (const line of out.split('\n')) {
+    const m = /^([^:]+):\s*(\S+)/.exec(line.trim());
+    if (m) tags[m[1]] = m[2];
+  }
+  return tags;
+}
+
+function main() {
+  const tags = readDistTags();
+  const next = tags.next;
+  const latest = tags.latest;
+
+  if (!next) {
+    console.log(`No 'next' dist-tag on ${PKG} — nothing to prune.`);
+    return;
+  }
+  if (!latest) {
+    console.log(`No 'latest' dist-tag on ${PKG} — refusing to prune 'next' (${next}).`);
+    return;
+  }
+  if (next !== latest && comparePrecedence(next, latest) < 0) {
+    console.log(`Dropping stale '${PKG}@next' (${next} < latest ${latest})…`);
+    if (DRY_RUN) {
+      console.log('--dry-run: skipping `npm dist-tag rm`.');
+      return;
+    }
+    execFileSync('npm', ['dist-tag', 'rm', PKG, 'next'], { stdio: 'inherit' });
+    console.log(`Dropped '${PKG}@next'.`);
+  } else {
+    console.log(`Keeping '${PKG}@next' (${next}) — not behind latest (${latest}).`);
+  }
+}
+
+// Only run when invoked directly (not when imported for testing).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/345

---

## Why

The release-step added in #348 (`npx --yes semver` inside release.yml's publish job) **failed in the v0.2.3 Release run** with `sh: 1: semver: not found` (exit 127). Two problems:

1. `npx semver` does not resolve reliably in the CI runner.
2. Living in the publish job, its failure marked the **Release run red even though the npm publish succeeded** — exactly the kind of false-alarm that hides real publish failures.

(0.2.3 published fine; only the prune step errored, so `next: 0.2.0-next.2` is still stale.)

## What

- **New `scripts/prune-stale-next-dist-tag.mjs`** — dependency-free (no `npx`), unit-tested semver-precedence comparator. Drops `next` only when it lags `latest`; an ahead prerelease is preserved; idempotent; `--dry-run` supported.
- **New `.github/workflows/prune-stale-next-dist-tag.yml`** — `workflow_dispatch` (with a `dry_run` input), reuses the `NPM_TOKEN` secret. Run via the Actions tab or `gh workflow run`.
- **`release.yml`** — removed the fragile inline step; registry dist-tag mutation now lives out-of-band so it can never fail a release.

## Verification

- Comparator unit-checked (incl. the prerelease-of-same-version edge `sort -V` gets wrong).
- `node scripts/prune-stale-next-dist-tag.mjs --dry-run` against the live registry correctly reports `Dropping stale '@takazudo/zdtp@next' (0.2.0-next.2 < latest 0.2.3)`.
- After merge, the workflow is dispatched to actually drop the stale tag.

Re #345.