### PR TITLE
ZDTP Multi-Instance & Scoped Apply — v0.3.0 (epic #352)

### DIFF
--- a/doc/src/content/docs/reference/configure-panel.mdx
+++ b/doc/src/content/docs/reference/configure-panel.mdx
@@ -107,10 +107,9 @@ export interface PanelConfig {
   /**
    * Host-supplied tab configuration. Required.
    * The panel renders its tab strip from this array.
-   *  - Reserved ids ('color', 'color-secondary', 'font', 'spacing', 'size') dispatch
-   *    to built-in tab components.
-   *  - Any other id dispatches to GenericTab, which renders the tab's tiers using
-   *    kind-appropriate editors.
+   *  - Reserved ids ('color', 'color-secondary') dispatch to built-in color tab
+   *    components. Every other id dispatches to GenericTab, which renders the
+   *    tab's tiers using kind-appropriate editors.
    */
   tabs: readonly TabConfig[];
   /**
@@ -345,7 +344,7 @@ const spacingTab: TabConfig = {
   ],
 };
 
-configurePanel({
+const handle = configurePanel({
   storagePrefix: 'myapp-design-token-panel',
   consoleNamespace: 'myapp',
   modalClassPrefix: 'myapp-design-token-panel-modal',
@@ -359,6 +358,7 @@ configurePanel({
     'myapp-spacing': 'src/styles/spacing.css',
   },
 });
+// handle.instanceId === 'myapp-design-token-panel'
 ```
 
 ## Lifecycle helpers

--- a/doc/src/content/docs/reference/configure-panel.mdx
+++ b/doc/src/content/docs/reference/configure-panel.mdx
@@ -1,20 +1,21 @@
 ---
 title: configurePanel
 sidebar_position: 2
-description: Configure-once init, the PanelConfig shape with tabs-based manifest, and the lifecycle helpers (show / hide / toggle / reapply).
+description: Multi-instance init, the PanelConfig shape with tabs-based manifest, PanelInstanceHandle, applySink, and the lifecycle helpers (show / hide / toggle / reapply).
 ---
 
-The package's entire portable contract enters through a single, idempotent setup function.
-Hosts call `configurePanel({...})` exactly once per page lifecycle, before the panel adapter is dynamically imported.
+The package's entire portable contract enters through a single setup function.
+`configurePanel({...})` supports **multiple independent panel instances** — call it with distinct `storagePrefix` values to register separate instances.
+Each call returns a `PanelInstanceHandle`.
 
-This page pins the public shape of `PanelConfig`, the `configurePanel` call, and the runtime lifecycle helpers (`showDesignTokenPanel`, `hideDesignTokenPanel`, `toggleDesignPanel`, `reapplyPersistedOverrides`).
+This page pins the public shape of `PanelConfig`, the `configurePanel` call, `PanelInstanceHandle`, the `applySink` contract, and the runtime lifecycle helpers.
 
 ## `configurePanel(config)`
 
 ```ts
 import { configurePanel } from '@takazudo/zdtp';
 
-configurePanel({
+const handle = configurePanel({
   storagePrefix: 'myapp-design-token-panel',
   consoleNamespace: 'myapp',
   modalClassPrefix: 'myapp-design-token-panel-modal',
@@ -42,23 +43,51 @@ configurePanel({
     'myapp-spacing': 'src/styles/spacing.css',
   },
 });
+
+// handle.instanceId === 'myapp-design-token-panel'
+// handle.open() / close() / toggle() / destroy()
 ```
 
 ### Required behaviours
 
-- **One-shot.** Calling `configurePanel` more than once with different values throws. Calling it twice with structurally-equal values is a silent no-op (handles Astro view-transition reruns that re-parse the inline JSON config).
+- **Multi-instance.** Calling `configurePanel` with a **distinct** `storagePrefix` registers a new independent instance — independent storage keys, DOM root, toggle event, and apply target. No throw.
+- **Idempotent for same prefix+config.** Calling `configurePanel` again with the same `storagePrefix` and structurally-equal values is a silent no-op that returns the same handle. This covers Astro view-transition reruns that re-parse the inline JSON config.
+- **Same-prefix-different-config THROWS.** If an instance for the prefix already exists but the config differs, `configurePanel` throws immediately. Call `handle.destroy()` first, then `configurePanel` again to re-configure.
 - **Synchronous.** No I/O, no awaits. Safe to call inline at module-init time.
-- **Pure data only.** Every field on `PanelConfig` (and every nested field) MUST be JSON-serializable. The Astro frontmatter → island prop handoff stringifies the config; function fields silently disappear under that round-trip.
+- **Pure data only (except `applySink`).** Every field on `PanelConfig` other than `applySink` MUST be JSON-serializable. The Astro frontmatter → island prop handoff stringifies the config; function fields silently disappear under that round-trip. `applySink` carries function references and must not be included in the Astro inline JSON config.
 
 <Warning title="No defaults — explicit configure required">
 Importing the package without calling `configurePanel(...)` first leaves the panel in a minimal stub state with an empty `tabs` array. The panel will render "no tokens configured". Hosts MUST call `configurePanel(...)` to see useful behaviour.
 </Warning>
 
+## `PanelInstanceHandle`
+
+```ts
+export interface PanelInstanceHandle {
+  /** Stable instance id — equal to the instance's storagePrefix. */
+  readonly instanceId: string;
+  /** Show this instance's panel. */
+  open(): void;
+  /** Hide this instance's panel. */
+  close(): void;
+  /** Toggle this instance's panel open/closed. */
+  toggle(): void;
+  /**
+   * Deregister this instance. Unmounts the Preact tree, removes the DOM
+   * root, and unbinds the instance's toggle-event listener. After
+   * destroy() the prefix can be re-configured via configurePanel.
+   */
+  destroy(): void;
+}
+```
+
+Two `configurePanel` calls with the same `storagePrefix` and equal config return the **same handle** (referential identity is preserved across idempotent re-calls). Distinct prefixes return distinct handles.
+
 ## `PanelConfig` interface
 
 ```ts
 export interface PanelConfig {
-  /** Base for every derived storage key. */
+  /** Base for every derived storage key. Also the instance id. */
   storagePrefix: string;
   /** Console API namespace — installed as `window[consoleNamespace].showDesignPanel`, etc. */
   consoleNamespace: string;
@@ -68,6 +97,13 @@ export interface PanelConfig {
   schemaId: string;
   /** Default filename base — exports save as `${exportFilenameBase}.json`. */
   exportFilenameBase: string;
+  /**
+   * Optional window-event name that toggles THIS instance's panel.
+   * The default (single-panel) instance keeps `toggle-design-token-panel`.
+   * Any other instance defaults to `toggle-${storagePrefix}` when this field
+   * is omitted, giving each instance its own independent toggle channel.
+   */
+  toggleEvent?: string;
   /**
    * Host-supplied tab configuration. Required.
    * The panel renders its tab strip from this array.
@@ -93,6 +129,12 @@ export interface PanelConfig {
    */
   applyRouting?: Record<string, string>;
   /**
+   * Optional apply sink. Routes this instance's CSS-var writes off :root.
+   * Not JSON-serializable — supply via a custom adapter, not inline Astro config.
+   * See the applySink section below.
+   */
+  applySink?: ApplySink;
+  /**
    * Optional id rename map applied during loadPersistedState migration.
    * Keys are old ids found in persisted state; values are:
    *   - string — new canonical id; the value moves to that key.
@@ -107,20 +149,86 @@ export interface PanelConfig {
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `storagePrefix` | `string` | yes | Drives every persisted localStorage key. |
+| `storagePrefix` | `string` | yes | Drives every persisted localStorage key. Also the instance id. |
 | `consoleNamespace` | `string` | yes | Globals installed under `window[consoleNamespace]`. |
 | `modalClassPrefix` | `string` | yes | BEM root for every modal the panel owns. |
 | `schemaId` | `string` | yes | Emitted as `$schema` on exports; required on import. |
 | `exportFilenameBase` | `string` | yes | Saves as `${exportFilenameBase}.json`. |
+| `toggleEvent` | `string` | no | Toggle-event name for this instance. Default: `toggle-${storagePrefix}` (non-default instances); the default instance uses `toggle-design-token-panel`. |
 | `tabs` | [`TabConfig[]`](/docs/reference/token-manifest/) | yes | Tab strip definition. The Color tab reads its data from the tier model via `colorExtras` + `TierItem[]`. |
 | `colorPresets` | `Record<string, ColorScheme>` | no | Host-supplied scheme presets — see [Color cluster](/docs/reference/color-cluster/#host-supplied-scheme-presets). |
 | `applyEndpoint` | `string` | no | Apply POST target — see [Apply pipeline](/docs/reference/apply-pipeline/). |
 | `applyRouting` | `Record<string, string>` | no | Apply routing map — see [Apply pipeline](/docs/reference/apply-pipeline/). |
+| `applySink` | `ApplySink` | no | Optional CSS-var write target. Not JSON-serializable. See below. |
 | `legacyIdRenameMap` | `Record<string, string \| null>` | no | Migration map for persisted id renames and drops. |
 
 <Info title="JSON-serializable invariant">
-Every field on `PanelConfig` (including nested `tabs` content) must round-trip through `JSON.stringify` without loss. The Astro host-adapter parses the inline `<script type="application/json">` payload on every page; function fields, class instances, and `Symbol` keys silently disappear and surface later as cryptic runtime errors.
+Every field on `PanelConfig` (including nested `tabs` content) other than `applySink` must round-trip through `JSON.stringify` without loss. The Astro host-adapter parses the inline `<script type="application/json">` payload on every page; function fields, class instances, and `Symbol` keys silently disappear and surface later as cryptic runtime errors.
 </Info>
+
+## `applySink` — optional CSS-var write target
+
+When `PanelConfig.applySink` is supplied, all CSS-var writes and clears for that instance route through the sink rather than `document.documentElement`. This enables embedding the panel in a shadow root, iframe document, or test spy without touching `:root`.
+
+```ts
+export interface ApplySink {
+  /** Upsert the given var name→value pairs on the sink target. */
+  apply(pairs: ReadonlyArray<readonly [string, string]>): void;
+  /** Remove the given var names from the sink target. */
+  clear(names: readonly string[]): void;
+}
+```
+
+Contract:
+
+- `apply(pairs)` — **upsert**: set each `[name, value]` CSS var on the sink target.
+- `clear(names)` — **remove**: remove each named CSS var from the sink target.
+- **Reset sends the full token set.** When the user clicks Reset, `sink.clear` receives every var the instance can own (all palette, base-role, semantic, and non-color tab vars) — not just dirty vars — so the sink target is completely cleaned.
+- **Default (no sink):** writes go to `document.documentElement` (unchanged behaviour).
+- **Sink errors are non-fatal.** The pipeline swallows them with `console.warn` and continues.
+- **The host owns the sink target's lifecycle.** Keep the target alive as long as the instance is alive.
+- **Not JSON-serializable.** Supply it by constructing the config object with the sink already attached, or via a custom adapter that calls `configurePanel` directly.
+
+```ts
+// Example: routing a panel instance to a shadow root
+const shadow = shadowHost.attachShadow({ mode: 'open' });
+
+const handle = configurePanel({
+  storagePrefix: 'myapp-shadow-panel',
+  // ...other required fields...
+  applySink: {
+    apply(pairs) {
+      for (const [name, value] of pairs) {
+        (shadow.host as HTMLElement).style.setProperty(name, value);
+      }
+    },
+    clear(names) {
+      for (const name of names) {
+        (shadow.host as HTMLElement).style.removeProperty(name);
+      }
+    },
+  },
+});
+```
+
+## Per-instance toggle events
+
+Each panel instance has its own toggle-event channel so multiple panels on one page do not cross-talk.
+
+| Instance | `toggleEvent` field | Effective toggle-event name |
+| --- | --- | --- |
+| Default (single-panel path) | (ignored) | `toggle-design-token-panel` |
+| Any non-default, field omitted | — | `toggle-${storagePrefix}` |
+| Any non-default, field supplied | a custom string | the supplied string |
+
+The default instance is whichever instance's `storagePrefix` equals the historical package default (`'zudo-design-token-panel'`). All other instances get per-prefix channels.
+
+```ts
+// Dispatch the toggle event for a non-default instance:
+window.dispatchEvent(new CustomEvent('toggle-myapp-preview-panel'));
+// or, if you supplied toggleEvent: 'my-custom-event':
+window.dispatchEvent(new CustomEvent('my-custom-event'));
+```
 
 ## Storage-key derivation
 

--- a/packages/zdtp/CHANGELOG.md
+++ b/packages/zdtp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.0
 
 ### Features
 

--- a/packages/zdtp/CHANGELOG.md
+++ b/packages/zdtp/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **Multi-instance support.** `configurePanel(config)` now returns a `PanelInstanceHandle` and supports multiple independent panel instances on one page. Calling it with a distinct `storagePrefix` registers a new instance (independent storage keys, DOM root, toggle event, apply target). Calling it again with the same prefix and structurally-equal config is a no-op that returns the same handle (covers Astro view-transition reruns). Calling it with the same prefix but a structurally-different config throws immediately (`RECONFIGURE_RULE = 'reject-with-error'`); call `handle.destroy()` first to re-configure a prefix. Additive and backward-compatible — single-panel hosts observe no change. ([#353](https://github.com/Takazudo/zudo-design-token-panel/issues/353))
+
+- **`PanelInstanceHandle`.** `configurePanel` now returns a handle with `{ instanceId, open(), close(), toggle(), destroy() }`. `instanceId` equals `storagePrefix`. `destroy()` deregisters the instance, unmounts its Preact tree, removes its DOM root, and unbinds its toggle-event listener — freeing the prefix for re-configuration. ([#353](https://github.com/Takazudo/zudo-design-token-panel/issues/353))
+
+- **Per-instance toggle events.** The default instance (the historical `storagePrefix`) keeps `toggle-design-token-panel` unchanged. Any instance with a non-default prefix listens on `config.toggleEvent` when supplied, or `toggle-${storagePrefix}` by default — giving each instance its own independent toggle channel. `PanelConfig.toggleEvent?: string` is a new optional field. ([#354](https://github.com/Takazudo/zudo-design-token-panel/issues/354))
+
+- **`PanelConfig.applySink`.** An optional `{ apply(pairs), clear(names) }` sink routes this instance's CSS-var writes and clears through a caller-supplied object instead of `document.documentElement`. Useful for shadow DOM, iframe, or test-spy contexts. `apply` = upsert; `clear` = remove. Reset sends the full token-name set for the instance to `sink.clear` so the sink target is completely cleaned. Sink errors are non-fatal (`console.warn`). The host owns the sink target's lifecycle. `applySink` carries function references and must not be passed through the Astro inline JSON config. ([#355](https://github.com/Takazudo/zudo-design-token-panel/issues/355))
+
 ## 0.2.3
 
 ### Bug Fixes

--- a/packages/zdtp/PORTABLE-CONTRACT.md
+++ b/packages/zdtp/PORTABLE-CONTRACT.md
@@ -14,16 +14,19 @@ configuration (tiers, items, color cluster extras) are all host-supplied.
 
 ---
 
-## 1. `configurePanel({...})` — configure-once init
+## 1. `configurePanel({...})` — multi-instance init
 
-The package exposes a single, idempotent setup function. Hosts call it exactly
-once per page lifecycle, before the panel adapter is dynamically imported
-(typically from a small Astro host script that gates the adapter behind a
-visibility / persistence probe — see §6).
+The package exposes a setup function that returns a `PanelInstanceHandle`.
+Hosts call it once per `storagePrefix` per page lifecycle, before the panel
+adapter for that instance is dynamically imported (typically from a small Astro
+host script that gates the adapter behind a visibility / persistence probe —
+see §6). The same function supports **multiple independent panel instances** on
+one page: call it with a distinct `storagePrefix` to register a new instance;
+call it with the same prefix and equal config for an idempotent no-op.
 
 ```ts
 export interface PanelConfig {
-  /** Base for every derived storage key. See §2. */
+  /** Base for every derived storage key. Also the instance id. See §2. */
   storagePrefix: string;
   /** Console API namespace — installed as `window[consoleNamespace].showDesignPanel`, etc. */
   consoleNamespace: string;
@@ -33,6 +36,16 @@ export interface PanelConfig {
   schemaId: string;
   /** Default filename base — exports save as `${exportFilenameBase}.json`. */
   exportFilenameBase: string;
+  /**
+   * Optional window-event name that toggles THIS instance's panel.
+   *
+   * The default (single-panel) instance keeps the historical public event
+   * `toggle-design-token-panel` and ignores this field. A configured instance
+   * with a NON-default `storagePrefix` listens on this name; when omitted it
+   * defaults to `toggle-${storagePrefix}` so two panels on one page get
+   * independent toggle channels with no cross-talk.
+   */
+  toggleEvent?: string;
   /**
    * Host-supplied tab configuration (required). The panel renders a tab strip
    * from this array. See §3 for the full tab/tier model.
@@ -74,6 +87,16 @@ export interface PanelConfig {
    */
   applyRouting?: Record<string, string>;
   /**
+   * Optional apply sink. Routes this instance's CSS-var writes and clears
+   * through the caller-supplied object instead of `document.documentElement`.
+   * See §3.5 for the full sink contract.
+   *
+   * NOTE: this field carries a function reference and is therefore NOT
+   * JSON-serializable. It cannot pass through Astro's inline JSON config.
+   * Supply it via a post-configure call or a custom adapter.
+   */
+  applySink?: ApplySink;
+  /**
    * Optional id rename map applied during `loadPersistedState` migration.
    * Keys are old ids found in persisted state; values are either the new
    * canonical id (string) or `null` to drop the legacy id entirely.
@@ -82,7 +105,48 @@ export interface PanelConfig {
   legacyIdRenameMap?: Record<string, string | null>;
 }
 
-export function configurePanel(config: PanelConfig): void;
+/**
+ * Apply sink — routes CSS-var writes for one panel instance somewhere other
+ * than the host `:root`. See §3.5.
+ */
+export interface ApplySink {
+  /** Upsert the given var name→value pairs on the sink target. */
+  apply(pairs: ReadonlyArray<readonly [string, string]>): void;
+  /** Remove the given var names from the sink target. */
+  clear(names: readonly string[]): void;
+}
+
+/**
+ * Handle returned by `configurePanel`. Identifies one configured instance
+ * and exposes its imperative lifecycle controls.
+ *
+ * `instanceId` equals `config.storagePrefix` — the registry key.
+ * Two `configurePanel` calls with the same prefix+config return the SAME
+ * handle (referential identity is stable across idempotent re-calls).
+ */
+export interface PanelInstanceHandle {
+  /** Stable instance id — equal to the instance's `storagePrefix`. */
+  readonly instanceId: string;
+  /** Show this instance's panel. */
+  open(): void;
+  /** Hide this instance's panel. */
+  close(): void;
+  /** Toggle this instance's panel open/closed. */
+  toggle(): void;
+  /**
+   * Deregister this instance from the registry. Unmounts the instance's
+   * Preact tree, removes its DOM root, and unbinds its toggle-event listener.
+   * After `destroy()` the prefix can be re-configured by calling
+   * `configurePanel` again.
+   */
+  destroy(): void;
+}
+
+/**
+ * Configure one panel instance. Returns the instance handle.
+ * Call once per `storagePrefix` per page lifecycle.
+ */
+export function configurePanel(config: PanelConfig): PanelInstanceHandle;
 
 /**
  * Lazy preset attachment. Hosts that don't want to ship the preset library
@@ -104,20 +168,70 @@ export function assertValidPanelConfig(value: unknown): asserts value is PanelCo
 
 Required behaviours:
 
-- **One-shot.** Calling `configurePanel` more than once with different values
-  is an error. The panel may either throw or warn-and-ignore, but it MUST
-  NOT silently overwrite a previously-configured cluster mid-session.
+- **Multi-instance.** Calling `configurePanel` with a **distinct**
+  `storagePrefix` registers an independent panel instance (no throw). Distinct
+  instances derive independent storage keys, DOM roots, and toggle events and
+  do not interfere with each other.
+- **Idempotent for same prefix+config.** Calling `configurePanel` a second
+  time with the same `storagePrefix` and structurally-equal config values is a
+  no-op and returns the SAME handle. This covers Astro view-transition reruns
+  that re-parse the inline JSON config.
+- **Same-prefix-different-config THROWS (`RECONFIGURE_RULE = 'reject-with-error'`).** Calling
+  `configurePanel` with a `storagePrefix` already in the registry but a
+  structurally-different config throws immediately. To re-configure a prefix,
+  call `handle.destroy()` first, then `configurePanel` again.
 - **Synchronous.** No I/O, no awaits. The call must be cheap enough to run
   inline at module-init from the Astro frontmatter side.
-- **Pure data only.** Every field on `PanelConfig` (and every nested field
-  inside `tabs`) MUST be JSON-serializable. This is the hard precondition for
-  the Astro frontmatter → island prop handoff (§6): Astro stringifies props,
-  so functions / class instances do not survive.
+- **Pure data only (except `applySink`).** Every field on `PanelConfig` other
+  than `applySink` MUST be JSON-serializable. This is the hard precondition
+  for the Astro frontmatter → island prop handoff (§6): Astro stringifies
+  props, so functions / class instances do not survive. `applySink` carries
+  function references and MUST NOT be included in the Astro JSON config.
 - **No default `PanelConfig` baked into the package.** Hosts MUST configure
   the panel explicitly via `<DesignTokenPanelHost config={...} />` or a
   direct `configurePanel({...})` call. The package ships zero baked-in
   identifiers — every storage prefix, namespace, and manifest entry comes
   from the host.
+
+### Multi-instance example
+
+```ts
+// Primary panel instance
+const primaryHandle = configurePanel({
+  storagePrefix: 'myapp-design-token-panel',
+  // ...other fields
+});
+
+// Secondary panel instance — distinct prefix, independent instance
+const secondaryHandle = configurePanel({
+  storagePrefix: 'myapp-preview-panel',
+  toggleEvent: 'toggle-preview-panel', // optional; default: toggle-${storagePrefix}
+  // ...other fields
+});
+
+// Each handle controls only its own instance:
+primaryHandle.open();    // opens primary panel
+secondaryHandle.toggle(); // toggles secondary panel
+
+// Listen for the secondary panel's toggle event:
+window.dispatchEvent(new CustomEvent('toggle-preview-panel'));
+
+// To re-configure a prefix, destroy first:
+primaryHandle.destroy();
+configurePanel({ storagePrefix: 'myapp-design-token-panel', /* new config */ });
+```
+
+### Per-instance toggle events
+
+| Instance | `storagePrefix` | `toggleEvent` field | Effective toggle event name |
+| --- | --- | --- | --- |
+| Default (single-panel path) | `'zudo-design-token-panel'` (the historical default) | (ignored) | `toggle-design-token-panel` |
+| Any other | any distinct value | omitted | `toggle-${storagePrefix}` |
+| Any other | any distinct value | supplied | the supplied string |
+
+The default instance keeps the historical `toggle-design-token-panel` event for
+backwards compatibility. Every non-default instance gets its own independent
+channel so two panels on one page do not cross-talk.
 
 ---
 
@@ -288,8 +402,71 @@ item's persisted value as the id of an item in the referenced tier. The
 emitted CSS override is `var(--target-cssvar)` where `target-cssvar` is the
 `cssVar` of the matched item in the base tier.
 
-The contract requires this read/write target to be `:root`. No shadow DOM, no
-scoped overrides — this is intentional, the panel ships a global tweak.
+By default the write target is `:root` (`document.documentElement`). When a
+`PanelConfig.applySink` is configured for the instance, writes are routed
+through the sink instead — see §3.5.
+
+### 3.5 `applySink` — optional CSS-var write target
+
+When `PanelConfig.applySink` is set, all CSS-var writes and clears for that
+panel instance route through the sink rather than `document.documentElement`.
+This enables embedding the panel in a shadow root, an iframe document, or a
+test spy without touching `:root`.
+
+```ts
+interface ApplySink {
+  /** Upsert the given var name→value pairs on the sink target. */
+  apply(pairs: ReadonlyArray<readonly [string, string]>): void;
+  /** Remove the given var names from the sink target. */
+  clear(names: readonly string[]): void;
+}
+```
+
+Contract:
+
+- `apply(pairs)` — **upsert**: set each `pairs[i][0]` CSS var to
+  `pairs[i][1]` on the sink target.
+- `clear(names)` — **remove**: remove each named CSS var from the sink target.
+- **Reset clears the instance's full token set.** When the user clicks Reset,
+  `sink.clear` receives every var the instance can own (all palette,
+  base-role, semantic, and non-color tab vars) — not just the currently-dirty
+  vars — so the sink target is completely cleaned.
+- **Default (no sink):** writes go to `document.documentElement` (unchanged
+  behaviour for existing integrations).
+- **Sink errors are non-fatal.** The apply pipeline swallows errors from
+  `sink.apply` and `sink.clear` with `console.warn` and continues.
+- **The host owns the sink.** The package calls `apply`/`clear`; it does not
+  manage the sink target's lifecycle. A host that passes a shadow-root target
+  must keep the target alive as long as the panel instance is alive.
+- **Not JSON-serializable.** `applySink` carries function references and
+  MUST NOT be included in the Astro inline JSON config. Supply it via a
+  post-configure approach or a custom adapter that calls `configurePanel`
+  directly after adding the sink field.
+
+Example — routing a panel instance to a shadow root:
+
+```ts
+const shadowHost = document.createElement('div');
+document.body.appendChild(shadowHost);
+const shadow = shadowHost.attachShadow({ mode: 'open' });
+
+const handle = configurePanel({
+  storagePrefix: 'myapp-shadow-panel',
+  // ...other required fields...
+  applySink: {
+    apply(pairs) {
+      for (const [name, value] of pairs) {
+        (shadow.host as HTMLElement).style.setProperty(name, value);
+      }
+    },
+    clear(names) {
+      for (const name of names) {
+        (shadow.host as HTMLElement).style.removeProperty(name);
+      }
+    },
+  },
+});
+```
 
 ### 3.5 Helpers (re-exported from the package root)
 
@@ -843,7 +1020,9 @@ Items this contract deliberately does NOT pin down:
   existing user state round-trips without migration.
 - **Schema id versioning.** `schemaId` is a configure-time string; bumping
   it is the host's responsibility.
-- **Shadow-DOM scoping.** The panel writes to `:root` only.
+- **Shadow-DOM scoping.** The panel writes to `:root` by default; hosts
+  that need scoped writes use `PanelConfig.applySink` (§3.5). The sink
+  target's lifecycle is owned by the host — not pinned here.
 - **Theme-API surface.** The panel does not expose a programmatic API for
   reading the current overrides outside the persist envelope.
 
@@ -855,9 +1034,10 @@ Cross-reference table — what each section pins down.
 
 | Topic                                                                                       | Section       |
 | ------------------------------------------------------------------------------------------- | ------------- |
-| `configurePanel({...})` signature and lifecycle                                             | §1            |
+| `configurePanel({...})` signature, multi-instance, `PanelInstanceHandle`, per-instance toggle events | §1     |
 | Storage-key derivation                                                                      | §2, §8        |
 | `TabConfig` / `TierConfig` / `TierItem` / `TierValueKind` interfaces and apply behaviour   | §3            |
+| `applySink` — optional CSS-var write target (upsert / clear / Reset full set)              | §3.5          |
 | `ColorClusterExtras` shape and multi-cluster support                                        | §4.1, §4.3    |
 | JSON-serializable constraint on color tab config                                            | §4.2          |
 | `colorPresets` and `setPanelColorPresets()` lazy attachment                                 | §4.4          |

--- a/packages/zdtp/PORTABLE-CONTRACT.md
+++ b/packages/zdtp/PORTABLE-CONTRACT.md
@@ -468,7 +468,7 @@ const handle = configurePanel({
 });
 ```
 
-### 3.5 Helpers (re-exported from the package root)
+### 3.6 Helpers (re-exported from the package root)
 
 ```ts
 export function isLengthKind(v: TierValueKind): boolean;

--- a/packages/zdtp/README.md
+++ b/packages/zdtp/README.md
@@ -432,31 +432,98 @@ The zfb (zudo-front-builder) integration is documented in that project's own rep
 
 ## 5. `configurePanel()` and the `PanelConfig` shape
 
-`configurePanel(config)` is the configure-once init. The Astro host adapter calls it for you (it reads the inline JSON config emitted by `<DesignTokenPanelHost>` and forwards it). For a non-Astro host, you would call `configurePanel(myPanelConfig)` yourself before the panel adapter is dynamically imported.
+`configurePanel(config)` is the multi-instance init. It returns a `PanelInstanceHandle`. The Astro host adapter calls it for you (it reads the inline JSON config emitted by `<DesignTokenPanelHost>` and forwards it). For a non-Astro host, you would call `configurePanel(myPanelConfig)` yourself before the panel adapter is dynamically imported.
 
 ```ts
 import { configurePanel, type PanelConfig } from '@takazudo/zdtp';
 
-configurePanel(myPanelConfig);
+const handle = configurePanel(myPanelConfig);
+// handle.instanceId === myPanelConfig.storagePrefix
+// handle.open() / close() / toggle() / destroy()
 ```
 
 ### 5.1 Behaviour
 
-- **One-shot per page lifecycle.** Calling `configurePanel` twice with identical values is a no-op. Calling it twice with different values throws — silently overwriting a previously-configured cluster mid-session is the failure mode the contract explicitly rules out.
+- **Multi-instance.** Call `configurePanel` with a **distinct** `storagePrefix` to register an independent panel instance (independent storage keys, DOM root, toggle event, and apply target). No throw.
+- **Idempotent for same prefix+config.** Calling `configurePanel` again with the same `storagePrefix` and structurally-equal config values is a no-op and returns the same handle. This covers Astro view-transition reruns that re-parse the inline JSON config.
+- **Same-prefix-different-config THROWS.** Calling `configurePanel` with an already-registered prefix but a different config throws immediately. To re-configure a prefix, call `handle.destroy()` first, then `configurePanel` again.
 - **Synchronous, no I/O.** The call must be cheap enough to run inline at module init.
-- **JSON-serializable input.** Every nested field MUST round-trip through `JSON.stringify` / `JSON.parse` without loss. No function fields, no class instances, no `Symbol` keys, no `undefined`-where-`null`-is-meant. This is the hard precondition for the Astro frontmatter → client island handoff (§8).
+- **JSON-serializable input (except `applySink`).** Every nested field other than `applySink` MUST round-trip through `JSON.stringify` / `JSON.parse` without loss. `applySink` carries function references and must not be passed through the Astro inline JSON config.
 
-### 5.2 Field summary
+### 5.2 `PanelInstanceHandle`
+
+```ts
+export interface PanelInstanceHandle {
+  /** Stable instance id — equal to the instance's `storagePrefix`. */
+  readonly instanceId: string;
+  open(): void;   // show this instance's panel
+  close(): void;  // hide this instance's panel
+  toggle(): void; // toggle open/closed
+  /**
+   * Deregister this instance. Unmounts Preact tree, removes DOM root,
+   * unbinds toggle-event listener. Prefix can then be re-configured.
+   */
+  destroy(): void;
+}
+```
+
+### 5.3 Field summary
 
 | Field                | Type                           | Purpose                                                                                                                                                                |
 | -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `storagePrefix`      | `string`                       | Base for every derived `localStorage` key. See §9.                                                                                                                     |
+| `storagePrefix`      | `string`                       | Base for every derived `localStorage` key. Also the instance id. See §9.                                                                                               |
 | `consoleNamespace`   | `string`                       | Global object the package installs `showDesignPanel` / `hideDesignPanel` / `toggleDesignPanel` on (e.g. `consoleNamespace: 'myapp'` → `window.myapp.showDesignPanel`). |
 | `modalClassPrefix`   | `string`                       | BEM root class for every modal the panel owns (export, import, apply). Emits `${prefix}__overlay`, `${prefix}__panel`, etc.                                            |
 | `schemaId`           | `string`                       | `$schema` value emitted into export JSON and required on import.                                                                                                       |
 | `exportFilenameBase` | `string`                       | Default download filename base — exports save as `${exportFilenameBase}.json`.                                                                                         |
+| `toggleEvent`        | `string` (optional)            | Window-event name that toggles THIS instance. Defaults to `toggle-${storagePrefix}` for non-default instances; the default instance keeps `toggle-design-token-panel`. |
 | `tabs`               | `readonly TabConfig[]`         | **Required.** Tab strip data — each entry is a tab with one or more `TierConfig` objects. The color tab (id `'color'`) additionally requires `colorExtras`. See §6.    |
 | `colorPresets`       | `Record<string, ColorScheme>` (optional) | Optional named scheme presets surfaced in the Color tab "Scheme..." dropdown. Defaults to `{}`. See §7.5.                                              |
+| `applySink`          | `ApplySink` (optional)         | Optional sink that routes this instance's CSS-var writes off `:root`. See §5.4. Not JSON-serializable — do not include in Astro inline config.                        |
+
+### 5.4 `applySink` — optional write target
+
+When `PanelConfig.applySink` is set for an instance, all CSS-var writes and clears for that instance route through the sink rather than `document.documentElement`. This enables embedding the panel in a shadow root, iframe, or test spy without touching `:root`.
+
+```ts
+export interface ApplySink {
+  /** Upsert the given var name→value pairs on the sink target. */
+  apply(pairs: ReadonlyArray<readonly [string, string]>): void;
+  /** Remove the given var names from the sink target. */
+  clear(names: readonly string[]): void;
+}
+```
+
+Key behaviours:
+
+- `apply` = **upsert**: set each named CSS var on the sink target.
+- `clear` = **remove**: remove each named CSS var from the sink target.
+- **Reset clears the full token set**: when the user clicks Reset, `sink.clear` receives every var the instance can own (not just dirty vars) so the sink target is fully cleaned.
+- **Sink errors are non-fatal**: `console.warn` is emitted and the apply pipeline continues.
+- **The host owns the sink target's lifecycle.** Keep the sink target alive as long as the panel instance is alive.
+- **Not JSON-serializable.** Supply it after `configurePanel` via a custom adapter or by constructing the config object with the sink already attached.
+
+```ts
+// Example: routing to a shadow root
+const shadow = shadowHost.attachShadow({ mode: 'open' });
+
+const handle = configurePanel({
+  storagePrefix: 'myapp-shadow-panel',
+  // ...other required fields...
+  applySink: {
+    apply(pairs) {
+      for (const [name, value] of pairs) {
+        (shadow.host as HTMLElement).style.setProperty(name, value);
+      }
+    },
+    clear(names) {
+      for (const name of names) {
+        (shadow.host as HTMLElement).style.removeProperty(name);
+      }
+    },
+  },
+});
+```
 
 ### 5.3 Mount strategy & auto-mount
 
@@ -577,13 +644,15 @@ The panel walks each `TierItem` on apply:
 
 - If `readonly`, the row is display-only — no writes.
 - For a **base tier item**: if the override map has a non-empty string for
-  `id`, the panel calls `document.documentElement.style.setProperty(item.cssVar, value)`.
-  Otherwise it removes the inline property so the consumer's stylesheet default wins.
+  `id`, the panel writes `item.cssVar` ← value. Otherwise it removes the
+  inline property so the consumer's stylesheet default wins.
 - For a **ref-tier item** (`referencesTier` set): the persisted value is the id
   of an item in the referenced base tier. The apply pipeline emits
   `var(--base-tier-cssvar)` as the written value.
 
-The write target is always `:root`. No shadow DOM, no scoped overrides — the panel ships a global tweak intentionally.
+The default write target is `:root` (`document.documentElement`). An instance
+with `PanelConfig.applySink` set routes writes through the sink instead — see
+§5.4 for the full sink contract.
 
 ---
 

--- a/packages/zdtp/package.json
+++ b/packages/zdtp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@takazudo/zdtp",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Dynamic design-token tweak panel — host-config-driven, framework-agnostic Preact UI.",
   "private": false,
   "license": "MIT",

--- a/packages/zdtp/src/__tests__/apply-sink.test.ts
+++ b/packages/zdtp/src/__tests__/apply-sink.test.ts
@@ -1,0 +1,470 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for the `applySink` feature (issue #355 Z3).
+ *
+ * Acceptance criteria:
+ * - With an `applySink`, token changes invoke `sink.apply`/`sink.clear`
+ *   and `document.documentElement.style.setProperty`/`removeProperty`
+ *   records ZERO calls.
+ * - Reset calls `sink.clear` with the instance's FULL token-name set (not
+ *   just currently-dirty ones).
+ * - A sink that throws does NOT break the panel.
+ * - Without a sink, behavior is byte-identical (spy parity vs. current).
+ * - Scheme switch on a sink instance touches only its own vars; the default
+ *   instance still reads host theme from `data-theme`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetPanelConfigForTests, configurePanel } from '../config/panel-config';
+import type { ApplySink } from '../state/tweak-state';
+import {
+  applyColorState,
+  applyFullState,
+  clearAppliedColorStyles,
+  clearAppliedStyles,
+  getActiveSchemeName,
+  initColorFromScheme,
+} from '../state/tweak-state';
+import {
+  FIXTURE_CLUSTER,
+  FIXTURE_PANEL_CONFIG,
+  FIXTURE_TABS,
+  installFixturePanelConfig,
+} from './_test-helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSinkSpy(): ApplySink & {
+  applyCalls: Array<ReadonlyArray<readonly [string, string]>>;
+  clearCalls: Array<readonly string[]>;
+} {
+  const applyCalls: Array<ReadonlyArray<readonly [string, string]>> = [];
+  const clearCalls: Array<readonly string[]> = [];
+  return {
+    applyCalls,
+    clearCalls,
+    apply(pairs) {
+      applyCalls.push(pairs);
+    },
+    clear(names) {
+      clearCalls.push(names);
+    },
+  };
+}
+
+/** Flatten all pairs from all sink.apply() calls into one array. */
+function flatApplyPairs(
+  calls: Array<ReadonlyArray<readonly [string, string]>>,
+): Array<readonly [string, string]> {
+  return calls.flat();
+}
+
+/** Flatten all names from all sink.clear() calls into one array. */
+function flatClearNames(calls: Array<readonly string[]>): string[] {
+  return calls.flat();
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let setPropertySpy: ReturnType<typeof vi.spyOn>;
+let removePropertySpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // Spy on document.documentElement.style mutations so we can verify that
+  // the sink path does NOT touch :root.
+  setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty');
+  removePropertySpy = vi.spyOn(document.documentElement.style, 'removeProperty');
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+});
+
+afterEach(() => {
+  setPropertySpy.mockRestore();
+  removePropertySpy.mockRestore();
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+  __resetPanelConfigForTests();
+});
+
+// ---------------------------------------------------------------------------
+// applyColorState — sink routing
+// ---------------------------------------------------------------------------
+
+describe('applyColorState with sink', () => {
+  it('routes writes to sink and does NOT touch document.documentElement', () => {
+    const sink = makeSinkSpy();
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER, sink);
+
+    // Sink received all writes.
+    const pairs = flatApplyPairs(sink.applyCalls);
+    expect(pairs.length).toBeGreaterThan(0);
+
+    // None reached :root.
+    expect(setPropertySpy).not.toHaveBeenCalled();
+    expect(removePropertySpy).not.toHaveBeenCalled();
+  });
+
+  it('writes all palette slots to the sink', () => {
+    const sink = makeSinkSpy();
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER, sink);
+
+    const pairs = flatApplyPairs(sink.applyCalls);
+    const names = pairs.map(([name]) => name);
+    for (let i = 0; i < FIXTURE_CLUSTER.paletteSize; i++) {
+      expect(names).toContain(`--fixture-p${i}`);
+    }
+  });
+
+  it('writes semantic vars to the sink', () => {
+    const sink = makeSinkSpy();
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER, sink);
+
+    const names = flatApplyPairs(sink.applyCalls).map(([n]) => n);
+    expect(names).toContain('--fixture-semantic-accent');
+    expect(names).toContain('--fixture-semantic-muted');
+    expect(names).toContain('--fixture-semantic-active');
+  });
+
+  it('without sink writes to document.documentElement (default path unchanged)', () => {
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER); // no sink
+
+    expect(setPropertySpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyFullState — sink routing end-to-end
+// ---------------------------------------------------------------------------
+
+describe('applyFullState with sink', () => {
+  it('routes all writes through sink and keeps :root pristine', () => {
+    const sink = makeSinkSpy();
+    installFixturePanelConfig({ applySink: sink });
+
+    const state = {
+      color: initColorFromScheme(FIXTURE_CLUSTER),
+      spacing: { 'hsp-md': '20px' },
+      typography: {},
+      size: {},
+    };
+
+    applyFullState(state, { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: sink });
+
+    // Sink received writes.
+    const pairs = flatApplyPairs(sink.applyCalls);
+    expect(pairs.length).toBeGreaterThan(0);
+
+    // :root was not touched.
+    expect(setPropertySpy).not.toHaveBeenCalled();
+    expect(removePropertySpy).not.toHaveBeenCalled();
+  });
+
+  it('spacing override appears in sink apply pairs', () => {
+    const sink = makeSinkSpy();
+    const cfg = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: sink };
+    installFixturePanelConfig({ applySink: sink });
+
+    const state = {
+      color: initColorFromScheme(FIXTURE_CLUSTER),
+      spacing: { 'hsp-md': '99px' },
+      typography: {},
+      size: {},
+    };
+
+    applyFullState(state, cfg);
+
+    const pairs = flatApplyPairs(sink.applyCalls);
+    const spacingPair = pairs.find(([name]) => name === '--zd-spacing-hgap-md');
+    expect(spacingPair).toBeDefined();
+    expect(spacingPair?.[1]).toBe('99px');
+  });
+
+  it('without sink writes to :root (default path unchanged)', () => {
+    installFixturePanelConfig();
+
+    const state = {
+      color: initColorFromScheme(FIXTURE_CLUSTER),
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    applyFullState(state); // no cfg → uses getPanelConfig()
+
+    expect(setPropertySpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearAppliedStyles — full token-name set for sink instances
+// ---------------------------------------------------------------------------
+
+describe('clearAppliedStyles with sink — Reset sends full token-name set', () => {
+  it('calls sink.clear with the full token-name set (palette + semantic + non-color tabs)', () => {
+    const sink = makeSinkSpy();
+    const cfg = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: sink };
+    installFixturePanelConfig({ applySink: sink });
+
+    clearAppliedStyles(undefined, cfg);
+
+    // :root was not touched.
+    expect(removePropertySpy).not.toHaveBeenCalled();
+
+    const cleared = flatClearNames(sink.clearCalls);
+
+    // All palette slots present.
+    for (let i = 0; i < FIXTURE_CLUSTER.paletteSize; i++) {
+      expect(cleared).toContain(`--fixture-p${i}`);
+    }
+    // Semantic vars present.
+    expect(cleared).toContain('--fixture-semantic-accent');
+    expect(cleared).toContain('--fixture-semantic-muted');
+    expect(cleared).toContain('--fixture-semantic-active');
+    // Non-color tab vars present.
+    expect(cleared).toContain('--zd-spacing-hgap-md');
+    expect(cleared).toContain('--zd-spacing-vgap-sm');
+    expect(cleared).toContain('--zd-font-base-size');
+    expect(cleared).toContain('--radius-lg');
+  });
+
+  it('full token-name set covers even vars that were never set (not just dirty ones)', () => {
+    const sink = makeSinkSpy();
+    const cfg = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: sink };
+    installFixturePanelConfig({ applySink: sink });
+
+    // Simulate Reset from a fresh state — nothing was applied before.
+    clearAppliedStyles(undefined, cfg);
+
+    const cleared = flatClearNames(sink.clearCalls);
+    // Even though no overrides were applied, all vars are in the clear set.
+    expect(cleared).toContain('--fixture-p0');
+    expect(cleared).toContain('--zd-spacing-hgap-md');
+  });
+
+  it('without sink clears document.documentElement (default path unchanged)', () => {
+    installFixturePanelConfig();
+    // Seed a var so there's something to clear.
+    document.documentElement.style.setProperty('--fixture-p0', '#ff0000');
+    setPropertySpy.mockClear();
+
+    clearAppliedStyles();
+
+    expect(removePropertySpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearAppliedColorStyles — sink routing
+// ---------------------------------------------------------------------------
+
+describe('clearAppliedColorStyles with sink', () => {
+  it('routes clears through sink only', () => {
+    const sink = makeSinkSpy();
+    installFixturePanelConfig({ applySink: sink });
+
+    clearAppliedColorStyles([FIXTURE_CLUSTER], sink);
+
+    expect(removePropertySpy).not.toHaveBeenCalled();
+    const cleared = flatClearNames(sink.clearCalls);
+    expect(cleared).toContain('--fixture-p0');
+    expect(cleared).toContain('--fixture-semantic-accent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sink errors are non-fatal
+// ---------------------------------------------------------------------------
+
+describe('applySink error handling', () => {
+  it('sink.apply throwing does not throw from applyColorState', () => {
+    const throwingSink: ApplySink = {
+      apply() {
+        throw new Error('sink error');
+      },
+      clear() {
+        throw new Error('sink error');
+      },
+    };
+
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    // Must not throw.
+    expect(() => applyColorState(state, FIXTURE_CLUSTER, throwingSink)).not.toThrow();
+  });
+
+  it('sink.clear throwing does not throw from clearAppliedStyles', () => {
+    const throwingSink: ApplySink = {
+      apply() {
+        throw new Error('sink error');
+      },
+      clear() {
+        throw new Error('sink error');
+      },
+    };
+
+    const cfg = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: throwingSink };
+    installFixturePanelConfig({ applySink: throwingSink });
+
+    // Must not throw.
+    expect(() => clearAppliedStyles(undefined, cfg)).not.toThrow();
+  });
+
+  it('sink errors emit a console.warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const throwingSink: ApplySink = {
+      apply() {
+        throw new Error('sink error');
+      },
+      clear() {},
+    };
+
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER, throwingSink);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('applySink'),
+      expect.anything(),
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getActiveSchemeName — sink instance falls back to panel state
+// ---------------------------------------------------------------------------
+
+describe('getActiveSchemeName — sink instance scheme fallback', () => {
+  it('default instance reads data-theme from document when colorMode is set', () => {
+    // Use a cluster that has colorMode enabled.
+    const clusterWithMode = {
+      ...FIXTURE_CLUSTER,
+      panelSettings: {
+        colorScheme: 'default',
+        colorMode: {
+          defaultMode: 'dark' as const,
+          lightScheme: 'light-scheme',
+          darkScheme: 'dark-scheme',
+        },
+      },
+    };
+
+    // Default instance (no cfg or no sink) → reads host data-theme.
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const name = getActiveSchemeName(clusterWithMode, undefined);
+    expect(name).toBe('dark-scheme');
+  });
+
+  it('sink instance ignores data-theme and uses the cluster colorScheme fallback', () => {
+    const clusterWithMode = {
+      ...FIXTURE_CLUSTER,
+      panelSettings: {
+        colorScheme: 'my-default-scheme',
+        colorMode: {
+          defaultMode: 'dark' as const,
+          lightScheme: 'light-scheme',
+          darkScheme: 'dark-scheme',
+        },
+      },
+    };
+
+    const sink = makeSinkSpy();
+    const cfgWithSink = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: sink };
+
+    // Even though data-theme is 'dark', the sink instance should NOT read it.
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const name = getActiveSchemeName(clusterWithMode, cfgWithSink);
+    expect(name).toBe('my-default-scheme');
+  });
+
+  it('default instance (cfg without sink) still reads data-theme', () => {
+    const clusterWithMode = {
+      ...FIXTURE_CLUSTER,
+      panelSettings: {
+        colorScheme: 'my-default-scheme',
+        colorMode: {
+          defaultMode: 'light' as const,
+          lightScheme: 'light-scheme',
+          darkScheme: 'dark-scheme',
+        },
+      },
+    };
+
+    // cfg is provided but has no applySink → not a sink instance.
+    const cfgNoSink = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS };
+    document.documentElement.setAttribute('data-theme', 'light');
+    const name = getActiveSchemeName(clusterWithMode, cfgNoSink);
+    expect(name).toBe('light-scheme');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spy parity — default path byte-identical to pre-sink behavior
+// ---------------------------------------------------------------------------
+
+describe('spy parity — default path unchanged when no sink is configured', () => {
+  it('applyColorState without sink calls setProperty exactly as before', () => {
+    installFixturePanelConfig();
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER);
+
+    // Must have called setProperty for palette + semantic vars.
+    const calls = setPropertySpy.mock.calls.map(([name]: [string]) => name);
+    // Palette.
+    for (let i = 0; i < FIXTURE_CLUSTER.paletteSize; i++) {
+      expect(calls).toContain(`--fixture-p${i}`);
+    }
+    // Semantic.
+    expect(calls).toContain('--fixture-semantic-accent');
+    // Sink was not called because there is no sink.
+    // (No sink object to assert on — the property reads default config which
+    //  has no applySink, so the default path runs.)
+  });
+
+  it('clearAppliedStyles without sink calls removeProperty on :root', () => {
+    installFixturePanelConfig();
+    document.documentElement.style.setProperty('--fixture-p0', '#ff0000');
+    setPropertySpy.mockClear();
+
+    clearAppliedStyles();
+
+    expect(removePropertySpy).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// configurePanel with applySink — integration smoke test
+// ---------------------------------------------------------------------------
+
+describe('configurePanel with applySink', () => {
+  it('applyFullState picks up the sink from configurePanel', () => {
+    __resetPanelConfigForTests();
+    const sink = makeSinkSpy();
+    const cfg = configurePanel({ ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS, applySink: sink });
+    // cfg returns the handle; the config is registered as the default instance.
+
+    const state = {
+      color: initColorFromScheme(FIXTURE_CLUSTER),
+      spacing: { 'hsp-md': '42px' },
+      typography: {},
+      size: {},
+    };
+
+    // applyFullState with no cfg arg should pick up the default (just configured) instance.
+    applyFullState(state);
+
+    expect(setPropertySpy).not.toHaveBeenCalled();
+    const pairs = flatApplyPairs(sink.applyCalls);
+    expect(pairs.length).toBeGreaterThan(0);
+
+    // Return value is PanelInstanceHandle (used for type check only).
+    expect(cfg.instanceId).toBe(FIXTURE_PANEL_CONFIG.storagePrefix);
+  });
+});

--- a/packages/zdtp/src/__tests__/configure-panel-reinit.test.ts
+++ b/packages/zdtp/src/__tests__/configure-panel-reinit.test.ts
@@ -48,11 +48,19 @@ describe('configurePanel — structural re-init guard (P0-4)', () => {
     expect(() => configurePanel(reparsed)).not.toThrow();
   });
 
-  it('still throws on a structurally different second call', () => {
+  it('still throws on a same-prefix structurally-different second call', () => {
     configurePanel(BASE);
-    expect(() => configurePanel({ ...BASE, storagePrefix: 'other' })).toThrow(
+    // Same prefix, different non-prefix field → genuine config conflict, throws.
+    expect(() => configurePanel({ ...BASE, consoleNamespace: 'other' })).toThrow(
       /already called with different values/,
     );
+  });
+
+  it('does NOT throw when the second call uses a distinct storagePrefix (multi-instance)', () => {
+    configurePanel(BASE);
+    // A distinct prefix registers an independent instance — the multi-instance
+    // model lifted the global one-shot singleton to a per-prefix registry (#353).
+    expect(() => configurePanel({ ...BASE, storagePrefix: 'other' })).not.toThrow();
   });
 });
 

--- a/packages/zdtp/src/__tests__/instance-scoping-state.test.tsx
+++ b/packages/zdtp/src/__tests__/instance-scoping-state.test.tsx
@@ -1,0 +1,321 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for instance-scoped STATE operations (issue #357).
+ *
+ * The multi-instance epic (#353/#354/#356) made the panel's render / open-key /
+ * toggle-event path per-instance, but a codex review found the STATE path was
+ * still routed through `getPanelConfig()` (the most-recently-configured /
+ * default instance): a mounted non-default panel's persist / apply / reset /
+ * init calls — and the Astro console handlers — drove the DEFAULT instance, so
+ * two coexisting instances contaminated each other's storage, apply-sink, and
+ * root.
+ *
+ * Existing coverage these COMPLEMENT (do not duplicate):
+ *  - multi-instance-sink-integration.test.ts — applyFullState/clearAppliedStyles
+ *    scoping when the cfg is passed EXPLICITLY to the helper.
+ *  - multi-instance-lifecycle.test.tsx — handle.open/close/toggle independence.
+ *
+ * Gap closed here — the STATE path specifically:
+ *  1. The panel's own persist/apply/reset path (driven via A's `instanceConfig`,
+ *     exactly as the mounted panel.tsx now threads it) writes/clears/persists to
+ *     A's storage keys + A's sink, and NEVER B's — even while B is the default.
+ *  2. A reset on a mounted non-default instance clears only that instance's
+ *     vars/storage.
+ *  3. (P2) The console-handler binding the Astro adapter installs (the instance
+ *     `handle`, captured at install time) still targets instance A after B is
+ *     configured — whereas the no-arg `getPanelConfig()`-resolving export would
+ *     have driven B. Proves the order-sensitivity bug is fixed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { useEffect } from 'preact/hooks';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  getPanelConfig,
+  panelRootId,
+  storageKey_stateV3,
+  type ApplySink,
+  type PanelConfig,
+} from '../config/panel-config';
+import {
+  applyFullState,
+  clearAppliedStyles,
+  clearPersistedState,
+  getActivePrimaryCluster,
+  initColorFromScheme,
+  loadPersistedState,
+  savePersistedState,
+  type TweakState,
+} from '../state/tweak-state';
+import { usePersist } from '../state/persist';
+import { FIXTURE_TABS } from './_test-helpers';
+import { __resetInstanceBindingsForTests } from '../index';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(prefix: string, overrides: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    storagePrefix: prefix,
+    consoleNamespace: prefix,
+    modalClassPrefix: `${prefix}-modal`,
+    schemaId: `${prefix}/v1`,
+    exportFilenameBase: prefix,
+    tabs: FIXTURE_TABS,
+    ...overrides,
+  };
+}
+
+function makeSinkSpy(): ApplySink & {
+  applyCalls: Array<ReadonlyArray<readonly [string, string]>>;
+  clearCalls: Array<readonly string[]>;
+} {
+  const applyCalls: Array<ReadonlyArray<readonly [string, string]>> = [];
+  const clearCalls: Array<readonly string[]> = [];
+  return {
+    applyCalls,
+    clearCalls,
+    apply(pairs) {
+      applyCalls.push(pairs);
+    },
+    clear(names) {
+      clearCalls.push(names);
+    },
+  };
+}
+
+function flatApplyPairs(
+  calls: Array<ReadonlyArray<readonly [string, string]>>,
+): Array<readonly [string, string]> {
+  return calls.flat();
+}
+
+function flatClearNames(calls: Array<readonly string[]>): string[] {
+  return calls.flat();
+}
+
+/** A fresh full TweakState seeded from the given instance's primary cluster. */
+function fullTweakStateFor(cfg: PanelConfig): TweakState {
+  return {
+    color: initColorFromScheme(getActivePrimaryCluster(cfg)),
+    spacing: { 'hsp-md': '20px' },
+    typography: {},
+    size: {},
+  };
+}
+
+let setPropertySpy: ReturnType<typeof vi.spyOn>;
+let removePropertySpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty');
+  removePropertySpy = vi.spyOn(document.documentElement.style, 'removeProperty');
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+  __resetInstanceBindingsForTests();
+  __resetPanelConfigForTests();
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  setPropertySpy.mockRestore();
+  removePropertySpy.mockRestore();
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+  __resetInstanceBindingsForTests();
+  __resetPanelConfigForTests();
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+// ---------------------------------------------------------------------------
+// 1. The panel's persist path, scoped to A's instanceConfig, hits A only
+// ---------------------------------------------------------------------------
+
+describe('state path — usePersist scoped to a non-default instance writes to A only', () => {
+  it('persistSpacing on A routes its CSS-var writes to A\'s sink and persists to A\'s storage key, never B', async () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB); // B is now the active default — getPanelConfig() → B
+
+    // Drive the panel's persist pipeline exactly as panel.tsx does: render a
+    // tiny component that calls `usePersist(setState, A's instanceConfig)` (the
+    // real hook the mounted panel uses) and fires persistSpacing on mount.
+    let stateRef: TweakState | null = fullTweakStateFor(cfgA);
+    function Harness() {
+      const setState = (updater: (prev: TweakState | null) => TweakState | null) => {
+        stateRef = updater(stateRef);
+      };
+      const { persistSpacing } = usePersist(setState, cfgA);
+      useEffect(() => {
+        persistSpacing((prev) => ({ ...prev, 'hsp-md': '99px' }));
+      }, [persistSpacing]);
+      return null;
+    }
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    render(<Harness />, host);
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+
+    // A's sink received writes; B's did not.
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBeGreaterThan(0);
+    expect(flatApplyPairs(sinkB.applyCalls).length).toBe(0);
+    // :root untouched — A has a sink.
+    expect(setPropertySpy).not.toHaveBeenCalled();
+
+    // Persisted to A's storage key, NOT B's.
+    expect(localStorage.getItem(storageKey_stateV3(cfgA))).not.toBeNull();
+    expect(localStorage.getItem(storageKey_stateV3(cfgB))).toBeNull();
+
+    render(null, host);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Apply / load / save / clear via A's cfg hit A's storage keys + sink only
+// ---------------------------------------------------------------------------
+
+describe('state path — apply/save/load/clear scoped to A do not touch B', () => {
+  it('savePersistedState + loadPersistedState round-trip on A\'s key, with B configured as default', () => {
+    const cfgA = makeConfig('inst-alpha');
+    const cfgB = makeConfig('inst-beta');
+    configurePanel(cfgA);
+    configurePanel(cfgB); // B is the default
+
+    const stateA = fullTweakStateFor(cfgA);
+    // Save scoped to A (panel.tsx passes instanceConfig as the 3rd arg).
+    savePersistedState(stateA, undefined, cfgA);
+
+    // A's key written, B's key absent.
+    expect(localStorage.getItem(storageKey_stateV3(cfgA))).not.toBeNull();
+    expect(localStorage.getItem(storageKey_stateV3(cfgB))).toBeNull();
+
+    // Load scoped to A reads A's key back; load scoped to B finds nothing.
+    const loadedA = loadPersistedState(
+      undefined,
+      undefined,
+      getActivePrimaryCluster(cfgA),
+      cfgA,
+    );
+    expect(loadedA).not.toBeNull();
+    expect(loadedA?.spacing['hsp-md']).toBe('20px');
+
+    const loadedB = loadPersistedState(
+      undefined,
+      undefined,
+      getActivePrimaryCluster(cfgB),
+      cfgB,
+    );
+    expect(loadedB).toBeNull();
+  });
+
+  it('applyFullState scoped to A routes to sinkA only, not sinkB, while B is default', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    applyFullState(fullTweakStateFor(cfgA), cfgA);
+
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBeGreaterThan(0);
+    expect(flatApplyPairs(sinkB.applyCalls).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Reset on a mounted non-default instance clears only that instance
+// ---------------------------------------------------------------------------
+
+describe('state path — reset (handleResetAll) on a non-default instance clears only that instance', () => {
+  it('clearPersistedState + clearAppliedStyles scoped to A clear A\'s storage + A\'s sink, leaving B intact', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB); // B is the active default
+
+    // Seed BOTH instances' persisted state.
+    savePersistedState(fullTweakStateFor(cfgA), undefined, cfgA);
+    savePersistedState(fullTweakStateFor(cfgB), undefined, cfgB);
+    expect(localStorage.getItem(storageKey_stateV3(cfgA))).not.toBeNull();
+    expect(localStorage.getItem(storageKey_stateV3(cfgB))).not.toBeNull();
+
+    // Reset A only (the two calls panel.tsx's handleResetAll makes, scoped to A).
+    clearPersistedState(undefined, cfgA);
+    clearAppliedStyles(undefined, cfgA);
+
+    // A's storage gone; B's storage survives.
+    expect(localStorage.getItem(storageKey_stateV3(cfgA))).toBeNull();
+    expect(localStorage.getItem(storageKey_stateV3(cfgB))).not.toBeNull();
+
+    // A's sink received the clear; B's sink never did.
+    expect(flatClearNames(sinkA.clearCalls).length).toBeGreaterThan(0);
+    expect(flatClearNames(sinkB.clearCalls).length).toBe(0);
+    // :root untouched — A has a sink.
+    expect(removePropertySpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. (P2) console handler binding targets its configured instance, not default
+// ---------------------------------------------------------------------------
+
+describe('console handler binding (P2) — handle targets its own instance after another is configured', () => {
+  it('instance A\'s handle (what the console handler now binds to) drives A even when B is the default', async () => {
+    await import('../index');
+
+    const cfgA = makeConfig('inst-alpha');
+    const cfgB = makeConfig('inst-beta');
+    // A configured first, then B — so getPanelConfig() (the OLD no-arg console
+    // path) resolves to B, the most-recently-configured default.
+    const handleA = configurePanel(cfgA);
+    configurePanel(cfgB);
+    expect(getPanelConfig().storagePrefix).toBe('inst-beta');
+
+    // The adapter now binds the console handler to A's handle. Driving it must
+    // open A's root, NOT B's — proving the binding is instance-bound, not
+    // resolved via the default at call time.
+    handleA.open();
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+
+    expect(document.getElementById(panelRootId(cfgA)), 'A mounted').not.toBeNull();
+    expect(document.getElementById(panelRootId(cfgB)), 'B did NOT mount').toBeNull();
+  });
+
+  it('the no-arg default-resolving export drives the DEFAULT instance (B) — contrast that motivated the P2 fix', async () => {
+    const mod = await import('../index');
+
+    const cfgA = makeConfig('inst-alpha');
+    const cfgB = makeConfig('inst-beta');
+    configurePanel(cfgA);
+    configurePanel(cfgB); // B is the default
+
+    // showDesignTokenPanel() resolves getPanelConfig() at call time → B. This is
+    // the historical single-default-instance behaviour (preserved for back-compat);
+    // the P2 bug was that the Astro console handler for namespace A ALSO used this
+    // no-arg path, so A's console call drove B. The adapter now binds the handle
+    // instead (covered above).
+    mod.showDesignTokenPanel();
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+
+    expect(document.getElementById(panelRootId(cfgB)), 'default (B) mounted').not.toBeNull();
+    expect(document.getElementById(panelRootId(cfgA)), 'A not driven by no-arg export').toBeNull();
+  });
+});

--- a/packages/zdtp/src/__tests__/instance-scoping-state.test.tsx
+++ b/packages/zdtp/src/__tests__/instance-scoping-state.test.tsx
@@ -51,7 +51,9 @@ import {
   type TweakState,
 } from '../state/tweak-state';
 import { usePersist } from '../state/persist';
+import { buildApplyOverrides } from '../apply/build-apply-overrides';
 import { FIXTURE_TABS } from './_test-helpers';
+import type { TabConfig } from '../tokens/tier-model';
 import { __resetInstanceBindingsForTests } from '../index';
 
 // ---------------------------------------------------------------------------
@@ -106,6 +108,35 @@ function fullTweakStateFor(cfg: PanelConfig): TweakState {
     typography: {},
     size: {},
   };
+}
+
+/**
+ * A spacing-only tabs variant whose `hsp-md` item writes a DISTINCT cssVar.
+ * Used to prove the apply-payload (buildApplyOverrides) reads THIS instance's
+ * tab manifest, not the active default's.
+ */
+function spacingTabsWithCssVar(cssVar: string): readonly TabConfig[] {
+  return [
+    {
+      id: 'spacing',
+      label: 'Spacing',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Spacing',
+          items: [
+            {
+              id: 'hsp-md',
+              cssVar,
+              label: 'hsp-md',
+              default: '40px',
+              type: { kind: 'length', step: 1, unit: 'px' },
+            },
+          ],
+        },
+      ],
+    },
+  ];
 }
 
 let setPropertySpy: ReturnType<typeof vi.spyOn>;
@@ -266,6 +297,48 @@ describe('state path — reset (handleResetAll) on a non-default instance clears
     expect(flatClearNames(sinkB.clearCalls).length).toBe(0);
     // :root untouched — A has a sink.
     expect(removePropertySpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3b. Apply payload (buildApplyOverrides) reads A's cluster + tabs, not default
+// ---------------------------------------------------------------------------
+
+describe('apply payload — buildApplyOverrides scoped to A emits A\'s cssVars, not the default instance\'s', () => {
+  it('non-color tab override resolves through A\'s tab manifest, not B\'s, while B is the default', () => {
+    // A and B both define an `hsp-md` spacing item, but under DIFFERENT cssVars.
+    // The apply POST payload must use the cssVar from the instance that's
+    // applying (A) — the codex finding was that buildApplyOverrides fell back to
+    // getPanelConfig().tabs (= B, the default), POSTing the wrong token name.
+    const tabsA = spacingTabsWithCssVar('--inst-a-hsp-md');
+    const tabsB = spacingTabsWithCssVar('--inst-b-hsp-md');
+    const cfgA = makeConfig('inst-alpha', { tabs: tabsA });
+    const cfgB = makeConfig('inst-beta', { tabs: tabsB });
+    configurePanel(cfgA);
+    configurePanel(cfgB); // B is the active default
+
+    const state: TweakState = {
+      color: initColorFromScheme(getActivePrimaryCluster(cfgA)),
+      spacing: { 'hsp-md': '99px' },
+      typography: {},
+      size: {},
+    };
+
+    // The instance-scoped call panel.tsx's ApplyModal now makes: pass A's
+    // primary cluster + A's tabs.
+    const payloadA = buildApplyOverrides(
+      state,
+      undefined,
+      getActivePrimaryCluster(cfgA),
+      cfgA.tabs,
+    );
+    expect(payloadA['--inst-a-hsp-md']).toBe('99px');
+    expect(payloadA['--inst-b-hsp-md']).toBeUndefined();
+
+    // The OLD no-tabs call resolved getPanelConfig().tabs = B → B's cssVar.
+    const payloadDefault = buildApplyOverrides(state, undefined);
+    expect(payloadDefault['--inst-b-hsp-md']).toBe('99px');
+    expect(payloadDefault['--inst-a-hsp-md']).toBeUndefined();
   });
 });
 

--- a/packages/zdtp/src/__tests__/multi-instance-lifecycle.test.tsx
+++ b/packages/zdtp/src/__tests__/multi-instance-lifecycle.test.tsx
@@ -46,6 +46,29 @@ function makeConfig(prefix: string, overrides: Partial<PanelConfig> = {}): Panel
   };
 }
 
+/** Minimal one-tier `size` tab whose label is unique-per-instance for the render assertion. */
+function genericTab(id: string, label: string): PanelConfig['tabs'][number] {
+  return {
+    id,
+    label,
+    tiers: [
+      {
+        id: `${id}-raw`,
+        label: `${label} tier`,
+        items: [
+          {
+            id: `${id}-item`,
+            cssVar: `--${id}-item`,
+            label: `${label} item`,
+            default: '1rem',
+            type: { kind: 'length', step: 0.0625, unit: 'rem' },
+          },
+        ],
+      },
+    ],
+  };
+}
+
 async function waitForEffectFlush(): Promise<void> {
   await new Promise<void>((resolve) =>
     requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
@@ -200,5 +223,27 @@ describe('multi-instance lifecycle (#354)', () => {
     window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
     await waitForEffectFlush();
     expect(isOpen(cfgA), 'A works again after re-configure').toBe(true);
+  });
+
+  it('each mounted panel renders ITS OWN tabs, not the active default instance config', async () => {
+    await import('../index');
+
+    // Two instances with DISTINCT manifests. B is configured last, so it is the
+    // active default — yet A's mounted panel must still render A's tab.
+    const cfgA = makeConfig('alpha', { tabs: [genericTab('size', 'Alpha Size')] });
+    const cfgB = makeConfig('beta', { tabs: [genericTab('size', 'Beta Size')] });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgB)));
+    await waitForEffectFlush();
+
+    const aText = rootFor(cfgA)!.textContent ?? '';
+    const bText = rootFor(cfgB)!.textContent ?? '';
+    expect(aText, 'A renders its own tab label').toContain('Alpha Size');
+    expect(aText, 'A does not leak B label').not.toContain('Beta Size');
+    expect(bText, 'B renders its own tab label').toContain('Beta Size');
+    expect(bText, 'B does not leak A label').not.toContain('Alpha Size');
   });
 });

--- a/packages/zdtp/src/__tests__/multi-instance-lifecycle.test.tsx
+++ b/packages/zdtp/src/__tests__/multi-instance-lifecycle.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+/**
+ * Per-instance lifecycle / event / mount tests for issue #354 (Z2).
+ *
+ * Z1 lifted the global singleton to a per-`storagePrefix` registry; Z2 wires
+ * events / lifecycle / mount to that model. These tests assert the new
+ * user-observable guarantees:
+ *
+ *   1. Two configured panels (distinct `storagePrefix`es) each mount into their
+ *      OWN root and open/close via their OWN toggle event — no cross-talk.
+ *   2. `handle.destroy()` removes ONLY that instance's root + listeners (and
+ *      unmounts its Preact tree); the other panel keeps working.
+ *   3. The default (un-configured) instance keeps the historical
+ *      `toggle-design-token-panel` event; a configured non-default instance
+ *      uses `toggle-${storagePrefix}` (or `config.toggleEvent`).
+ *
+ * The probes mirror the single-panel regression tests
+ * (`toggle-event-after-close.test.tsx`): mount + open ⇒ the "Design Tokens"
+ * header sentinel appears inside the instance's root; close ⇒ it disappears.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getOpenKey } from '../state/tweak-state';
+import { __resetInstanceBindingsForTests } from '../index';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  panelRootId,
+  toggleEventName,
+  type PanelConfig,
+} from '../config/panel-config';
+
+const OPEN_PANEL_HEADER_TEXT = 'Design Tokens';
+const DEFAULT_TOGGLE_EVENT = 'toggle-design-token-panel';
+
+function makeConfig(prefix: string, overrides: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    storagePrefix: prefix,
+    consoleNamespace: prefix,
+    modalClassPrefix: `${prefix}-modal`,
+    schemaId: `${prefix}/v1`,
+    exportFilenameBase: prefix,
+    tabs: [],
+    ...overrides,
+  };
+}
+
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+function rootFor(cfg: PanelConfig): HTMLElement | null {
+  return document.getElementById(panelRootId(cfg));
+}
+
+function isOpen(cfg: PanelConfig): boolean {
+  const root = rootFor(cfg);
+  return !!root && (root.textContent ?? '').includes(OPEN_PANEL_HEADER_TEXT);
+}
+
+describe('multi-instance lifecycle (#354)', () => {
+  beforeEach(() => {
+    // Drain real window-event listeners BEFORE clearing the registry so no
+    // stale per-instance listener survives into the next test (deleting the
+    // bindings map alone would orphan live listeners — see
+    // `__resetInstanceBindingsForTests`).
+    __resetInstanceBindingsForTests();
+    __resetPanelConfigForTests();
+    localStorage.clear();
+    document.body.innerHTML = '';
+    const w = window as unknown as Record<string, unknown>;
+    delete w.__zudoDesignTokenPanelAdapter;
+    delete w.__zudoDesignTokenPanelLifecycle;
+  });
+
+  afterEach(() => {
+    __resetInstanceBindingsForTests();
+    document.body.innerHTML = '';
+    localStorage.clear();
+  });
+
+  it('derives a per-instance toggle event for non-default prefixes and keeps the legacy name for the default', () => {
+    const def = makeConfig('zudo-design-token-panel'); // === DEFAULT prefix
+    expect(toggleEventName(def)).toBe(DEFAULT_TOGGLE_EVENT);
+
+    const a = makeConfig('alpha');
+    expect(toggleEventName(a)).toBe('toggle-alpha');
+
+    const custom = makeConfig('beta', { toggleEvent: 'beta:flip' });
+    expect(toggleEventName(custom)).toBe('beta:flip');
+  });
+
+  it('two panels open/close independently via their own toggle events with no cross-talk', async () => {
+    await import('../index');
+
+    const cfgA = makeConfig('alpha');
+    const cfgB = makeConfig('beta');
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // Open A via its own event — B must stay closed/unmounted.
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    await waitForEffectFlush();
+    expect(isOpen(cfgA), 'A opens on its own event').toBe(true);
+    expect(rootFor(cfgB), 'B did not mount from A event').toBeNull();
+    expect(localStorage.getItem(getOpenKey(cfgA))).toBe('1');
+    expect(localStorage.getItem(getOpenKey(cfgB))).toBeNull();
+
+    // Open B via its own event — A stays open, independent.
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgB)));
+    await waitForEffectFlush();
+    expect(isOpen(cfgB), 'B opens on its own event').toBe(true);
+    expect(isOpen(cfgA), 'A still open — B event did not touch it').toBe(true);
+
+    // Close A via its event — B unaffected.
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    await waitForEffectFlush();
+    expect(isOpen(cfgA), 'A closed by its event').toBe(false);
+    expect(isOpen(cfgB), 'B still open after A close').toBe(true);
+    expect(localStorage.getItem(getOpenKey(cfgA))).toBeNull();
+    expect(localStorage.getItem(getOpenKey(cfgB))).toBe('1');
+  });
+
+  it('two panels open/close independently via their handle methods', async () => {
+    await import('../index');
+
+    const cfgA = makeConfig('alpha');
+    const cfgB = makeConfig('beta');
+    const handleA = configurePanel(cfgA);
+    const handleB = configurePanel(cfgB);
+
+    handleA.open();
+    handleB.open();
+    await waitForEffectFlush();
+    expect(isOpen(cfgA)).toBe(true);
+    expect(isOpen(cfgB)).toBe(true);
+
+    handleA.close();
+    await waitForEffectFlush();
+    expect(isOpen(cfgA)).toBe(false);
+    expect(isOpen(cfgB), 'B unaffected by A.close()').toBe(true);
+
+    handleB.toggle();
+    await waitForEffectFlush();
+    expect(isOpen(cfgB), 'B toggled closed').toBe(false);
+    expect(isOpen(cfgA), 'A unaffected by B.toggle()').toBe(false);
+  });
+
+  it('destroy() tears down only its own instance and leaves the other panel working', async () => {
+    await import('../index');
+
+    const cfgA = makeConfig('alpha');
+    const cfgB = makeConfig('beta');
+    const handleA = configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // Mount + open both.
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgB)));
+    await waitForEffectFlush();
+    expect(rootFor(cfgA)).not.toBeNull();
+    expect(rootFor(cfgB)).not.toBeNull();
+
+    // Destroy A — its root is removed; B untouched.
+    handleA.destroy();
+    await waitForEffectFlush();
+    expect(rootFor(cfgA), 'A root removed by destroy()').toBeNull();
+    expect(isOpen(cfgB), 'B still open after A destroyed').toBe(true);
+
+    // A's toggle event is now inert (listener removed) — it must NOT remount.
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    await waitForEffectFlush();
+    expect(rootFor(cfgA), 'A toggle event inert after destroy').toBeNull();
+
+    // B still responds to its own event.
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgB)));
+    await waitForEffectFlush();
+    expect(isOpen(cfgB), 'B closes on its own event after A destroyed').toBe(false);
+  });
+
+  it('a destroyed prefix can be re-configured and re-bound', async () => {
+    await import('../index');
+
+    const cfgA = makeConfig('alpha');
+    const handleA = configurePanel(cfgA);
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    await waitForEffectFlush();
+    expect(isOpen(cfgA)).toBe(true);
+
+    handleA.destroy();
+    await waitForEffectFlush();
+    expect(rootFor(cfgA)).toBeNull();
+
+    // Re-configure the same prefix (now free) and toggle again.
+    configurePanel(cfgA);
+    window.dispatchEvent(new CustomEvent(toggleEventName(cfgA)));
+    await waitForEffectFlush();
+    expect(isOpen(cfgA), 'A works again after re-configure').toBe(true);
+  });
+});

--- a/packages/zdtp/src/__tests__/multi-instance-sink-integration.test.ts
+++ b/packages/zdtp/src/__tests__/multi-instance-sink-integration.test.ts
@@ -1,0 +1,521 @@
+// @vitest-environment jsdom
+
+/**
+ * Complementary tests for the multi-instance + applySink model (Z4, issue #356).
+ *
+ * These tests COMPLEMENT the existing coverage in:
+ *  - panel-config.test.ts          — registry model, idempotency, same-prefix rules
+ *  - multi-instance-lifecycle.test.tsx — toggle events, DOM roots, handle methods
+ *  - apply-sink.test.ts            — single-instance sink routing, full token-name clear
+ *
+ * Gaps covered here:
+ *
+ *  1. TWO COEXISTING INSTANCES — end-to-end assertion that separate storage keys,
+ *     separate toggle events, AND separate mount roots are all independent in one test.
+ *
+ *  2. DESTROY ISOLATION WITH SINK — tear down one sink instance, assert the OTHER
+ *     still applies/clears correctly through its own sink.
+ *
+ *  3. SAME-PREFIX RECONFIGURE VIA DESTROY — assert the escape hatch works:
+ *     destroy() + configurePanel() with new config succeeds (no throw).
+ *
+ *  4. APPLY-SINK ROUTING WITH TWO INSTANCES — two panels each with a DISTINCT sink.
+ *     Writes to one instance do NOT reach the other instance's sink.
+ *
+ *  5. DEFAULT-INSTANCE BACKWARD-COMPAT PARITY — spy parity for the no-sink default
+ *     path when two instances exist simultaneously (one sink, one not).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  getPanelConfig,
+  panelRootId,
+  toggleEventName,
+  storageKey_open,
+  storageKey_stateV3,
+  type PanelConfig,
+} from '../config/panel-config';
+import {
+  applyColorState,
+  applyFullState,
+  clearAppliedStyles,
+  initColorFromScheme,
+  type ApplySink,
+} from '../state/tweak-state';
+import {
+  FIXTURE_CLUSTER,
+  FIXTURE_PANEL_CONFIG,
+  FIXTURE_TABS,
+} from './_test-helpers';
+import { __resetInstanceBindingsForTests } from '../index';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(prefix: string, overrides: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    storagePrefix: prefix,
+    consoleNamespace: prefix,
+    modalClassPrefix: `${prefix}-modal`,
+    schemaId: `${prefix}/v1`,
+    exportFilenameBase: prefix,
+    tabs: FIXTURE_TABS,
+    ...overrides,
+  };
+}
+
+function makeSinkSpy(): ApplySink & {
+  applyCalls: Array<ReadonlyArray<readonly [string, string]>>;
+  clearCalls: Array<readonly string[]>;
+} {
+  const applyCalls: Array<ReadonlyArray<readonly [string, string]>> = [];
+  const clearCalls: Array<readonly string[]> = [];
+  return {
+    applyCalls,
+    clearCalls,
+    apply(pairs) {
+      applyCalls.push(pairs);
+    },
+    clear(names) {
+      clearCalls.push(names);
+    },
+  };
+}
+
+function flatApplyPairs(
+  calls: Array<ReadonlyArray<readonly [string, string]>>,
+): Array<readonly [string, string]> {
+  return calls.flat();
+}
+
+function flatClearNames(calls: Array<readonly string[]>): string[] {
+  return calls.flat();
+}
+
+function fullTweakState() {
+  return {
+    color: initColorFromScheme(FIXTURE_CLUSTER),
+    spacing: { 'hsp-md': '20px' },
+    typography: {},
+    size: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+let setPropertySpy: ReturnType<typeof vi.spyOn>;
+let removePropertySpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  setPropertySpy = vi.spyOn(document.documentElement.style, 'setProperty');
+  removePropertySpy = vi.spyOn(document.documentElement.style, 'removeProperty');
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+  __resetInstanceBindingsForTests();
+  __resetPanelConfigForTests();
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  setPropertySpy.mockRestore();
+  removePropertySpy.mockRestore();
+  document.documentElement.removeAttribute('style');
+  document.documentElement.removeAttribute('data-theme');
+  __resetInstanceBindingsForTests();
+  __resetPanelConfigForTests();
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+// ---------------------------------------------------------------------------
+// 1. Two coexisting instances — separate storage keys, toggle events, roots
+// ---------------------------------------------------------------------------
+
+describe('two coexisting instances — independence of storage keys, toggle events, and mount roots', () => {
+  it('all three independence axes hold simultaneously for two registered instances', () => {
+    const cfgA = makeConfig('inst-alpha');
+    const cfgB = makeConfig('inst-beta');
+    const handleA = configurePanel(cfgA);
+    const handleB = configurePanel(cfgB);
+
+    // Handles are distinct objects with distinct instanceIds
+    expect(handleA).not.toBe(handleB);
+    expect(handleA.instanceId).toBe('inst-alpha');
+    expect(handleB.instanceId).toBe('inst-beta');
+
+    // Toggle event channels are independent — derived from each instance's registered config
+    expect(toggleEventName(cfgA)).toBe('toggle-inst-alpha');
+    expect(toggleEventName(cfgB)).toBe('toggle-inst-beta');
+    expect(toggleEventName(cfgA)).not.toBe(toggleEventName(cfgB));
+
+    // Mount root ids are independent
+    expect(panelRootId(cfgA)).toBe('inst-alpha-root');
+    expect(panelRootId(cfgB)).toBe('inst-beta-root');
+    expect(panelRootId(cfgA)).not.toBe(panelRootId(cfgB));
+
+    // Storage keys are independent (derived from registered config prefix, not just pure function)
+    expect(storageKey_open(cfgA)).not.toBe(storageKey_open(cfgB));
+    expect(storageKey_stateV3(cfgA)).not.toBe(storageKey_stateV3(cfgB));
+    expect(storageKey_stateV3(cfgA)).toBe('inst-alpha-state-v3');
+    expect(storageKey_stateV3(cfgB)).toBe('inst-beta-state-v3');
+  });
+
+  it('writing a localStorage entry for one instance does NOT contaminate the other', () => {
+    const cfgA = makeConfig('inst-alpha');
+    const cfgB = makeConfig('inst-beta');
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // Simulate alpha writing its open-state key (keyed by prefix)
+    localStorage.setItem(storageKey_open(cfgA), '1');
+
+    expect(localStorage.getItem(storageKey_open(cfgA))).toBe('1');
+    expect(localStorage.getItem(storageKey_open(cfgB))).toBeNull(); // beta unaffected
+  });
+
+  it('toggle event for the default prefix keeps the historical public name', () => {
+    // The default prefix must use 'toggle-design-token-panel' for backward compat;
+    // non-default prefixes get per-instance channels.
+    const cfgDefault = makeConfig('zudo-design-token-panel');
+    const cfgNonDefault = makeConfig('inst-alpha');
+    configurePanel(cfgDefault);
+    configurePanel(cfgNonDefault);
+
+    expect(toggleEventName(cfgDefault)).toBe('toggle-design-token-panel');
+    expect(toggleEventName(cfgNonDefault)).toBe('toggle-inst-alpha');
+    expect(toggleEventName(cfgNonDefault)).not.toBe('toggle-design-token-panel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. destroy() isolation — one sink instance torn down, other still applies
+// ---------------------------------------------------------------------------
+
+describe('destroy() isolation — sink instance torn down, other instance still applies', () => {
+  it('after destroying instance A, instance B (the new default) routes apply through its sink via registry lookup', () => {
+    // This test drives applyFullState WITHOUT an explicit cfg arg so it resolves
+    // the default instance from the registry. After A is destroyed, B becomes the
+    // default, so the no-arg call must reach sinkB — verifying the registry fallback.
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    const handleA = configurePanel(cfgA);
+    configurePanel(cfgB); // B is now the default
+
+    // Destroy A — B should become the new default
+    handleA.destroy();
+
+    // No-arg call resolves the default from the registry (should now be B)
+    const state = fullTweakState();
+    applyFullState(state); // no cfg — uses getPanelConfig() → B
+
+    // B's sink must have received the writes via the registry default
+    expect(flatApplyPairs(sinkB.applyCalls).length).toBeGreaterThan(0);
+    // A's sink never received anything (A was destroyed before any apply)
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBe(0);
+  });
+
+  it('after destroying instance A, clearAppliedStyles via registry still routes to B\'s sink', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    const handleA = configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    handleA.destroy();
+
+    // No-arg clear — resolves default from registry (B), must route to sinkB
+    clearAppliedStyles();
+
+    expect(flatClearNames(sinkB.clearCalls).length).toBeGreaterThan(0);
+    // :root must not be touched (B has a sink)
+    expect(removePropertySpy).not.toHaveBeenCalled();
+    // A's sink was never called
+    expect(flatClearNames(sinkA.clearCalls).length).toBe(0);
+  });
+
+  it('after destroying one instance, getPanelConfig() resolves to the remaining instance', () => {
+    const cfgA = makeConfig('inst-alpha');
+    const cfgB = makeConfig('inst-beta');
+    configurePanel(cfgA);
+    configurePanel(cfgB); // B is the default after this
+
+    expect(getPanelConfig().storagePrefix).toBe('inst-beta');
+
+    // Destroy B — A should become the new default
+    const handleB = configurePanel(cfgB); // idempotent — same handle
+    handleB.destroy();
+
+    // Registry should now resolve to A as the default instance
+    expect(getPanelConfig().storagePrefix).toBe('inst-alpha');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Same-prefix reconfigure rule: reject-with-error + destroy escape hatch
+// ---------------------------------------------------------------------------
+
+describe('same-prefix reconfigure rule (RECONFIGURE_RULE = reject-with-error) — destroy escape hatch', () => {
+  it('destroy() then configurePanel() with new config for same prefix succeeds', () => {
+    // Without destroy the same-prefix-different-config rule throws (covered in
+    // panel-config.test.ts). This test exercises the escape hatch: destroy first,
+    // then re-configure the same prefix with a structurally-different config.
+    const cfg = makeConfig('inst-alpha');
+    const handle = configurePanel(cfg);
+
+    const newCfg = { ...cfg, consoleNamespace: 'alpha-v2' };
+    // Pre-destroy: must still throw
+    expect(() => configurePanel(newCfg)).toThrow(/already called with different values/);
+
+    // Destroy first, then re-configure
+    handle.destroy();
+    expect(() => configurePanel(newCfg)).not.toThrow();
+    // The re-configured instance is now the default
+    expect(getPanelConfig().consoleNamespace).toBe('alpha-v2');
+  });
+
+  it('destroy() + re-configure + apply works end-to-end with a new sink', () => {
+    const sinkV1 = makeSinkSpy();
+    const sinkV2 = makeSinkSpy();
+
+    const cfg = makeConfig('inst-alpha', { applySink: sinkV1 });
+    const handle = configurePanel(cfg);
+    handle.destroy();
+
+    // Re-configure with new sink
+    const newCfg = makeConfig('inst-alpha', { applySink: sinkV2 });
+    const newHandle = configurePanel(newCfg);
+    expect(newHandle.instanceId).toBe('inst-alpha');
+
+    // Apply via the re-configured instance
+    applyFullState(fullTweakState(), newCfg);
+
+    // New sink received writes; old sink did not
+    expect(flatApplyPairs(sinkV2.applyCalls).length).toBeGreaterThan(0);
+    expect(flatApplyPairs(sinkV1.applyCalls).length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Apply-sink routing with TWO instances — writes to A never reach B's sink
+// ---------------------------------------------------------------------------
+
+describe('apply-sink routing — two instances with distinct sinks do not cross-talk', () => {
+  it('applyFullState on instance A only calls sinkA.apply, not sinkB.apply', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    const state = fullTweakState();
+    applyFullState(state, cfgA);
+
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBeGreaterThan(0);
+    expect(flatApplyPairs(sinkB.applyCalls).length).toBe(0);
+  });
+
+  it('applyFullState on instance B only calls sinkB.apply, not sinkA.apply', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    const state = fullTweakState();
+    applyFullState(state, cfgB);
+
+    expect(flatApplyPairs(sinkB.applyCalls).length).toBeGreaterThan(0);
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBe(0);
+  });
+
+  it('clearAppliedStyles on instance A only calls sinkA.clear, not sinkB.clear', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    clearAppliedStyles(undefined, cfgA);
+
+    expect(flatClearNames(sinkA.clearCalls).length).toBeGreaterThan(0);
+    expect(flatClearNames(sinkB.clearCalls).length).toBe(0);
+    // :root must not be touched
+    expect(removePropertySpy).not.toHaveBeenCalled();
+  });
+
+  it('applyColorState routes only to the explicitly provided sink, not to a second instance sink', () => {
+    const sinkA = makeSinkSpy();
+    const sinkB = makeSinkSpy();
+
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta', { applySink: sinkB });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // applyColorState takes the sink explicitly — call with sinkA
+    const state = initColorFromScheme(FIXTURE_CLUSTER);
+    applyColorState(state, FIXTURE_CLUSTER, sinkA);
+
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBeGreaterThan(0);
+    expect(flatApplyPairs(sinkB.applyCalls).length).toBe(0);
+    expect(setPropertySpy).not.toHaveBeenCalled();
+  });
+
+  it('apply from one instance does not write to :root when the other instance has no sink', () => {
+    const sinkA = makeSinkSpy();
+    // cfgB has NO sink — it would write to :root if called
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = makeConfig('inst-beta'); // no sink
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // Apply only via A (which has sink)
+    applyFullState(fullTweakState(), cfgA);
+
+    // :root still clean — A has a sink
+    expect(setPropertySpy).not.toHaveBeenCalled();
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Default-instance backward-compat parity — no-sink path unchanged
+// ---------------------------------------------------------------------------
+
+describe('default-instance backward compat — no-sink path writes to :root (spy parity)', () => {
+  it('applyFullState without a sink calls setProperty on document.documentElement', () => {
+    const cfgDefault = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS };
+    configurePanel(cfgDefault);
+
+    applyFullState(fullTweakState(), cfgDefault);
+
+    expect(setPropertySpy).toHaveBeenCalled();
+    const calls = setPropertySpy.mock.calls.map(([name]: [string]) => name);
+    // Palette vars
+    for (let i = 0; i < FIXTURE_CLUSTER.paletteSize; i++) {
+      expect(calls).toContain(`--fixture-p${i}`);
+    }
+    // Semantic vars
+    expect(calls).toContain('--fixture-semantic-accent');
+    // Spacing var
+    expect(calls).toContain('--zd-spacing-hgap-md');
+  });
+
+  it('clearAppliedStyles without a sink calls removeProperty on document.documentElement', () => {
+    const cfgDefault = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS };
+    configurePanel(cfgDefault);
+
+    // Seed a var first
+    document.documentElement.style.setProperty('--fixture-p0', '#ff0000');
+    setPropertySpy.mockClear();
+
+    clearAppliedStyles(undefined, cfgDefault);
+
+    expect(removePropertySpy).toHaveBeenCalled();
+  });
+
+  it('when one instance has a sink and one does not, the no-sink instance still writes to :root', () => {
+    const sinkA = makeSinkSpy();
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgB = { ...FIXTURE_PANEL_CONFIG, storagePrefix: 'inst-beta', tabs: FIXTURE_TABS };
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // Apply through the no-sink instance B
+    applyFullState(fullTweakState(), cfgB);
+
+    expect(setPropertySpy).toHaveBeenCalled();
+    // sinkA was not involved
+    expect(flatApplyPairs(sinkA.applyCalls).length).toBe(0);
+  });
+
+  it('default path setProperty calls are not affected by a separate sink-instance being registered', () => {
+    const sinkA = makeSinkSpy();
+    const cfgA = makeConfig('inst-alpha', { applySink: sinkA });
+    const cfgDefault = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS };
+    configurePanel(cfgA);
+    configurePanel(cfgDefault);
+
+    applyFullState(fullTweakState(), cfgDefault);
+
+    // The default path must still write its full set of vars
+    const calls = setPropertySpy.mock.calls.map(([name]: [string]) => name);
+    for (let i = 0; i < FIXTURE_CLUSTER.paletteSize; i++) {
+      expect(calls).toContain(`--fixture-p${i}`);
+    }
+    expect(calls).toContain('--fixture-semantic-accent');
+  });
+
+  it('resetted no-sink instance calls removeProperty for all tab vars', () => {
+    const cfgDefault = { ...FIXTURE_PANEL_CONFIG, tabs: FIXTURE_TABS };
+    configurePanel(cfgDefault);
+
+    // Seed a spacing var
+    document.documentElement.style.setProperty('--zd-spacing-hgap-md', '99px');
+    setPropertySpy.mockClear();
+
+    clearAppliedStyles(undefined, cfgDefault);
+
+    const removedNames = removePropertySpy.mock.calls.map(([name]: [string]) => name);
+    expect(removedNames).toContain('--zd-spacing-hgap-md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. apply + clear pair — same sink instance, complete upsert/remove cycle
+// ---------------------------------------------------------------------------
+
+describe('apply + clear cycle — sink upsert then remove', () => {
+  it('apply followed by clear sends all names through the same sink', () => {
+    const sink = makeSinkSpy();
+    const cfg = makeConfig('inst-alpha', { applySink: sink });
+    configurePanel(cfg);
+
+    // Apply (upsert)
+    applyFullState(fullTweakState(), cfg);
+    const applied = flatApplyPairs(sink.applyCalls);
+    expect(applied.length).toBeGreaterThan(0);
+
+    // Clear (remove) — must receive all var names known to this instance
+    clearAppliedStyles(undefined, cfg);
+    const cleared = flatClearNames(sink.clearCalls);
+    expect(cleared.length).toBeGreaterThan(0);
+
+    // :root not touched throughout
+    expect(setPropertySpy).not.toHaveBeenCalled();
+    expect(removePropertySpy).not.toHaveBeenCalled();
+  });
+
+  it('clear sends the FULL token-name set even when no previous apply was called', () => {
+    const sink = makeSinkSpy();
+    const cfg = makeConfig('inst-alpha', { applySink: sink });
+    configurePanel(cfg);
+
+    // Clear without any prior apply — must still send the full set
+    clearAppliedStyles(undefined, cfg);
+
+    const cleared = flatClearNames(sink.clearCalls);
+    expect(cleared.length).toBeGreaterThan(0);
+    // Should contain palette vars
+    expect(cleared).toContain('--fixture-p0');
+    // Should contain non-color tab vars
+    expect(cleared).toContain('--zd-spacing-hgap-md');
+  });
+});

--- a/packages/zdtp/src/__tests__/panel-config-globalthis.test.ts
+++ b/packages/zdtp/src/__tests__/panel-config-globalthis.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   configurePanel as ConfigurePanelFn,
   getPanelConfig as GetPanelConfigFn,
+  registerPostConfigureHook as RegisterHookFn,
   __resetPanelConfigForTests as ResetFn,
   PanelConfig,
 } from '../config/panel-config';
@@ -133,5 +134,28 @@ describe('panel-config globalThis singleton — multi-instance isolation', () =>
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it('a pre-configure hook registered via instance A still fires when instance B configures (#111 cross-chunk)', async () => {
+    // Regression guard for the multi-instance lift (#353 Z1): the pending
+    // pre-configure hook list MUST live on the shared globalThis registry, not
+    // in module scope. index.tsx (chunk A) registers POST_CONFIGURE_REAPPLY_HOOK
+    // before the host adapter (chunk B) calls configurePanel. If the pending
+    // list were module-scoped, chunk B would drain an empty list and the #111
+    // reapply hook would never run on first load.
+    const instanceA = await import('../config/panel-config');
+
+    const hook = vi.fn();
+    // Register through instance A BEFORE any configure call.
+    (instanceA.registerPostConfigureHook as typeof RegisterHookFn)(hook);
+    expect(hook).not.toHaveBeenCalled();
+
+    vi.resetModules();
+    const instanceB = await import('../config/panel-config');
+    expect(instanceA.configurePanel).not.toBe(instanceB.configurePanel);
+
+    // Configure through instance B — the hook parked via A must fire exactly once.
+    (instanceB.configurePanel as typeof ConfigurePanelFn)(BASE_CONFIG);
+    expect(hook).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/zdtp/src/__tests__/panel-config.test.ts
+++ b/packages/zdtp/src/__tests__/panel-config.test.ts
@@ -123,7 +123,44 @@ describe('panel-config — derivation flips with a non-default config', () => {
   });
 });
 
-describe('panel-config — configurePanel idempotency', () => {
+describe('panel-config — configurePanel idempotency (per prefix)', () => {
+  const CONFIG_A: PanelConfig = {
+    storagePrefix: 'aaa',
+    consoleNamespace: 'aaa',
+    modalClassPrefix: 'aaa-modal',
+    schemaId: 'aaa/v1',
+    exportFilenameBase: 'aaa',
+    tabs: [],
+  };
+
+  /** Same prefix as CONFIG_A but a structurally-different non-prefix field. */
+  const CONFIG_A_CONFLICT: PanelConfig = {
+    ...CONFIG_A,
+    consoleNamespace: 'aaa-renamed',
+  };
+
+  it('calling configurePanel twice with identical values is a no-op (does not throw)', () => {
+    configurePanel(CONFIG_A);
+    expect(() => configurePanel({ ...CONFIG_A })).not.toThrow();
+    expect(getPanelConfig()).toEqual(CONFIG_A);
+  });
+
+  it('idempotent re-call for the same prefix returns the SAME handle', () => {
+    const handle = configurePanel(CONFIG_A);
+    const again = configurePanel({ ...CONFIG_A });
+    expect(again).toBe(handle);
+    expect(again.instanceId).toBe('aaa');
+  });
+
+  it('same prefix but structurally-different config throws (reconfigure rule: reject-with-error)', () => {
+    configurePanel(CONFIG_A);
+    expect(() => configurePanel(CONFIG_A_CONFLICT)).toThrow(/already called with different values/);
+    // The first config is preserved — the conflicting call did not overwrite it.
+    expect(getPanelConfig()).toEqual(CONFIG_A);
+  });
+});
+
+describe('panel-config — multi-instance registry (distinct prefixes)', () => {
   const CONFIG_A: PanelConfig = {
     storagePrefix: 'aaa',
     consoleNamespace: 'aaa',
@@ -142,17 +179,58 @@ describe('panel-config — configurePanel idempotency', () => {
     tabs: [],
   };
 
-  it('calling configurePanel twice with identical values is a no-op (does not throw)', () => {
+  it('a distinct prefix registers a second instance without throwing', () => {
     configurePanel(CONFIG_A);
-    expect(() => configurePanel({ ...CONFIG_A })).not.toThrow();
+    expect(() => configurePanel(CONFIG_B)).not.toThrow();
+  });
+
+  it('returns distinct handles whose instanceId equals the storagePrefix', () => {
+    const handleA = configurePanel(CONFIG_A);
+    const handleB = configurePanel(CONFIG_B);
+    expect(handleA).not.toBe(handleB);
+    expect(handleA.instanceId).toBe('aaa');
+    expect(handleB.instanceId).toBe('bbb');
+  });
+
+  it('the most-recently-configured instance becomes the default getPanelConfig() returns', () => {
+    configurePanel(CONFIG_A);
+    configurePanel(CONFIG_B);
+    // CONFIG_B was configured last → it is the active/default instance.
+    expect(getPanelConfig()).toEqual(CONFIG_B);
+  });
+
+  it('two instances derive independent storage keys / root ids from their prefixes', () => {
+    const handleA = configurePanel(CONFIG_A);
+    const handleB = configurePanel(CONFIG_B);
+    void handleA;
+    void handleB;
+    // Storage keys are a pure function of storagePrefix → fully independent.
+    expect(storageKey_stateV3(CONFIG_A)).toBe('aaa-state-v3');
+    expect(storageKey_stateV3(CONFIG_B)).toBe('bbb-state-v3');
+    expect(storageKey_open(CONFIG_A)).toBe('aaa-open');
+    expect(storageKey_open(CONFIG_B)).toBe('bbb-open');
+    expect(panelRootId(CONFIG_A)).toBe('aaa-root');
+    expect(panelRootId(CONFIG_B)).toBe('bbb-root');
+  });
+
+  it('destroy() deregisters an instance and re-points the default to the remaining one', () => {
+    const handleA = configurePanel(CONFIG_A);
+    configurePanel(CONFIG_B);
+    // B is the default; destroying B falls the default back to A.
+    const handleB = configurePanel(CONFIG_B); // idempotent — same handle as before
+    void handleA;
+    handleB.destroy();
     expect(getPanelConfig()).toEqual(CONFIG_A);
   });
 
-  it('calling configurePanel twice with different values throws', () => {
-    configurePanel(CONFIG_A);
-    expect(() => configurePanel(CONFIG_B)).toThrow(/already called with different values/);
-    // The first config is preserved — the second call did not silently overwrite.
-    expect(getPanelConfig()).toEqual(CONFIG_A);
+  it('destroy() then re-configure the same prefix with a different config no longer throws', () => {
+    const handleA = configurePanel(CONFIG_A);
+    handleA.destroy();
+    // After destroy the prefix is free — a fresh config under the same prefix
+    // is accepted (the reconfigure escape hatch documented on RECONFIGURE_RULE).
+    const reconfigured: PanelConfig = { ...CONFIG_A, consoleNamespace: 'aaa-v2' };
+    expect(() => configurePanel(reconfigured)).not.toThrow();
+    expect(getPanelConfig()).toEqual(reconfigured);
   });
 });
 

--- a/packages/zdtp/src/apply-modal.tsx
+++ b/packages/zdtp/src/apply-modal.tsx
@@ -37,7 +37,11 @@ import {
   resolveSecondaryColorCluster,
   type PanelConfig,
 } from './config/panel-config';
-import { type ColorTweakState, type TweakState } from './state/tweak-state';
+import {
+  getActivePrimaryCluster,
+  type ColorTweakState,
+  type TweakState,
+} from './state/tweak-state';
 import { serialize } from './utils/design-token-serde';
 
 const COPY_REVERT_MS = 2000;
@@ -276,8 +280,14 @@ export function ApplyModal(props: ApplyModalProps) {
   }, [copyLabel]);
 
   const flattenedOverrides = useMemo(() => {
+    // Resolve THIS instance's primary cluster + tabs so the payload's CSS-var
+    // names / tab token set come from the panel that's applying — NOT the active
+    // default instance (#357). Without this, panel A would POST A's endpoint with
+    // vars/tabs derived from default panel B (wrong token names → rejects or
+    // edits to the wrong tokens).
+    const primaryCluster = getActivePrimaryCluster(cfg);
     // Primary zd cluster — diffed against the scheme baseline.
-    const zdOverrides = buildApplyOverrides(state, colorDefaults);
+    const zdOverrides = buildApplyOverrides(state, colorDefaults, primaryCluster, cfg.tabs);
     // Optional secondary cluster. Three short-circuits:
     //
     //   1. Host opted out (`secondaryColorCluster: null`) — `secondaryCluster`
@@ -292,7 +302,12 @@ export function ApplyModal(props: ApplyModalProps) {
     const secondaryCluster = resolveSecondaryColorCluster(cfg);
     const secondaryOverrides =
       secondaryCluster && state.secondary
-        ? buildApplyOverrides({ ...state, color: state.secondary }, undefined, secondaryCluster)
+        ? buildApplyOverrides(
+            { ...state, color: state.secondary },
+            undefined,
+            secondaryCluster,
+            cfg.tabs,
+          )
         : {};
     return { ...zdOverrides, ...secondaryOverrides };
   }, [state, colorDefaults, cfg]);

--- a/packages/zdtp/src/apply-modal.tsx
+++ b/packages/zdtp/src/apply-modal.tsx
@@ -35,6 +35,7 @@ import {
   modalClass,
   resolveApplyRouting,
   resolveSecondaryColorCluster,
+  type PanelConfig,
 } from './config/panel-config';
 import { type ColorTweakState, type TweakState } from './state/tweak-state';
 import { serialize } from './utils/design-token-serde';
@@ -58,6 +59,15 @@ export interface ApplyModalProps {
    * clear any inline-applied styles, and reset in-memory state to empty.
    */
   onApplied: () => void;
+  /**
+   * The mounted panel instance's config (multi-instance, #357). When supplied,
+   * the modal resolves its apply routing / endpoint / secondary cluster / modal
+   * classes from THIS instance rather than the active default instance — so an
+   * Apply on panel A targets A's endpoint+routing, not whichever instance was
+   * configured last. Omitted (e.g. a direct test render) → `getPanelConfig()`,
+   * preserving the single-panel path.
+   */
+  instanceConfig?: PanelConfig;
 }
 
 /**
@@ -206,10 +216,13 @@ function buildClasses(cfg: ReturnType<typeof getPanelConfig>): ModalClasses {
 // ---------------------------------------------------------------------------
 
 export function ApplyModal(props: ApplyModalProps) {
-  const { state, open, onClose, colorDefaults, onApplied } = props;
+  const { state, open, onClose, colorDefaults, onApplied, instanceConfig } = props;
   const dialogRef = useRef<HTMLDialogElement | null>(null);
   const primaryButtonRef = useRef<HTMLDivElement | null>(null);
-  const cfg = getPanelConfig();
+  // Resolve THIS instance's config (multi-instance, #357): the mounted panel
+  // passes its `instanceConfig`; a prop-less test render falls back to the
+  // active default instance.
+  const cfg = instanceConfig ?? getPanelConfig();
   const cls = useMemo(() => buildClasses(cfg), [cfg]);
 
   // Instance-scoped id for aria-labelledby. useId() ensures uniqueness when

--- a/packages/zdtp/src/astro/host-adapter.ts
+++ b/packages/zdtp/src/astro/host-adapter.ts
@@ -56,6 +56,7 @@ import {
   storageKey_stateV3,
   storageKey_visible,
   type PanelConfig,
+  type PanelInstanceHandle,
 } from '../config/panel-config';
 import { ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } from '../state/tweak-state';
 
@@ -219,23 +220,42 @@ async function loadPanelModule(state: DesignTokenPanelAdapterState) {
   return state.modulePromise;
 }
 
+/**
+ * Install the console API on `window[namespace]`, bound to THIS instance's
+ * handle (multi-instance, #357).
+ *
+ * The handlers must target the instance whose namespace they were installed
+ * under — NOT `getPanelConfig()` at call time. Previously they called the
+ * no-arg exports (`panel.showDesignTokenPanel()` etc.), which resolve the
+ * most-recently-configured (default) instance: once a SECOND instance was
+ * configured, namespace A's console call drove instance B. Binding to the
+ * instance `handle` (captured at install time, keyed by its `storagePrefix`)
+ * keeps namespace A's console call driving instance A regardless of which
+ * instance is the active default.
+ *
+ * `handle.open/close/toggle` route through the per-instance lifecycle hooks the
+ * panel module installs at load. We still `await loadPanelModule(state)` first
+ * so those hooks are installed (and the panel root materialises) before the
+ * handle method fires — otherwise the handle methods are no-ops.
+ */
 function installConsoleApi(
   win: AdapterWindow,
   namespace: string,
   state: DesignTokenPanelAdapterState,
+  handle: PanelInstanceHandle,
 ): void {
   const existing = (win[namespace] as ConsoleApiSurface | undefined) ?? {};
   existing.showDesignPanel = async () => {
-    const panel = await loadPanelModule(state);
-    panel.showDesignTokenPanel();
+    await loadPanelModule(state);
+    handle.open();
   };
   existing.hideDesignPanel = async () => {
-    const panel = await loadPanelModule(state);
-    panel.hideDesignTokenPanel();
+    await loadPanelModule(state);
+    handle.close();
   };
   existing.toggleDesignPanel = async () => {
-    const panel = await loadPanelModule(state);
-    panel.toggleDesignPanel();
+    await loadPanelModule(state);
+    handle.toggle();
   };
   win[namespace] = existing;
 }
@@ -258,7 +278,10 @@ function installConsoleApi(
   const config: PanelConfig = inline.legacyIdRenameMap
     ? inline
     : { ...inline, legacyIdRenameMap: { ...ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP } };
-  configurePanel(config);
+  // Capture THIS instance's handle (keyed by its storagePrefix). The console
+  // handlers bind to it so a namespace's console call always targets ITS
+  // instance, never whichever instance was configured last (#357).
+  const handle = configurePanel(config);
 
   // Re-read via `getPanelConfig()` so the storage/namespace derivations use
   // the canonical source. (`configurePanel` shallow-clones, so `config` and
@@ -270,8 +293,8 @@ function installConsoleApi(
 
   // 2. Install console API every time — `bound` only gates the lazy-load
   //    probes, since the console handlers are idempotent (re-assigning the
-  //    same closures is a no-op semantically).
-  installConsoleApi(win, cfg.consoleNamespace, state);
+  //    same closures is a no-op semantically). Bind to this instance's handle.
+  installConsoleApi(win, cfg.consoleNamespace, state, handle);
 
   if (state.bound) return;
   state.bound = true;

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -283,13 +283,32 @@ interface InstanceRegistry {
    * prefix to key on yet — it mirrors the historical global holding slot.
    */
   pendingColorPresets: Record<string, ColorScheme> | null;
+  /**
+   * Post-configure hooks registered via `registerPostConfigureHook` BEFORE any
+   * instance was configured. Drained into the first instance to be configured.
+   *
+   * MUST live on the shared registry (not module scope): in Vite/Astro
+   * multi-entry builds, `index.tsx` registers POST_CONFIGURE_REAPPLY_HOOK from
+   * one `panel-config` module instance while the host adapter calls
+   * `configurePanel` through another. The two instances share this registry via
+   * the globalThis symbol, so the configuring side sees the hook the
+   * registering side parked. A module-scoped array would be per-chunk — the
+   * configuring chunk would drain an empty list and the #111 reapply hook would
+   * never fire on first load.
+   */
+  pendingPostConfigureHooks: (() => void)[];
 }
 
 function getRegistry(): InstanceRegistry {
   const g = globalThis as unknown as Record<symbol, InstanceRegistry | undefined>;
   let registry = g[REGISTRY_SYMBOL];
   if (!registry) {
-    registry = { instances: new Map(), defaultPrefix: null, pendingColorPresets: null };
+    registry = {
+      instances: new Map(),
+      defaultPrefix: null,
+      pendingColorPresets: null,
+      pendingPostConfigureHooks: [],
+    };
     g[REGISTRY_SYMBOL] = registry;
   }
   return registry;
@@ -420,8 +439,8 @@ export function configurePanel(config: PanelConfig): PanelInstanceHandle {
   // hooks — they target "the default single-panel instance" and there is no
   // ambiguity until a second instance appears.
   const isFirstInstance = registry.instances.size === 0;
-  const adoptedHooks = isFirstInstance ? [...pendingPostConfigureHooks] : [];
-  if (isFirstInstance) pendingPostConfigureHooks.length = 0;
+  const adoptedHooks = isFirstInstance ? [...registry.pendingPostConfigureHooks] : [];
+  if (isFirstInstance) registry.pendingPostConfigureHooks.length = 0;
   const record: PanelInstanceRecord = {
     config: installedConfig,
     pendingColorPresets: null,
@@ -472,10 +491,13 @@ function getDefaultRecord(): PanelInstanceRecord | null {
 export function registerPostConfigureHook(hook: () => void): void {
   const record = getDefaultRecord();
   if (record === null) {
-    // No instance configured yet — park the hook so the next configurePanel
-    // attaches and runs it. Mirrors the historical pre-configure behaviour.
-    if (pendingPostConfigureHooks.includes(hook)) return;
-    pendingPostConfigureHooks.push(hook);
+    // No instance configured yet — park the hook on the SHARED registry so the
+    // next configurePanel (possibly from a different code-split module instance
+    // in a Vite/Astro multi-entry build) attaches and runs it. Mirrors the
+    // historical globalThis-slot pre-configure behaviour.
+    const registry = getRegistry();
+    if (registry.pendingPostConfigureHooks.includes(hook)) return;
+    registry.pendingPostConfigureHooks.push(hook);
     return;
   }
   if (record.postConfigureHooks.includes(hook)) return; // idempotent on reference
@@ -484,14 +506,6 @@ export function registerPostConfigureHook(hook: () => void): void {
   // index.tsx module-init and configurePanel is non-load-bearing.
   hook();
 }
-
-/**
- * Hooks registered via `registerPostConfigureHook` BEFORE any instance was
- * configured. Drained into the first instance to be configured. Module-scope
- * (not on the registry) is acceptable: index.tsx's single module-init registers
- * exactly one stable hook here, and `configurePanel` drains it on first use.
- */
-const pendingPostConfigureHooks: (() => void)[] = [];
 
 /**
  * Read the active panel config. Returns the config of the default (most-
@@ -512,7 +526,7 @@ export function __resetPanelConfigForTests(): void {
   registry.instances.clear();
   registry.defaultPrefix = null;
   registry.pendingColorPresets = null;
-  pendingPostConfigureHooks.length = 0;
+  registry.pendingPostConfigureHooks.length = 0;
 }
 
 // Re-export cluster resolution helpers so callers can import from panel-config

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -308,6 +308,16 @@ interface InstanceRegistry {
    * never fire on first load.
    */
   pendingPostConfigureHooks: (() => void)[];
+  /**
+   * Z2 per-instance lifecycle hooks (configured / open / close / toggle /
+   * destroy). MUST live on the shared registry for the same reason as
+   * `pendingPostConfigureHooks`: in Vite/Astro multi-entry builds `index.tsx`
+   * installs the hooks from one `panel-config` module instance while
+   * `configurePanel` fires the `configured` hook from another. A module-scoped
+   * object would be per-chunk — the configuring chunk would see unset hooks and
+   * second+ instances would never bind their per-instance toggle events.
+   */
+  lifecycleHooks: PanelLifecycleHooks;
 }
 
 function getRegistry(): InstanceRegistry {
@@ -319,6 +329,7 @@ function getRegistry(): InstanceRegistry {
       defaultPrefix: null,
       pendingColorPresets: null,
       pendingPostConfigureHooks: [],
+      lifecycleHooks: {},
     };
     g[REGISTRY_SYMBOL] = registry;
   }
@@ -339,19 +350,19 @@ function makeHandle(prefix: string): PanelInstanceHandle {
   return {
     instanceId: prefix,
     open() {
-      panelLifecycleHooks.open?.(prefix);
+      getRegistry().lifecycleHooks.open?.(prefix);
     },
     close() {
-      panelLifecycleHooks.close?.(prefix);
+      getRegistry().lifecycleHooks.close?.(prefix);
     },
     toggle() {
-      panelLifecycleHooks.toggle?.(prefix);
+      getRegistry().lifecycleHooks.toggle?.(prefix);
     },
     destroy() {
       // Model-level cleanup: drop the instance from the registry. Z2 extends
-      // this via `panelLifecycleHooks.destroy` to also unmount the Preact tree
+      // this via the `destroy` lifecycle hook to also unmount the Preact tree
       // and remove the DOM root.
-      panelLifecycleHooks.destroy?.(prefix);
+      getRegistry().lifecycleHooks.destroy?.(prefix);
       const registry = getRegistry();
       registry.instances.delete(prefix);
       if (registry.defaultPrefix === prefix) {
@@ -392,20 +403,25 @@ export interface PanelLifecycleHooks {
   destroy?: (instanceId: string) => void;
 }
 
-const panelLifecycleHooks: PanelLifecycleHooks = {};
-
 /**
  * Z2 seam: install per-instance lifecycle handlers used by every instance
  * handle's open/close/toggle/destroy plus the per-configure `configured` hook.
  * Last call wins (Z2 owns its own idempotency). No-op-friendly: unset handlers
  * leave the corresponding hook a no-op.
+ *
+ * Stored on the SHARED globalThis registry (not module scope) so the install
+ * side (`index.tsx`) and the fire side (`configurePanel`) observe the same
+ * hooks even when a Vite/Astro multi-entry build code-splits `panel-config`
+ * into two module instances — mirrors `pendingPostConfigureHooks`.
  */
 export function __setPanelLifecycleHooks(hooks: PanelLifecycleHooks): void {
-  panelLifecycleHooks.configured = hooks.configured;
-  panelLifecycleHooks.open = hooks.open;
-  panelLifecycleHooks.close = hooks.close;
-  panelLifecycleHooks.toggle = hooks.toggle;
-  panelLifecycleHooks.destroy = hooks.destroy;
+  getRegistry().lifecycleHooks = {
+    configured: hooks.configured,
+    open: hooks.open,
+    close: hooks.close,
+    toggle: hooks.toggle,
+    destroy: hooks.destroy,
+  };
 }
 
 /**
@@ -482,7 +498,7 @@ export function configurePanel(config: PanelConfig): PanelInstanceHandle {
   // Fire the Z2 per-configure hook for THIS (every) instance, so the lifecycle
   // module can bind the instance's toggle-event channel at configure time —
   // including the 2nd+ instance that the post-configure-hook adoption skips.
-  panelLifecycleHooks.configured?.(prefix);
+  registry.lifecycleHooks.configured?.(prefix);
   return record.handle;
 }
 
@@ -541,6 +557,19 @@ export function registerPostConfigureHook(hook: () => void): void {
  */
 export function getPanelConfig(): PanelConfig {
   return getDefaultRecord()?.config ?? DEFAULT_PANEL_CONFIG;
+}
+
+/**
+ * Resolve the registered config for a SPECIFIC instance by its `storagePrefix`
+ * (=== `instanceId`), or `null` when no such instance is registered.
+ *
+ * Z2 uses this so a non-default panel mounts/operates against ITS OWN config
+ * (tabs, schema, apply settings, custom `toggleEvent`) instead of the active
+ * default instance's config — distinct instances stay fully independent even
+ * while another prefix is the active default.
+ */
+export function getPanelConfigByPrefix(prefix: string): PanelConfig | null {
+  return getRegistry().instances.get(prefix)?.config ?? null;
 }
 
 /**

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -79,6 +79,17 @@ export interface PanelConfig {
   /** Default filename base — exports save as `${exportFilenameBase}.json`. */
   exportFilenameBase: string;
   /**
+   * Optional window-event name that toggles THIS instance's panel.
+   *
+   * The default (single-panel) instance keeps the historical public event
+   * `toggle-design-token-panel` (plus its `toggle-color-tweak-panel` alias) and
+   * ignores this field — see `toggleEventName()`. A configured instance with a
+   * NON-default `storagePrefix` listens on this name; when omitted it defaults
+   * to `toggle-${storagePrefix}` so two panels on one page get independent
+   * toggle channels with no cross-talk.
+   */
+  toggleEvent?: string;
+  /**
    * Optional host-supplied color-scheme presets.
    *
    * Surfaces additional named `ColorScheme` entries in the Color tab's
@@ -364,6 +375,17 @@ function makeHandle(prefix: string): PanelInstanceHandle {
  * register without reaching into private module scope.
  */
 export interface PanelLifecycleHooks {
+  /**
+   * Fired ONCE per newly-registered instance, immediately after
+   * `configurePanel` installs it (and AFTER the instance's post-configure
+   * hooks run). Z2 uses this to bind the instance's per-instance toggle-event
+   * listener at configure time — unlike `registerPostConfigureHook` (which
+   * adopts parked hooks for the FIRST instance only), this fires for EVERY
+   * `configurePanel` call, including the 2nd+ instance, so a non-default
+   * panel's `toggle-${storagePrefix}` channel is live the moment it is
+   * configured.
+   */
+  configured?: (instanceId: string) => void;
   open?: (instanceId: string) => void;
   close?: (instanceId: string) => void;
   toggle?: (instanceId: string) => void;
@@ -374,11 +396,12 @@ const panelLifecycleHooks: PanelLifecycleHooks = {};
 
 /**
  * Z2 seam: install per-instance lifecycle handlers used by every instance
- * handle's open/close/toggle/destroy. Last call wins (Z2 owns its own
- * idempotency). No-op-friendly: unset handlers leave the corresponding handle
- * method a no-op.
+ * handle's open/close/toggle/destroy plus the per-configure `configured` hook.
+ * Last call wins (Z2 owns its own idempotency). No-op-friendly: unset handlers
+ * leave the corresponding hook a no-op.
  */
 export function __setPanelLifecycleHooks(hooks: PanelLifecycleHooks): void {
+  panelLifecycleHooks.configured = hooks.configured;
   panelLifecycleHooks.open = hooks.open;
   panelLifecycleHooks.close = hooks.close;
   panelLifecycleHooks.toggle = hooks.toggle;
@@ -456,6 +479,10 @@ export function configurePanel(config: PanelConfig): PanelInstanceHandle {
   for (const hook of record.postConfigureHooks) {
     hook();
   }
+  // Fire the Z2 per-configure hook for THIS (every) instance, so the lifecycle
+  // module can bind the instance's toggle-event channel at configure time —
+  // including the 2nd+ instance that the post-configure-hook adoption skips.
+  panelLifecycleHooks.configured?.(prefix);
   return record.handle;
 }
 
@@ -632,6 +659,54 @@ export function panelRootId(cfg: PanelConfig): string {
 }
 
 /**
+ * The public `storagePrefix` of the default (single-panel) instance. An
+ * instance whose prefix equals this keeps the historical public toggle-event
+ * name; every other prefix gets a per-instance channel. Kept in lockstep with
+ * `DEFAULT_PANEL_CONFIG.storagePrefix`.
+ */
+const DEFAULT_STORAGE_PREFIX = DEFAULT_PANEL_CONFIG.storagePrefix;
+
+/**
+ * Historical public toggle-event name. Hosts have shipped `window.dispatchEvent(
+ * new CustomEvent('toggle-design-token-panel'))` since the single-panel era, so
+ * the default instance MUST keep emitting/listening on this name regardless of
+ * its derived `toggle-${storagePrefix}` form.
+ */
+export const DEFAULT_TOGGLE_EVENT = 'toggle-design-token-panel';
+
+/**
+ * Window-event name that toggles this instance's panel.
+ *
+ *  - Default instance (prefix === `DEFAULT_STORAGE_PREFIX`): the historical
+ *    `toggle-design-token-panel`. The `index.tsx` listener additionally binds
+ *    the deprecated `toggle-color-tweak-panel` alias for this instance only.
+ *  - Configured instance (any other prefix): `cfg.toggleEvent` when supplied,
+ *    else `toggle-${storagePrefix}` — a per-instance channel so two panels do
+ *    not cross-talk.
+ */
+export function toggleEventName(cfg: PanelConfig): string {
+  if (cfg.storagePrefix === DEFAULT_STORAGE_PREFIX) return DEFAULT_TOGGLE_EVENT;
+  return cfg.toggleEvent ?? `toggle-${cfg.storagePrefix}`;
+}
+
+/** Base name of the internal per-instance open-state sync event (see below). */
+const OPEN_STATE_CHANGED_EVENT_BASE = '__zdtp:open-state-changed';
+
+/**
+ * Per-instance internal sync event name. `index.tsx` dispatches this on
+ * `window` after writing `localStorage[OPEN_KEY]`; the mounted `panel.tsx`
+ * listens for it and re-reads `OPEN_KEY`. Keyed by `storagePrefix` so a change
+ * to panel A's open state only pokes panel A's listener — two panels on one
+ * page stay fully independent (issue #354).
+ *
+ * Internal (double-underscore prefix) — NOT part of the public DOM contract;
+ * hosts must dispatch the public toggle event, never this one.
+ */
+export function openStateChangedEventName(cfg: PanelConfig): string {
+  return `${OPEN_STATE_CHANGED_EVENT_BASE}:${cfg.storagePrefix}`;
+}
+
+/**
  * BEM-style modal class. Pass an empty `suffix` for the base block, or
  * `'--export'` / `'__title'` etc. for elements / modifiers.
  */
@@ -679,6 +754,14 @@ export function assertValidPanelConfig(value: unknown): asserts value is PanelCo
   assertValidTabs(cfg.tabs);
 
   // Optional fields — only validate when present.
+  if (
+    cfg.toggleEvent !== undefined &&
+    (typeof cfg.toggleEvent !== 'string' || (cfg.toggleEvent as string).length === 0)
+  ) {
+    throw new Error(
+      `[design-token-panel] PanelConfig.toggleEvent must be a non-empty string when set (got ${typeof cfg.toggleEvent})`,
+    );
+  }
   if (cfg.applyEndpoint !== undefined && typeof cfg.applyEndpoint !== 'string') {
     throw new Error(
       `[design-token-panel] PanelConfig.applyEndpoint must be a string when set (got ${typeof cfg.applyEndpoint})`,

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -65,6 +65,23 @@ import { structuralEqual } from '../utils/structural-equal';
 export type ApplyRoutingMap = Record<string, string>;
 
 /**
+ * Apply sink interface — allows routing CSS-var writes somewhere other than
+ * the host `:root` (e.g. a shadow root, an iframe document, or a spy in
+ * tests).
+ *
+ * - `apply(pairs)` — upsert the given var name→value pairs.
+ * - `clear(names)` — remove the given var names.
+ *
+ * Both methods receive only the vars that belong to THIS panel instance.
+ * Sink errors are non-fatal: the apply pipeline swallows them with
+ * `console.warn` and continues.
+ */
+export interface ApplySink {
+  apply(pairs: ReadonlyArray<readonly [string, string]>): void;
+  clear(names: readonly string[]): void;
+}
+
+/**
  * The portable PanelConfig shape.
  */
 export interface PanelConfig {
@@ -117,6 +134,21 @@ export interface PanelConfig {
    * under the reserved id 'color-secondary'.
    */
   tabs: readonly TabConfig[];
+  /**
+   * Optional apply sink. When present, CSS-var writes and clears for this
+   * panel instance are routed through the sink instead of
+   * `document.documentElement`. This allows embedding the panel in a shadow
+   * DOM, an iframe, or a test spy without touching `:root`.
+   *
+   * Sink errors are non-fatal — the panel swallows them with `console.warn`.
+   * When absent the default path writes to `document.documentElement`
+   * (unchanged behavior).
+   *
+   * NOTE: this field carries a function reference and is therefore NOT
+   * JSON-serializable. It cannot be passed through Astro's inline JSON
+   * config. Supply it via a post-configure call or a custom adapter.
+   */
+  applySink?: ApplySink;
   /**
    * Optional id rename map applied during `loadPersistedState` migration.
    * Keys are old ids found in persisted state; values are either:

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -8,16 +8,32 @@
  *
  * Plumbing approach
  * -----------------
- * Module-level singleton (NOT Preact context). The panel is a single-instance
- * dev tool, config is set once before the adapter mounts, and every read site
- * is happy to pay a function call to read the current config.
+ * Module-level registry (NOT Preact context), keyed by `storagePrefix`. Each
+ * distinct prefix owns one panel *instance* — its config, its post-configure
+ * hooks, its returned handle. Every read site is happy to pay a function call
+ * to read the current config. Historically this was a single global singleton;
+ * issue #353 (Z1) lifts it to a per-instance registry so multiple panels with
+ * distinct `storagePrefix`es can coexist on one page.
  *
- * Idempotency
- * -----------
- * `configurePanel` is one-shot. Calling it twice with structurally-equal
- * values is a silent no-op (a freshly-parsed inline JSON config can be
- * byte-equal to the previous call but referentially distinct, e.g. on Astro
- * view-transition reruns). Calling with structurally-different values throws.
+ * Backward-compatible default instance
+ * ------------------------------------
+ * The single-panel path is unchanged. `getPanelConfig()` (no argument) returns
+ * the config of the most-recently-configured instance — the "default" / active
+ * instance — or `DEFAULT_PANEL_CONFIG` when no host has called `configurePanel`
+ * yet. A host that only ever calls `configurePanel` once observes the exact
+ * same behaviour as the old singleton.
+ *
+ * Idempotency & re-configure rule (same-prefix)
+ * ---------------------------------------------
+ * `configurePanel(config)` returns an instance handle. For a GIVEN prefix it is
+ * one-shot: calling it again with structurally-equal values is a no-op and
+ * returns the SAME handle (a freshly-parsed inline JSON config can be byte-equal
+ * to the previous call but referentially distinct, e.g. on Astro view-transition
+ * reruns). Calling again with the same prefix but structurally-DIFFERENT values
+ * REJECTS WITH AN ERROR (see `configurePanel` JSDoc) — config conflicts surface
+ * immediately instead of silently corrupting one of the callers' assumptions.
+ * Calling with a DISTINCT prefix registers a new, independent instance and does
+ * NOT throw. This is the chosen rule for Z4/Z5; see `RECONFIGURE_RULE` below.
  *
  * Default fallback
  * ----------------
@@ -128,6 +144,48 @@ export interface PanelConfig {
 }
 
 /**
+ * Handle returned by `configurePanel`. Identifies one configured panel
+ * instance and exposes its imperative lifecycle controls.
+ *
+ * Identity & keying
+ * -----------------
+ * `instanceId` equals the instance's `storagePrefix` — the registry key. Two
+ * `configurePanel` calls with the same prefix+config return the SAME handle
+ * object (referential identity is stable across idempotent re-calls); distinct
+ * prefixes return distinct handles.
+ *
+ * Method bodies — seams for later sub-tasks
+ * -----------------------------------------
+ * This sub-task (Z1) owns the instance MODEL only. `open` / `close` / `toggle`
+ * carry the correct method shape but defer their actual mount/visibility wiring
+ * to Z2 (events/lifecycle/mount). Today they drive the SAME global show/hide
+ * surface the console API uses for the default (single-panel) instance, so the
+ * default path keeps working end-to-end; Z2 replaces the bodies with
+ * per-instance event dispatch keyed by `instanceId`. `destroy()` deregisters
+ * the instance from the registry (model-level cleanup); Z2 extends it to also
+ * unmount the instance's Preact tree and remove its DOM root.
+ *
+ * @see RECONFIGURE_RULE for the same-prefix-different-config behaviour.
+ */
+export interface PanelInstanceHandle {
+  /** Stable instance id — equal to the instance's `storagePrefix` (the registry key). */
+  readonly instanceId: string;
+  /** Show this instance's panel. Z2 wires per-instance mount/visibility; today drives the shared show surface. */
+  open(): void;
+  /** Hide this instance's panel. Z2 wires per-instance mount/visibility; today drives the shared hide surface. */
+  close(): void;
+  /** Toggle this instance's panel open/closed. Z2 wires per-instance mount/visibility. */
+  toggle(): void;
+  /**
+   * Deregister this instance. Removes it from the registry so its prefix can be
+   * re-configured with a fresh config (and so it stops being the default
+   * instance `getPanelConfig()` resolves to). Z2 extends this to also unmount
+   * the instance's Preact tree and remove its DOM root.
+   */
+  destroy(): void;
+}
+
+/**
  * Default config — minimal stub values. Hosts MUST call `configurePanel(...)`
  * with real values to see useful behaviour.
  */
@@ -146,24 +204,38 @@ export const DEFAULT_PANEL_CONFIG: PanelConfig = {
 };
 
 // ---------------------------------------------------------------------------
-// Singleton storage
+// Instance registry (keyed by storagePrefix)
 // ---------------------------------------------------------------------------
 
 /**
- * The symbol key used to store the singleton slot on globalThis.
+ * Same-prefix-different-config rule (CHOSEN: reject-with-error).
  *
- * WHY globalThis instead of module-scope `let` bindings:
- * Vite's multi-entry build (e.g. Astro) can produce TWO separate module
- * instances of panel-config.ts — one in the host-adapter chunk, one in the
- * panel module chunk. Module-scope variables are per-instance, so
- * configurePanel() on instance A is invisible to getPanelConfig() on instance
- * B. Storing state on a Symbol.for() registry key makes all instances share
- * one slot regardless of chunk fragmentation. See epic #108 for context.
+ * When `configurePanel` is called a second time with a prefix that is ALREADY
+ * registered but a structurally-DIFFERENT config, we throw. The alternative
+ * (deterministic-update) was rejected because:
+ *
+ *  - PORTABLE-CONTRACT §1 pins `configurePanel` as one-shot per page lifecycle
+ *    ("MUST NOT silently overwrite a previously-configured cluster mid-session").
+ *  - The existing single-panel tests assert the throw, and the throw is what
+ *    surfaces a genuine config-conflict bug (two callers fighting over one
+ *    prefix) instead of letting the last writer silently win.
+ *
+ * Multi-instance does NOT need same-prefix mutation: a host that wants a second
+ * panel uses a DISTINCT `storagePrefix`, which registers an independent
+ * instance with no throw. Z4/Z5 must follow this rule — to re-configure a
+ * prefix, call `handle.destroy()` first, then `configurePanel` again.
+ *
+ * Exported (machine-discoverable) so Z4/Z5 can branch on the chosen rule
+ * without re-deriving it from the throw behaviour.
  */
-const SLOT_SYMBOL = Symbol.for('@takazudo/zdtp:singleton');
+export const RECONFIGURE_RULE = 'reject-with-error' as const;
 
-interface SingletonSlot {
-  configuredConfig: PanelConfig | null;
+/**
+ * One registered panel instance. Owns its config, its pending color presets
+ * (parked before configure), its post-configure hooks, and its handle.
+ */
+interface PanelInstanceRecord {
+  config: PanelConfig;
   pendingColorPresets: Record<string, ColorScheme> | null;
   /**
    * Post-configure hooks — callbacks registered by src/index.tsx that must run
@@ -174,50 +246,208 @@ interface SingletonSlot {
    * Deferring reapply until configurePanel fires avoids the race entirely.
    */
   postConfigureHooks: (() => void)[];
-}
-
-function getSingletonSlot(): SingletonSlot {
-  const g = globalThis as unknown as Record<symbol, SingletonSlot | undefined>;
-  let slot = g[SLOT_SYMBOL];
-  if (!slot) {
-    slot = { configuredConfig: null, pendingColorPresets: null, postConfigureHooks: [] };
-    g[SLOT_SYMBOL] = slot;
-  }
-  return slot;
+  /** Stable handle for this instance — identity preserved across idempotent re-calls. */
+  handle: PanelInstanceHandle;
 }
 
 /**
- * Configure the panel runtime. Call exactly once per page lifecycle, before
- * the adapter is imported / mounted. Idempotent: calling twice with
- * structurally-equal values is a silent no-op; calling twice with structurally
- * different values throws so config conflicts surface immediately instead of
- * silently corrupting one of the two callers' assumptions.
+ * The symbol key used to store the instance registry on globalThis.
  *
- * The re-init guard MUST use structural deep-equality, NOT referential
- * identity. The Astro host-adapter parses the inline JSON config on every
- * script run, including post view-transition reruns; that produces a
- * freshly-parsed object that is byte-for-byte identical to the previous call
- * but referentially distinct.
+ * WHY globalThis instead of module-scope `let` bindings:
+ * Vite's multi-entry build (e.g. Astro) can produce TWO separate module
+ * instances of panel-config.ts — one in the host-adapter chunk, one in the
+ * panel module chunk. Module-scope variables are per-instance, so
+ * configurePanel() on instance A is invisible to getPanelConfig() on instance
+ * B. Storing state on a Symbol.for() registry key makes all instances share
+ * one registry regardless of chunk fragmentation. See epic #108 for context.
+ *
+ * Symbol value is unchanged from the pre-#353 singleton so external tests that
+ * read `Symbol.for('@takazudo/zdtp:singleton')` directly keep working — and so
+ * the two code-split module instances continue to share one slot.
  */
-export function configurePanel(config: PanelConfig): void {
-  const slot = getSingletonSlot();
-  if (slot.configuredConfig !== null) {
-    if (structuralEqual(slot.configuredConfig, config)) return;
+const REGISTRY_SYMBOL = Symbol.for('@takazudo/zdtp:singleton');
+
+interface InstanceRegistry {
+  /** All configured instances, keyed by `storagePrefix`. */
+  instances: Map<string, PanelInstanceRecord>;
+  /**
+   * Prefix of the "default" / active instance — the one `getPanelConfig()`
+   * (no-arg) resolves to. Set to the most-recently-configured prefix so the
+   * single-panel path is unchanged. `null` when no instance is configured.
+   */
+  defaultPrefix: string | null;
+  /**
+   * Color presets parked via `setPanelColorPresets` before ANY instance was
+   * configured. Merged into the first instance to be configured. Kept at the
+   * registry level (not per-instance) because the pre-configure caller has no
+   * prefix to key on yet — it mirrors the historical global holding slot.
+   */
+  pendingColorPresets: Record<string, ColorScheme> | null;
+}
+
+function getRegistry(): InstanceRegistry {
+  const g = globalThis as unknown as Record<symbol, InstanceRegistry | undefined>;
+  let registry = g[REGISTRY_SYMBOL];
+  if (!registry) {
+    registry = { instances: new Map(), defaultPrefix: null, pendingColorPresets: null };
+    g[REGISTRY_SYMBOL] = registry;
+  }
+  return registry;
+}
+
+/**
+ * Build the handle for a freshly-registered instance. The handle closes over
+ * the prefix only (the registry record is looked up lazily on each call) so it
+ * stays valid as the record mutates and so `destroy()` can deregister cleanly.
+ *
+ * The open/close/toggle bodies are deliberately thin seams for Z2 — see the
+ * `PanelInstanceHandle` JSDoc. They route through the lazily-imported public
+ * show/hide surface so the DEFAULT (single-panel) instance works end-to-end
+ * today; Z2 replaces them with per-instance dispatch keyed by `instanceId`.
+ */
+function makeHandle(prefix: string): PanelInstanceHandle {
+  return {
+    instanceId: prefix,
+    open() {
+      panelLifecycleHooks.open?.(prefix);
+    },
+    close() {
+      panelLifecycleHooks.close?.(prefix);
+    },
+    toggle() {
+      panelLifecycleHooks.toggle?.(prefix);
+    },
+    destroy() {
+      // Model-level cleanup: drop the instance from the registry. Z2 extends
+      // this via `panelLifecycleHooks.destroy` to also unmount the Preact tree
+      // and remove the DOM root.
+      panelLifecycleHooks.destroy?.(prefix);
+      const registry = getRegistry();
+      registry.instances.delete(prefix);
+      if (registry.defaultPrefix === prefix) {
+        // Fall back the default pointer to whatever instance remains (last
+        // configured), or null when none are left.
+        const remaining = [...registry.instances.keys()];
+        registry.defaultPrefix = remaining.length > 0 ? remaining[remaining.length - 1] : null;
+      }
+    },
+  };
+}
+
+/**
+ * Z2 lifecycle seam. Z2 (events/lifecycle/mount) installs handlers here so the
+ * instance handle's open/close/toggle/destroy route to real per-instance
+ * mount + visibility behaviour. Z1 leaves it empty: the handle methods are
+ * no-ops until Z2 wires them, which is fine because the default single-panel
+ * path is driven by the existing console API / window events, not by handles.
+ *
+ * Exported (with the `__` internal prefix) so the lifecycle module (Z2) can
+ * register without reaching into private module scope.
+ */
+export interface PanelLifecycleHooks {
+  open?: (instanceId: string) => void;
+  close?: (instanceId: string) => void;
+  toggle?: (instanceId: string) => void;
+  destroy?: (instanceId: string) => void;
+}
+
+const panelLifecycleHooks: PanelLifecycleHooks = {};
+
+/**
+ * Z2 seam: install per-instance lifecycle handlers used by every instance
+ * handle's open/close/toggle/destroy. Last call wins (Z2 owns its own
+ * idempotency). No-op-friendly: unset handlers leave the corresponding handle
+ * method a no-op.
+ */
+export function __setPanelLifecycleHooks(hooks: PanelLifecycleHooks): void {
+  panelLifecycleHooks.open = hooks.open;
+  panelLifecycleHooks.close = hooks.close;
+  panelLifecycleHooks.toggle = hooks.toggle;
+  panelLifecycleHooks.destroy = hooks.destroy;
+}
+
+/**
+ * Configure a panel instance. Call once per `storagePrefix` per page lifecycle,
+ * before that instance's adapter is imported / mounted. Returns the instance
+ * handle (`{ instanceId, open, close, toggle, destroy }`).
+ *
+ * Keying & multi-instance: the instance is keyed by `config.storagePrefix`.
+ * Distinct prefixes register independent instances (no throw); each derives its
+ * own storage keys, root id, modal classes, etc.
+ *
+ * Same-prefix idempotency: calling again with the same prefix and structurally-
+ * equal values is a no-op and returns the SAME handle. The re-init guard MUST
+ * use structural deep-equality, NOT referential identity — the Astro
+ * host-adapter parses the inline JSON config on every script run (including
+ * post view-transition reruns), producing a freshly-parsed object that is
+ * byte-for-byte identical to the previous call but referentially distinct.
+ *
+ * Same-prefix-different-config: REJECTS WITH AN ERROR (chosen rule — see
+ * `RECONFIGURE_RULE`). To re-configure a prefix, `destroy()` the existing
+ * handle first, then call `configurePanel` again.
+ *
+ * The most-recently-configured instance becomes the "default" instance that the
+ * no-arg `getPanelConfig()` resolves to, preserving the single-panel path.
+ */
+export function configurePanel(config: PanelConfig): PanelInstanceHandle {
+  const registry = getRegistry();
+  const prefix = config.storagePrefix;
+  const existing = registry.instances.get(prefix);
+  if (existing) {
+    if (structuralEqual(existing.config, config)) {
+      // Idempotent re-call for this prefix — keep the installed config and the
+      // stable handle, just re-point the default to this prefix (Astro
+      // view-transition reruns re-assert "this is the active instance").
+      registry.defaultPrefix = prefix;
+      return existing.handle;
+    }
+    // RECONFIGURE_RULE = 'reject-with-error': same prefix, different config.
     throw new Error(
-      '[design-token-panel] configurePanel() was already called with different values. ' +
-        'Configuration is one-shot per page lifecycle.',
+      '[design-token-panel] configurePanel() was already called with different values ' +
+        `for storagePrefix "${prefix}". Configuration is one-shot per prefix per page ` +
+        'lifecycle. To re-configure this prefix, call handle.destroy() first, then ' +
+        'configurePanel() again. (Use a distinct storagePrefix for a second panel instance.)',
     );
   }
-  slot.configuredConfig = slot.pendingColorPresets
-    ? { ...config, colorPresets: slot.pendingColorPresets }
-    : { ...config };
-  slot.pendingColorPresets = null;
-  // Fire post-configure hooks. These run AFTER the host's config is installed,
-  // ensuring reapply paths (reapplyPersistedOverrides / reapplyFromStorage) use
-  // the correct storagePrefix — not the DEFAULT sentinel. See issue #111 H2 fix.
-  for (const hook of slot.postConfigureHooks) {
+
+  // Fresh instance for this prefix. Merge any registry-level pending presets
+  // (parked before ANY instance was configured) into this first instance.
+  const presets = registry.pendingColorPresets;
+  const installedConfig: PanelConfig = presets ? { ...config, colorPresets: presets } : { ...config };
+  registry.pendingColorPresets = null;
+  // Drain any hooks parked before this (the first-configured) instance existed.
+  // Only the FIRST instance to be configured adopts the parked pre-configure
+  // hooks — they target "the default single-panel instance" and there is no
+  // ambiguity until a second instance appears.
+  const isFirstInstance = registry.instances.size === 0;
+  const adoptedHooks = isFirstInstance ? [...pendingPostConfigureHooks] : [];
+  if (isFirstInstance) pendingPostConfigureHooks.length = 0;
+  const record: PanelInstanceRecord = {
+    config: installedConfig,
+    pendingColorPresets: null,
+    postConfigureHooks: adoptedHooks,
+    handle: makeHandle(prefix),
+  };
+  registry.instances.set(prefix, record);
+  registry.defaultPrefix = prefix;
+  // Fire post-configure hooks for THIS instance. These run AFTER the host's
+  // config is installed, ensuring reapply paths (reapplyPersistedOverrides /
+  // reapplyFromStorage) use the correct storagePrefix — not the DEFAULT
+  // sentinel. See issue #111 H2 fix.
+  for (const hook of record.postConfigureHooks) {
     hook();
   }
+  return record.handle;
+}
+
+/**
+ * Resolve the registry record for the default (active) instance, or `null` when
+ * no instance has been configured yet.
+ */
+function getDefaultRecord(): PanelInstanceRecord | null {
+  const registry = getRegistry();
+  if (registry.defaultPrefix === null) return null;
+  return registry.instances.get(registry.defaultPrefix) ?? null;
 }
 
 /**
@@ -225,43 +455,64 @@ export function configurePanel(config: PanelConfig): void {
  * host's config. Used by src/index.tsx to defer reapplyPersistedOverrides and
  * reapplyFromStorage until AFTER the host has supplied the correct storagePrefix.
  *
+ * Scope: this targets the DEFAULT (single-panel) instance — the historical
+ * single-panel contract. When no instance is configured yet, the hook is parked
+ * on a registry-level pending list and attached to the first instance to be
+ * configured. When the default instance already exists, the hook fires
+ * immediately so late registrants don't miss the trigger.
+ *
  * H2 fix for issue #111: module-init in index.tsx previously ran reapply
  * synchronously — before configurePanel — using DEFAULT_PANEL_CONFIG's prefix,
  * causing a default-prefix panel to mount and clobber host-prefix storage keys
  * on the first toggle when contaminated localStorage was present.
  *
  * Idempotent: if the same hook reference is registered twice, the second call
- * is a no-op. If configurePanel has already been called, the hook fires
- * immediately so late registrants don't miss the trigger.
+ * is a no-op.
  */
 export function registerPostConfigureHook(hook: () => void): void {
-  const slot = getSingletonSlot();
-  if (slot.postConfigureHooks.includes(hook)) return; // idempotent on reference
-  slot.postConfigureHooks.push(hook);
-  // If configurePanel was already called, run the hook immediately so ordering
-  // between index.tsx module-init and configurePanel is non-load-bearing.
-  if (slot.configuredConfig !== null) {
-    hook();
+  const record = getDefaultRecord();
+  if (record === null) {
+    // No instance configured yet — park the hook so the next configurePanel
+    // attaches and runs it. Mirrors the historical pre-configure behaviour.
+    if (pendingPostConfigureHooks.includes(hook)) return;
+    pendingPostConfigureHooks.push(hook);
+    return;
   }
+  if (record.postConfigureHooks.includes(hook)) return; // idempotent on reference
+  record.postConfigureHooks.push(hook);
+  // The default instance already exists → run immediately so ordering between
+  // index.tsx module-init and configurePanel is non-load-bearing.
+  hook();
 }
 
 /**
- * Read the active panel config. Returns the value passed to `configurePanel`
- * if one was supplied, else `DEFAULT_PANEL_CONFIG`.
+ * Hooks registered via `registerPostConfigureHook` BEFORE any instance was
+ * configured. Drained into the first instance to be configured. Module-scope
+ * (not on the registry) is acceptable: index.tsx's single module-init registers
+ * exactly one stable hook here, and `configurePanel` drains it on first use.
+ */
+const pendingPostConfigureHooks: (() => void)[] = [];
+
+/**
+ * Read the active panel config. Returns the config of the default (most-
+ * recently-configured) instance, else `DEFAULT_PANEL_CONFIG` when no host has
+ * called `configurePanel`.
  */
 export function getPanelConfig(): PanelConfig {
-  return getSingletonSlot().configuredConfig ?? DEFAULT_PANEL_CONFIG;
+  return getDefaultRecord()?.config ?? DEFAULT_PANEL_CONFIG;
 }
 
 /**
- * Test-only: clear the singleton so unit tests can exercise different configs
- * in isolation.
+ * Test-only: clear the entire instance registry so unit tests can exercise
+ * different configs in isolation. Resets the default pointer, every registered
+ * instance, parked presets, and parked pre-configure hooks.
  */
 export function __resetPanelConfigForTests(): void {
-  const slot = getSingletonSlot();
-  slot.configuredConfig = null;
-  slot.pendingColorPresets = null;
-  slot.postConfigureHooks = [];
+  const registry = getRegistry();
+  registry.instances.clear();
+  registry.defaultPrefix = null;
+  registry.pendingColorPresets = null;
+  pendingPostConfigureHooks.length = 0;
 }
 
 // Re-export cluster resolution helpers so callers can import from panel-config
@@ -669,12 +920,16 @@ export function resolveApplyRouting(cfg: PanelConfig = getPanelConfig()): ApplyR
  * non-empty map overwrites the previous one (no throw, unlike
  * `configurePanel`) — the dropdown source-of-truth is whichever bundle
  * landed last.
+ *
+ * Scope: targets the DEFAULT (active) instance — the historical single-panel
+ * contract. When no instance is configured yet, the presets are parked at the
+ * registry level and merged into the first instance to be configured.
  */
 export function setPanelColorPresets(presets: Record<string, ColorScheme>): void {
-  const slot = getSingletonSlot();
-  if (slot.configuredConfig === null) {
-    slot.pendingColorPresets = presets;
+  const record = getDefaultRecord();
+  if (record === null) {
+    getRegistry().pendingColorPresets = presets;
     return;
   }
-  slot.configuredConfig = { ...slot.configuredConfig, colorPresets: presets };
+  record.config = { ...record.config, colorPresets: presets };
 }

--- a/packages/zdtp/src/export-modal.tsx
+++ b/packages/zdtp/src/export-modal.tsx
@@ -29,7 +29,12 @@ import {
   initColorFromSchemeData,
 } from './state/tweak-state';
 import { colorSchemes } from './config/color-schemes';
-import { exportFilename, getPanelConfig, modalClass } from './config/panel-config';
+import {
+  exportFilename,
+  getPanelConfig,
+  modalClass,
+  type PanelConfig,
+} from './config/panel-config';
 
 export interface ExportModalProps {
   onClose: () => void;
@@ -38,6 +43,13 @@ export interface ExportModalProps {
   /** Color baseline used for diff-only output. Optional: callers without DOM
    *  access (tests) can omit and we'll treat the entire color block as changed. */
   colorDefaults?: ColorTweakState;
+  /**
+   * The mounted panel instance's config (multi-instance, #357). When supplied,
+   * the modal derives its filename hint + modal classes + title id from THIS
+   * instance rather than the active default instance. Omitted (e.g. a direct
+   * test render) → `getPanelConfig()`, preserving the single-panel path.
+   */
+  instanceConfig?: PanelConfig;
 }
 
 /** Resolve a color baseline for diff-only serialization. */
@@ -54,13 +66,15 @@ function resolveColorDefaults(
   return fallback;
 }
 
-export function ExportModal({ onClose, state, colorDefaults }: ExportModalProps) {
+export function ExportModal({ onClose, state, colorDefaults, instanceConfig }: ExportModalProps) {
   const [copyLabel, setCopyLabel] = useState('Copy');
   const [includeDefaults, setIncludeDefaults] = useState(false);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const copyButtonRef = useRef<HTMLDivElement>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const cfg = getPanelConfig();
+  // Resolve THIS instance's config (multi-instance, #357); a prop-less test
+  // render falls back to the active default instance.
+  const cfg = instanceConfig ?? getPanelConfig();
   const exportFilenameHint = exportFilename(cfg);
 
   // Memo the serialized JSON so flipping the toggle doesn't rebuild on every

--- a/packages/zdtp/src/import-modal.tsx
+++ b/packages/zdtp/src/import-modal.tsx
@@ -28,7 +28,7 @@ import {
   getDesignTokenSchema,
 } from './utils/design-token-serde';
 import type { ColorTweakState, TweakState } from './state/tweak-state';
-import { getPanelConfig, modalClass } from './config/panel-config';
+import { getPanelConfig, modalClass, type PanelConfig } from './config/panel-config';
 import { structuralEqual } from './utils/structural-equal';
 
 export interface ImportModalProps {
@@ -38,6 +38,13 @@ export interface ImportModalProps {
   onLoad: (state: TweakState) => void;
   /** Color baseline filled in for fields absent from the payload. */
   colorDefaults: ColorTweakState;
+  /**
+   * The mounted panel instance's config (multi-instance, #357). When supplied,
+   * the modal derives its modal classes + title id from THIS instance rather
+   * than the active default instance. Omitted (e.g. a direct test render) →
+   * `getPanelConfig()`, preserving the single-panel path.
+   */
+  instanceConfig?: PanelConfig;
 }
 
 interface InlineNote {
@@ -45,12 +52,14 @@ interface InlineNote {
   text: string;
 }
 
-export function ImportModal({ onClose, onLoad, colorDefaults }: ImportModalProps) {
+export function ImportModal({ onClose, onLoad, colorDefaults, instanceConfig }: ImportModalProps) {
   const [text, setText] = useState('');
   const [note, setNote] = useState<InlineNote | null>(null);
   const dialogRef = useRef<HTMLDialogElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const cfg = getPanelConfig();
+  // Resolve THIS instance's config (multi-instance, #357); a prop-less test
+  // render falls back to the active default instance.
+  const cfg = instanceConfig ?? getPanelConfig();
   const expectedSchema = getDesignTokenSchema();
 
   useEffect(() => {

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -292,7 +292,7 @@ function unmountInstance(cfg: PanelConfig): void {
 // adapter calls configurePanel internally, but a Vite-only host needs to
 // reach it from the package root per PORTABLE-CONTRACT.md §1.
 export { configurePanel, setPanelColorPresets } from './config/panel-config';
-export type { PanelConfig, PanelInstanceHandle } from './config/panel-config';
+export type { PanelConfig, PanelInstanceHandle, ApplySink } from './config/panel-config';
 
 /**
  * Internal-test-only accessor that returns this panel-module bundle's view of

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -56,10 +56,14 @@ import {
   loadPersistedState,
 } from './state/tweak-state';
 import {
+  __setPanelLifecycleHooks,
+  DEFAULT_TOGGLE_EVENT,
   getPanelConfig,
+  openStateChangedEventName,
   panelRootId,
   registerPostConfigureHook,
   storageKey_visible,
+  toggleEventName,
   type PanelConfig,
 } from './config/panel-config';
 
@@ -67,85 +71,72 @@ import {
 // Public DOM contract (kept in sync with astro/host-adapter.ts)
 // ---------------------------------------------------------------------------
 
-/** Root element id that hosts the Preact panel tree. Derived from `panelConfig.storagePrefix`. */
-function getPanelId(): string {
-  return panelRootId(getPanelConfig());
+/**
+ * Root element id that hosts the Preact panel tree. Derived from
+ * `cfg.storagePrefix` — pass the instance's config so a non-default panel
+ * mounts into ITS own `${storagePrefix}-root`, not the default instance's.
+ */
+function getPanelId(cfg: PanelConfig): string {
+  return panelRootId(cfg);
 }
 
-/** Adapter's visibility-intent flag. Derived from `panelConfig.storagePrefix` (colon separator). */
-function getStorageKey(): string {
-  return storageKey_visible(getPanelConfig());
+/** Adapter's visibility-intent flag. Derived from `cfg.storagePrefix` (colon separator). */
+function getStorageKey(cfg: PanelConfig): string {
+  return storageKey_visible(cfg);
 }
 
-const TOGGLE_EVENT = 'toggle-design-token-panel';
-/** Deprecated — kept so legacy callers still flip the panel. */
+/** Deprecated — kept so legacy callers still flip the default panel. */
 const TOGGLE_EVENT_ALIAS = 'toggle-color-tweak-panel';
 
 /**
- * Internal sync event. The module-scope toggle handler writes
- * `localStorage[OPEN_KEY]` to the new desired value and then dispatches this
- * on `window`; the mounted panel's `useEffect`-installed listener re-reads
- * `OPEN_KEY` and calls `setOpen` accordingly. Single source of truth lives in
- * `localStorage[OPEN_KEY]`; the event is just a "go re-read" pulse.
+ * Dispatch the instance's internal open-state sync event so a mounted
+ * `panel.tsx` re-reads `localStorage[OPEN_KEY]` and updates its `open` state.
+ * SSR-safe. The event name is per-instance (`openStateChangedEventName(cfg)`,
+ * defined in `config/panel-config.ts`) so a change to panel A's open state only
+ * pokes panel A's listener, never panel B's — the two share `window` but must
+ * stay fully independent (issue #354).
  *
- * Internal name (double-underscore prefix) — not part of the public DOM
- * contract; hosts must continue to dispatch `toggle-design-token-panel`.
- *
- * Why this exists: the old design had `panel.tsx`'s own window listener
- * toggle internal `open` state via `setOpen((prev) => !prev)`. That made the
- * in-component listener authoritative for the toggle, but its registration is
- * deferred until Preact's `useEffect` flushes (one rAF after mount). A click
- * that lands during that window — or any subtle pre-hydration / SPA-nav race
- * that drops the in-component listener — is silently lost; the user has to
- * click twice. The internal sync event lets the module-scope handler own the
- * authoritative write and notify the panel separately, so the panel's job is
- * the trivial one (re-read storage), not toggle arithmetic.
+ * The toggle handler writes `localStorage[OPEN_KEY]` to the new desired value
+ * first and then dispatches this event; the panel's listener just re-reads the
+ * key. Single source of truth lives in `localStorage[OPEN_KEY]`; the event is
+ * a "go re-read" pulse — no toggle arithmetic in the listener, so a missed
+ * pulse during Preact's effect-flush rAF gap self-heals on the next render.
  */
-const OPEN_STATE_CHANGED_EVENT = '__zdtp:open-state-changed';
-
-/**
- * Dispatch the internal sync event so a mounted `panel.tsx` re-reads
- * `localStorage[OPEN_KEY]` and updates its `open` state. SSR-safe.
- *
- * Internal — exported for tests only.
- */
-function notifyPanelOpenChanged(): void {
+function notifyPanelOpenChanged(cfg: PanelConfig): void {
   if (typeof window === 'undefined') return;
-  window.dispatchEvent(new CustomEvent(OPEN_STATE_CHANGED_EVENT));
+  window.dispatchEvent(new CustomEvent(openStateChangedEventName(cfg)));
 }
-
-export const __OPEN_STATE_CHANGED_EVENT_FOR_TEST = OPEN_STATE_CHANGED_EVENT;
 
 // ---------------------------------------------------------------------------
 // Storage helpers (SSR-safe, tolerant of private mode / quota errors)
 // ---------------------------------------------------------------------------
 
-function setStoredVisibility(isVisible: boolean): void {
+function setStoredVisibility(cfg: PanelConfig, isVisible: boolean): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(getStorageKey(), isVisible ? '1' : '0');
+    window.localStorage.setItem(getStorageKey(cfg), isVisible ? '1' : '0');
   } catch {
     /* ignore */
   }
 }
 
-function wasVisible(): boolean {
+function wasVisible(cfg: PanelConfig): boolean {
   if (typeof window === 'undefined') return false;
   try {
-    return window.localStorage.getItem(getStorageKey()) === '1';
+    return window.localStorage.getItem(getStorageKey(cfg)) === '1';
   } catch {
     return false;
   }
 }
 
-function hasPersistedOverrides(): boolean {
+function hasPersistedOverrides(cfg: PanelConfig): boolean {
   if (typeof window === 'undefined') return false;
   try {
     // Check v3 key first; fall back to v2 for sessions that have not yet
     // migrated (migration runs on first loadPersistedState call, i.e. once
     // the panel mounts — before mount we may only see the v2 key).
     const ls = window.localStorage;
-    return ls.getItem(getStorageKeyV3()) !== null || ls.getItem(getStorageKeyV2()) !== null;
+    return ls.getItem(getStorageKeyV3(cfg)) !== null || ls.getItem(getStorageKeyV2(cfg)) !== null;
   } catch {
     return false;
   }
@@ -162,10 +153,10 @@ function hasPersistedOverrides(): boolean {
  * `seedOpenStateBeforeMount` — see the seed function's docstring for the
  * timing rationale.
  */
-function isPanelCurrentlyOpen(): boolean {
+function isPanelCurrentlyOpen(cfg: PanelConfig): boolean {
   if (typeof window === 'undefined') return false;
   try {
-    return window.localStorage.getItem(getOpenKey()) === '1';
+    return window.localStorage.getItem(getOpenKey(cfg)) === '1';
   } catch {
     return false;
   }
@@ -197,10 +188,10 @@ function isPanelCurrentlyOpen(): boolean {
  * Keep this in lockstep with `OPEN_KEY` reads in `panel.tsx` (the first
  * `useEffect` in `DesignTokenTweakPanel`).
  */
-function seedOpenStateBeforeMount(desiredOpen: boolean): void {
+function seedOpenStateBeforeMount(cfg: PanelConfig, desiredOpen: boolean): void {
   if (typeof window === 'undefined') return;
   try {
-    const openKey = getOpenKey();
+    const openKey = getOpenKey(cfg);
     if (desiredOpen) window.localStorage.setItem(openKey, '1');
     else window.localStorage.removeItem(openKey);
   } catch {
@@ -212,9 +203,9 @@ function seedOpenStateBeforeMount(desiredOpen: boolean): void {
 // Mount / unmount
 // ---------------------------------------------------------------------------
 
-function findRoot(): HTMLElement | null {
+function findRoot(cfg: PanelConfig): HTMLElement | null {
   if (typeof document === 'undefined') return null;
-  return document.getElementById(getPanelId());
+  return document.getElementById(getPanelId(cfg));
 }
 
 // Stable id for the injected <style> element so injection is idempotent
@@ -248,16 +239,38 @@ function ensurePanelStyles(): void {
  * mount-effect reads `OPEN_KEY` synchronously, so the seed has to be visible
  * by then.
  */
-function ensureMounted(): boolean {
+function ensureMounted(cfg: PanelConfig): boolean {
   if (typeof document === 'undefined') return false;
-  const panelId = getPanelId();
+  // Bind this instance's toggle-event listener at its materialization point so
+  // that, after the first programmatic interaction (handle.open/toggle, show/
+  // hide), a host-dispatched `toggle-${storagePrefix}` window event keeps
+  // flipping the SAME instance. Idempotent per prefix. The default instance is
+  // additionally bound eagerly at module init.
+  bindInstance(cfg);
+  const panelId = getPanelId(cfg);
   if (document.getElementById(panelId)) return false;
   ensurePanelStyles();
   const root = document.createElement('div');
   root.id = panelId;
   document.body.appendChild(root);
-  render(<DesignTokenTweakPanel />, root);
+  // Pass the instance's storagePrefix so the panel reads ITS own open key and
+  // subscribes to ITS own per-instance sync event — two panels on one page
+  // stay fully independent (issue #354).
+  render(<DesignTokenTweakPanel storagePrefix={cfg.storagePrefix} />, root);
   return true;
+}
+
+/**
+ * Full Preact unmount + DOM-root removal for ONE instance. Drives the panel's
+ * `useEffect` cleanups (so its window/document listeners detach) before
+ * detaching the root, so a destroyed instance leaks nothing. No-op when the
+ * instance is not mounted.
+ */
+function unmountInstance(cfg: PanelConfig): void {
+  const root = findRoot(cfg);
+  if (!root) return;
+  render(null, root);
+  root.remove();
 }
 
 // NOTE: `dispatchToggle()` was removed in favour of `notifyPanelOpenChanged()`.
@@ -345,53 +358,73 @@ export {
 export type { TweakState } from './state/tweak-state';
 export { emptyOverrides } from './state/tweak-state';
 
-export function showDesignTokenPanel(): void {
+/**
+ * Show ONE instance's panel. Internal per-instance core shared by the public
+ * default-instance API (`showDesignTokenPanel`) and the per-instance handle's
+ * `open()`. Every storage read/write and the sync-event dispatch are keyed by
+ * `cfg.storagePrefix`, so distinct instances stay independent.
+ */
+function showInstance(cfg: PanelConfig): void {
   if (typeof window === 'undefined') return;
-  const isFreshMount = !findRoot();
+  const isFreshMount = !findRoot(cfg);
   // Write OPEN_KEY synchronously so both the fresh-mount path (panel reads on
   // mount) and the steady-state path (panel reads on sync event) see the
   // same authoritative value.
-  seedOpenStateBeforeMount(true);
-  ensureMounted();
-  setStoredVisibility(true);
+  seedOpenStateBeforeMount(cfg, true);
+  ensureMounted(cfg);
+  setStoredVisibility(cfg, true);
   // Fresh mount: panel.tsx's mount-effect picks up OPEN_KEY="1" and renders
   // open — no listener race because the listener doesn't run yet anyway.
   if (isFreshMount) return;
   // Steady state: always notify the mounted panel to re-read OPEN_KEY.
-  // `seedOpenStateBeforeMount(true)` already wrote OPEN_KEY='1' above, so a
+  // `seedOpenStateBeforeMount(cfg, true)` already wrote OPEN_KEY='1' above, so a
   // post-seed `isPanelCurrentlyOpen()` probe would *always* read "open" — it
   // cannot distinguish "already open" from "just re-shown after a hide". The
-  // notify must therefore be unconditional (mirrors `hideDesignTokenPanel`).
+  // notify must therefore be unconditional (mirrors `hideInstance`).
   // The sync event is idempotent: if the panel is genuinely already open the
   // panel's `setOpen(true)` is a no-op via Preact's setState identity check.
-  notifyPanelOpenChanged();
+  notifyPanelOpenChanged(cfg);
 }
 
-export function hideDesignTokenPanel(): void {
+/** Hide ONE instance's panel. See `showInstance` for the per-instance keying. */
+function hideInstance(cfg: PanelConfig): void {
   if (typeof window === 'undefined') return;
-  const isFreshMount = !findRoot();
-  seedOpenStateBeforeMount(false);
-  ensureMounted();
-  setStoredVisibility(false);
+  const isFreshMount = !findRoot(cfg);
+  seedOpenStateBeforeMount(cfg, false);
+  ensureMounted(cfg);
+  setStoredVisibility(cfg, false);
   if (isFreshMount) return;
   // After the seed, isPanelCurrentlyOpen() returns false. We don't have the
   // pre-seed value here, so just always notify — the sync event is idempotent
   // (panel re-reads OPEN_KEY and calls setOpen(false); if already false, no
   // re-render thanks to Preact's identity check on setState).
-  notifyPanelOpenChanged();
+  notifyPanelOpenChanged(cfg);
+}
+
+/** Toggle ONE instance's panel. See `showInstance` for the per-instance keying. */
+function toggleInstance(cfg: PanelConfig): void {
+  if (typeof window === 'undefined') return;
+  // Snapshot intent *before* the seed flips `OPEN_KEY`.
+  const willBeOpen = !isPanelCurrentlyOpen(cfg);
+  const isFreshMount = !findRoot(cfg);
+  seedOpenStateBeforeMount(cfg, willBeOpen);
+  ensureMounted(cfg);
+  setStoredVisibility(cfg, willBeOpen);
+  // Fresh mount: seed already drove the mount-effect to the desired state.
+  if (isFreshMount) return;
+  notifyPanelOpenChanged(cfg);
+}
+
+export function showDesignTokenPanel(): void {
+  showInstance(getPanelConfig());
+}
+
+export function hideDesignTokenPanel(): void {
+  hideInstance(getPanelConfig());
 }
 
 export function toggleDesignPanel(): void {
-  if (typeof window === 'undefined') return;
-  // Snapshot intent *before* the seed flips `OPEN_KEY`.
-  const willBeOpen = !isPanelCurrentlyOpen();
-  const isFreshMount = !findRoot();
-  seedOpenStateBeforeMount(willBeOpen);
-  ensureMounted();
-  setStoredVisibility(willBeOpen);
-  // Fresh mount: seed already drove the mount-effect to the desired state.
-  if (isFreshMount) return;
-  notifyPanelOpenChanged();
+  toggleInstance(getPanelConfig());
 }
 
 /**
@@ -433,12 +466,16 @@ export function reapplyPersistedOverrides(): void {
  * reflects the user's last state, not an artefact of the unmount path.
  */
 function unmountForSwap(): void {
-  const root = findRoot();
+  // Astro page-swap is a default-instance (single-panel) concern — the astro
+  // fallback / lifecycle adapter is a global, document-level channel. Resolve
+  // the active instance at call time.
+  const cfg = getPanelConfig();
+  const root = findRoot(cfg);
   if (!root) return;
-  const shouldRestore = wasVisible();
+  const shouldRestore = wasVisible(cfg);
   render(null, root);
   root.remove();
-  if (shouldRestore) setStoredVisibility(true);
+  if (shouldRestore) setStoredVisibility(cfg, true);
 }
 
 /**
@@ -452,11 +489,12 @@ function unmountForSwap(): void {
  * same way the adapter's module-init path kills it on hard-nav.
  */
 function reapplyFromStorage(): void {
+  const cfg = getPanelConfig();
   reapplyPersistedOverrides();
-  if (wasVisible()) {
-    showDesignTokenPanel();
-  } else if (hasPersistedOverrides()) {
-    hideDesignTokenPanel();
+  if (wasVisible(cfg)) {
+    showInstance(cfg);
+  } else if (hasPersistedOverrides(cfg)) {
+    hideInstance(cfg);
   }
 }
 
@@ -499,22 +537,164 @@ function reapplyFromStorage(): void {
  *   is already correct — so the very next render reads the right value
  *   from the mount-effect path (line 170 in `panel.tsx`).
  */
-function handleExternalToggleEvent(): void {
-  const isFreshMount = !findRoot();
+function handleExternalToggleEvent(cfg: PanelConfig): void {
+  const isFreshMount = !findRoot(cfg);
   // When the panel root is absent (fresh mount, or SPA-nav zombie state where
   // `unmountForSwap` removed the root but left `OPEN_KEY='1'` behind), the
   // user's intent on this toggle event is unambiguously "open" — deriving
   // direction from a possibly-stale `OPEN_KEY` would mount the panel CLOSED
   // and require a second click. See zudolab/zudo-doc#1633 / #1640 / #1631.
-  const willBeOpen = isFreshMount ? true : !isPanelCurrentlyOpen();
-  seedOpenStateBeforeMount(willBeOpen);
-  ensureMounted();
+  const willBeOpen = isFreshMount ? true : !isPanelCurrentlyOpen(cfg);
+  seedOpenStateBeforeMount(cfg, willBeOpen);
+  ensureMounted(cfg);
   // Fresh mount: the seed has already driven the mount-effect to the desired
   // state; no in-component listener exists to notify yet. The sync event
   // would harmlessly land in the void.
   if (isFreshMount) return;
-  notifyPanelOpenChanged();
+  notifyPanelOpenChanged(cfg);
 }
+
+// ---------------------------------------------------------------------------
+// Per-instance event/lifecycle bindings (#354)
+//
+// Each configured panel instance owns ITS OWN window-event wiring: a toggle-
+// event listener (keyed by `toggleEventName(cfg)`) and — for the default
+// instance only — the deprecated `toggle-color-tweak-panel` alias. Two panels
+// with distinct `storagePrefix`es therefore bind and tear down fully
+// independently; `destroy()` on one removes only that one's listeners + root.
+//
+// This is a SEPARATE concern from the framework-agnostic lifecycle adapter
+// below (`setLifecycleAdapter`): that adapter is a single, document-level
+// page-swap channel for the default (single-panel) astro flow, whereas these
+// bindings are per-instance window-event channels. Keeping them in distinct
+// registries lets two panels coexist without either one's bind/teardown
+// touching the other's listeners or the shared astro adapter.
+// ---------------------------------------------------------------------------
+
+/** One instance's active window-event bindings. */
+interface InstanceBindingRecord {
+  /** Listener removers — drained on `unbindInstance`. */
+  cleanups: Array<() => void>;
+}
+
+type InstanceBindingsWindow = Window & {
+  __zudoDesignTokenPanelInstanceBindings?: Map<string, InstanceBindingRecord>;
+};
+
+function getInstanceBindings(): Map<string, InstanceBindingRecord> {
+  const w = window as InstanceBindingsWindow;
+  if (w.__zudoDesignTokenPanelInstanceBindings) return w.__zudoDesignTokenPanelInstanceBindings;
+  const map = new Map<string, InstanceBindingRecord>();
+  w.__zudoDesignTokenPanelInstanceBindings = map;
+  return map;
+}
+
+/**
+ * Idempotently bind ONE instance's toggle-event listener(s). Keyed by
+ * `cfg.storagePrefix` — a second call for an already-bound prefix is a no-op,
+ * so re-running the post-configure hook (Astro view-transition reruns) never
+ * stacks duplicate listeners.
+ *
+ * The handler closes over the instance config so it always operates on the
+ * right storage keys / root / sync event, regardless of which instance is the
+ * default at dispatch time.
+ */
+function bindInstance(cfg: PanelConfig): void {
+  if (typeof window === 'undefined') return;
+  const bindings = getInstanceBindings();
+  if (bindings.has(cfg.storagePrefix)) return;
+
+  const toggleEvent = toggleEventName(cfg);
+  const handler = (): void => handleExternalToggleEvent(cfg);
+  window.addEventListener(toggleEvent, handler);
+  const cleanups: Array<() => void> = [() => window.removeEventListener(toggleEvent, handler)];
+
+  // The deprecated alias only ever flipped the default single-panel instance;
+  // binding it for every instance would let one panel's legacy event leak into
+  // another. Scope it to the default instance only.
+  if (toggleEvent === DEFAULT_TOGGLE_EVENT) {
+    window.addEventListener(TOGGLE_EVENT_ALIAS, handler);
+    cleanups.push(() => window.removeEventListener(TOGGLE_EVENT_ALIAS, handler));
+  }
+
+  bindings.set(cfg.storagePrefix, { cleanups });
+}
+
+/** Remove ONE instance's toggle-event listener(s). No-op when not bound. */
+function unbindInstance(instanceId: string): void {
+  if (typeof window === 'undefined') return;
+  const bindings = getInstanceBindings();
+  const record = bindings.get(instanceId);
+  if (!record) return;
+  for (const fn of record.cleanups) {
+    try {
+      fn();
+    } catch {
+      /* a listener-removal that throws should not abort the teardown */
+    }
+  }
+  bindings.delete(instanceId);
+}
+
+/**
+ * Test-only: drain EVERY instance's window-event listeners and clear the
+ * bindings map. Unlike `delete window.__zudoDesignTokenPanelInstanceBindings`,
+ * this actively removes the real `addEventListener` registrations — dropping
+ * the map alone would orphan live listeners that then leak across tests (a
+ * stale listener from a previous test re-mounts a panel on the next dispatch).
+ *
+ * Exported with the `__` internal prefix; not part of the public API.
+ */
+export function __resetInstanceBindingsForTests(): void {
+  if (typeof window === 'undefined') return;
+  const bindings = getInstanceBindings();
+  for (const instanceId of [...bindings.keys()]) {
+    unbindInstance(instanceId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Z2 lifecycle-hook wiring: back the instance handle's open/close/toggle/
+// destroy (from `configurePanel(...)`) with real per-instance behaviour. The
+// handle methods receive an `instanceId` (=== storagePrefix); we look the
+// instance's config up via `configForInstance` so every storage/event read is
+// correctly keyed.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a `PanelConfig` for a handle method given its `instanceId`. The
+ * registry does not expose a per-prefix config getter, but the default
+ * instance's config (`getPanelConfig()`) carries the matching prefix in the
+ * single-/active-panel case. When the ids differ we still return the active
+ * config but override `storagePrefix` so all derivations key off the right
+ * instance — every derivation in this module is a pure function of
+ * `storagePrefix`, so this is sufficient and avoids reaching into registry
+ * internals.
+ */
+function configForInstance(instanceId: string): PanelConfig {
+  const active = getPanelConfig();
+  if (active.storagePrefix === instanceId) return active;
+  return { ...active, storagePrefix: instanceId };
+}
+
+__setPanelLifecycleHooks({
+  // Fires once per `configurePanel` (every instance, incl. the 2nd+). Bind the
+  // instance's toggle-event channel now so a host-dispatched
+  // `toggle-${storagePrefix}` window event works immediately, before any
+  // handle method or mount.
+  configured: (instanceId) => bindInstance(configForInstance(instanceId)),
+  open: (instanceId) => showInstance(configForInstance(instanceId)),
+  close: (instanceId) => hideInstance(configForInstance(instanceId)),
+  toggle: (instanceId) => toggleInstance(configForInstance(instanceId)),
+  destroy: (instanceId) => {
+    // Remove ONLY this instance's listeners + root, and unmount its Preact
+    // tree (so its effect cleanups fire). The registry-level deregistration is
+    // handled by Z1's `handle.destroy()` AFTER this hook runs.
+    const cfg = configForInstance(instanceId);
+    unbindInstance(instanceId);
+    unmountInstance(cfg);
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Framework-agnostic lifecycle adapter (#50)
@@ -703,14 +883,20 @@ const POST_CONFIGURE_REAPPLY_HOOK = (): void => {
 
 if (typeof window !== 'undefined') {
   const state = getAdapterState();
+  // Bind the DEFAULT instance's toggle listener eagerly so the historical
+  // single-panel path (hosts that dispatch `toggle-design-token-panel` before
+  // — or without — calling configurePanel) keeps working out of the box.
+  // Configured instances are bound at configure time via the `configured`
+  // lifecycle hook above.
+  bindInstance(getPanelConfig());
+
   if (!state.bound) {
     state.bound = true;
 
-    window.addEventListener(TOGGLE_EVENT, handleExternalToggleEvent);
-    window.addEventListener(TOGGLE_EVENT_ALIAS, handleExternalToggleEvent);
-
     // Initial bindings: astro fallback. `setLifecycleAdapter(...)` rewrites
-    // this set later if a host installs an adapter.
+    // this set later if a host installs an adapter. This is a single,
+    // document-level page-swap channel (NOT per-instance) — see the
+    // per-instance bindings section above for the toggle-event channels.
     bindAstroFallback(state);
 
     // H2 fix (#111): register reapply as a post-configure hook instead of

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -277,7 +277,7 @@ function ensureMounted(): boolean {
 // adapter calls configurePanel internally, but a Vite-only host needs to
 // reach it from the package root per PORTABLE-CONTRACT.md §1.
 export { configurePanel, setPanelColorPresets } from './config/panel-config';
-export type { PanelConfig } from './config/panel-config';
+export type { PanelConfig, PanelInstanceHandle } from './config/panel-config';
 
 /**
  * Internal-test-only accessor that returns this panel-module bundle's view of

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -59,6 +59,7 @@ import {
   __setPanelLifecycleHooks,
   DEFAULT_TOGGLE_EVENT,
   getPanelConfig,
+  getPanelConfigByPrefix,
   openStateChangedEventName,
   panelRootId,
   registerPostConfigureHook,
@@ -253,10 +254,11 @@ function ensureMounted(cfg: PanelConfig): boolean {
   const root = document.createElement('div');
   root.id = panelId;
   document.body.appendChild(root);
-  // Pass the instance's storagePrefix so the panel reads ITS own open key and
-  // subscribes to ITS own per-instance sync event — two panels on one page
-  // stay fully independent (issue #354).
-  render(<DesignTokenTweakPanel storagePrefix={cfg.storagePrefix} />, root);
+  // Pass the instance's OWN config so the panel reads ITS own open/visible
+  // keys, subscribes to ITS own per-instance sync event, and renders ITS own
+  // tabs — two panels on one page stay fully independent (issue #354). `cfg`
+  // is the registered per-instance config (via `configForInstance`).
+  render(<DesignTokenTweakPanel instanceConfig={cfg} />, root);
   return true;
 }
 
@@ -662,16 +664,21 @@ export function __resetInstanceBindingsForTests(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve a `PanelConfig` for a handle method given its `instanceId`. The
- * registry does not expose a per-prefix config getter, but the default
- * instance's config (`getPanelConfig()`) carries the matching prefix in the
- * single-/active-panel case. When the ids differ we still return the active
- * config but override `storagePrefix` so all derivations key off the right
- * instance — every derivation in this module is a pure function of
- * `storagePrefix`, so this is sufficient and avoids reaching into registry
- * internals.
+ * Resolve the `PanelConfig` for a handle method / lifecycle hook given its
+ * `instanceId`. Prefer the instance's OWN registered config so a non-default
+ * panel uses its real tabs / schema / apply settings / custom `toggleEvent`,
+ * not the active default instance's — distinct instances stay independent even
+ * while another prefix is the active default.
+ *
+ * Fallback (synthesize from the active config, overriding only `storagePrefix`)
+ * covers the default-instance-before-configure window: the eager module-init
+ * bind runs with `DEFAULT_PANEL_CONFIG` before any `configurePanel`, so the
+ * instance is not yet registered. Every derivation that fallback feeds is a
+ * pure function of `storagePrefix`, so it is correct for that bootstrap case.
  */
 function configForInstance(instanceId: string): PanelConfig {
+  const registered = getPanelConfigByPrefix(instanceId);
+  if (registered) return registered;
   const active = getPanelConfig();
   if (active.storagePrefix === instanceId) return active;
   return { ...active, storagePrefix: instanceId };

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -13,7 +13,12 @@ import SizeTab from './tabs/size-tab';
 import SpacingTab from './tabs/spacing-tab';
 import GenericTab from './tabs/generic-tab';
 import { TooltipProvider } from './controls/tooltip';
-import { getPanelConfig, storageKey_visible } from './config/panel-config';
+import {
+  getPanelConfig,
+  openStateChangedEventName,
+  storageKey_visible,
+  type PanelConfig,
+} from './config/panel-config';
 import type { TabConfig } from './tokens/tier-model';
 import { usePersist } from './state/persist';
 import {
@@ -106,10 +111,37 @@ function freshTweakState(): TweakState {
 
 // --- Main Component ---
 
-export default function DesignTokenTweakPanel() {
+/**
+ * Props for the panel shell.
+ *
+ * `storagePrefix` identifies WHICH configured instance this mounted tree
+ * belongs to (issue #354). The adapter (`index.tsx`) passes `cfg.storagePrefix`
+ * at `render(...)` time. The panel uses it to derive its OWN open key, visible
+ * key, and per-instance open-state sync-event name — so two panels on one page
+ * read/write distinct storage keys and listen on distinct sync events, never
+ * cross-talking. Omitted (e.g. a direct test render) → the active/default
+ * instance, preserving the historical single-panel behaviour.
+ */
+interface DesignTokenTweakPanelProps {
+  storagePrefix?: string;
+}
+
+export default function DesignTokenTweakPanel({ storagePrefix }: DesignTokenTweakPanelProps = {}) {
+  // Per-instance config: every storage key + the sync-event name are pure
+  // functions of `storagePrefix`, so override just that field on the active
+  // config. When the prop is omitted we fall back to the active instance,
+  // matching the single-panel default. Memoised so the derived config object
+  // is stable across re-renders (the prop is fixed for a mount's lifetime).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const instanceConfig = useMemo<PanelConfig>(() => {
+    const active = getPanelConfig();
+    if (storagePrefix === undefined || storagePrefix === active.storagePrefix) return active;
+    return { ...active, storagePrefix };
+  }, [storagePrefix]);
+
   // Scope WAI-ARIA IDs to this panel instance so that two mounted panels in
   // the same document do not share dtp-tab-* / dtp-panel-* IDs.
-  const instanceId = useId();
+  const ariaIdScope = useId();
   const [open, setOpen] = useState(false);
   const [showExport, setShowExport] = useState(false);
   const [showImport, setShowImport] = useState(false);
@@ -147,7 +179,7 @@ export default function DesignTokenTweakPanel() {
   // Restore open state, position, and size from localStorage after mount (avoids SSR hydration mismatch)
   useEffect(() => {
     try {
-      if (localStorage.getItem(getOpenKey()) === '1') setOpen(true);
+      if (localStorage.getItem(getOpenKey(instanceConfig)) === '1') setOpen(true);
     } catch {
       /* ignore */
     }
@@ -160,6 +192,7 @@ export default function DesignTokenTweakPanel() {
     setDensity(loadDensity());
     // Initial narrow-check
     setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist density on change
@@ -176,19 +209,19 @@ export default function DesignTokenTweakPanel() {
   // here ensures every close path (public API or internal UI) stays in lockstep.
   useEffect(() => {
     try {
-      const openKey = getOpenKey();
+      const openKey = getOpenKey(instanceConfig);
       if (open) localStorage.setItem(openKey, '1');
       else localStorage.removeItem(openKey);
     } catch {
       /* ignore */
     }
     try {
-      const visibleKey = storageKey_visible(getPanelConfig());
+      const visibleKey = storageKey_visible(instanceConfig);
       localStorage.setItem(visibleKey, open ? '1' : '0');
     } catch {
       /* ignore */
     }
-  }, [open]);
+  }, [open, instanceConfig]);
 
   // ESC key closes the panel when no modal is open. When a modal is open the
   // native <dialog> handles ESC first (fires cancel → onClose), and we must
@@ -215,25 +248,30 @@ export default function DesignTokenTweakPanel() {
   // internal sync event on `window`. This component is downstream: it doesn't
   // compute the toggle from its own `prev` state — it just mirrors storage.
   //
+  // The event name and the open key are BOTH keyed by this instance's
+  // `storagePrefix` (issue #354): the panel listens only on its OWN
+  // per-instance sync event and reads only its OWN open key, so panel A's
+  // toggle never flips panel B.
+  //
   // The two historical public event names (`toggle-design-token-panel` and
-  // its deprecated `toggle-color-tweak-panel` alias) are now handled in
-  // `index.tsx` (see `handleExternalToggleEvent`). Removing them from this
-  // effect eliminates the dual-listener race that caused the
-  // "click-twice-after-close" regression — see `index.tsx` for the full
-  // rationale.
+  // its deprecated `toggle-color-tweak-panel` alias) are handled in `index.tsx`
+  // (see `handleExternalToggleEvent`). Removing them from this effect
+  // eliminates the dual-listener race that caused the "click-twice-after-close"
+  // regression — see `index.tsx` for the full rationale.
   useEffect(() => {
+    const eventName = openStateChangedEventName(instanceConfig);
     function syncOpenFromStorage() {
       try {
-        setOpen(localStorage.getItem(getOpenKey()) === '1');
+        setOpen(localStorage.getItem(getOpenKey(instanceConfig)) === '1');
       } catch {
         /* ignore */
       }
     }
-    window.addEventListener('__zdtp:open-state-changed', syncOpenFromStorage);
+    window.addEventListener(eventName, syncOpenFromStorage);
     return () => {
-      window.removeEventListener('__zdtp:open-state-changed', syncOpenFromStorage);
+      window.removeEventListener(eventName, syncOpenFromStorage);
     };
-  }, []);
+  }, [instanceConfig]);
 
   // Re-initialize the COLOR slice when the color scheme or light/dark mode
   // changes. Global tweak model (see README §9): the stored palette is
@@ -640,9 +678,9 @@ export default function DesignTokenTweakPanel() {
                     tabRefs.current[tab.id] = el;
                   }}
                   role="tab"
-                  id={`dtp-tab-${instanceId}-${tab.id}`}
+                  id={`dtp-tab-${ariaIdScope}-${tab.id}`}
                   aria-selected={isSelected}
-                  aria-controls={`dtp-panel-${instanceId}-${tab.id}`}
+                  aria-controls={`dtp-panel-${ariaIdScope}-${tab.id}`}
                   tabIndex={isSelected ? 0 : -1}
                   onClick={() => setActiveTab(tab.id)}
                   onKeyDown={handleTabKeyDown}
@@ -657,14 +695,14 @@ export default function DesignTokenTweakPanel() {
           </div>
           <div className="tokenpanel-density">
             <label
-              htmlFor={`dtp-density-${instanceId}`}
+              htmlFor={`dtp-density-${ariaIdScope}`}
               className="tokenpanel-density-label"
               title="Tab grid density: dense / cozy / wide (forces 1 column)"
             >
               Density
             </label>
             <input
-              id={`dtp-density-${instanceId}`}
+              id={`dtp-density-${ariaIdScope}`}
               type="range"
               min={0}
               max={2}
@@ -690,8 +728,8 @@ export default function DesignTokenTweakPanel() {
               <div
                 key={tab.id}
                 role="tabpanel"
-                id={`dtp-panel-${instanceId}-${tab.id}`}
-                aria-labelledby={`dtp-tab-${instanceId}-${tab.id}`}
+                id={`dtp-panel-${ariaIdScope}-${tab.id}`}
+                aria-labelledby={`dtp-tab-${ariaIdScope}-${tab.id}`}
                 tabIndex={0}
                 hidden={!isSelected}
               >

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -114,30 +114,31 @@ function freshTweakState(): TweakState {
 /**
  * Props for the panel shell.
  *
- * `storagePrefix` identifies WHICH configured instance this mounted tree
- * belongs to (issue #354). The adapter (`index.tsx`) passes `cfg.storagePrefix`
- * at `render(...)` time. The panel uses it to derive its OWN open key, visible
- * key, and per-instance open-state sync-event name — so two panels on one page
- * read/write distinct storage keys and listen on distinct sync events, never
- * cross-talking. Omitted (e.g. a direct test render) → the active/default
- * instance, preserving the historical single-panel behaviour.
+ * `instanceConfig` is the FULL registered config of the instance this mounted
+ * tree belongs to (issue #354). The adapter (`index.tsx`) passes it at
+ * `render(...)` time. The panel reads its OWN open key, visible key,
+ * per-instance open-state sync-event name, AND its OWN tabs from this config —
+ * so two panels on one page read/write distinct storage keys, listen on
+ * distinct sync events, and render distinct manifests, never cross-talking.
+ * Omitted (e.g. a direct test render) → the active/default instance, preserving
+ * the historical single-panel behaviour.
  */
 interface DesignTokenTweakPanelProps {
-  storagePrefix?: string;
+  instanceConfig?: PanelConfig;
 }
 
-export default function DesignTokenTweakPanel({ storagePrefix }: DesignTokenTweakPanelProps = {}) {
-  // Per-instance config: every storage key + the sync-event name are pure
-  // functions of `storagePrefix`, so override just that field on the active
-  // config. When the prop is omitted we fall back to the active instance,
-  // matching the single-panel default. Memoised so the derived config object
-  // is stable across re-renders (the prop is fixed for a mount's lifetime).
+export default function DesignTokenTweakPanel({
+  instanceConfig: instanceConfigProp,
+}: DesignTokenTweakPanelProps = {}) {
+  // Resolve the instance config: the passed-in registered config, or the active
+  // default instance for a direct (prop-less) test render. Memoised so the
+  // object identity is stable across re-renders (the prop is fixed for a
+  // mount's lifetime), which keeps the [instanceConfig] effect deps quiet.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const instanceConfig = useMemo<PanelConfig>(() => {
-    const active = getPanelConfig();
-    if (storagePrefix === undefined || storagePrefix === active.storagePrefix) return active;
-    return { ...active, storagePrefix };
-  }, [storagePrefix]);
+  const instanceConfig = useMemo<PanelConfig>(
+    () => instanceConfigProp ?? getPanelConfig(),
+    [instanceConfigProp],
+  );
 
   // Scope WAI-ARIA IDs to this panel instance so that two mounted panels in
   // the same document do not share dtp-tab-* / dtp-panel-* IDs.
@@ -490,19 +491,18 @@ export default function DesignTokenTweakPanel({ storagePrefix }: DesignTokenTwea
     setState(freshTweakState());
   }, []);
 
-  // Build the active tab list from PanelConfig.tabs (now required).
-  // useMemo with no deps is intentional — configurePanel is one-shot per
-  // lifecycle, so the list never changes after mount.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Build the active tab list from this instance's PanelConfig.tabs (required).
+  // Keyed on `instanceConfig` so a non-default panel renders ITS own manifest,
+  // not the active default instance's (#354). configurePanel is one-shot per
+  // prefix, so the list is stable for a mount's lifetime.
   const activeTabs = useMemo((): readonly { id: string; label: string }[] => {
-    return getPanelConfig().tabs.map((t: TabConfig) => ({ id: t.id, label: t.label }));
-  }, []);
+    return instanceConfig.tabs.map((t: TabConfig) => ({ id: t.id, label: t.label }));
+  }, [instanceConfig]);
 
-  // Build an id→TabConfig lookup for GenericTab dispatch.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Build an id→TabConfig lookup for GenericTab dispatch (this instance's tabs).
   const tabConfigById = useMemo((): Record<string, TabConfig> => {
     const out: Record<string, TabConfig> = {};
-    for (const t of getPanelConfig().tabs) {
+    for (const t of instanceConfig.tabs) {
       out[t.id] = t;
     }
     return out;

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -37,6 +37,7 @@ import {
   defaultSize,
   densityToGridMin,
   emptyOverrides,
+  getActivePrimaryCluster,
   getOpenKey,
   initColorFromScheme,
   initSecondaryFromConfig,
@@ -98,14 +99,18 @@ function computePanelSize(
  *
  * Extracted from four identical inline object literals throughout the panel
  * so that adding or renaming a state slice only requires one change.
+ *
+ * `cfg` scopes the colour-cluster + secondary-cluster derivation to THIS
+ * mounted panel instance (multi-instance, #357). Omitting it resolves the
+ * default instance, preserving the single-panel path.
  */
-function freshTweakState(): TweakState {
+function freshTweakState(cfg?: PanelConfig): TweakState {
   return {
-    color: initColorFromScheme(),
+    color: initColorFromScheme(getActivePrimaryCluster(cfg)),
     spacing: emptyOverrides(),
     typography: emptyOverrides(),
     size: emptyOverrides(),
-    secondary: initSecondaryFromConfig(),
+    secondary: initSecondaryFromConfig(cfg),
   };
 }
 
@@ -175,7 +180,7 @@ export default function DesignTokenTweakPanel({
   const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   const { persistColor, persistSpacing, persistFont, persistSize, persistSecondary, persistTab } =
-    usePersist(setState);
+    usePersist(setState, instanceConfig);
 
   // Restore open state, position, and size from localStorage after mount (avoids SSR hydration mismatch)
   useEffect(() => {
@@ -184,23 +189,26 @@ export default function DesignTokenTweakPanel({
     } catch {
       /* ignore */
     }
-    const loaded = loadPosition();
+    const loaded = loadPosition(instanceConfig);
     setPosition(loaded);
     positionRef.current = loaded;
-    const loadedSize = loadSize();
+    const loadedSize = loadSize(instanceConfig);
     setSize(loadedSize);
     sizeRef.current = loadedSize;
-    setDensity(loadDensity());
+    setDensity(loadDensity(instanceConfig));
     // Initial narrow-check
     setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist density on change
-  const handleDensityChange = useCallback((next: PanelDensity) => {
-    setDensity(next);
-    saveDensity(next);
-  }, []);
+  const handleDensityChange = useCallback(
+    (next: PanelDensity) => {
+      setDensity(next);
+      saveDensity(next, instanceConfig);
+    },
+    [instanceConfig],
+  );
 
   // Persist open state, and keep the adapter-level :visible key in sync.
   // The adapter (index.tsx) only writes :visible from its public API paths
@@ -291,23 +299,36 @@ export default function DesignTokenTweakPanel({
     function handleSchemeChange() {
       // Clear only the color cluster inline vars so the new scheme's <style>
       // tag takes effect for color; spacing/font/size inline vars stay applied.
-      clearAppliedColorStyles();
+      // Scoped to THIS instance's clusters + sink so a scheme change on panel A
+      // never wipes panel B's color vars / sink target (#357).
+      clearAppliedColorStyles(undefined, undefined, instanceConfig);
       setState((prev) =>
         prev
-          ? { ...prev, color: initColorFromScheme(), secondary: initSecondaryFromConfig() }
-          : freshTweakState(),
+          ? {
+              ...prev,
+              color: initColorFromScheme(getActivePrimaryCluster(instanceConfig)),
+              secondary: initSecondaryFromConfig(instanceConfig),
+            }
+          : freshTweakState(instanceConfig),
       );
     }
     window.addEventListener('color-scheme-changed', handleSchemeChange);
     return () => window.removeEventListener('color-scheme-changed', handleSchemeChange);
-  }, []);
+  }, [instanceConfig]);
 
-  // Initialize state on first open
+  // Initialize state on first open. Every storage read + apply is scoped to
+  // THIS instance's config (#357): panel A loads from A's storage keys and
+  // applies through A's sink, never touching B's.
   useEffect(() => {
     if (!open || state) return;
-    const persisted = loadPersistedState();
+    const persisted = loadPersistedState(
+      undefined,
+      undefined,
+      getActivePrimaryCluster(instanceConfig),
+      instanceConfig,
+    );
     if (persisted) {
-      applyFullState(persisted);
+      applyFullState(persisted, instanceConfig);
       setState(persisted);
       return;
     }
@@ -316,8 +337,8 @@ export default function DesignTokenTweakPanel({
     // The `secondary` slice is always seeded — every fresh-state path
     // includes it so the persisted envelope shape stays stable regardless
     // of the user's path.
-    setState(freshTweakState());
-  }, [open, state]);
+    setState(freshTweakState(instanceConfig));
+  }, [open, state, instanceConfig]);
 
   // Drag handler for panel header (stable — reads position from ref)
   const handleDragStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -360,7 +381,7 @@ export default function DesignTokenTweakPanel({
       // Commit final position to React state (single re-render on drag end).
       const finalPos = positionRef.current;
       setPosition(finalPos);
-      savePosition(finalPos);
+      savePosition(finalPos, instanceConfig);
     }
 
     document.addEventListener('mousemove', onMouseMove);
@@ -369,7 +390,7 @@ export default function DesignTokenTweakPanel({
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };
-  }, []);
+  }, [instanceConfig]);
 
   // Resize handler for the bottom-right grip — mirrors handleDragStart's
   // structure: writes directly to the DOM during the drag (to avoid 60 fps
@@ -407,7 +428,7 @@ export default function DesignTokenTweakPanel({
       resizeCleanupRef.current = null;
       const finalSize = sizeRef.current;
       setSize(finalSize);
-      saveSize(finalSize);
+      saveSize(finalSize, instanceConfig);
       // Re-clamp position against the new size — a wider panel may need its
       // anchor pulled back into the viewport.
       const finalPos = clampPosition(
@@ -418,7 +439,7 @@ export default function DesignTokenTweakPanel({
       );
       if (finalPos.top !== positionRef.current.top || finalPos.left !== positionRef.current.left) {
         setPosition(finalPos);
-        savePosition(finalPos);
+        savePosition(finalPos, instanceConfig);
       }
     }
 
@@ -428,7 +449,7 @@ export default function DesignTokenTweakPanel({
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };
-  }, []);
+  }, [instanceConfig]);
 
   // Clean up drag + resize listeners on unmount
   useEffect(() => {
@@ -447,7 +468,7 @@ export default function DesignTokenTweakPanel({
       setSize((prev) => {
         const clamped = clampSize(prev.width, prev.height);
         if (clamped.width !== prev.width || clamped.height !== prev.height) {
-          saveSize(clamped);
+          saveSize(clamped, instanceConfig);
         }
         return clamped;
       });
@@ -455,41 +476,46 @@ export default function DesignTokenTweakPanel({
       const panelHeight = panelRef.current?.offsetHeight ?? 600;
       setPosition((prev) => {
         const clamped = clampPosition(prev.top, prev.left, panelWidth, panelHeight);
-        savePosition(clamped);
+        savePosition(clamped, instanceConfig);
         return clamped;
       });
     }
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, []);
+  }, [instanceConfig]);
 
-  const handleLoadFromJson = useCallback((loaded: TweakState) => {
-    // Replace the panel state with the loaded tweak, apply CSS vars, persist
-    // to localStorage (v2). Unknown tokens have already been filtered out by
-    // deserialize().
-    applyFullState(loaded);
-    savePersistedState(loaded);
-    setState(loaded);
-  }, []);
+  const handleLoadFromJson = useCallback(
+    (loaded: TweakState) => {
+      // Replace the panel state with the loaded tweak, apply CSS vars, persist
+      // to localStorage (v3). Unknown tokens have already been filtered out by
+      // deserialize(). Apply + persist are scoped to THIS instance (#357).
+      applyFullState(loaded, instanceConfig);
+      savePersistedState(loaded, undefined, instanceConfig);
+      setState(loaded);
+    },
+    [instanceConfig],
+  );
 
   const handleResetAll = useCallback(() => {
-    clearPersistedState();
-    clearAppliedStyles();
+    // Clear + reset are scoped to THIS instance's storage keys, clusters, and
+    // sink so a reset on panel A never touches panel B's storage/vars (#357).
+    clearPersistedState(undefined, instanceConfig);
+    clearAppliedStyles(undefined, instanceConfig);
     // Always seed the secondary slice — every fresh-state path emits a
     // uniform envelope shape so persistence stays consistent.
-    setState(freshTweakState());
-  }, []);
+    setState(freshTweakState(instanceConfig));
+  }, [instanceConfig]);
 
   const handleApplied = useCallback(() => {
     // After a successful apply the on-disk CSS now matches the current tweak,
     // so drop the persisted override envelope and any inline overrides — the
-    // page will re-render from the fresh stylesheet.
-    clearPersistedState();
-    clearAppliedStyles();
+    // page will re-render from the fresh stylesheet. Scoped to THIS instance (#357).
+    clearPersistedState(undefined, instanceConfig);
+    clearAppliedStyles(undefined, instanceConfig);
     // Always seed the secondary slice — every fresh-state path emits a
     // uniform envelope shape.
-    setState(freshTweakState());
-  }, []);
+    setState(freshTweakState(instanceConfig));
+  }, [instanceConfig]);
 
   // Build the active tab list from this instance's PanelConfig.tabs (required).
   // Keyed on `instanceConfig` so a non-default panel renders ITS own manifest,
@@ -739,7 +765,7 @@ export default function DesignTokenTweakPanel({
                     state={state.color}
                     persistColor={persistColor}
                     secondaryTab={tabConfigById['color-secondary'] ?? null}
-                    secondaryState={state.secondary ?? initSecondaryFromConfig() ?? null}
+                    secondaryState={state.secondary ?? initSecondaryFromConfig(instanceConfig) ?? null}
                     persistSecondary={persistSecondary}
                   />
                 )}
@@ -806,7 +832,8 @@ export default function DesignTokenTweakPanel({
         <ExportModal
           onClose={() => setShowExport(false)}
           state={state}
-          colorDefaults={initColorFromScheme()}
+          colorDefaults={initColorFromScheme(getActivePrimaryCluster(instanceConfig))}
+          instanceConfig={instanceConfig}
         />
       )}
 
@@ -814,7 +841,8 @@ export default function DesignTokenTweakPanel({
         <ImportModal
           onClose={() => setShowImport(false)}
           onLoad={handleLoadFromJson}
-          colorDefaults={initColorFromScheme()}
+          colorDefaults={initColorFromScheme(getActivePrimaryCluster(instanceConfig))}
+          instanceConfig={instanceConfig}
         />
       )}
 
@@ -823,8 +851,9 @@ export default function DesignTokenTweakPanel({
           state={state}
           open={showApply}
           onClose={() => setShowApply(false)}
-          colorDefaults={initColorFromScheme()}
+          colorDefaults={initColorFromScheme(getActivePrimaryCluster(instanceConfig))}
           onApplied={handleApplied}
+          instanceConfig={instanceConfig}
         />
       )}
 

--- a/packages/zdtp/src/state/persist.ts
+++ b/packages/zdtp/src/state/persist.ts
@@ -46,9 +46,8 @@ export function usePersist(setState: SetState<TweakState>, cfg?: PanelConfig) {
         return next;
       });
     },
-    // cfg is intentionally included in the deps array so the callback
-    // re-binds when the config reference changes (e.g. hot-reload in dev).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // cfg is intentionally included so the callback re-binds when the
+    // config reference changes (e.g. hot-reload in dev).
     [setState, cfg],
   );
 

--- a/packages/zdtp/src/state/persist.ts
+++ b/packages/zdtp/src/state/persist.ts
@@ -23,21 +23,33 @@ import {
   type TokenOverrides,
   type TweakState,
 } from './tweak-state';
+import type { PanelConfig } from '../config/panel-config';
 
 type SetState<T> = (updater: (prev: T | null) => T | null) => void;
 
-export function usePersist(setState: SetState<TweakState>) {
+/**
+ * `usePersist` hook.
+ *
+ * Accepts an optional `cfg` — the panel instance config. When supplied its
+ * `applySink` (if any) routes every CSS-var write through the sink instead
+ * of `document.documentElement`. Omitting `cfg` uses `getPanelConfig()` via
+ * the no-arg `applyFullState` call, preserving the single-panel default path.
+ */
+export function usePersist(setState: SetState<TweakState>, cfg?: PanelConfig) {
   const persist = useCallback(
     (updater: (prev: TweakState) => TweakState) => {
       setState((prev) => {
         if (!prev) return prev;
         const next = updater(prev);
-        applyFullState(next);
+        applyFullState(next, cfg);
         savePersistedState(next);
         return next;
       });
     },
-    [setState],
+    // cfg is intentionally included in the deps array so the callback
+    // re-binds when the config reference changes (e.g. hot-reload in dev).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setState, cfg],
   );
 
   /**

--- a/packages/zdtp/src/state/persist.ts
+++ b/packages/zdtp/src/state/persist.ts
@@ -32,8 +32,10 @@ type SetState<T> = (updater: (prev: T | null) => T | null) => void;
  *
  * Accepts an optional `cfg` — the panel instance config. When supplied its
  * `applySink` (if any) routes every CSS-var write through the sink instead
- * of `document.documentElement`. Omitting `cfg` uses `getPanelConfig()` via
- * the no-arg `applyFullState` call, preserving the single-panel default path.
+ * of `document.documentElement`, AND its `storagePrefix` scopes the persisted
+ * envelope to THIS instance's storage key (multi-instance, #357). Omitting
+ * `cfg` resolves the default instance via `getPanelConfig()` inside both
+ * `applyFullState` and `savePersistedState`, preserving the single-panel path.
  */
 export function usePersist(setState: SetState<TweakState>, cfg?: PanelConfig) {
   const persist = useCallback(
@@ -42,7 +44,7 @@ export function usePersist(setState: SetState<TweakState>, cfg?: PanelConfig) {
         if (!prev) return prev;
         const next = updater(prev);
         applyFullState(next, cfg);
-        savePersistedState(next);
+        savePersistedState(next, undefined, cfg);
         return next;
       });
     },

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -57,6 +57,7 @@ import {
   storageKey_stateV1,
   storageKey_stateV2,
   storageKey_stateV3,
+  type PanelConfig,
 } from '../config/panel-config';
 import { resolvePrimaryColorCluster } from '../config/cluster-config';
 import type { TabConfig } from '../tokens/tier-model';
@@ -93,37 +94,47 @@ export type { TabOverrides } from '../apply/tier-resolver';
  *
  * **Lazy derivation**
  *
- * Each helper reads `getPanelConfig()` on every call so a `configurePanel`
- * call that lands *after* this module is imported still influences the keys
- * the panel hits. Capturing the values at module load would freeze them
- * before the host has a chance to configure.
+ * Each helper reads `getPanelConfig()` on every call by default so a
+ * `configurePanel` call that lands *after* this module is imported still
+ * influences the keys the panel hits. Capturing the values at module load
+ * would freeze them before the host has a chance to configure.
+ *
+ * **Per-instance derivation (multi-instance, #353 Z1)**
+ *
+ * Each accessor takes an OPTIONAL `cfg: PanelConfig`. Passing it derives the
+ * key for THAT instance instead of the default (active) instance — the seam
+ * Z2/Z3 use to scope storage, mount, and apply to a specific panel instance.
+ * Omitting it preserves the historical single-panel behaviour (resolve the
+ * default instance via `getPanelConfig()`). Storage keys are a pure function of
+ * `cfg.storagePrefix`, so two instances with distinct prefixes derive fully
+ * independent keys.
  */
-export function getStorageKeyV1(): string {
-  return storageKey_stateV1(getPanelConfig());
+export function getStorageKeyV1(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_stateV1(cfg);
 }
 
-export function getStorageKeyV2(): string {
-  return storageKey_stateV2(getPanelConfig());
+export function getStorageKeyV2(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_stateV2(cfg);
 }
 
-export function getStorageKeyV3(): string {
-  return storageKey_stateV3(getPanelConfig());
+export function getStorageKeyV3(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_stateV3(cfg);
 }
 
-export function getOpenKey(): string {
-  return storageKey_open(getPanelConfig());
+export function getOpenKey(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_open(cfg);
 }
 
-export function getPositionKey(): string {
-  return storageKey_position(getPanelConfig());
+export function getPositionKey(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_position(cfg);
 }
 
-export function getSizeKey(): string {
-  return storageKey_size(getPanelConfig());
+export function getSizeKey(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_size(cfg);
 }
 
-export function getDensityKey(): string {
-  return storageKey_density(getPanelConfig());
+export function getDensityKey(cfg: PanelConfig = getPanelConfig()): string {
+  return storageKey_density(cfg);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -179,9 +179,9 @@ export function defaultPosition(): PanelPosition {
   return { top, left };
 }
 
-export function loadPosition(): PanelPosition {
+export function loadPosition(cfg?: PanelConfig): PanelPosition {
   try {
-    const saved = localStorage.getItem(getPositionKey());
+    const saved = localStorage.getItem(getPositionKey(cfg));
     if (saved) {
       const parsed = JSON.parse(saved) as PanelPosition;
       if (typeof parsed.top === 'number' && typeof parsed.left === 'number') {
@@ -194,9 +194,9 @@ export function loadPosition(): PanelPosition {
   return defaultPosition();
 }
 
-export function savePosition(pos: PanelPosition) {
+export function savePosition(pos: PanelPosition, cfg?: PanelConfig) {
   try {
-    localStorage.setItem(getPositionKey(), JSON.stringify(pos));
+    localStorage.setItem(getPositionKey(cfg), JSON.stringify(pos));
   } catch {
     /* ignore */
   }
@@ -262,9 +262,9 @@ export function clampSize(width: number, height: number): PanelSize {
   };
 }
 
-export function loadSize(): PanelSize {
+export function loadSize(cfg?: PanelConfig): PanelSize {
   try {
-    const saved = localStorage.getItem(getSizeKey());
+    const saved = localStorage.getItem(getSizeKey(cfg));
     if (saved) {
       const parsed = JSON.parse(saved) as PanelSize;
       if (
@@ -282,9 +282,9 @@ export function loadSize(): PanelSize {
   return defaultSize();
 }
 
-export function saveSize(size: PanelSize) {
+export function saveSize(size: PanelSize, cfg?: PanelConfig) {
   try {
-    localStorage.setItem(getSizeKey(), JSON.stringify(size));
+    localStorage.setItem(getSizeKey(cfg), JSON.stringify(size));
   } catch {
     /* ignore */
   }
@@ -316,9 +316,9 @@ export function densityToGridMin(density: PanelDensity): string {
   return '18rem';
 }
 
-export function loadDensity(): PanelDensity {
+export function loadDensity(cfg?: PanelConfig): PanelDensity {
   try {
-    const saved = localStorage.getItem(getDensityKey());
+    const saved = localStorage.getItem(getDensityKey(cfg));
     if (saved === '0' || saved === '1' || saved === '2') {
       return Number(saved) as PanelDensity;
     }
@@ -328,9 +328,9 @@ export function loadDensity(): PanelDensity {
   return DEFAULT_DENSITY;
 }
 
-export function saveDensity(density: PanelDensity) {
+export function saveDensity(density: PanelDensity, cfg?: PanelConfig) {
   try {
-    localStorage.setItem(getDensityKey(), String(density));
+    localStorage.setItem(getDensityKey(cfg), String(density));
   } catch {
     /* ignore */
   }
@@ -587,12 +587,16 @@ export function initSecondaryDefaults(cluster: ColorClusterDataConfig): ColorTwe
 
 /**
  * Convenience helper used by `panel.tsx` and tests: seed a fresh secondary
- * `ColorTweakState` from the active panel config's secondary cluster.
+ * `ColorTweakState` from the panel config's secondary cluster.
  * Returns `undefined` when the host opted out of the secondary cluster
  * (`secondaryColorCluster: null` or omitted).
+ *
+ * `cfg` scopes the secondary-cluster lookup to a specific panel instance
+ * (multi-instance, #357). Omitting it resolves the default instance, preserving
+ * the single-panel path.
  */
-export function initSecondaryFromConfig(): ColorTweakState | undefined {
-  const secondary = resolveSecondaryColorCluster();
+export function initSecondaryFromConfig(cfg?: PanelConfig): ColorTweakState | undefined {
+  const secondary = resolveSecondaryColorCluster(cfg);
   return secondary ? initSecondaryDefaults(secondary) : undefined;
 }
 
@@ -1200,9 +1204,27 @@ function nonColorTabVarNames(cfg: PanelConfig): string[] {
  *
  * When `sink` is supplied, clears are routed through it instead of
  * `document.documentElement`.
+ *
+ * `cfg` scopes the clear to a specific panel instance (multi-instance, #357):
+ * when supplied AND no explicit `clusters` / `sink` are given, the default
+ * cluster wipe set is derived from `cfg`'s tabs and clears route through
+ * `cfg.applySink`. An explicitly-passed `clusters` or `sink` still wins, so the
+ * historical `(clusters, sink)` call shape (e.g. the scheme-change path before
+ * #357, and existing tests) is unchanged. Omitting all three preserves the
+ * single-panel default-instance behaviour.
  */
 export function clearAppliedColorStyles(
-  clusters: readonly ColorClusterDataConfig[] = defaultClusterWipeSet(),
+  clusters?: readonly ColorClusterDataConfig[],
+  sink?: ApplySink,
+  cfg?: PanelConfig,
+) {
+  const resolvedClusters = clusters ?? defaultClusterWipeSet(cfg);
+  const resolvedSink = sink ?? cfg?.applySink;
+  return clearAppliedColorStylesImpl(resolvedClusters, resolvedSink);
+}
+
+function clearAppliedColorStylesImpl(
+  clusters: readonly ColorClusterDataConfig[],
   sink?: ApplySink,
 ) {
   if (sink) {
@@ -1536,17 +1558,18 @@ function hydrateV2OrV3Object(
   },
   cluster: ColorClusterDataConfig,
   colorDefaults?: ColorTweakState,
+  cfg: PanelConfig = getPanelConfig(),
 ): TweakState | null {
   if (!obj.color || !isValidColorShape(obj.color, cluster.paletteSize)) return null;
 
   const defaults = colorDefaults ?? tryInitColorFromScheme(cluster);
   const typographySlice = obj.typography !== undefined ? obj.typography : obj.font;
-  // Rename map sourced from the active panel config. Defaults to an
+  // Rename map sourced from THIS instance's panel config. Defaults to an
   // empty map (no renaming) so hosts whose manifest ids are stable are
   // not corrupted — see issue #51 and the doc on
   // `ZDTP_LEGACY_TYPOGRAPHY_RENAME_MAP` for the opt-in zdtp-internal
   // map.
-  const renameMap = getPanelConfig().legacyIdRenameMap ?? {};
+  const renameMap = cfg.legacyIdRenameMap ?? {};
   const next: TweakState = {
     color: hydrateColorState(obj.color as Partial<ColorTweakState>, defaults),
     // New sections added after v1 migration — tolerate their absence so
@@ -1566,7 +1589,7 @@ function hydrateV2OrV3Object(
   // entirely — the apply path also skips secondary writes, and the
   // JSON envelope simply omits the slice for opt-out hosts. Defaults
   // come from `initSecondaryDefaults(cluster)`.
-  const secondaryCluster = resolveSecondaryColorCluster();
+  const secondaryCluster = resolveSecondaryColorCluster(cfg);
   if (
     secondaryCluster &&
     obj.secondary &&
@@ -1589,10 +1612,11 @@ export function loadPersistedState(
   storage: StorageLike = localStorage,
   colorDefaults?: ColorTweakState,
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
+  cfg: PanelConfig = getPanelConfig(),
 ): TweakState | null {
-  const STORAGE_KEY_V1 = getStorageKeyV1();
-  const STORAGE_KEY_V2 = getStorageKeyV2();
-  const STORAGE_KEY_V3 = getStorageKeyV3();
+  const STORAGE_KEY_V1 = getStorageKeyV1(cfg);
+  const STORAGE_KEY_V2 = getStorageKeyV2(cfg);
+  const STORAGE_KEY_V3 = getStorageKeyV3(cfg);
 
   // 1. v3 wins.
   const rawV3 = safeGet(storage, STORAGE_KEY_V3);
@@ -1609,7 +1633,7 @@ export function loadPersistedState(
         secondary?: unknown;
         tabs?: unknown;
       };
-      const next = hydrateV2OrV3Object(obj, cluster, colorDefaults);
+      const next = hydrateV2OrV3Object(obj, cluster, colorDefaults, cfg);
       if (next !== null) {
         // Renormalize storage when the typography migration actually changed
         // the slice (rename or null-drop) OR the legacy `font` alias was
@@ -1649,7 +1673,7 @@ export function loadPersistedState(
         secondary?: unknown;
         tabs?: unknown;
       };
-      const migrated = hydrateV2OrV3Object(obj, cluster, colorDefaults);
+      const migrated = hydrateV2OrV3Object(obj, cluster, colorDefaults, cfg);
       if (migrated !== null) {
         try {
           storage.setItem(STORAGE_KEY_V3, JSON.stringify(migrated));
@@ -1703,29 +1727,48 @@ export function loadPersistedState(
   return null;
 }
 
-/** Persist the full `TweakState` to v3. */
-export function savePersistedState(state: TweakState, storage: StorageLike = localStorage) {
+/**
+ * Persist the full `TweakState` to v3.
+ *
+ * `cfg` scopes the storage key to a specific panel instance (multi-instance,
+ * #357). Omitting it resolves the default instance via `getPanelConfig()`,
+ * preserving the single-panel path.
+ */
+export function savePersistedState(
+  state: TweakState,
+  storage: StorageLike = localStorage,
+  cfg: PanelConfig = getPanelConfig(),
+) {
   try {
-    storage.setItem(getStorageKeyV3(), JSON.stringify(state));
+    storage.setItem(getStorageKeyV3(cfg), JSON.stringify(state));
   } catch {
     // Storage full.
   }
 }
 
-/** Remove v3 (and lingering v2/v1) keys. */
-export function clearPersistedState(storage: StorageLike = localStorage) {
+/**
+ * Remove v3 (and lingering v2/v1) keys.
+ *
+ * `cfg` scopes the cleared keys to a specific panel instance (multi-instance,
+ * #357). Omitting it resolves the default instance via `getPanelConfig()`,
+ * preserving the single-panel path.
+ */
+export function clearPersistedState(
+  storage: StorageLike = localStorage,
+  cfg: PanelConfig = getPanelConfig(),
+) {
   try {
-    storage.removeItem(getStorageKeyV3());
+    storage.removeItem(getStorageKeyV3(cfg));
   } catch {
     /* ignore */
   }
   try {
-    storage.removeItem(getStorageKeyV2());
+    storage.removeItem(getStorageKeyV2(cfg));
   } catch {
     /* ignore */
   }
   try {
-    storage.removeItem(getStorageKeyV1());
+    storage.removeItem(getStorageKeyV1(cfg));
   } catch {
     /* ignore */
   }

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -57,8 +57,13 @@ import {
   storageKey_stateV1,
   storageKey_stateV2,
   storageKey_stateV3,
+  type ApplySink,
   type PanelConfig,
 } from '../config/panel-config';
+
+// Re-export ApplySink so callers can import the type from the state module
+// (same pattern used for TabOverrides).
+export type { ApplySink } from '../config/panel-config';
 import { resolvePrimaryColorCluster } from '../config/cluster-config';
 import type { TabConfig } from '../tokens/tier-model';
 import {
@@ -684,7 +689,28 @@ export function cssColorToHex(color: string): string {
   }
 }
 
-export function setCssVar(name: string, value: string) {
+/**
+ * Write a single CSS custom property. When `sink` is supplied the write is
+ * routed through it; otherwise it falls through to `document.documentElement`.
+ *
+ * This helper is kept intentionally thin — callers batch pairs themselves
+ * (e.g. `applyColorState`) and flush them to the sink in one call.
+ * Individual-call routing here keeps every existing call site unchanged while
+ * still allowing per-call sink overrides during the internal batch loops.
+ */
+export function setCssVar(name: string, value: string, sink?: ApplySink) {
+  if (sink) {
+    // Sink batching is the caller's responsibility; we just delegate.
+    // The sink's `apply` contract is "upsert these pairs" so a single-pair
+    // call is valid — it's the cheapest per-call contract that doesn't
+    // require the caller to collect pairs up front.
+    try {
+      sink.apply([[name, value]]);
+    } catch (err) {
+      console.warn('[design-token-panel] applySink.apply threw; falling back silently.', err);
+    }
+    return;
+  }
   document.documentElement.style.setProperty(name, value);
 }
 
@@ -754,12 +780,24 @@ function hexToRgb(hex: string): { r: number; g: number; b: number; aa: number } 
  * light/dark mode. Reads `panelSettings` from the cluster so a
  * host-supplied cluster can declare its own scheme + light/dark pairing
  * without editing the panel package.
+ *
+ * When `cfg` is supplied AND it has an `applySink`, this instance is a
+ * "sink instance" — it does NOT read the host's `data-theme` attribute
+ * (which belongs to the host's document, not to this instance). Instead it
+ * falls back to the panel's own `colorScheme` setting so it picks the
+ * correct default scheme and a scheme switch touches only its own overrides.
  */
 export function getActiveSchemeName(
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
+  cfg?: PanelConfig,
 ): string {
   const settings = cluster.panelSettings;
-  if (settings.colorMode) {
+  // Sink instances must NOT read the host document's data-theme — the host
+  // theme attribute targets the host's own :root, which is irrelevant to a
+  // panel routed to a different sink target. Fall back to the static
+  // colorScheme declared in the cluster's panelSettings instead.
+  const isSinkInstance = cfg !== undefined && cfg.applySink !== undefined;
+  if (settings.colorMode && !isSinkInstance) {
     const theme = document.documentElement.getAttribute('data-theme');
     if (theme === 'light') return settings.colorMode.lightScheme;
     if (theme === 'dark') return settings.colorMode.darkScheme;
@@ -864,8 +902,33 @@ export function safeIndex(index: number, len: number): number {
 export function applyColorState(
   state: ColorTweakState,
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
+  sink?: ApplySink,
 ) {
   const len = state.palette.length;
+  if (sink) {
+    // Batch all writes for this cluster into one sink.apply() call.
+    const pairs: [string, string][] = [];
+    for (let i = 0; i < len; i++) {
+      pairs.push([resolvePaletteCssVar(cluster, i), state.palette[i]]);
+    }
+    for (const [key, cssName] of Object.entries(cluster.baseRoles)) {
+      if (typeof cssName !== 'string' || cssName.length === 0) continue;
+      const stateIndex = state[key as BaseRoleKey];
+      if (typeof stateIndex !== 'number') continue;
+      pairs.push([cssName, state.palette[safeIndex(stateIndex, len)]]);
+    }
+    for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
+      const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
+      pairs.push([cssName, resolveMapping(mapping, state.palette, state.background, state.foreground)]);
+    }
+    try {
+      sink.apply(pairs);
+    } catch (err) {
+      console.warn('[design-token-panel] applySink.apply threw; falling back silently.', err);
+    }
+    return;
+  }
+  // Default path — write directly to document.documentElement.
   // Palette slots.
   for (let i = 0; i < len; i++) {
     setCssVar(resolvePaletteCssVar(cluster, i), state.palette[i]);
@@ -895,7 +958,39 @@ export function applyColorState(
  * Read-only tokens are skipped in both directions: they are informational rows
  * in the UI and are never written to storage.
  */
-export function applyTokenOverrides(tokens: readonly TokenDef[], overrides: TokenOverrides) {
+export function applyTokenOverrides(
+  tokens: readonly TokenDef[],
+  overrides: TokenOverrides,
+  sink?: ApplySink,
+) {
+  if (sink) {
+    const applyPairs: [string, string][] = [];
+    const clearNames: string[] = [];
+    for (const t of tokens) {
+      if (t.readonly) continue;
+      const v = overrides[t.id];
+      if (typeof v === 'string' && v.length > 0) {
+        applyPairs.push([t.cssVar, v]);
+      } else {
+        clearNames.push(t.cssVar);
+      }
+    }
+    if (applyPairs.length > 0) {
+      try {
+        sink.apply(applyPairs);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.apply threw; falling back silently.', err);
+      }
+    }
+    if (clearNames.length > 0) {
+      try {
+        sink.clear(clearNames);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.clear threw; falling back silently.', err);
+      }
+    }
+    return;
+  }
   for (const t of tokens) {
     if (t.readonly) continue;
     const v = overrides[t.id];
@@ -914,20 +1009,40 @@ export function applyTokenOverrides(tokens: readonly TokenDef[], overrides: Toke
  * Tab configs AND the primary color cluster are read from `panelConfig`
  * at call time so a host that calls `configurePanel` before mount sees its
  * own data driving the apply pass.
+ *
+ * When `cfg` is supplied its `applySink` (if any) is used to route all
+ * CSS-var writes for this instance. Omitting `cfg` uses the default active
+ * config (single-panel path, unchanged behavior).
  */
-export function applyFullState(state: TweakState) {
-  const config = getPanelConfig();
+export function applyFullState(state: TweakState, cfg?: PanelConfig) {
+  const config = cfg ?? getPanelConfig();
+  const sink = config.applySink;
   // Primary color cluster is derived from the color TabConfig.
-  applyColorState(state.color, getActivePrimaryCluster(config));
+  applyColorState(state.color, getActivePrimaryCluster(config), sink);
   // Apply spacing / typography / size from tabs[] (required field post-Wave-5).
-  applyTabOverridesFlat(config.tabs, 'spacing', state.spacing);
-  applyTabOverridesFlat(config.tabs, 'font', state.typography);
-  applyTabOverridesFlat(config.tabs, 'size', state.size);
+  applyTabOverridesFlat(config.tabs, 'spacing', state.spacing, sink);
+  applyTabOverridesFlat(config.tabs, 'font', state.typography, sink);
+  applyTabOverridesFlat(config.tabs, 'size', state.size, sink);
   // The secondary cluster is host-driven via the 'color-secondary' tab.
   // When no such tab is configured, skip the secondary apply pass entirely.
   const secondaryCluster = resolveSecondaryColorCluster(config);
   if (secondaryCluster && state.secondary) {
-    applyColorState(state.secondary, secondaryCluster);
+    applyColorState(state.secondary, secondaryCluster, sink);
+  }
+  // Apply generic tab overrides (v3 envelope tabs field).
+  // The `tabs` field stores `TabOverrides` (tierId → { itemId → value }).
+  // `applyTabOverridesFlat` takes a flat `TokenOverrides` (itemId → value),
+  // so we flatten each tab's tier map before passing it through.
+  if (state.tabs) {
+    for (const [tabId, tabOverrides] of Object.entries(state.tabs)) {
+      const flatOverrides: TokenOverrides = {};
+      for (const tierOverrides of Object.values(tabOverrides)) {
+        for (const [itemId, value] of Object.entries(tierOverrides)) {
+          flatOverrides[itemId] = value;
+        }
+      }
+      applyTabOverridesFlat(config.tabs, tabId, flatOverrides, sink);
+    }
   }
 }
 
@@ -939,11 +1054,15 @@ export function applyFullState(state: TweakState) {
  * property removed so the stylesheet default re-asserts.
  *
  * Skips gracefully when the tab is not found (host config without that tab).
+ *
+ * When `sink` is supplied, CSS-var writes and clears are routed through it
+ * instead of `document.documentElement`.
  */
 function applyTabOverridesFlat(
   tabs: readonly TabConfig[],
   tabId: string,
   overrides: TokenOverrides,
+  sink?: ApplySink,
 ) {
   const tab = tabs.find((t) => t.id === tabId);
   if (!tab) return;
@@ -961,6 +1080,45 @@ function applyTabOverridesFlat(
       }
     }
     tabOverrides[tier.id] = tierOverrides;
+  }
+
+  if (sink) {
+    // Collect all apply pairs and clear names, then flush to the sink.
+    const applyPairs: [string, string][] = [];
+    const clearNames: string[] = [];
+    for (const tier of tab.tiers) {
+      for (const item of tier.items) {
+        if (item.readonly) continue;
+        try {
+          const resolved = resolveTierItemValue(tab, tier.id, item.id, tabOverrides);
+          const cssValue = emitTierItemCssValue(resolved);
+          const hasOverride =
+            typeof overrides[item.id] === 'string' && overrides[item.id].length > 0;
+          if (hasOverride || tier.referencesTier !== undefined) {
+            applyPairs.push([item.cssVar, cssValue]);
+          } else {
+            clearNames.push(item.cssVar);
+          }
+        } catch {
+          clearNames.push(item.cssVar);
+        }
+      }
+    }
+    if (applyPairs.length > 0) {
+      try {
+        sink.apply(applyPairs);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.apply threw; falling back silently.', err);
+      }
+    }
+    if (clearNames.length > 0) {
+      try {
+        sink.clear(clearNames);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.clear threw; falling back silently.', err);
+      }
+    }
+    return;
   }
 
   // Apply each item using the resolver so reference tiers emit var() refs.
@@ -996,11 +1154,48 @@ function applyTabOverridesFlat(
  * Default wipe set — follows the host's configuration. Derives the clusters
  * to clear from the color tabs (primary + optional secondary).
  */
-function defaultClusterWipeSet(): readonly ColorClusterDataConfig[] {
-  const cfg = getPanelConfig();
-  const primary = getActivePrimaryCluster(cfg);
-  const secondary = resolveSecondaryColorCluster(cfg);
+function defaultClusterWipeSet(cfg?: PanelConfig): readonly ColorClusterDataConfig[] {
+  const config = cfg ?? getPanelConfig();
+  const primary = getActivePrimaryCluster(config);
+  const secondary = resolveSecondaryColorCluster(config);
   return secondary ? [primary, secondary] : [primary];
+}
+
+/**
+ * Collect ALL CSS var names owned by a color cluster (palette slots, base
+ * roles, semantic vars). Used by the sink-aware clear path to call
+ * `sink.clear(fullTokenNameSet)` for a full-instance reset.
+ */
+function clusterVarNames(cluster: ColorClusterDataConfig): string[] {
+  const names: string[] = [];
+  for (let i = 0; i < cluster.paletteSize; i++) {
+    names.push(resolvePaletteCssVar(cluster, i));
+  }
+  for (const prop of Object.values(cluster.baseRoles)) {
+    if (typeof prop === 'string' && prop.length > 0) names.push(prop);
+  }
+  for (const cssName of Object.values(cluster.semanticCssNames)) {
+    names.push(cssName);
+  }
+  return names;
+}
+
+/**
+ * Collect ALL CSS var names owned by non-color tabs (spacing/font/size and
+ * generic host tabs). Used by the sink-aware reset path.
+ */
+function nonColorTabVarNames(cfg: PanelConfig): string[] {
+  const names: string[] = [];
+  for (const tab of cfg.tabs) {
+    if (tab.id === 'color' || tab.id === 'color-secondary') continue;
+    for (const tier of tab.tiers) {
+      for (const item of tier.items) {
+        if (item.readonly) continue;
+        names.push(item.cssVar);
+      }
+    }
+  }
+  return names;
 }
 
 /**
@@ -1015,10 +1210,28 @@ function defaultClusterWipeSet(): readonly ColorClusterDataConfig[] {
  *
  * Accepts an optional list of clusters so callers can scope the wipe to a
  * subset; the default covers both the primary and secondary clusters.
+ *
+ * When `sink` is supplied, clears are routed through it instead of
+ * `document.documentElement`.
  */
 export function clearAppliedColorStyles(
   clusters: readonly ColorClusterDataConfig[] = defaultClusterWipeSet(),
+  sink?: ApplySink,
 ) {
+  if (sink) {
+    const names: string[] = [];
+    for (const cluster of clusters) {
+      names.push(...clusterVarNames(cluster));
+    }
+    if (names.length > 0) {
+      try {
+        sink.clear(names);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.clear threw; falling back silently.', err);
+      }
+    }
+    return;
+  }
   const root = document.documentElement;
   for (const cluster of clusters) {
     for (let i = 0; i < cluster.paletteSize; i++) {
@@ -1042,18 +1255,47 @@ export function clearAppliedColorStyles(
  * subset; the default wipes both the primary and secondary clusters so a
  * panel-level reset leaves no stale inline overrides on `:root` regardless
  * of which cluster was last edited.
+ *
+ * When `cfg` is supplied its `applySink` (if any) routes the clear through the
+ * sink with the FULL token-name set for this instance (not just dirty vars).
+ * This satisfies the Reset contract: the sink `clear` receives every var the
+ * instance can own, so the sink's target element is completely clean.
  */
 export function clearAppliedStyles(
-  clusters: readonly ColorClusterDataConfig[] = defaultClusterWipeSet(),
+  clusters?: readonly ColorClusterDataConfig[],
+  cfg?: PanelConfig,
 ) {
+  const config = cfg ?? getPanelConfig();
+  const sink = config.applySink;
+  const resolvedClusters = clusters ?? defaultClusterWipeSet(config);
+
+  if (sink) {
+    // Collect the FULL token-name set for this instance so the sink target
+    // is completely cleaned — not just the currently-dirty vars.
+    const names: string[] = [];
+    for (const cluster of resolvedClusters) {
+      names.push(...clusterVarNames(cluster));
+    }
+    names.push(...nonColorTabVarNames(config));
+    if (names.length > 0) {
+      try {
+        sink.clear(names);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.clear threw; falling back silently.', err);
+      }
+    }
+    return;
+  }
+
+  // Default path — write/remove directly on document.documentElement.
   // Color cluster vars (palette / base roles / semantic).
-  clearAppliedColorStyles(clusters);
+  clearAppliedColorStyles(resolvedClusters);
   // Tabs — clear all cssVars for items in spacing/font/size tabs so the
   // stylesheet defaults take effect again.
   const root = document.documentElement;
-  for (const tab of getPanelConfig().tabs) {
+  for (const tab of config.tabs) {
     // Color tab vars are handled above via cluster clear paths.
-    if (tab.id === 'color') continue;
+    if (tab.id === 'color' || tab.id === 'color-secondary') continue;
     for (const tier of tab.tiers) {
       for (const item of tier.items) {
         if (item.readonly) continue;

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -690,27 +690,14 @@ export function cssColorToHex(color: string): string {
 }
 
 /**
- * Write a single CSS custom property. When `sink` is supplied the write is
- * routed through it; otherwise it falls through to `document.documentElement`.
+ * Write a single CSS custom property to `document.documentElement`.
  *
- * This helper is kept intentionally thin — callers batch pairs themselves
- * (e.g. `applyColorState`) and flush them to the sink in one call.
- * Individual-call routing here keeps every existing call site unchanged while
- * still allowing per-call sink overrides during the internal batch loops.
+ * The sink-aware write path bypasses this helper entirely: sink callers
+ * collect all pairs into a batch and call `sink.apply(pairs)` directly.
+ * This helper is used only by the default (no-sink) path in the `else`
+ * branches of `applyColorState`, `applyTabOverridesFlat`, etc.
  */
-export function setCssVar(name: string, value: string, sink?: ApplySink) {
-  if (sink) {
-    // Sink batching is the caller's responsibility; we just delegate.
-    // The sink's `apply` contract is "upsert these pairs" so a single-pair
-    // call is valid — it's the cheapest per-call contract that doesn't
-    // require the caller to collect pairs up front.
-    try {
-      sink.apply([[name, value]]);
-    } catch (err) {
-      console.warn('[design-token-panel] applySink.apply threw; falling back silently.', err);
-    }
-    return;
-  }
+export function setCssVar(name: string, value: string) {
   document.documentElement.style.setProperty(name, value);
 }
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/352

---

## Summary

Implements epic #352 — two **general, backward-compatible** public capabilities for `@takazudo/zdtp`, plus the 0.3.0 release bump. The default single-panel path is unchanged (spy-parity verified).

### 1. Multiple independent panel instances
- The one-shot global config singleton (`globalThis[Symbol.for('@takazudo/zdtp:singleton')]`) is replaced by an **instance registry keyed by `storagePrefix`**.
- `configurePanel(config)` now returns a **`PanelInstanceHandle`** `{ instanceId, open(), close(), toggle(), destroy() }`; it is **re-callable for a distinct prefix** (no throw), **idempotent** for same prefix+config, and **rejects** same-prefix-different-config (`RECONFIGURE_RULE = 'reject-with-error'` — `destroy()` then reconfigure).
- Per-instance: storage keys, mount root (`${storagePrefix}-root`), internal sync event, and **toggle event** (default keeps `toggle-design-token-panel`; configured → `config.toggleEvent ?? toggle-${storagePrefix}`). The `<style>` element stays shared. `destroy()` tears down only its own instance.

### 2. Configurable apply sink (route overrides off `:root`)
- New optional `PanelConfig.applySink?: { apply(pairs), clear(names) }` (type also exported as `ApplySink`).
- `apply` = upsert, `clear` = remove, **Reset clears the instance's full token set**; sink errors are non-fatal. Absent → writes to `document.documentElement` exactly as before. Sink-instance scheme falls back to panel state rather than host `data-theme`.

### 3. Release prep
- `@takazudo/zdtp` **0.2.3 → 0.3.0** (minor, additive). CHANGELOG/README/PORTABLE-CONTRACT/doc-site updated. Tarball pack-smoke typechecks the new public API against the built `.tgz`.

## Review

Codex deep-review found and **fixed** 2 cross-instance correctness bugs (mounted non-default panel's persist/apply/reset/init + Astro console handlers were falling back to the default instance) and the Apply-modal POST payload, with new state-isolation regression tests. Two out-of-scope follow-ups raised as `agent-found` issues (#360 build-dependent test gating, #361 export/import serde still uses the default manifest).

## Verification
- `pnpm typecheck` clean
- **1033 node tests + 114 browser (Playwright) tests pass** on the merged base
- `pnpm build` + tarball pack-smoke green

## Topic waves
- W1: #353 Z1 config core · W2: #354 Z2 lifecycle + #355 Z3 sink · W3: #356 Z4 tests + #357 Z5 docs · W4: #358 Z6 release prep

## Downstream
`Takazudo/zudo-sg#74` depends on the published 0.3.0 — **npm publish is gated on maintainer confirmation** (not done by this automated run).