### PR TITLE
fix(serde): round-trip generic (custom-id) tab overrides through Export/Load (#365)

### DIFF
--- a/packages/zdtp/src/utils/__tests__/design-token-serde.test.ts
+++ b/packages/zdtp/src/utils/__tests__/design-token-serde.test.ts
@@ -10,7 +10,8 @@ import {
 } from '../design-token-serde';
 import type { ColorTweakState, TweakState } from '../../state/tweak-state';
 import { __resetPanelConfigForTests } from '../../config/panel-config';
-import { installFixturePanelConfig, FIXTURE_CLUSTER } from '../../__tests__/_test-helpers';
+import { installFixturePanelConfig, FIXTURE_CLUSTER, FIXTURE_TABS } from '../../__tests__/_test-helpers';
+import type { TabConfig } from '../../tokens/tier-model';
 
 beforeEach(() => {
   installFixturePanelConfig();
@@ -484,5 +485,139 @@ describe('getDesignTokenSchema', () => {
     // (from FIXTURE_PANEL_CONFIG). This is the host-configured "expected" schema
     // for import validation UI. serialize() independently always emits SCHEMA_V2.
     expect(getDesignTokenSchema()).toBe('zudo-design-tokens/v1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serialize / deserialize — generic (custom-id) tabs (issue #363)
+// ---------------------------------------------------------------------------
+
+/**
+ * A host-coined GENERIC tab: id `ui-color` is NOT one of the reserved dedicated
+ * slices (color/spacing/font/size), so its overrides live in `state.tabs['ui-color']`
+ * and must round-trip under `tabs['ui-color'].raw`. Deliberately TWO tiers
+ * (`brand` with two items, `surface` with one) so the round-trip exercises the
+ * tier-aware reverse lookup — a single-tier fixture would not prove that items
+ * are rebucketed into the correct tier on deserialize. Text-kind rows mirror the
+ * #363 repro (custom text tabs that can't use the reserved `color` id).
+ */
+const GENERIC_TAB: TabConfig = {
+  id: 'ui-color',
+  label: 'UI Color',
+  tiers: [
+    {
+      id: 'brand',
+      label: 'Brand',
+      items: [
+        { id: 'brand-base', cssVar: '--ui-brand', label: 'brand', default: 'rebeccapurple', type: { kind: 'text' } },
+        { id: 'brand-ink', cssVar: '--ui-brand-ink', label: 'brand ink', default: 'white', type: { kind: 'text' } },
+      ],
+    },
+    {
+      id: 'surface',
+      label: 'Surface',
+      items: [
+        { id: 'surface-base', cssVar: '--ui-surface', label: 'surface', default: 'canvas', type: { kind: 'text' } },
+      ],
+    },
+  ],
+};
+
+/** Install the fixture config WITH the generic `ui-color` tab appended. */
+function installWithGenericTab(): void {
+  installFixturePanelConfig({ tabs: [...FIXTURE_TABS, GENERIC_TAB] });
+}
+
+describe('serialize/deserialize — generic (custom-id) tabs', () => {
+  beforeEach(() => {
+    installWithGenericTab();
+  });
+
+  it('serialize emits tabs[<customId>].raw (cssVar-keyed) when a generic-tab item differs from its default', () => {
+    const state = makeState({ tabs: { 'ui-color': { brand: { 'brand-base': '#ff0000' } } } });
+    const json = serialize(state, { colorDefaults: COLOR_BASELINE });
+    expect(json.tabs?.['ui-color']?.['raw']).toEqual({ '--ui-brand': '#ff0000' });
+  });
+
+  it('serialize drops a generic-tab override that equals the item default (diff-only)', () => {
+    // 'rebeccapurple' is the declared default for --ui-brand, so it must NOT appear.
+    const state = makeState({ tabs: { 'ui-color': { brand: { 'brand-base': 'rebeccapurple' } } } });
+    const json = serialize(state, { colorDefaults: COLOR_BASELINE });
+    expect(json.tabs?.['ui-color']).toBeUndefined();
+  });
+
+  it('serialize under includeDefaults dumps every editable generic-tab item', () => {
+    const json = serialize(makeState(), { colorDefaults: COLOR_BASELINE, includeDefaults: true });
+    expect(json.tabs?.['ui-color']?.['raw']).toEqual({
+      '--ui-brand': 'rebeccapurple',
+      '--ui-brand-ink': 'white',
+      '--ui-surface': 'canvas',
+    });
+  });
+
+  it('round-trips generic-tab overrides across MULTIPLE tiers (serialize → JSON → deserialize)', () => {
+    const original = makeState({
+      tabs: {
+        'ui-color': {
+          brand: { 'brand-base': '#ff0000', 'brand-ink': '#eeeeee' },
+          surface: { 'surface-base': 'navy' },
+        },
+      },
+    });
+
+    const json = serialize(original, { colorDefaults: COLOR_BASELINE });
+    // Sanity: every changed item lands under the single synthetic external `raw` key.
+    expect(json.tabs?.['ui-color']?.['raw']).toEqual({
+      '--ui-brand': '#ff0000',
+      '--ui-brand-ink': '#eeeeee',
+      '--ui-surface': 'navy',
+    });
+
+    const parsed = JSON.parse(JSON.stringify(json));
+    const { state, unknownTokens } = deserialize(parsed, { colorDefaults: COLOR_BASELINE });
+
+    expect(unknownTokens).toEqual([]);
+    // Tier-aware reconstruction: items are rebucketed into their original tiers.
+    expect(state.tabs).toEqual(original.tabs);
+  });
+
+  it('collects unknown cssVars inside a generic tab into unknownTokens', () => {
+    const payload: DesignTokenJsonV2 = {
+      $schema: SCHEMA_V2,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        'ui-color': {
+          raw: {
+            '--ui-brand': '#ff0000',
+            '--ui-bogus': 'nope',
+          },
+        },
+      },
+    };
+    const { state, unknownTokens } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.tabs).toEqual({ 'ui-color': { brand: { 'brand-base': '#ff0000' } } });
+    expect(unknownTokens).toEqual(['--ui-bogus']);
+  });
+
+  it('ignores an unconfigured/foreign generic tab id present in the JSON (not admitted into state.tabs)', () => {
+    const payload: DesignTokenJsonV2 = {
+      $schema: SCHEMA_V2,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        'not-a-configured-tab': { raw: { '--whatever': '1rem' } },
+      },
+    };
+    const { state, unknownTokens } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.tabs).toBeUndefined();
+    // A foreign tab id is ignored wholesale — its cssVars are NOT reported as unknown tokens.
+    expect(unknownTokens).toEqual([]);
+  });
+
+  it('no generic-tab overrides → tabs omitted on serialize, state.tabs undefined on deserialize (no regression)', () => {
+    const json = serialize(makeState(), { colorDefaults: COLOR_BASELINE });
+    expect(json.tabs?.['ui-color']).toBeUndefined();
+
+    const { state } = deserialize(JSON.parse(JSON.stringify(json)), { colorDefaults: COLOR_BASELINE });
+    expect(state.tabs).toBeUndefined();
   });
 });

--- a/packages/zdtp/src/utils/design-token-serde.ts
+++ b/packages/zdtp/src/utils/design-token-serde.ts
@@ -40,6 +40,13 @@
  * }
  * ```
  *
+ * Host-coined GENERIC tabs (any configured tab whose id is not one of the
+ * dedicated slices `color` / `color-secondary` / `spacing` / `font` / `size`)
+ * round-trip the same way as spacing/size: their overrides live in
+ * `state.tabs[id]` (the v3 envelope) and serialize under `tabs[id].raw`,
+ * cssVar-keyed (issue #363). The apply path (`applyFullState`) already consumes
+ * `state.tabs`; serialize + deserialize make Export/Load symmetric with it.
+ *
  * Key decisions (issue #74):
  * - cssVar-keyed leaves for portability across host id renames.
  * - Tier-2 ref values are stored as the literal `var(--tier1-cssvar)` CSS
@@ -65,7 +72,7 @@
  * Read-only manifest tokens are skipped in both directions.
  */
 
-import type { ColorTweakState, TokenOverrides, TweakState } from '../state/tweak-state';
+import type { ColorTweakState, TabOverrides, TokenOverrides, TweakState } from '../state/tweak-state';
 import { getActivePrimaryCluster } from '../state/tweak-state';
 import { getPanelConfig, type PanelConfig } from '../config/panel-config';
 import { resolvePaletteCssVar } from '../config/cluster-config';
@@ -96,6 +103,61 @@ function getTabItems(tabId: string, cfg: PanelConfig = getPanelConfig()): readon
     }
   }
   return items;
+}
+
+/**
+ * Tab ids handled by a dedicated serde slice — the four reserved external tab
+ * ids plus `color-secondary` (carried by `state.secondary`, not `state.tabs`).
+ * Everything else configured in `cfg.tabs` is a host-coined GENERIC tab whose
+ * overrides live in `state.tabs[id]` and round-trip under `tabs[id].raw`.
+ */
+const RESERVED_TAB_IDS: ReadonlySet<string> = new Set([
+  'color',
+  'color-secondary',
+  'spacing',
+  'font',
+  'size',
+]);
+
+/**
+ * Flatten a tier-nested `TabOverrides` (`tierId → itemId → value`) into a flat
+ * `TokenOverrides` (`itemId → value`) so it can be fed to `serializeOverridesV2`,
+ * which keys diff/emit by item id. Item ids are unique across a tab's tiers
+ * (enforced by panel-config validation), so the flatten is lossless; any stale
+ * or readonly item id that lingers in the persisted map is filtered out later by
+ * `serializeOverridesV2` (it only walks the manifest items).
+ */
+function flattenTabOverrides(tabOverrides: TabOverrides | undefined): TokenOverrides {
+  const flat: TokenOverrides = {};
+  if (!tabOverrides) return flat;
+  for (const tierMap of Object.values(tabOverrides)) {
+    for (const [itemId, value] of Object.entries(tierMap)) {
+      flat[itemId] = value;
+    }
+  }
+  return flat;
+}
+
+/**
+ * Build a `cssVar → { tierId, itemId }` reverse lookup for a tab (readonly items
+ * skipped). Used by the generic-tab deserialize pass to rebuild the tier-nested
+ * `TabOverrides` shape — `getTabItems` flattens away the tier id, so it can't be
+ * used here. Returns an empty map when the tab is not configured.
+ */
+function buildTabVarLookup(
+  tabId: string,
+  cfg: PanelConfig,
+): Map<string, { tierId: string; itemId: string }> {
+  const map = new Map<string, { tierId: string; itemId: string }>();
+  const tab = cfg.tabs.find((t) => t.id === tabId);
+  if (!tab) return map;
+  for (const tier of tab.tiers) {
+    for (const item of tier.items) {
+      if (item.readonly) continue;
+      map.set(item.cssVar, { tierId: tier.id, itemId: item.id });
+    }
+  }
+  return map;
 }
 
 /** The canonical v2 schema identifier emitted by serialize(). */
@@ -181,7 +243,14 @@ export interface DesignTokenJson {
  */
 export type V2TierMap = Record<string, string | number>;
 
-/** Per-tab overrides in v2 format. Key is tier id. */
+/**
+ * Per-tab overrides in v2 format. Keyed nominally by tier id — but only the
+ * `color` tab uses real tier ids (`palette` / `semantic`). Every other tab
+ * (spacing / font / size AND host-coined generic tabs) uses the single synthetic
+ * external key `raw` regardless of its internal tier ids; the cssVar leaves under
+ * `raw` carry the identity, so the external JSON never depends on a tab's
+ * internal tier structure.
+ */
 export type V2TabEntry = Record<string, V2TierMap>;
 
 /** v2 external JSON document shape. */
@@ -297,6 +366,20 @@ export function serialize(
 
   const sizeTab = serializeOverridesV2(getTabItems('size', cfg), state.size, opts);
   if (sizeTab) tabs['size'] = sizeTab;
+
+  // Generic (host-coined, custom-id) tabs — any configured tab that isn't one of
+  // the dedicated slices above. Their overrides live in `state.tabs[id]` (the v3
+  // envelope) and are emitted under `tabs[id].raw`, cssVar-keyed, exactly like
+  // spacing/size. Driven by `cfg.tabs` so this is symmetric with the deserialize
+  // pass and with the apply path (`applyFullState`), which already consumes
+  // `state.tabs`. The stored override value is written verbatim — no `var()`
+  // resolution here (that belongs to the apply/build path, not serde).
+  for (const tab of cfg.tabs) {
+    if (RESERVED_TAB_IDS.has(tab.id)) continue;
+    const flat = flattenTabOverrides(state.tabs?.[tab.id]);
+    const genericTab = serializeOverridesV2(getTabItems(tab.id, cfg), flat, opts);
+    if (genericTab) tabs[tab.id] = genericTab;
+  }
 
   if (Object.keys(tabs).length > 0) {
     out.tabs = tabs;
@@ -509,8 +592,47 @@ function deserializeV2(
     : undefined;
   const size = deserializeOverridesV2(sizeRaw, getTabItems('size', cfg), 'size', unknownTokens, warnings);
 
+  // Generic (custom-id) tabs — driven by the CONFIGURED tabs, not arbitrary
+  // payload keys, so foreign / unconfigured tab ids in the JSON are ignored
+  // rather than admitted into `state.tabs` (there is no "unknownTabs" channel;
+  // unknown cssVars within a configured tab still surface via `unknownTokens`).
+  // Rebuilds the tier-nested `TabOverrides` shape so the round-trip equals what
+  // `persistTab` writes and `applyFullState` consumes.
+  let tabsState: Record<string, TabOverrides> | undefined;
+  for (const tab of cfg.tabs) {
+    if (RESERVED_TAB_IDS.has(tab.id)) continue;
+    const tabEntry = tabsRaw[tab.id];
+    const rawMap =
+      tabEntry && typeof tabEntry === 'object' && !Array.isArray(tabEntry)
+        ? (tabEntry as Record<string, unknown>)['raw']
+        : undefined;
+    if (!rawMap || typeof rawMap !== 'object' || Array.isArray(rawMap)) continue;
+
+    const lookup = buildTabVarLookup(tab.id, cfg);
+    const tierBuckets: Record<string, Record<string, string>> = {};
+    let wrote = false;
+    for (const [cssVar, value] of Object.entries(rawMap as Record<string, unknown>)) {
+      const hit = lookup.get(cssVar);
+      if (!hit) {
+        unknownTokens.push(cssVar);
+        continue;
+      }
+      if (typeof value !== 'string' || value.length === 0) {
+        warnings.push(`${tab.id}.raw.${cssVar} is not a non-empty string; ignored.`);
+        continue;
+      }
+      const bucket = tierBuckets[hit.tierId] ?? (tierBuckets[hit.tierId] = {});
+      bucket[hit.itemId] = value;
+      wrote = true;
+    }
+    if (wrote) {
+      if (!tabsState) tabsState = {};
+      tabsState[tab.id] = tierBuckets;
+    }
+  }
+
   return {
-    state: { color, spacing, typography, size },
+    state: { color, spacing, typography, size, ...(tabsState ? { tabs: tabsState } : {}) },
     unknownTokens,
     warnings,
   };


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/365
    - https://github.com/Takazudo/zudo-design-token-panel/issues/364 (epic)

---

## Summary

Fixes #363 (round-trip asymmetry). The design-token serde (`packages/zdtp/src/utils/design-token-serde.ts`) only handled the four dedicated state slices (`color`/`spacing`/`font`/`size`). Host-coined **generic / custom-id tabs** store their overrides in `state.tabs[id]` (the v3 envelope) and are applied live by `applyFullState`, but `serialize()` never emitted them and `deserializeV2()` never repopulated them — so a custom-id `GenericTab`'s edits were silently dropped from Export and could not be restored via Load-from-JSON.

This adds a **symmetric** generic-tab pass to both serde halves.

## Changes

- **`serialize()`** — after the dedicated passes, iterate `cfg.tabs` and for each non-reserved tab emit its `state.tabs[id]` overrides under `tabs[id].raw` (cssVar-keyed), reusing `serializeOverridesV2` after flattening the tier-nested `TabOverrides`. Values are written verbatim (no `var()` resolution — that belongs to the apply/build path). Diff-only and `includeDefaults` come for free.
- **`deserializeV2()`** — after the dedicated passes, iterate the **configured** non-reserved tabs (not arbitrary JSON keys, so foreign tab ids are ignored), read `tabs[id].raw`, map each cssVar back to `{tierId, itemId}` via a new tier-aware reverse lookup, and rebuild `state.tabs[id]`. Unknown cssVars still surface via `unknownTokens`; `state.tabs` stays `undefined` when empty (no four-slice regression).
- **Reserved-id set**: `color`, `color-secondary`, `spacing`, `font`, `size` — everything else is generic.
- Doc comments updated (top-of-file `tabs` section + `V2TabEntry` synthetic `raw`-key clarification).

## Test Plan

- Added a 2-tier custom-id fixture tab (`ui-color`) and 7 cases: serialize (diff-only emit + diff-only drop + `includeDefaults`), **multi-tier round-trip** (proves tier-aware reconstruction), unknown-cssVar collection, foreign-tab-id ignored, and the no-generic-tab no-regression path.
- `pnpm -F @takazudo/zdtp typecheck` — clean
- `pnpm -F @takazudo/zdtp test --run` — 1167 tests pass (37 serde, incl. 7 new)
- `pnpm -F @takazudo/zdtp build` — clean