### PR TITLE
fix(test): skip bin integration suite when dist/bin/server.js is absent (#368)

### DIFF
--- a/packages/zdtp/src/bin/__tests__/server.integration.test.ts
+++ b/packages/zdtp/src/bin/__tests__/server.integration.test.ts
@@ -6,7 +6,9 @@
  * the full build wiring: shebang banner, chmod +x, and Vite's bundled output.
  * If you change anything in `src/bin/`, run
  * `pnpm --filter @takazudo/zdtp build` BEFORE re-running
- * this file — the test refuses to run if the bin output is missing.
+ * this file — the whole suite is SKIPPED (with a console warning) when the bin
+ * output is missing, so a fresh checkout that hasn't built `dist` stays green.
+ * CI builds before running tests, so the suite still runs there.
  *
  * The tests prefer `--port 0` and parse the OS-assigned port from the bin's
  * startup log, except for the EADDRINUSE case where we deliberately reuse a
@@ -25,11 +27,26 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import type { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BIN_PATH = resolve(HERE, '../../../dist/bin/server.js');
 const STARTUP_LINE_RE = /listening on https?:\/\/[^:]+:(\d+)/;
+
+/**
+ * The integration suite spawns the BUILT bin, so it can only run after a build.
+ * Detect the artifact once at module load and gate the suite with
+ * `describe.skipIf` (below) — skipping (not throwing) keeps a fresh, unbuilt
+ * checkout green while still running the suite in CI, which builds first.
+ */
+const BIN_EXISTS = existsSync(BIN_PATH);
+if (!BIN_EXISTS) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[design-token-panel integration test] dist/bin/server.js not found — ' +
+      'skipping bin integration suite. Run `pnpm --filter @takazudo/zdtp build` to enable it.',
+  );
+}
 
 /**
  * The bin is always spawned with `stdio: ['ignore', 'pipe', 'pipe']`, so its
@@ -160,16 +177,7 @@ function makeTmpFixture(): TmpFixture {
   return { dir, routingPath, tokensPath };
 }
 
-beforeAll(() => {
-  if (!existsSync(BIN_PATH)) {
-    throw new Error(
-      `[design-token-panel integration test] missing ${BIN_PATH}. ` +
-        'Run `pnpm --filter @takazudo/zdtp build` first.',
-    );
-  }
-});
-
-describe('zdtp-server bin (integration)', () => {
+describe.skipIf(!BIN_EXISTS)('zdtp-server bin (integration)', () => {
   const cleanupTasks: Array<() => Promise<void> | void> = [];
 
   afterEach(async () => {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/368
    - https://github.com/Takazudo/zudo-design-token-panel/issues/367 (epic)

---

## Summary

Fixes #360. `packages/zdtp/src/bin/__tests__/server.integration.test.ts` spawns the BUILT `dist/bin/server.js` and threw in a `beforeAll` guard when that artifact was missing. Because the `node` vitest project includes `src/**/*.test.ts`, a fresh `pnpm vitest run --project node` (no prior build) reported a **failing** suite.

A missing build artifact should make the suite **skip with a clear signal**, not hard-fail the whole node project.

## Changes

- Detect the built bin once at module load (`const BIN_EXISTS = existsSync(BIN_PATH)`) and gate the suite with `describe.skipIf(!BIN_EXISTS)('zdtp-server bin (integration)', …)` — tests are collected-but-skipped, so no "no test suite found" error.
- Remove the throwing `beforeAll` guard and emit a one-time `console.warn` (only when `!BIN_EXISTS`) pointing at `pnpm --filter @takazudo/zdtp build`.
- Remove the now-unused `beforeAll` import; update the header doc comment (the suite now *skips* rather than *refuses to run* when the bin is absent).
- `vitest.config.ts` unchanged (issue option 1, not a separate build-dependent project).

**No loss of CI coverage:** `ci.yml` / `pr-checks.yml` / `main-deploy.yml` and the local `b4push` script all run `pnpm build` before tests, so `dist/bin/server.js` exists and the suite still runs in CI. The skip only triggers on a fresh local/agent checkout.

## Test Plan

- **Bin absent** (fresh-checkout repro): `pnpm -F @takazudo/zdtp test --run --project node` → **70 passed | 1 skipped**, exit 0; the integration suite reports **skipped**, not failed.
- **Bin present** (post-build / CI): the integration suite **runs** (6 tests pass).
- Full package suite (both projects, bin present): **1167 tests pass**.
- `pnpm -F @takazudo/zdtp typecheck` clean (no unused `beforeAll`).