### PR TITLE
fix(panel): mount the configured tabs on the toggle window event for single-instance non-Astro hosts (#370)

### DIFF
--- a/packages/zdtp/src/__tests__/issue-370-toggle-event-empty-body.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-370-toggle-event-empty-body.test.tsx
@@ -197,6 +197,38 @@ describe('issue #370 — reserved event opens the configured panel for a custom-
     const defaultRoot = document.getElementById(panelRootId(DEFAULT_PANEL_CONFIG));
     expect(defaultRoot, 'no empty default-prefix panel mounted').toBeNull();
   });
+
+  it('custom-prefix host that opts into the reserved event name opens (and STAYS open) on one dispatch', async () => {
+    // A host following the older host-side mitigation sets
+    // `toggleEvent: 'toggle-design-token-panel'` on a custom-prefix config. That
+    // binds a second listener on the reserved event; with the dispatch-time
+    // fallback BOTH the eager default listener and the custom listener resolve
+    // to this same instance. The handler must dedupe per dispatch so the panel
+    // is toggled exactly once (regression: it opened then immediately closed).
+    await import('../index');
+    const { configurePanel, panelRootId, DEFAULT_PANEL_CONFIG } = await import(
+      '../config/panel-config'
+    );
+
+    const cfg = makeConfig('zudo-sg-tweak', {
+      toggleEvent: 'toggle-design-token-panel',
+      tabs: [sizeTab('SG Size')],
+    });
+    configurePanel(cfg);
+
+    window.dispatchEvent(new CustomEvent('toggle-design-token-panel'));
+    await waitForEffectFlush();
+
+    const customRoot = document.getElementById(panelRootId(cfg));
+    expect(customRoot, 'configured panel mounted').not.toBeNull();
+    // Body present ⇒ still open after the single dispatch (a double-toggle would
+    // have closed it, leaving the root present but rendering null).
+    expect(customRoot!.textContent ?? '', 'panel stays open after one dispatch').toContain(
+      'SG Size tier',
+    );
+    const defaultRoot = document.getElementById(panelRootId(DEFAULT_PANEL_CONFIG));
+    expect(defaultRoot, 'no empty default-prefix panel mounted').toBeNull();
+  });
 });
 
 describe('issue #370 — panel tabConfigById tracks instanceConfig (no stale useMemo)', () => {

--- a/packages/zdtp/src/__tests__/issue-370-toggle-event-empty-body.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-370-toggle-event-empty-body.test.tsx
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for issue #370 — panel renders an empty body (no tabs /
+ * editors) for a single-instance non-Astro (zfb/Preact) host that self-mounts
+ * via `configurePanel(config)` + the historical `toggle-design-token-panel`
+ * window event.
+ *
+ * Root cause (the 0.2.3 → 0.3.x regression)
+ * -----------------------------------------
+ * The multi-instance refactor (#353/#354) binds the DEFAULT instance's toggle-
+ * event listener EAGERLY at module init (`src/index.tsx`), before the host
+ * calls `configurePanel()`. The handler closed over `DEFAULT_PANEL_CONFIG`
+ * (empty `tabs`). The later `configurePanel()` fires a `configured` hook that
+ * re-runs `bindInstance`, but it no-ops because the prefix is already bound —
+ * so the toggle window event kept mounting the panel against the stale, empty
+ * config. The public console API (`showDesignTokenPanel`) reads the live config
+ * and was unaffected, which is why ONLY the window-event path regressed (that is
+ * exactly what non-Astro hosts dispatch).
+ *
+ * Two facets, both producing "toolbar mounts, body empty":
+ *  1. Default-`storagePrefix` host (e.g. zudo-doc) dispatching the reserved
+ *     `toggle-design-token-panel`.
+ *  2. Custom-`storagePrefix` host (e.g. zudo-sg) dispatching the same reserved
+ *     event — which used to mount the empty default instance instead of the
+ *     host's configured panel.
+ *
+ * Harness note: each test resets the module registry (`vi.resetModules`) AND
+ * actively drains any window-event listeners left by the previous test's module
+ * instance, so the eager module-init bind re-runs from a clean slate every time
+ * (the bug only reproduces when module init binds the default listener before
+ * `configurePanel`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import type { PanelConfig } from '../config/panel-config';
+
+const REGISTRY_SYMBOL = Symbol.for('@takazudo/zdtp:singleton');
+const DEFAULT_PREFIX = 'zudo-design-token-panel';
+/** Tier-section heading text is body-only — distinct from the tab BUTTON label. */
+const PANEL_TOOLBAR_SENTINEL = 'Design Tokens';
+
+interface InstanceBindingRecord {
+  cleanups: Array<() => void>;
+}
+
+/**
+ * Drain any real `addEventListener` registrations left on `window` by a prior
+ * test's index module instance, then drop the bindings map. Dropping the map
+ * alone would orphan live listeners that then leak across tests.
+ */
+function drainInstanceBindings(): void {
+  const w = window as unknown as {
+    __zudoDesignTokenPanelInstanceBindings?: Map<string, InstanceBindingRecord>;
+  };
+  const bindings = w.__zudoDesignTokenPanelInstanceBindings;
+  if (bindings) {
+    for (const record of bindings.values()) {
+      for (const fn of record.cleanups) {
+        try {
+          fn();
+        } catch {
+          /* a listener-removal that throws must not abort the drain */
+        }
+      }
+    }
+    bindings.clear();
+  }
+  delete w.__zudoDesignTokenPanelInstanceBindings;
+}
+
+function clearGlobalThisSlot(): void {
+  delete (globalThis as unknown as Record<symbol, unknown>)[REGISTRY_SYMBOL];
+}
+
+function makeConfig(prefix: string, overrides: Partial<PanelConfig> = {}): PanelConfig {
+  return {
+    storagePrefix: prefix,
+    consoleNamespace: prefix,
+    modalClassPrefix: `${prefix}-modal`,
+    schemaId: `${prefix}/v1`,
+    exportFilenameBase: prefix,
+    tabs: [],
+    ...overrides,
+  };
+}
+
+/** Minimal one-tier `size` tab. The tier label (`${label} tier`) renders in the
+ * tab BODY (TierSection heading), so asserting on it proves the body — not just
+ * a tab button — rendered. */
+function sizeTab(label: string): PanelConfig['tabs'][number] {
+  return {
+    id: 'size',
+    label,
+    tiers: [
+      {
+        id: 'size-raw',
+        label: `${label} tier`,
+        items: [
+          {
+            id: 'size-item',
+            cssVar: '--size-item',
+            label: `${label} item`,
+            default: '1rem',
+            type: { kind: 'length', step: 0.0625, unit: 'rem' },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+beforeEach(() => {
+  drainInstanceBindings();
+  const w = window as unknown as Record<string, unknown>;
+  delete w.__zudoDesignTokenPanelLifecycle;
+  delete w.__zudoDesignTokenPanelAdapter;
+  clearGlobalThisSlot();
+  localStorage.clear();
+  document.body.innerHTML = '';
+  vi.resetModules();
+});
+
+afterEach(() => {
+  drainInstanceBindings();
+  clearGlobalThisSlot();
+  localStorage.clear();
+  document.body.innerHTML = '';
+});
+
+describe('issue #370 — toggle window event mounts the configured tabs (default prefix)', () => {
+  it('default-prefix host: configurePanel AFTER import, then toggle-design-token-panel renders the real tab body', async () => {
+    // Import triggers module init → binds the default-prefix toggle listener
+    // with the EMPTY DEFAULT_PANEL_CONFIG, before any configurePanel call.
+    await import('../index');
+    const { configurePanel, panelRootId } = await import('../config/panel-config');
+
+    const cfg = makeConfig(DEFAULT_PREFIX, { tabs: [sizeTab('Tokens Size')] });
+    configurePanel(cfg);
+
+    window.dispatchEvent(new CustomEvent('toggle-design-token-panel'));
+    await waitForEffectFlush();
+
+    const root = document.getElementById(panelRootId(cfg));
+    expect(root, 'panel mounted on the reserved window event').not.toBeNull();
+    expect(root!.textContent ?? '', 'toolbar shell mounted').toContain(PANEL_TOOLBAR_SENTINEL);
+    expect(
+      root!.textContent ?? '',
+      'the configured tab body renders (regression: it was empty)',
+    ).toContain('Tokens Size tier');
+  });
+
+  it('also opens via the deprecated toggle-color-tweak-panel alias with the real config', async () => {
+    await import('../index');
+    const { configurePanel, panelRootId } = await import('../config/panel-config');
+
+    const cfg = makeConfig(DEFAULT_PREFIX, { tabs: [sizeTab('Tokens Size')] });
+    configurePanel(cfg);
+
+    window.dispatchEvent(new CustomEvent('toggle-color-tweak-panel'));
+    await waitForEffectFlush();
+
+    const root = document.getElementById(panelRootId(cfg));
+    expect(root, 'panel mounted on the legacy alias event').not.toBeNull();
+    expect(root!.textContent ?? '').toContain('Tokens Size tier');
+  });
+});
+
+describe('issue #370 — reserved event opens the configured panel for a custom-prefix host', () => {
+  it('custom-prefix-only host dispatching toggle-design-token-panel opens its panel, not an empty default', async () => {
+    await import('../index');
+    const { configurePanel, panelRootId, DEFAULT_PANEL_CONFIG } = await import(
+      '../config/panel-config'
+    );
+
+    const cfg = makeConfig('zudo-sg-tweak', { tabs: [sizeTab('SG Size')] });
+    configurePanel(cfg);
+
+    // The host dispatches the historical reserved event (not toggle-${prefix}).
+    window.dispatchEvent(new CustomEvent('toggle-design-token-panel'));
+    await waitForEffectFlush();
+
+    // The configured (custom-prefix) panel opens with its real body...
+    const customRoot = document.getElementById(panelRootId(cfg));
+    expect(customRoot, 'configured custom-prefix panel mounted').not.toBeNull();
+    expect(customRoot!.textContent ?? '').toContain('SG Size tier');
+
+    // ...and no empty default-prefix panel is mounted alongside it.
+    const defaultRoot = document.getElementById(panelRootId(DEFAULT_PANEL_CONFIG));
+    expect(defaultRoot, 'no empty default-prefix panel mounted').toBeNull();
+  });
+});
+
+describe('issue #370 — panel tabConfigById tracks instanceConfig (no stale useMemo)', () => {
+  it('re-rendering the panel with a changed instanceConfig updates the tab BODY, not just the tab strip', async () => {
+    const { configurePanel } = await import('../config/panel-config');
+    const { getOpenKey } = await import('../state/tweak-state');
+    const { default: DesignTokenTweakPanel } = await import('../panel');
+
+    const cfgA = makeConfig('iss370-a', { tabs: [sizeTab('Alpha Size')] });
+    const cfgB = makeConfig('iss370-b', { tabs: [sizeTab('Beta Size')] });
+    configurePanel(cfgA);
+    configurePanel(cfgB);
+
+    // Seed both instances open so the panel body renders on mount.
+    localStorage.setItem(getOpenKey(cfgA), '1');
+    localStorage.setItem(getOpenKey(cfgB), '1');
+
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    render(<DesignTokenTweakPanel instanceConfig={cfgA} />, root);
+    await waitForEffectFlush();
+    expect(root.textContent ?? '', 'A body rendered').toContain('Alpha Size tier');
+
+    // Re-render the SAME component instance with a different config (a prop
+    // change, NOT a remount). The body's id→TabConfig dispatch map must follow
+    // the new config — a stale useMemo([]) would update the tab strip but leave
+    // the body dispatching against the old config.
+    render(<DesignTokenTweakPanel instanceConfig={cfgB} />, root);
+    await waitForEffectFlush();
+    const text = root.textContent ?? '';
+    expect(text, 'B body now rendered').toContain('Beta Size tier');
+    expect(text, 'stale A body gone').not.toContain('Alpha Size tier');
+  });
+});

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -579,6 +579,14 @@ interface InstanceBindingRecord {
   cleanups: Array<() => void>;
 }
 
+/**
+ * A toggle Event annotated with the set of instance prefixes already driven in
+ * THIS dispatch. The DOM delivers one shared Event object to every listener of
+ * a given name, so listeners that resolve to the same instance can coordinate
+ * through it (see `bindInstance`'s dedupe).
+ */
+type DedupableToggleEvent = Event & { __zdtpToggledPrefixes?: Set<string> };
+
 type InstanceBindingsWindow = Window & {
   __zudoDesignTokenPanelInstanceBindings?: Map<string, InstanceBindingRecord>;
 };
@@ -651,8 +659,21 @@ function bindInstance(cfg: PanelConfig): void {
   const prefix = cfg.storagePrefix;
   const toggleEvent = toggleEventName(cfg);
   const isDefaultEvent = toggleEvent === DEFAULT_TOGGLE_EVENT;
-  const handler = (): void =>
-    handleExternalToggleEvent(resolveLiveInstanceConfig(prefix, isDefaultEvent, cfg));
+  const handler = (event: Event): void => {
+    const target = resolveLiveInstanceConfig(prefix, isDefaultEvent, cfg);
+    // A single dispatch can reach multiple listeners on the same event name —
+    // the eagerly-bound default listener AND a custom instance that opted into
+    // the reserved name via `config.toggleEvent`. With the dispatch-time
+    // fallback both can resolve to the SAME instance, which would toggle it
+    // twice (open, then immediately close) in one dispatch (#370). Dedupe by the
+    // resolved instance id, carried on the shared Event object.
+    const ev = event as DedupableToggleEvent;
+    const seen = ev.__zdtpToggledPrefixes ?? new Set<string>();
+    if (seen.has(target.storagePrefix)) return;
+    seen.add(target.storagePrefix);
+    ev.__zdtpToggledPrefixes = seen;
+    handleExternalToggleEvent(target);
+  };
   window.addEventListener(toggleEvent, handler);
   const cleanups: Array<() => void> = [() => window.removeEventListener(toggleEvent, handler)];
 

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -592,34 +592,79 @@ function getInstanceBindings(): Map<string, InstanceBindingRecord> {
 }
 
 /**
+ * Resolve the config a toggle-event handler should drive, re-read at DISPATCH
+ * time rather than captured at bind time.
+ *
+ * Fixes #370. The default instance's listener is bound eagerly at module init
+ * with `DEFAULT_PANEL_CONFIG` (empty `tabs`), BEFORE the host calls
+ * `configurePanel()`. The post-configure `bindInstance` re-call no-ops for an
+ * already-bound prefix, so a handler that closed over the bind-time config would
+ * mount an empty-bodied panel forever. Re-reading by prefix picks up the real
+ * config the host registered after import. Two facets, both producing the
+ * "toolbar mounts, body empty" symptom:
+ *
+ *  1. Default-`storagePrefix` host: `getPanelConfigByPrefix(prefix)` returns the
+ *     host's now-registered config (real tabs) instead of the stale empty one.
+ *  2. Custom-`storagePrefix`-only host dispatching the historical reserved
+ *     `toggle-design-token-panel`: no default-prefix instance is registered, so
+ *     the by-prefix lookup misses. For the reserved default event we then fall
+ *     back to the active (most-recently-configured) instance so the host's real
+ *     panel opens instead of the empty default. A genuine multi-instance page
+ *     that DOES register a default-prefix instance keeps the reserved event on
+ *     that instance (the by-prefix lookup hits first).
+ *
+ * When nothing is configured yet (`getPanelConfigByPrefix` misses and the active
+ * config is still the default), this returns `fallback` (= the bind-time config,
+ * i.e. `DEFAULT_PANEL_CONFIG`), preserving the pre-configure bootstrap path.
+ */
+function resolveLiveInstanceConfig(
+  prefix: string,
+  isDefaultEvent: boolean,
+  fallback: PanelConfig,
+): PanelConfig {
+  const registered = getPanelConfigByPrefix(prefix);
+  if (registered) return registered;
+  if (isDefaultEvent) {
+    const active = getPanelConfig();
+    if (active.storagePrefix !== prefix) return active;
+  }
+  return fallback;
+}
+
+/**
  * Idempotently bind ONE instance's toggle-event listener(s). Keyed by
  * `cfg.storagePrefix` — a second call for an already-bound prefix is a no-op,
  * so re-running the post-configure hook (Astro view-transition reruns) never
  * stacks duplicate listeners.
  *
- * The handler closes over the instance config so it always operates on the
- * right storage keys / root / sync event, regardless of which instance is the
- * default at dispatch time.
+ * The handler re-resolves the live instance config by prefix at DISPATCH time
+ * (see `resolveLiveInstanceConfig`) so it always operates on the right storage
+ * keys / root / sync event / tabs — even though the default instance is bound
+ * eagerly at module init, before the host's `configurePanel()` supplies the real
+ * config (#370).
  */
 function bindInstance(cfg: PanelConfig): void {
   if (typeof window === 'undefined') return;
   const bindings = getInstanceBindings();
   if (bindings.has(cfg.storagePrefix)) return;
 
+  const prefix = cfg.storagePrefix;
   const toggleEvent = toggleEventName(cfg);
-  const handler = (): void => handleExternalToggleEvent(cfg);
+  const isDefaultEvent = toggleEvent === DEFAULT_TOGGLE_EVENT;
+  const handler = (): void =>
+    handleExternalToggleEvent(resolveLiveInstanceConfig(prefix, isDefaultEvent, cfg));
   window.addEventListener(toggleEvent, handler);
   const cleanups: Array<() => void> = [() => window.removeEventListener(toggleEvent, handler)];
 
   // The deprecated alias only ever flipped the default single-panel instance;
   // binding it for every instance would let one panel's legacy event leak into
   // another. Scope it to the default instance only.
-  if (toggleEvent === DEFAULT_TOGGLE_EVENT) {
+  if (isDefaultEvent) {
     window.addEventListener(TOGGLE_EVENT_ALIAS, handler);
     cleanups.push(() => window.removeEventListener(TOGGLE_EVENT_ALIAS, handler));
   }
 
-  bindings.set(cfg.storagePrefix, { cleanups });
+  bindings.set(prefix, { cleanups });
 }
 
 /** Remove ONE instance's toggle-event listener(s). No-op when not bound. */

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -525,14 +525,18 @@ export default function DesignTokenTweakPanel({
     return instanceConfig.tabs.map((t: TabConfig) => ({ id: t.id, label: t.label }));
   }, [instanceConfig]);
 
-  // Build an id→TabConfig lookup for GenericTab dispatch (this instance's tabs).
+  // Build an id→TabConfig lookup for the tab-body dispatch (this instance's
+  // tabs). Keyed on `instanceConfig` — same as `activeTabs` above — so the body
+  // dispatch map tracks the active config. A prior `useMemo([])` left this map
+  // frozen at first render: a config change updated the tab strip (`activeTabs`)
+  // but the body kept dispatching against the stale map, rendering empty (#370).
   const tabConfigById = useMemo((): Record<string, TabConfig> => {
     const out: Record<string, TabConfig> = {};
     for (const t of instanceConfig.tabs) {
       out[t.id] = t;
     }
     return out;
-  }, []);
+  }, [instanceConfig]);
 
   // --- Tab keyboard navigation (WAI-ARIA tablist pattern) ---
   const handleTabKeyDown = useCallback(


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/370

---

## Summary

Fixes #370 — bumping `@takazudo/zdtp` 0.2.3 → 0.3.1 broke the panel's tab body (empty: no Color/Font/Spacing/Size tabs, no editors) for single-instance **non-Astro (zfb/Preact)** hosts that self-mount via `configurePanel(config)` + the `toggle-design-token-panel` window event. The toolbar shell rendered but the body was empty. This regressed the 0.3.0 changelog's "single-panel hosts observe no change."

## Root cause

The 0.3.0 multi-instance refactor binds the **default** instance's `toggle-design-token-panel` listener **eagerly at module init** — before the host calls `configurePanel()`. The handler closed over `DEFAULT_PANEL_CONFIG` (empty `tabs`). The later `configurePanel()` fires a `configured` hook that re-runs `bindInstance`, but it no-ops because the prefix is already bound — so the window-event path kept mounting the panel against the stale, empty config.

The public console API (`showDesignTokenPanel`) reads the **live** config, so it was unaffected — which is exactly why only the historical `toggle-design-token-panel` **window-event** path (what non-Astro hosts dispatch) regressed.

## Changes

- **`src/index.tsx`** — the toggle handler now re-resolves the instance config **by prefix at dispatch time** (`resolveLiveInstanceConfig`) instead of capturing it at bind time:
  - Default-`storagePrefix` host (e.g. `zudo-doc`): the now-registered real config is picked up → real tabs render.
  - Custom-`storagePrefix`-only host dispatching the reserved event (e.g. `zudo-sg`): with no default-prefix instance registered, the reserved event falls back to the **active** (most-recently-configured) instance, so the host's real panel opens instead of an empty default. A genuine multi-instance page that registers a default-prefix instance keeps the reserved event on that instance (by-prefix lookup wins first).
  - Per-dispatch **dedupe** (by resolved instance id, carried on the shared `Event`) so a custom instance that opts into the reserved name via `config.toggleEvent` is toggled exactly once, not opened-then-closed (caught in review).
- **`src/panel.tsx`** — `tabConfigById` now depends on `[instanceConfig]` (was `[]`), matching its sibling `activeTabs`, so the tab-body dispatch map never goes stale on a config change.

## Test Plan

- New `src/__tests__/issue-370-toggle-event-empty-body.test.tsx` (5 cases): default-prefix window event renders the real body; the legacy `toggle-color-tweak-panel` alias; custom-prefix host dispatching the reserved event opens its real panel (no empty default); a custom host that opts into the reserved name stays open on one dispatch; and the panel's `tabConfigById` tracks `instanceConfig` across a config change.
- Full package suite green: **1172 tests / 73 files**. `tsc --noEmit` clean. `pnpm build` succeeds.
- Reviewed via `/codex-review` (one P2 — the double-toggle case — found and fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)