### PR TITLE
ci: disable package-manager-cache in prune workflow (#345)

### DIFF
--- a/.github/workflows/prune-stale-next-dist-tag.yml
+++ b/.github/workflows/prune-stale-next-dist-tag.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
+          # This job only needs node + npm (the script uses `npm dist-tag`); it
+          # does NOT set pnpm up. setup-node defaults package-manager-cache to
+          # true, which auto-detects pnpm from the repo and fails with
+          # "Unable to locate executable file: pnpm". Disable it.
+          package-manager-cache: false
 
       - name: Prune stale next dist-tag
         run: node scripts/prune-stale-next-dist-tag.mjs ${{ inputs.dry_run && '--dry-run' || '' }}


### PR DESCRIPTION
Follow-up to #349. The dispatched prune run failed at **Setup Node.js** with `Unable to locate executable file: pnpm`: `actions/setup-node` defaults `package-manager-cache: true`, auto-detects pnpm from the repo's `packageManager` field, and needs a pnpm binary — but this job intentionally doesn't set pnpm up (the script only uses `npm dist-tag`).

Fix: `package-manager-cache: false` on the setup-node step.

Re #345.