### PR TITLE
fix(serde): instance-scope export/import/revert serde (#361)

### DIFF
--- a/packages/zdtp/src/__tests__/instance-scoping-serde.test.ts
+++ b/packages/zdtp/src/__tests__/instance-scoping-serde.test.ts
@@ -1,0 +1,382 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for instance-scoped SERDE operations (issue #361).
+ *
+ * The multi-instance epic (#353/#354/#356) made the panel per-instance, and
+ * #357 scoped the persist / apply / reset / init / console paths to the mounted
+ * instance. But the Export / Import / revert SERDE path was left routed through
+ * `getPanelConfig()` (the most-recently-configured / DEFAULT instance):
+ *
+ *   - serialize() built export JSON from the DEFAULT instance's tab manifest,
+ *   - deserialize() validated the schema + mapped cssVars against the DEFAULT
+ *     instance's manifest,
+ *   - the Apply modal's revert blob was serialized from the DEFAULT manifest,
+ *
+ * — all wrong when a NON-default panel coexists with a later-configured one.
+ *
+ * The fix threads each serde function's NEW optional `cfg: PanelConfig`
+ * argument from the mounted instance. These tests prove the scoping at the
+ * serde layer directly: with instances A and B configured (B is the active
+ * default), A's serde operations use A's tab manifest + schema id + color
+ * cluster, never B's.
+ *
+ * Existing coverage these COMPLEMENT (do not duplicate):
+ *  - utils/__tests__/design-token-serde.test.ts — single-instance serde
+ *    round-trips against the fixture config (no-arg default path).
+ *  - instance-scoping-state.test.tsx — persist / apply / reset / init scoping.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  getPanelConfig,
+  type PanelConfig,
+} from '../config/panel-config';
+import {
+  DesignTokenSchemaError,
+  deserialize,
+  getDesignTokenSchema,
+  serialize,
+  type DesignTokenJsonV2,
+} from '../utils/design-token-serde';
+import type { ColorTweakState, TweakState } from '../state/tweak-state';
+import type { TabConfig } from '../tokens/tier-model';
+
+// ---------------------------------------------------------------------------
+// Fixtures — two instances A and B with DELIBERATELY DISTINCT manifests so a
+// leak of B's manifest into A's serde shows up as a wrong cssVar / schema id.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a single-tab-per-category manifest where every cssVar is prefixed with
+ * `ns` so A's and B's vars never collide. A spacing token, a font token, a size
+ * token, and a 4-slot color cluster (palette + one semantic) are enough to
+ * exercise every serde branch.
+ */
+function makeTabs(ns: string): readonly TabConfig[] {
+  return [
+    {
+      id: 'spacing',
+      label: 'Spacing',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Spacing',
+          items: [
+            {
+              id: 'hsp-md',
+              cssVar: `--${ns}-hgap-md`,
+              label: 'hsp-md',
+              default: '40px',
+              type: { kind: 'length', step: 1, unit: 'px' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'font',
+      label: 'Font',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Font Sizes',
+          items: [
+            {
+              id: 'text-base',
+              cssVar: `--${ns}-font-base`,
+              label: 'text-base',
+              default: '1.4rem',
+              type: { kind: 'length', step: 0.05, unit: 'rem' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'size',
+      label: 'Size',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Border Radius',
+          items: [
+            {
+              id: 'radius-lg',
+              cssVar: `--${ns}-radius-lg`,
+              label: 'radius-lg',
+              default: '8px',
+              type: { kind: 'length', step: 1, unit: 'px' },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: 'color',
+      label: 'Color',
+      colorExtras: {
+        id: `${ns}-cluster`,
+        label: `${ns} Cluster`,
+        baseRoles: {},
+        baseDefaults: {
+          background: 0,
+          foreground: 3,
+          cursor: 1,
+          selectionBg: 0,
+          selectionFg: 3,
+        },
+        defaultShikiTheme: 'dracula',
+        colorSchemes: {},
+        panelSettings: { colorScheme: '', colorMode: false },
+      },
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: Array.from({ length: 4 }, (_, i) => ({
+            id: `${ns}-p${i}`,
+            cssVar: `--${ns}-p${i}`,
+            label: `Palette ${i}`,
+            default: '#000000',
+            type: { kind: 'color' as const },
+          })),
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'palette',
+          items: [
+            {
+              id: 'accent',
+              cssVar: `--${ns}-semantic-accent`,
+              label: 'Accent',
+              default: `${ns}-p2`,
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+function makeConfig(ns: string): PanelConfig {
+  return {
+    storagePrefix: ns,
+    consoleNamespace: ns,
+    modalClassPrefix: `${ns}-modal`,
+    schemaId: `${ns}/v1`,
+    exportFilenameBase: ns,
+    tabs: makeTabs(ns),
+    colorPresets: {},
+  };
+}
+
+const CONFIG_A = makeConfig('aaa');
+const CONFIG_B = makeConfig('bbb');
+
+/** A 4-slot color baseline matching the 4-slot palette in makeTabs(). */
+function colorBaseline(): ColorTweakState {
+  return {
+    palette: ['#000000', '#404040', '#808080', '#ffffff'],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { accent: 2 },
+    shikiTheme: 'dracula',
+  };
+}
+
+/**
+ * A TweakState with exactly one override per category, keyed by the shared item
+ * ids (`hsp-md` / `text-base` / `radius-lg`). Both A's and B's manifests share
+ * those ids but map them to DIFFERENT cssVars, so the serialized output reveals
+ * which manifest drove the diff.
+ */
+function tweakState(): TweakState {
+  return {
+    color: { ...colorBaseline(), palette: ['#111111', '#404040', '#808080', '#ffffff'] },
+    spacing: { 'hsp-md': '99px' },
+    typography: { 'text-base': '2rem' },
+    size: { 'radius-lg': '12px' },
+  };
+}
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+  // Configure A first, then B — so B is the active DEFAULT instance that the
+  // no-arg getPanelConfig() resolves to. Any serde call that forgets to thread
+  // A's config would silently fall back to B and fail these assertions.
+  configurePanel(CONFIG_A);
+  configurePanel(CONFIG_B);
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+});
+
+describe('serde instance-scoping (#361)', () => {
+  it('the active default really is B (guards the test premise)', () => {
+    expect(getPanelConfig().storagePrefix).toBe('bbb');
+  });
+
+  describe('serialize() — export JSON uses the passed instance manifest', () => {
+    it("A's export emits A's cssVars, never B's", () => {
+      const json = serialize(tweakState(), { colorDefaults: colorBaseline() }, CONFIG_A);
+      const flat = JSON.stringify(json);
+
+      // A's raw cssVars are present.
+      expect(json.tabs?.spacing?.raw).toEqual({ '--aaa-hgap-md': '99px' });
+      expect(json.tabs?.font?.raw).toEqual({ '--aaa-font-base': '2rem' });
+      expect(json.tabs?.size?.raw).toEqual({ '--aaa-radius-lg': '12px' });
+
+      // B's cssVars must NOT leak anywhere in the document.
+      expect(flat).not.toContain('--bbb-');
+    });
+
+    it("A's export color block uses A's palette + semantic cssVars, never B's", () => {
+      const json = serialize(tweakState(), { colorDefaults: colorBaseline() }, CONFIG_A);
+      // Palette slot 0 changed (#111111) → emitted under A's palette cssVar.
+      expect(json.tabs?.color?.palette).toEqual({ '--aaa-p0': '#111111' });
+      expect(JSON.stringify(json)).not.toContain('--bbb-p');
+    });
+
+    it("B's export (default, no cfg arg) still uses B's manifest — back-compat", () => {
+      // No third arg → falls back to the active default (B). Proves the no-arg
+      // default path keeps resolving the default instance unchanged.
+      const json = serialize(tweakState(), { colorDefaults: colorBaseline() });
+      expect(json.tabs?.spacing?.raw).toEqual({ '--bbb-hgap-md': '99px' });
+      expect(JSON.stringify(json)).not.toContain('--aaa-');
+    });
+
+    it('explicit B cfg matches the no-arg default while B is active (byte-identical)', () => {
+      const now = () => new Date('2020-01-01T00:00:00.000Z');
+      const withArg = serialize(tweakState(), { colorDefaults: colorBaseline(), now }, CONFIG_B);
+      const noArg = serialize(tweakState(), { colorDefaults: colorBaseline(), now });
+      expect(JSON.stringify(withArg)).toBe(JSON.stringify(noArg));
+    });
+  });
+
+  describe('getDesignTokenSchema() — schema id comes from the passed instance', () => {
+    it("returns A's schema id when A's config is passed", () => {
+      expect(getDesignTokenSchema(CONFIG_A)).toBe('aaa/v1');
+    });
+
+    it('returns the default (B) schema id with no arg', () => {
+      expect(getDesignTokenSchema()).toBe('bbb/v1');
+    });
+  });
+
+  describe('deserialize() — import schema-check + mapping use the passed instance', () => {
+    it("A's import maps A's cssVars to ids; B's cssVars are unknown to A", () => {
+      // A payload written from A's manifest.
+      const payload: DesignTokenJsonV2 = {
+        $schema: 'zudo-design-tokens/v2',
+        exportedAt: '2020-01-01T00:00:00.000Z',
+        tabs: {
+          spacing: { raw: { '--aaa-hgap-md': '77px' } },
+          // A B-namespaced var: unknown to A's manifest → reported, not applied.
+          size: { raw: { '--bbb-radius-lg': '5px' } },
+        },
+      };
+
+      const { state, unknownTokens } = deserialize(
+        payload,
+        { colorDefaults: colorBaseline() },
+        CONFIG_A,
+      );
+
+      // A's var mapped back to the shared id.
+      expect(state.spacing).toEqual({ 'hsp-md': '77px' });
+      // B's var did NOT map under A — flagged unknown, dropped from state.
+      expect(state.size).toEqual({});
+      expect(unknownTokens).toContain('--bbb-radius-lg');
+    });
+
+    it("the SAME B-namespaced payload round-trips cleanly under B's config", () => {
+      // Same var that was "unknown" to A is known to B — proves the unknown
+      // result above is purely an instance-scoping effect, not a bad payload.
+      const payload: DesignTokenJsonV2 = {
+        $schema: 'zudo-design-tokens/v2',
+        exportedAt: '2020-01-01T00:00:00.000Z',
+        tabs: { size: { raw: { '--bbb-radius-lg': '5px' } } },
+      };
+      const { state, unknownTokens } = deserialize(
+        payload,
+        { colorDefaults: colorBaseline() },
+        CONFIG_B,
+      );
+      expect(state.size).toEqual({ 'radius-lg': '5px' });
+      expect(unknownTokens).not.toContain('--bbb-radius-lg');
+    });
+
+    it("A's import color palette maps A's palette cssVars, ignores B's", () => {
+      const payload: DesignTokenJsonV2 = {
+        $schema: 'zudo-design-tokens/v2',
+        exportedAt: '2020-01-01T00:00:00.000Z',
+        tabs: {
+          color: {
+            palette: { '--aaa-p1': '#abcdef', '--bbb-p1': '#fedcba' },
+          },
+        },
+      };
+      const { state } = deserialize(payload, { colorDefaults: colorBaseline() }, CONFIG_A);
+      // A's slot 1 took the A-keyed value; B's key was ignored (slot 1 not
+      // overwritten by '#fedcba').
+      expect(state.color.palette[1]).toBe('#abcdef');
+    });
+  });
+
+  describe('serialize → deserialize revert blob round-trips within an instance', () => {
+    it("A's revert blob, re-imported under A, restores the same overrides", () => {
+      const original = tweakState();
+      // Revert blob path (matches the Apply modal's buildPreviewJson): serialize
+      // with A's cfg, then re-deserialize with A's cfg.
+      const blob = serialize(original, { colorDefaults: colorBaseline() }, CONFIG_A);
+      const reparsed = JSON.parse(JSON.stringify(blob));
+      const { state, unknownTokens } = deserialize(
+        reparsed,
+        { colorDefaults: colorBaseline() },
+        CONFIG_A,
+      );
+      expect(unknownTokens).toEqual([]);
+      expect(state.spacing).toEqual({ 'hsp-md': '99px' });
+      expect(state.typography).toEqual({ 'text-base': '2rem' });
+      expect(state.size).toEqual({ 'radius-lg': '12px' });
+    });
+
+    it("A's revert blob re-imported under B yields ONLY unknown tokens (cross-instance leak guard)", () => {
+      const blob = serialize(tweakState(), { colorDefaults: colorBaseline() }, CONFIG_A);
+      const reparsed = JSON.parse(JSON.stringify(blob));
+      const { state, unknownTokens } = deserialize(
+        reparsed,
+        { colorDefaults: colorBaseline() },
+        CONFIG_B,
+      );
+      // None of A's cssVars map under B's manifest.
+      expect(state.spacing).toEqual({});
+      expect(state.typography).toEqual({});
+      expect(state.size).toEqual({});
+      expect(unknownTokens).toEqual(
+        expect.arrayContaining(['--aaa-hgap-md', '--aaa-font-base', '--aaa-radius-lg']),
+      );
+    });
+  });
+
+  describe('schema-mismatch is still thrown regardless of instance', () => {
+    it('a foreign $schema throws under A', () => {
+      expect(() =>
+        deserialize(
+          { $schema: 'some-other/v9', exportedAt: 'x' },
+          { colorDefaults: colorBaseline() },
+          CONFIG_A,
+        ),
+      ).toThrowError(DesignTokenSchemaError);
+    });
+  });
+});

--- a/packages/zdtp/src/apply-modal.tsx
+++ b/packages/zdtp/src/apply-modal.tsx
@@ -116,9 +116,17 @@ type CopyLabel = 'Copy pre-apply state to clipboard' | 'Copied!';
  * Pretty-print the pre-apply diff JSON so the success view can offer it as a
  * revert blob. The user pastes this back into Import → Apply to roll the
  * change back.
+ *
+ * `cfg` is THIS instance's config (multi-instance, #361) so the revert blob is
+ * computed from the mounted panel's OWN tab manifest + color cluster, not the
+ * active default instance's.
  */
-function buildPreviewJson(state: TweakState, colorDefaults: ColorTweakState | undefined): string {
-  return JSON.stringify(serialize(state, { colorDefaults }), null, 2);
+function buildPreviewJson(
+  state: TweakState,
+  colorDefaults: ColorTweakState | undefined,
+  cfg: PanelConfig,
+): string {
+  return JSON.stringify(serialize(state, { colorDefaults }, cfg), null, 2);
 }
 
 /**
@@ -340,7 +348,7 @@ export function ApplyModal(props: ApplyModalProps) {
     }
     // Snapshot the pre-apply JSON now so the success view can still show it
     // after the parent clears persisted state in `onApplied`.
-    const previewJson = buildPreviewJson(state, colorDefaults);
+    const previewJson = buildPreviewJson(state, colorDefaults, cfg);
     setPhase({ kind: 'applying' });
 
     try {

--- a/packages/zdtp/src/export-modal.tsx
+++ b/packages/zdtp/src/export-modal.tsx
@@ -82,12 +82,19 @@ export function ExportModal({ onClose, state, colorDefaults, instanceConfig }: E
   // the displayed timestamp reflects "when you clicked copy".
   const code = useMemo(() => {
     const baseline = resolveColorDefaults(state.color, colorDefaults);
-    const json = serialize(state, {
-      includeDefaults,
-      colorDefaults: baseline,
-    });
+    // Thread THIS instance's config (multi-instance, #361) so the export JSON
+    // is built from the mounted panel's OWN tab manifest + color cluster, not
+    // the active default instance's.
+    const json = serialize(
+      state,
+      {
+        includeDefaults,
+        colorDefaults: baseline,
+      },
+      cfg,
+    );
     return JSON.stringify(json, null, 2);
-  }, [state, colorDefaults, includeDefaults]);
+  }, [state, colorDefaults, includeDefaults, cfg]);
 
   useEffect(() => {
     const dialog = dialogRef.current;

--- a/packages/zdtp/src/import-modal.tsx
+++ b/packages/zdtp/src/import-modal.tsx
@@ -60,7 +60,10 @@ export function ImportModal({ onClose, onLoad, colorDefaults, instanceConfig }: 
   // Resolve THIS instance's config (multi-instance, #357); a prop-less test
   // render falls back to the active default instance.
   const cfg = instanceConfig ?? getPanelConfig();
-  const expectedSchema = getDesignTokenSchema();
+  // Thread THIS instance's config (multi-instance, #361) so the schema label
+  // surfaced in the UI comes from the mounted panel's OWN schema id, not the
+  // active default instance's.
+  const expectedSchema = getDesignTokenSchema(cfg);
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -117,9 +120,16 @@ export function ImportModal({ onClose, onLoad, colorDefaults, instanceConfig }: 
     }
 
     try {
-      const { state, unknownTokens, warnings } = deserialize(parsed, {
-        colorDefaults,
-      });
+      // Thread THIS instance's config (multi-instance, #361) so the
+      // schema-check + cssVar→id mapping validate against the mounted panel's
+      // OWN tab manifest + color cluster, not the active default instance's.
+      const { state, unknownTokens, warnings } = deserialize(
+        parsed,
+        {
+          colorDefaults,
+        },
+        cfg,
+      );
 
       if (unknownTokens.length > 0) {
         // Grouped console.warn so developers can inspect the list without

--- a/packages/zdtp/src/utils/design-token-serde.ts
+++ b/packages/zdtp/src/utils/design-token-serde.ts
@@ -67,7 +67,7 @@
 
 import type { ColorTweakState, TokenOverrides, TweakState } from '../state/tweak-state';
 import { getActivePrimaryCluster } from '../state/tweak-state';
-import { getPanelConfig } from '../config/panel-config';
+import { getPanelConfig, type PanelConfig } from '../config/panel-config';
 import { resolvePaletteCssVar } from '../config/cluster-config';
 import type { TierItem } from '../tokens/tier-model';
 
@@ -76,13 +76,18 @@ type SerdeItem = Pick<TierItem, 'id' | 'cssVar' | 'default' | 'readonly'>;
 
 /**
  * Collect all items (across all tiers) from the tab identified by `tabId` in
- * the active PanelConfig. Returns an empty array when the tab is not found.
+ * the supplied PanelConfig. Returns an empty array when the tab is not found.
  *
  * Used by serialize / deserialize to iterate the known items for a tab so
  * cssVar ↔ id mapping stays consistent with what the UI renders.
+ *
+ * `cfg` defaults to the active (most-recently-configured) instance so the
+ * single-default path and any non-panel caller stay byte-identical. The panel
+ * threads its OWN mounted instance config (multi-instance, #361) so a
+ * non-default panel's export/import iterates ITS manifest, not the default's.
  */
-function getTabItems(tabId: string): readonly SerdeItem[] {
-  const tab = getPanelConfig().tabs.find((t) => t.id === tabId);
+function getTabItems(tabId: string, cfg: PanelConfig = getPanelConfig()): readonly SerdeItem[] {
+  const tab = cfg.tabs.find((t) => t.id === tabId);
   if (!tab) return [];
   const items: SerdeItem[] = [];
   for (const tier of tab.tiers) {
@@ -109,14 +114,20 @@ function emptyOverrides(): TokenOverrides {
 }
 
 /**
- * Read the active design-token schema id at call time.
+ * Read the design-token schema id at call time.
  *
- * Returns the host-configured schema id from `panelConfig.schemaId`. Used as
- * the `$schema` value in legacy v1 exports (for hosts that have not upgraded
- * their config to v2). The canonical v2 serialize path always emits `SCHEMA_V2`.
+ * Returns the host-configured schema id from `cfg.schemaId`. Used as the
+ * `$schema` value in legacy v1 exports (for hosts that have not upgraded their
+ * config to v2) and as the expected-schema label the Import modal surfaces. The
+ * canonical v2 serialize path always emits `SCHEMA_V2`.
+ *
+ * `cfg` defaults to the active (most-recently-configured) instance so the
+ * single-default path stays byte-identical. The Import modal threads its OWN
+ * mounted instance config (multi-instance, #361) so a non-default panel
+ * validates against ITS schema id, not the default's.
  */
-export function getDesignTokenSchema(): string {
-  return getPanelConfig().schemaId;
+export function getDesignTokenSchema(cfg: PanelConfig = getPanelConfig()): string {
+  return cfg.schemaId;
 }
 
 // ---------------------------------------------------------------------------
@@ -251,8 +262,18 @@ export class DesignTokenSchemaError extends Error {
  * defaults; set `opts.includeDefaults = true` to dump everything.
  *
  * The output `$schema` is always `SCHEMA_V2` ("zudo-design-tokens/v2").
+ *
+ * `cfg` defaults to the active (most-recently-configured) instance so the
+ * single-default path stays byte-identical. The Export / Apply modals thread
+ * their OWN mounted instance config (multi-instance, #361) so a non-default
+ * panel's export JSON / revert blob is built from ITS tab manifest + color
+ * cluster, not the default instance's.
  */
-export function serialize(state: TweakState, opts: SerializeOptions = {}): DesignTokenJsonV2 {
+export function serialize(
+  state: TweakState,
+  opts: SerializeOptions = {},
+  cfg: PanelConfig = getPanelConfig(),
+): DesignTokenJsonV2 {
   const now = opts.now ? opts.now() : new Date();
   const out: DesignTokenJsonV2 = {
     $schema: SCHEMA_V2,
@@ -262,19 +283,19 @@ export function serialize(state: TweakState, opts: SerializeOptions = {}): Desig
   const tabs: Record<string, V2TabEntry> = {};
 
   // Color tab — keyed under "color".
-  const colorTab = serializeColorV2(state.color, opts);
+  const colorTab = serializeColorV2(state.color, opts, cfg);
   if (colorTab) tabs['color'] = colorTab;
 
   // Read items from tabs[] so a host-supplied config drives the diff pass.
   // The internal state slice is named `typography`; the external tab id is
   // `font` to match the external spec (issue #74). `deserialize()` maps back.
-  const spacingTab = serializeOverridesV2(getTabItems('spacing'), state.spacing, opts);
+  const spacingTab = serializeOverridesV2(getTabItems('spacing', cfg), state.spacing, opts);
   if (spacingTab) tabs['spacing'] = spacingTab;
 
-  const fontTab = serializeOverridesV2(getTabItems('font'), state.typography, opts);
+  const fontTab = serializeOverridesV2(getTabItems('font', cfg), state.typography, opts);
   if (fontTab) tabs['font'] = fontTab;
 
-  const sizeTab = serializeOverridesV2(getTabItems('size'), state.size, opts);
+  const sizeTab = serializeOverridesV2(getTabItems('size', cfg), state.size, opts);
   if (sizeTab) tabs['size'] = sizeTab;
 
   if (Object.keys(tabs).length > 0) {
@@ -302,10 +323,11 @@ export function serialize(state: TweakState, opts: SerializeOptions = {}): Desig
 function serializeColorV2(
   color: ColorTweakState,
   opts: SerializeOptions,
+  cfg: PanelConfig,
 ): V2TabEntry | undefined {
   const baseline = opts.colorDefaults;
   const full = opts.includeDefaults === true;
-  const cluster = getActivePrimaryCluster();
+  const cluster = getActivePrimaryCluster(cfg);
 
   const out: V2TabEntry = {};
   let wrote = false;
@@ -403,8 +425,18 @@ function serializeOverridesV2(
  *
  * Missing fields fall back to `opts.colorDefaults` (or, absent that, a
  * minimal neutral default) so the result is always a valid `TweakState`.
+ *
+ * `cfg` defaults to the active (most-recently-configured) instance so the
+ * single-default path stays byte-identical. The Import modal threads its OWN
+ * mounted instance config (multi-instance, #361) so a non-default panel's
+ * schema-check + cssVar→id mapping use ITS tab manifest + color cluster, not
+ * the default instance's.
  */
-export function deserialize(input: unknown, opts: DeserializeOptions = {}): DeserializeResult {
+export function deserialize(
+  input: unknown,
+  opts: DeserializeOptions = {},
+  cfg: PanelConfig = getPanelConfig(),
+): DeserializeResult {
   if (input === null || typeof input !== 'object' || Array.isArray(input)) {
     throw new DesignTokenSchemaError('not-object', 'Input is not a JSON object.');
   }
@@ -420,11 +452,11 @@ export function deserialize(input: unknown, opts: DeserializeOptions = {}): Dese
   }
 
   if (schema === SCHEMA_V2) {
-    return deserializeV2(obj, opts);
+    return deserializeV2(obj, opts, cfg);
   }
 
   if (schema === SCHEMA_V1) {
-    return deserializeV1(obj, opts);
+    return deserializeV1(obj, opts, cfg);
   }
 
   throw new DesignTokenSchemaError(
@@ -438,11 +470,15 @@ export function deserialize(input: unknown, opts: DeserializeOptions = {}): Dese
 // v2 deserialization
 // ---------------------------------------------------------------------------
 
-function deserializeV2(obj: Record<string, unknown>, opts: DeserializeOptions): DeserializeResult {
+function deserializeV2(
+  obj: Record<string, unknown>,
+  opts: DeserializeOptions,
+  cfg: PanelConfig,
+): DeserializeResult {
   const warnings: string[] = [];
   const unknownTokens: string[] = [];
-  const baseline = opts.colorDefaults ?? neutralColorDefaults();
-  const cluster = getActivePrimaryCluster();
+  const baseline = opts.colorDefaults ?? neutralColorDefaults(cfg);
+  const cluster = getActivePrimaryCluster(cfg);
 
   const tabsRaw = obj.tabs && typeof obj.tabs === 'object' && !Array.isArray(obj.tabs)
     ? (obj.tabs as Record<string, unknown>)
@@ -457,21 +493,21 @@ function deserializeV2(obj: Record<string, unknown>, opts: DeserializeOptions): 
   const spacingRaw = spacingTab && typeof spacingTab === 'object'
     ? (spacingTab as Record<string, unknown>)['raw']
     : undefined;
-  const spacing = deserializeOverridesV2(spacingRaw, getTabItems('spacing'), 'spacing', unknownTokens, warnings);
+  const spacing = deserializeOverridesV2(spacingRaw, getTabItems('spacing', cfg), 'spacing', unknownTokens, warnings);
 
   // Font tab (id "font" in v2 external, maps to internal "typography").
   const fontTab = tabsRaw['font'];
   const fontRaw = fontTab && typeof fontTab === 'object'
     ? (fontTab as Record<string, unknown>)['raw']
     : undefined;
-  const typography = deserializeOverridesV2(fontRaw, getTabItems('font'), 'font.raw', unknownTokens, warnings);
+  const typography = deserializeOverridesV2(fontRaw, getTabItems('font', cfg), 'font.raw', unknownTokens, warnings);
 
   // Size tab.
   const sizeTab = tabsRaw['size'];
   const sizeRaw = sizeTab && typeof sizeTab === 'object'
     ? (sizeTab as Record<string, unknown>)['raw']
     : undefined;
-  const size = deserializeOverridesV2(sizeRaw, getTabItems('size'), 'size', unknownTokens, warnings);
+  const size = deserializeOverridesV2(sizeRaw, getTabItems('size', cfg), 'size', unknownTokens, warnings);
 
   return {
     state: { color, spacing, typography, size },
@@ -578,17 +614,21 @@ function deserializeOverridesV2(
 // v1 deserialization (one-way migration, no longer a valid output format)
 // ---------------------------------------------------------------------------
 
-function deserializeV1(obj: Record<string, unknown>, opts: DeserializeOptions): DeserializeResult {
+function deserializeV1(
+  obj: Record<string, unknown>,
+  opts: DeserializeOptions,
+  cfg: PanelConfig,
+): DeserializeResult {
   const warnings: string[] = [];
   const unknownTokens: string[] = [];
-  const baseline = opts.colorDefaults ?? neutralColorDefaults();
+  const baseline = opts.colorDefaults ?? neutralColorDefaults(cfg);
 
   const color = deserializeColorV1(obj.color, baseline, warnings);
   // Read items from tabs[] so a host-supplied config drives validation.
   // v1 used "typography" as the key (not "font") for the typography tab.
-  const spacing = deserializeOverridesV1(obj.spacing, getTabItems('spacing'), 'spacing', unknownTokens, warnings);
-  const typography = deserializeOverridesV1(obj.typography, getTabItems('font'), 'typography', unknownTokens, warnings);
-  const size = deserializeOverridesV1(obj.size, getTabItems('size'), 'size', unknownTokens, warnings);
+  const spacing = deserializeOverridesV1(obj.spacing, getTabItems('spacing', cfg), 'spacing', unknownTokens, warnings);
+  const typography = deserializeOverridesV1(obj.typography, getTabItems('font', cfg), 'typography', unknownTokens, warnings);
+  const size = deserializeOverridesV1(obj.size, getTabItems('size', cfg), 'size', unknownTokens, warnings);
 
   return {
     state: { color, spacing, typography, size },
@@ -712,13 +752,14 @@ function numOr(v: unknown, fallback: number): number {
 /**
  * Minimal color state used as the last-resort baseline when the caller can't
  * provide one (e.g. unit tests without a DOM). The palette is sized to the
- * active panel config's color cluster `paletteSize` so smaller clusters
+ * supplied panel config's color cluster `paletteSize` so smaller clusters
  * don't end up with orphan trailing slots.
  *
- * Falls back to a length of 16 when no cluster is configured.
+ * Falls back to a length of 16 when no cluster is configured. `cfg` defaults to
+ * the active instance so the single-default path stays byte-identical.
  */
-function neutralColorDefaults(): ColorTweakState {
-  const cluster = getActivePrimaryCluster();
+function neutralColorDefaults(cfg: PanelConfig = getPanelConfig()): ColorTweakState {
+  const cluster = getActivePrimaryCluster(cfg);
   const size = cluster && cluster.paletteSize > 0 ? cluster.paletteSize : 16;
   const lastIdx = size - 1;
   const palette = Array.from({ length: size }, (_, i) => {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/361
    - https://github.com/Takazudo/zudo-design-token-panel/issues/352

---

Closes #361.

Completes the multi-instance scoping for the **Export / Import / revert serde** path (the one surface the epic #352 review fix left on the default instance).

## What
- `serialize` / `deserialize` / `getDesignTokenSchema` / `getTabItems` (+ private helpers `serializeColorV2`, `deserializeV2`, `deserializeV1`, `neutralColorDefaults`) take an explicit `cfg: PanelConfig = getPanelConfig()`. No-arg / omitted = active default instance → the single-default path stays byte-identical.
- Export/Import/Apply modals thread the mounted instance's `cfg` (already passed into them by `panel.tsx`) into the serde calls.
- Server side unchanged — it uses a filesystem write-serialization mutex (`server/serialize-write.ts`), not the design-token serde; there is no panel-instance manifest to scope there.

## Why
Without this, a non-default panel's export JSON, import schema-check, and revert blob were built from the **default** instance's `tabs` / `schemaId` — wrong manifest when two instances coexist. Same bug class as the P1/P2 fixed in #359.

## Tests
New `instance-scoping-serde.test.ts` (13 jsdom tests): with instances A/B configured (B active default), A's export/schema/import-mapping/revert all use A's manifest and never leak B's vars; explicit-default `serialize` is byte-identical to the no-arg call.

## Verification
typecheck clean · 1040 node tests pass (the only failure is the known pre-existing #360 dist-dependent integration suite) · `pnpm build` green.

Targets `main` so it lands in 0.3.0 before the npm publish.