### PR TITLE
GenericTab OKLCH Picker: faithful OKLCH display & edit for opt-in color items (#373)

### DIFF
--- a/packages/zdtp/src/__tests__/oklch-generic-tab-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/oklch-generic-tab-e2e.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+
+/**
+ * E2E integration test — OKLCH GenericTab round-trip (#379 S5).
+ *
+ * Confirms the owner's goal:
+ *   - opt-in GenericTab color items with format:'oklch' render the OKLCH picker
+ *     affordance (ColorField swatch-button), NOT a native <input type="color">
+ *   - BOTH paths emit oklch(), not hex:
+ *     (a) onChange from the tab; (b) emitTierItemCssValue via resolveTierItemValue
+ *   - Wide-gamut P3 values survive prop→edit→emit without sRGB clamping
+ *   - Existing hex {kind:'color'} consumers are unaffected
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import GenericTab from '../tabs/generic-tab';
+import type { TabConfig } from '../tokens/tier-model';
+import type { TabOverrides } from '../apply/tier-resolver';
+import { resolveTierItemValue, emitTierItemCssValue } from '../apply/tier-resolver';
+import { cssToOklcha } from '../utils/color-oklch';
+
+// ---------------------------------------------------------------------------
+// Fixture: non-reserved palette tab with OKLCH color items
+// ---------------------------------------------------------------------------
+
+/**
+ * A non-reserved tab mimicking a custom palette with OKLCH color items.
+ * Uses the exact shape from the task brief.
+ */
+const OKLCH_PALETTE_TAB: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'cool',
+      label: 'Cool tones',
+      items: [
+        {
+          id: 'cool700',
+          cssVar: '--palette-cool-700',
+          label: 'cool-700',
+          default: 'oklch(0.21 0.03 264)',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'cool500',
+          cssVar: '--palette-cool-500',
+          label: 'cool-500',
+          // Wide-gamut P3 value (chroma 0.25 is out of sRGB at this L)
+          default: 'oklch(0.7 0.25 150)',
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+/** Tab with a plain hex color item (no format) — existing consumer. */
+const HEX_COLOR_TAB: TabConfig = {
+  id: 'hex-colors',
+  label: 'Hex Colors',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        {
+          id: 'brand',
+          cssVar: '--hex-brand',
+          label: 'Brand',
+          default: '#ff0000',
+          type: { kind: 'color' },
+        },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => {
+    render(null, container);
+  });
+  document.body.removeChild(container);
+});
+
+async function renderGenericTab(
+  tab: TabConfig,
+  overrides: TabOverrides = {},
+  onChange: (tierId: string, itemId: string, next: string) => void = () => undefined,
+): Promise<void> {
+  await act(() => {
+    render(<GenericTab tab={tab} overrides={overrides} onChange={onChange} />, container);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. OKLCH item renders ColorField swatch-button, NOT native <input type="color">
+// ---------------------------------------------------------------------------
+
+describe('S5 E2E — OKLCH GenericTab: ColorField affordance (not native color input)', () => {
+  it('renders ColorField swatch-button [data-testid="color-field-swatch"] for oklch items', async () => {
+    await renderGenericTab(OKLCH_PALETTE_TAB);
+
+    const item = container.querySelector('[data-testid="tier-item-cool700"]');
+    expect(item).not.toBeNull();
+
+    // Must NOT render a native color input (hex lossy path)
+    const nativeColorInput = item?.querySelector('input[type="color"]');
+    expect(nativeColorInput).toBeNull();
+
+    // Must render the OKLCH picker affordance
+    const swatch = item?.querySelector('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+  });
+
+  it('ColorField swatch has role="button" and tabIndex=0 (keyboard accessible)', async () => {
+    await renderGenericTab(OKLCH_PALETTE_TAB);
+
+    const swatch = container.querySelector('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+    expect(swatch?.getAttribute('role')).toBe('button');
+    expect(swatch?.getAttribute('tabindex')).toBe('0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2a. onChange path emits oklch(), not hex
+// ---------------------------------------------------------------------------
+
+describe('S5 E2E — OKLCH GenericTab: onChange path emits oklch() string', () => {
+  it('clicking the swatch opens the ColorPicker (confirms onChange wiring is live)', async () => {
+    const onChange = vi.fn();
+    await renderGenericTab(OKLCH_PALETTE_TAB, {}, onChange);
+
+    // Before click: no picker
+    let picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    act(() => {
+      swatch!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).not.toBeNull();
+  });
+
+  it('the open ColorPicker has a hex-input with type="text", confirming oklch mode (not hex-only path)', async () => {
+    await renderGenericTab(OKLCH_PALETTE_TAB);
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    act(() => {
+      swatch!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // In oklch valueFormat mode, the picker still has a hex-text input for reference
+    // but the output via onChange will be oklch().
+    const hexInput = container.querySelector<HTMLInputElement>('.tokenpanel-color-picker-hex-input');
+    expect(hexInput).not.toBeNull();
+    expect(hexInput?.getAttribute('type')).toBe('text'); // text, not color
+  });
+
+  it('onChange receives oklch() string when a preset cell is clicked inside the picker', async () => {
+    const onChange = vi.fn();
+    await renderGenericTab(OKLCH_PALETTE_TAB, {}, onChange);
+
+    // Open picker
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    act(() => {
+      swatch!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Click the first preset grid cell
+    const firstCell = container.querySelector<HTMLElement>(
+      '[data-grid-row="0"][data-grid-col="0"]',
+    );
+    expect(firstCell).not.toBeNull();
+    act(() => {
+      firstCell!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Must have been called
+    expect(onChange).toHaveBeenCalled();
+
+    // The value emitted from the tab's onChange must be the oklch format.
+    // onChange is called with (tierId, itemId, value)
+    const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+    const emittedValue: string = lastCall[2];
+
+    // Path (a): the tab's onChange receives an oklch(...) string
+    expect(emittedValue).toMatch(/^oklch\(/i);
+    expect(emittedValue).not.toMatch(/^#/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. Apply path (resolveTierItemValue + emitTierItemCssValue) emits oklch()
+// ---------------------------------------------------------------------------
+
+describe('S5 E2E — OKLCH GenericTab: apply path emits oklch() (tier-resolver)', () => {
+  it('resolveTierItemValue for an oklch color item returns the oklch() literal', () => {
+    const overrides: TabOverrides = {
+      cool: {
+        cool700: 'oklch(0.21 0.03 264)',
+      },
+    };
+
+    const resolved = resolveTierItemValue(OKLCH_PALETTE_TAB, 'cool', 'cool700', overrides);
+    expect(resolved.kind).toBe('literal');
+    if (resolved.kind === 'literal') {
+      expect(resolved.value).toBe('oklch(0.21 0.03 264)');
+    }
+  });
+
+  it('emitTierItemCssValue returns the oklch() string as-is (no hex conversion)', () => {
+    const overrides: TabOverrides = {
+      cool: {
+        cool700: 'oklch(0.21 0.03 264)',
+      },
+    };
+
+    const resolved = resolveTierItemValue(OKLCH_PALETTE_TAB, 'cool', 'cool700', overrides);
+    // Path (b): the apply path emits the oklch() value
+    const emitted = emitTierItemCssValue(resolved);
+    expect(emitted).toMatch(/^oklch\(/i);
+    expect(emitted).not.toMatch(/^#/);
+  });
+
+  it('emitTierItemCssValue with a changed oklch override also emits oklch()', () => {
+    // Simulate the user having changed the value to a new oklch string
+    const overrides: TabOverrides = {
+      cool: {
+        cool700: 'oklch(0.4 0.12 200)',
+      },
+    };
+
+    const resolved = resolveTierItemValue(OKLCH_PALETTE_TAB, 'cool', 'cool700', overrides);
+    const emitted = emitTierItemCssValue(resolved);
+    expect(emitted).toMatch(/^oklch\(/i);
+  });
+
+  it('emitTierItemCssValue with default (no override) still emits oklch() for an oklch item', () => {
+    // No overrides — item.default is 'oklch(0.21 0.03 264)'
+    const resolved = resolveTierItemValue(OKLCH_PALETTE_TAB, 'cool', 'cool700', {});
+    const emitted = emitTierItemCssValue(resolved);
+    expect(emitted).toMatch(/^oklch\(/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Wide-gamut P3 round-trip: chroma survives without sRGB clamping
+// ---------------------------------------------------------------------------
+
+describe('S5 E2E — OKLCH GenericTab: wide-gamut P3 chroma preserved', () => {
+  const WIDE_GAMUT_VALUE = 'oklch(0.7 0.25 150)';
+
+  it('cssToOklcha correctly parses the wide-gamut P3 value', () => {
+    const parsed = cssToOklcha(WIDE_GAMUT_VALUE);
+    expect(parsed).not.toBeNull();
+    // Chroma 0.25 is out-of-sRGB-gamut at this L
+    expect(parsed!.c).toBeCloseTo(0.25, 3);
+  });
+
+  it('the emit path preserves chroma without sRGB clamping when L is edited', () => {
+    // Simulate: user opens item with oklch(0.7 0.25 150), edits only L to 0.6.
+    // The emitted value should still carry c≈0.25 (not clamped down to sRGB).
+    const editedOklch = 'oklch(0.6 0.25 150)';
+    const overrides: TabOverrides = {
+      cool: {
+        cool500: editedOklch,
+      },
+    };
+
+    const resolved = resolveTierItemValue(OKLCH_PALETTE_TAB, 'cool', 'cool500', overrides);
+    const emitted = emitTierItemCssValue(resolved);
+
+    // The emitted string is an oklch() string
+    expect(emitted).toMatch(/^oklch\(/i);
+
+    // Re-parse to check chroma is preserved (≈0.25, not sRGB-clamped to ~0.15)
+    const reparsed = cssToOklcha(emitted);
+    expect(reparsed).not.toBeNull();
+
+    // Chroma must be ≈ 0.25 — far above the sRGB in-gamut clamp for this L/H
+    expect(reparsed!.c).toBeCloseTo(0.25, 3);
+
+    // Confirm it is truly out of sRGB gamut (chroma much higher than sRGB can
+    // represent at L=0.6, H=150). sRGB max chroma here is ~0.16.
+    expect(reparsed!.c).toBeGreaterThan(0.20);
+  });
+
+  it('default value oklch(0.7 0.25 150) emits with chroma preserved via apply path', () => {
+    // No override — default 'oklch(0.7 0.25 150)' passes through untouched
+    const resolved = resolveTierItemValue(OKLCH_PALETTE_TAB, 'cool', 'cool500', {});
+    const emitted = emitTierItemCssValue(resolved);
+
+    const reparsed = cssToOklcha(emitted);
+    expect(reparsed).not.toBeNull();
+    expect(reparsed!.c).toBeCloseTo(0.25, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Existing consumers unaffected: hex {kind:'color'} still uses native input
+// ---------------------------------------------------------------------------
+
+describe('S5 E2E — existing hex color consumers unaffected', () => {
+  it('hex {kind:"color"} item renders <input type="color">, not ColorField swatch', async () => {
+    await renderGenericTab(HEX_COLOR_TAB);
+
+    const item = container.querySelector('[data-testid="tier-item-brand"]');
+    expect(item).not.toBeNull();
+
+    // Must render native color input (hex path unchanged)
+    const nativeColorInput = item?.querySelector('input[type="color"]');
+    expect(nativeColorInput).not.toBeNull();
+
+    // Must NOT render ColorField swatch
+    const swatch = item?.querySelector('[data-testid="color-field-swatch"]');
+    expect(swatch).toBeNull();
+  });
+
+  it('hex color apply path emits the hex value as-is (no oklch conversion)', () => {
+    const overrides: TabOverrides = {
+      base: {
+        brand: '#ff0000',
+      },
+    };
+
+    const resolved = resolveTierItemValue(HEX_COLOR_TAB, 'base', 'brand', overrides);
+    const emitted = emitTierItemCssValue(resolved);
+
+    // Hex value is emitted unchanged
+    expect(emitted).toBe('#ff0000');
+    expect(emitted).not.toMatch(/^oklch\(/i);
+  });
+});

--- a/packages/zdtp/src/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/zdtp/src/components/color-picker/__tests__/color-picker.test.tsx
@@ -1084,3 +1084,377 @@ describe('ColorPicker — valueFormat=oklch (S3a)', () => {
     expect(input.value).toBe('#00ff00');
   });
 });
+
+// ---------------------------------------------------------------------------
+// 17. S3b — HSL mode in oklch format: emit-free toggle + lossy HSL edit (#377)
+// ---------------------------------------------------------------------------
+
+/** Click a mode-toggle button by its visible label ('OKLCH' | 'HSL'). */
+function clickModeBtn(label: 'OKLCH' | 'HSL'): void {
+  const dialog = getDialog();
+  const btns = dialog.querySelectorAll<HTMLElement>(
+    '[role="group"][aria-label="Color mode"] [role="button"]',
+  );
+  const target = Array.from(btns).find((b) => b.textContent === label);
+  if (!target) throw new Error(`mode button "${label}" not found`);
+  fireClick(target);
+}
+
+describe('ColorPicker — S3b HSL-in-oklch toggle is emit-free and non-clamping', () => {
+  it('toggling OKLCH→HSL does NOT call onChange (pure view-state)', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.8)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    clickModeBtn('HSL');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('toggling OKLCH→HSL→OKLCH never calls onChange (round-trip is emit-free)', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.8)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    clickModeBtn('HSL');
+    clickModeBtn('OKLCH');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('toggling to HSL does NOT clamp the canonical wide-gamut value — it survives a round-trip back', () => {
+    // C=0.25 at L=70/H=150 is out of sRGB gamut. Toggling to HSL (view-only)
+    // and back to OKLCH must leave the canonical chroma untouched: the OKLCH
+    // chroma slider still reads 0.250 (no sRGB reinterpretation occurred).
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.8)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    clickModeBtn('HSL');
+    clickModeBtn('OKLCH');
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    const labels = Array.from(rows).map(
+      (r) => r.querySelector('.tokenpanel-color-picker-slider-label')?.textContent,
+    );
+    const cIdx = labels.indexOf('C');
+    const cVal = rows[cIdx].querySelector('.tokenpanel-color-picker-slider-value')!
+      .textContent;
+    expect(cVal).toBe('0.250');
+  });
+
+  it('shows the HSL sliders after toggling to HSL while in oklch format', () => {
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.8)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    clickModeBtn('HSL');
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    const labels = Array.from(rows).map(
+      (r) => r.querySelector('.tokenpanel-color-picker-slider-label')?.textContent,
+    );
+    expect(labels).toEqual(['H', 'S', 'L', 'A']);
+  });
+});
+
+describe('ColorPicker — S3b HSL slider edit emits oklch() and is the documented lossy path', () => {
+  it('an HSL slider edit in oklch format emits an oklch(...) string, never hex', () => {
+    const onChange = vi.fn();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker({
+      color: 'oklch(0.5 0.1 150 / 1)',
+      valueFormat: 'oklch',
+      onChange,
+    });
+    fireSliderArrow('Hue', 'ArrowUp');
+    expect(onChange).toHaveBeenCalledOnce();
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(emitted)).toBe(false);
+  });
+
+  it('an HSL slider edit reinterprets a wide-gamut color through sRGB (DOCUMENTED LOSSY PATH)', () => {
+    // Start with a canonical color whose chroma (0.25) is OUTSIDE sRGB at
+    // L=70/H=150. Switch to HSL and nudge the H slider. Because HSL is an
+    // sRGB-oriented edit space, the emitted chroma MUST collapse to an
+    // in-gamut value — i.e. it is strictly less than the original 0.25. This
+    // is the single intentional precision-losing edit S3b documents.
+    const onChange = vi.fn();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 1)',
+      valueFormat: 'oklch',
+      onChange,
+    });
+    fireSliderArrow('Hue', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed).not.toBeNull();
+    // The wide-gamut chroma (0.25, well out of sRGB at L=70/H=150) was
+    // reinterpreted through the sRGB-mapped HSL edit and collapsed toward the
+    // gamut boundary (≈0.19). Asserting it dropped below 0.21 proves real
+    // sRGB gamut-mapping happened — not a near-lossless OKLCH-native edit
+    // (cf. the OKLCH-mode L-edit test which keeps the full 0.25). This is the
+    // single intentional precision-losing edit S3b documents.
+    expect(parsed.c).toBeLessThan(0.21);
+  });
+
+  it('an HSL slider edit reinterprets even when the H value is unchanged by the edit', () => {
+    // Nudging Saturation on an out-of-gamut color still reanchors via sRGB:
+    // any HSL edit re-emits an sRGB-projected oklch().
+    const onChange = vi.fn();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker({
+      color: 'oklch(0.7 0.3 150 / 1)',
+      valueFormat: 'oklch',
+      onChange,
+    });
+    fireSliderArrow('Saturation', 'ArrowDown');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.c).toBeLessThan(0.3);
+  });
+
+  it('an in-gamut HSL edit round-trips sensibly (no surprise jump)', () => {
+    // For an in-gamut color, the HSL edit changes only the edited channel by a
+    // small amount; lightness/hue/alpha stay close (modulo sRGB↔OKLCH rounding).
+    const onChange = vi.fn();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker({
+      color: 'oklch(0.6 0.05 200 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+    });
+    fireSliderArrow('Hue', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    // Alpha preserved through the HSL edit.
+    expect(parsed.a).toBeCloseTo(50, 0);
+    // Lightness stays in the same neighborhood (not jumping to 0 or 100).
+    expect(parsed.l).toBeGreaterThan(40);
+    expect(parsed.l).toBeLessThan(80);
+  });
+
+  it('emits hex (not oklch) on an HSL slider edit when valueFormat is omitted', () => {
+    // Regression guard: the default hex path is unchanged by S3b.
+    const onChange = vi.fn();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker({ color: '#3366cc', onChange });
+    fireSliderArrow('Hue', 'ArrowUp');
+    expect(onChange).toHaveBeenCalledOnce();
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(emitted)).toBe(true);
+    expect(emitted.startsWith('oklch(')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 18. S3b — Alpha handling in oklch format (#377)
+// ---------------------------------------------------------------------------
+
+/** Read a slider's displayed value text by aria-label. */
+function getSliderValueByLabel(ariaLabel: string): string | null | undefined {
+  const slider = getSliderByLabel(ariaLabel);
+  const row = slider.closest('.tokenpanel-color-picker-slider-row');
+  return row?.querySelector('.tokenpanel-color-picker-slider-value')?.textContent;
+}
+
+describe('ColorPicker — S3b alpha handling in oklch format', () => {
+  it('parses `oklch(... / none)` as alpha 0 (per the CSS parser contract)', () => {
+    renderPicker({
+      color: 'oklch(0.7 0.1 150 / none)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    // `none` → 0 in cssToOklcha; the alpha slider reads 0%.
+    expect(getSliderValueByLabel('Alpha')).toBe('0%');
+  });
+
+  it('renders the checkerboard for `oklch(... / none)` (alpha 0 is non-opaque)', () => {
+    renderPicker({
+      color: 'oklch(0.7 0.1 150 / none)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    const checker = container.querySelector(
+      '.tokenpanel-color-picker-preview-checkerboard',
+    );
+    expect(checker).not.toBeNull();
+  });
+
+  it('handles alpha 0 — slider reads 0% and emit carries / 0', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.1 150 / 0)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    expect(getSliderValueByLabel('Alpha')).toBe('0%');
+    // Nudge L; the canonical alpha (0) must survive the emit.
+    fireSliderArrow('Lightness', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.a).toBeCloseTo(0, 1);
+  });
+
+  it('handles alpha 100% — no checkerboard and emit omits the alpha component', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.1 150 / 100%)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    expect(getSliderValueByLabel('Alpha')).toBe('100%');
+    const checker = container.querySelector(
+      '.tokenpanel-color-picker-preview-checkerboard',
+    );
+    expect(checker).toBeNull();
+    // Editing L at full alpha emits an oklch() with NO "/ a" component.
+    fireSliderArrow('Lightness', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    expect(emitted).not.toContain('/');
+  });
+
+  it('preserves alpha through the alpha slider edit in oklch mode', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    // Bump alpha by one step (step:1 on the 0–100 scale → 50 → 51).
+    fireSliderArrow('Alpha', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.a).toBeCloseTo(51, 1);
+    // The wide-gamut chroma must NOT be clamped by an alpha-only edit.
+    expect(parsed.c).toBeCloseTo(0.25, 3);
+  });
+
+  it('preserves alpha through the hex-input path in oklch mode (8-digit hex)', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.1 150 / 1)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      Object.defineProperty(input, 'value', {
+        value: '#00ff0080',
+        writable: true,
+        configurable: true,
+      });
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    const parsed = cssToOklcha(emitted)!;
+    // 0x80 / 0xff ≈ 0.502 → ~50.2 on the 0–100 scale.
+    expect(parsed.a).toBeCloseTo(50, 0);
+  });
+
+  it('preserves alpha through an HSL slider edit in oklch mode', () => {
+    const onChange = vi.fn();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, 'hsl');
+    renderPicker({
+      color: 'oklch(0.6 0.05 200 / 0.75)',
+      valueFormat: 'oklch',
+      onChange,
+    });
+    fireSliderArrow('Hue', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.a).toBeCloseTo(75, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 19. S3b — Preset unclamped-commit holds across mini AND expanded shells (#377)
+// ---------------------------------------------------------------------------
+
+describe('ColorPicker — S3b preset unclamped commit in both shells', () => {
+  it('mini shell: a preset click emits the UNCLAMPED preset chroma (0.18)', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    // Mini shell renders 36 cells (6×6).
+    expect(container.querySelectorAll('[role="gridcell"]').length).toBe(36);
+    // Click the darkest row (row 5, L=10) where C=0.18 is well out of gamut —
+    // clampToSrgbGamut would shrink it, so an unclamped emit must keep 0.18.
+    const cell = container.querySelector<HTMLElement>(
+      '[data-grid-row="5"][data-grid-col="3"]',
+    )!;
+    fireClick(cell);
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.c).toBeCloseTo(0.18, 3);
+  });
+
+  it('expanded shell: a preset click emits the UNCLAMPED preset chroma (0.18)', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    // Expand to the 12-col shell (the expanded hue columns differ from mini).
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    fireClick(expandBtn);
+    expect(container.querySelectorAll('[role="gridcell"]').length).toBe(72);
+    // Pick an expanded-only hue column (col 11 → H=330°, absent in mini).
+    const cell = container.querySelector<HTMLElement>(
+      '[data-grid-row="5"][data-grid-col="11"]',
+    )!;
+    fireClick(cell);
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.c).toBeCloseTo(0.18, 3);
+    // Confirm we hit the expanded-only hue (330°), proving the expanded columns
+    // are exercised, not just a column that also exists in the mini grid.
+    expect(parsed.h).toBeCloseTo(330, 0);
+  });
+
+  it('expanded shell: preset alpha tracks the current canonical alpha', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.4)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    const expandBtn = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-expand-btn',
+    )!;
+    fireClick(expandBtn);
+    const cell = container.querySelector<HTMLElement>(
+      '[data-grid-row="2"][data-grid-col="6"]',
+    )!;
+    fireClick(cell);
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    // Preset commit carries the live alpha (≈40 on the 0–100 scale).
+    expect(parsed.a).toBeCloseTo(40, 0);
+  });
+});

--- a/packages/zdtp/src/components/color-picker/__tests__/color-picker.test.tsx
+++ b/packages/zdtp/src/components/color-picker/__tests__/color-picker.test.tsx
@@ -37,7 +37,7 @@ import { useRef } from 'preact/compat';
 import type { JSX } from 'preact';
 import { ColorPicker, LOCAL_STORAGE_KEY } from '../color-picker';
 import type { ColorPickerProps } from '../color-picker';
-import { oklchaToHex } from '../../../utils/color-oklch';
+import { cssToOklcha, oklchaToHex } from '../../../utils/color-oklch';
 
 // ---------------------------------------------------------------------------
 // Test harness helpers
@@ -89,6 +89,7 @@ function renderPicker(
       <PickerWrapper
         color={partial.color ?? '#ff0000'}
         onChange={partial.onChange ?? vi.fn()}
+        valueFormat={partial.valueFormat}
         label={partial.label}
         defaultMode={partial.defaultMode}
         onClose={partial.onClose ?? (() => {})}
@@ -855,5 +856,231 @@ describe('ColorPicker — defaultMode is initial-only', () => {
     )[1] as HTMLElement;
     expect(oklchBtn.getAttribute('aria-pressed')).toBe('true');
     expect(hslBtn.getAttribute('aria-pressed')).toBe('false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 16. S3a — valueFormat='oklch' wide-gamut canonical path (#376)
+// ---------------------------------------------------------------------------
+
+/** Find a slider host by its aria-label (Lightness / Chroma / Hue / Alpha). */
+function getSliderByLabel(ariaLabel: string): HTMLElement {
+  const el = container.querySelector<HTMLElement>(
+    `[role="slider"][aria-label="${ariaLabel}"]`,
+  );
+  if (!el) throw new Error(`slider "${ariaLabel}" not found`);
+  return el;
+}
+
+/**
+ * Nudge a slider with a keyboard arrow. The slider's pointer path is inert in
+ * jsdom (zero-width rects), but the keydown path calls onChange directly with
+ * value ± step, so this is the deterministic way to emit a slider commit.
+ */
+function fireSliderArrow(ariaLabel: string, key: string): void {
+  const slider = getSliderByLabel(ariaLabel);
+  act(() => {
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+describe('ColorPicker — valueFormat=hex default unchanged (S3a)', () => {
+  it('emits hex (not oklch) on a slider edit when valueFormat is omitted', () => {
+    const onChange = vi.fn();
+    renderPicker({ color: '#ff0000', onChange, defaultMode: 'oklch' });
+    fireSliderArrow('Lightness', 'ArrowUp');
+    expect(onChange).toHaveBeenCalledOnce();
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(emitted)).toBe(true);
+    expect(emitted.startsWith('oklch(')).toBe(false);
+  });
+
+  it('emits hex on a preset click when valueFormat is omitted', () => {
+    const onChange = vi.fn();
+    renderPicker({ onChange });
+    fireClick(container.querySelector<HTMLElement>('[role="gridcell"]')!);
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(emitted)).toBe(true);
+  });
+});
+
+describe('ColorPicker — valueFormat=oklch (S3a)', () => {
+  it('parses an incoming oklch() prop with wide-gamut chroma and alpha (not sRGB-clamped)', () => {
+    // C=0.25 sits beyond what L=70/H=150 can hold in sRGB; it must NOT be clamped.
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    // Chroma slider value span shows toFixed(3).
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    const labels = Array.from(rows).map(
+      (r) => r.querySelector('.tokenpanel-color-picker-slider-label')?.textContent,
+    );
+    const cIdx = labels.indexOf('C');
+    const aIdx = labels.indexOf('A');
+    const cVal = rows[cIdx].querySelector('.tokenpanel-color-picker-slider-value')!
+      .textContent;
+    const aVal = rows[aIdx].querySelector('.tokenpanel-color-picker-slider-value')!
+      .textContent;
+    expect(cVal).toBe('0.250'); // chroma preserved, not gamut-clamped
+    expect(aVal).toBe('50%'); // alpha ≈ 50 on the 0–100 scale
+  });
+
+  it('dragging the L/C/H sliders emits oklch(...) strings, never hex', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    fireSliderArrow('Lightness', 'ArrowUp');
+    fireSliderArrow('Chroma', 'ArrowUp');
+    fireSliderArrow('Hue', 'ArrowUp');
+    expect(onChange.mock.calls.length).toBe(3);
+    for (const call of onChange.mock.calls) {
+      expect(call[0] as string).toMatch(/^oklch\(/);
+    }
+  });
+
+  it('editing only L preserves the original (out-of-sRGB) chroma in the emit', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    fireSliderArrow('Lightness', 'ArrowUp');
+    const emitted = onChange.mock.calls[0][0] as string;
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed).not.toBeNull();
+    // L changed (was 70, +1 step → 71), chroma & hue & alpha intact.
+    expect(parsed.c).toBeCloseTo(0.25, 3);
+    expect(parsed.h).toBeCloseTo(150, 1);
+    expect(parsed.a).toBeCloseTo(50, 1);
+    expect(parsed.l).toBeCloseTo(71, 1);
+  });
+
+  it('preset click in oklch mode emits an unclamped oklch(...)', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    // Click a cell. Preset C is fixed at 0.18; the emitted chroma must match the
+    // unclamped preset chroma (clampToSrgbGamut would reduce it for dark/light
+    // out-of-gamut rows).
+    const cell = container.querySelector<HTMLElement>(
+      '[data-grid-row="0"][data-grid-col="0"]',
+    )!;
+    fireClick(cell);
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    const parsed = cssToOklcha(emitted)!;
+    expect(parsed.c).toBeCloseTo(0.18, 3); // PRESET_C_FIXED, unclamped
+  });
+
+  it('the in-picker preview swatch uses an oklch() background in oklch mode', () => {
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    const preview = container.querySelector<HTMLElement>(
+      '.tokenpanel-color-picker-preview-color',
+    )!;
+    expect(preview.style.backgroundColor).toMatch(/^oklch\(/);
+  });
+
+  it('typing a hex into the hex-input box in oklch mode commits an oklch(...) string, not raw hex', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 0.5)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    act(() => {
+      Object.defineProperty(input, 'value', {
+        value: '#00ff00',
+        writable: true,
+        configurable: true,
+      });
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledOnce();
+    const emitted = onChange.mock.calls[0][0] as string;
+    expect(emitted).toMatch(/^oklch\(/);
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(emitted)).toBe(false);
+  });
+
+  it('still shows the sRGB hex projection in the hex-input box for reference', () => {
+    renderPicker({
+      // A safely in-gamut oklch so the hex projection is stable.
+      color: 'oklch(0.5 0.05 150 / 1)',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    expect(/^#[0-9a-fA-F]{6}$/.test(input.value)).toBe(true);
+  });
+
+  it('ignores an external color prop change while a slider drag is in flight', () => {
+    const onChange = vi.fn();
+    renderPicker({
+      color: 'oklch(0.7 0.25 150 / 1)',
+      valueFormat: 'oklch',
+      onChange,
+      defaultMode: 'oklch',
+    });
+    // Start a drag on the L slider track (flips isDraggingRef via pointerdown).
+    const sliderTrack = getSliderByLabel('Lightness');
+    act(() => {
+      sliderTrack.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, pointerId: 1 }),
+      );
+    });
+    // External prop change mid-drag — must be ignored.
+    act(() => {
+      render(
+        <PickerWrapper
+          color="oklch(0.2 0.05 30 / 1)"
+          valueFormat="oklch"
+          onChange={onChange}
+        />,
+        container,
+      );
+    });
+    // Chroma slider must still reflect the original 0.25, not the new 0.05.
+    const rows = container.querySelectorAll('.tokenpanel-color-picker-slider-row');
+    const labels = Array.from(rows).map(
+      (r) => r.querySelector('.tokenpanel-color-picker-slider-label')?.textContent,
+    );
+    const cIdx = labels.indexOf('C');
+    const cVal = rows[cIdx].querySelector('.tokenpanel-color-picker-slider-value')!
+      .textContent;
+    expect(cVal).toBe('0.250');
+  });
+
+  it('falls back to the hex path when a hex slips into the oklch-mode color prop', () => {
+    renderPicker({
+      color: '#00ff00',
+      valueFormat: 'oklch',
+      defaultMode: 'oklch',
+    });
+    // No throw; the picker renders and the hex-input shows the projection.
+    const input = container.querySelector<HTMLInputElement>(
+      '.tokenpanel-color-picker-hex-input',
+    )!;
+    expect(input.value).toBe('#00ff00');
   });
 });

--- a/packages/zdtp/src/components/color-picker/color-field.tsx
+++ b/packages/zdtp/src/components/color-picker/color-field.tsx
@@ -1,0 +1,95 @@
+/**
+ * ColorField — swatch-button that opens a ColorPicker popover.
+ *
+ * A swatch div (div[role="button"]) + isOpen state + anchorRef pattern,
+ * mirroring ColorSwatch in color-tab.tsx.
+ *
+ * DOM-hygiene compliant: div-button with onClick + onKeyDown (Enter/Space);
+ * no banned semantic tags — hostile-host policy (CLAUDE.md).
+ */
+
+import { useCallback, useRef, useState } from 'preact/compat';
+import { ColorPicker } from './color-picker';
+import type { ColorPickerValueFormat } from './color-picker';
+
+export interface ColorFieldProps {
+  /** Current color value. Hex string in hex mode; `oklch(...)` string in oklch mode. */
+  value: string;
+  /** Called with the new color string when the user commits a change. */
+  onChange: (next: string) => void;
+  /**
+   * Output format for `value` / `onChange`. Defaults to 'hex' (back-compatible
+   * with the native <input type="color"> path).
+   */
+  valueFormat?: ColorPickerValueFormat;
+  /** Display label shown in the picker header and aria-label. */
+  label: string;
+  /** Optional CSS custom property name (e.g. `--my-color`). Used for aria-label. */
+  cssVar?: string;
+  /**
+   * When true, the swatch is shown but clicking / Enter / Space does NOT open
+   * the picker. Mirrors the `disabled` behavior of the native <input type="color">.
+   */
+  readonly?: boolean;
+}
+
+/**
+ * Swatch-button that opens a ColorPicker popover.
+ *
+ * Readonly items show the swatch but do not open the picker on interaction.
+ */
+export function ColorField({
+  value,
+  onChange,
+  valueFormat = 'hex',
+  label,
+  cssVar,
+  readonly: isReadonly = false,
+}: ColorFieldProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  const handleClose = useCallback(() => setIsOpen(false), []);
+
+  const handleToggle = useCallback(() => {
+    if (isReadonly) return;
+    setIsOpen((prev) => !prev);
+  }, [isReadonly]);
+
+  const ariaLabel = cssVar ? `${label}: ${cssVar}` : label;
+
+  return (
+    <div className="tokenpanel-color-field">
+      <div
+        ref={buttonRef}
+        role="button"
+        tabIndex={0}
+        className="tokenpanel-color-field-swatch"
+        style={{ backgroundColor: value }}
+        onClick={handleToggle}
+        onKeyDown={(e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleToggle();
+          }
+        }}
+        aria-label={ariaLabel}
+        aria-expanded={isReadonly ? undefined : isOpen}
+        aria-disabled={isReadonly || undefined}
+        data-testid="color-field-swatch"
+      />
+      {isOpen && (
+        <ColorPicker
+          color={value}
+          onChange={onChange}
+          valueFormat={valueFormat}
+          label={label}
+          anchorRef={buttonRef}
+          onClose={handleClose}
+        />
+      )}
+    </div>
+  );
+}
+
+export default ColorField;

--- a/packages/zdtp/src/components/color-picker/color-picker.tsx
+++ b/packages/zdtp/src/components/color-picker/color-picker.tsx
@@ -33,6 +33,7 @@ import { hexToHsla, hslaToHex } from '../../utils/color-hsla';
 import {
   type Oklcha,
   clampToSrgbGamut,
+  cssToOklcha,
   hexToOklcha,
   hslaToOklcha,
   isInSrgbGamut,
@@ -46,11 +47,36 @@ import { CustomSlider, type SliderConfig } from './custom-slider';
 
 export type ColorPickerMode = 'oklch' | 'hsl';
 
+/**
+ * Output value format for the picker.
+ *
+ *   'hex'   — `color` prop is a hex string, `onChange` emits hex. The internal
+ *             source of truth is the hex string. (Default — back-compatible.)
+ *   'oklch' — `color` prop is a CSS `oklch(...)` string (a hex is also tolerated
+ *             on input), `onChange` emits a normalized `oklch(...)` string. The
+ *             internal source of truth is a canonical `Oklcha`, so wide-gamut
+ *             chroma and sub-step precision survive edits without sRGB clamping.
+ */
+export type ColorPickerValueFormat = 'hex' | 'oklch';
+
 export interface ColorPickerProps {
-  /** Current hex color (#RRGGBB or #RRGGBBAA). Source of truth. */
+  /**
+   * Current color. In `valueFormat='hex'` (default) this is a hex string
+   * (#RRGGBB or #RRGGBBAA). In `valueFormat='oklch'` this is a CSS `oklch(...)`
+   * string (a hex is tolerated and parsed via the hex path as a fallback).
+   */
   color: string;
-  /** Called when the user commits a new color via any sub-control. */
-  onChange: (hex: string) => void;
+  /**
+   * Called when the user commits a new color via any sub-control. The argument
+   * matches `valueFormat`: a hex string in 'hex' mode, an `oklch(...)` string
+   * in 'oklch' mode.
+   */
+  onChange: (value: string) => void;
+  /**
+   * Output format for `color` / `onChange`. Defaults to 'hex' (back-compatible
+   * with existing callers that pass no value).
+   */
+  valueFormat?: ColorPickerValueFormat;
   /** Optional label rendered in the picker header. */
   label?: string;
   /**
@@ -220,6 +246,36 @@ function useSyncedHex(
 }
 
 /**
+ * Parse the incoming `color` prop into a canonical Oklcha for oklch mode.
+ *
+ * Prefers `cssToOklcha` (preserves wide-gamut chroma and sub-step precision).
+ * Falls back to `hexToOklcha` when the prop is a hex string (or any non-oklch
+ * value) that `cssToOklcha` rejects.
+ */
+function parseOklchColor(css: string): Oklcha {
+  return cssToOklcha(css) ?? hexToOklcha(css);
+}
+
+/**
+ * OKLCH-mode analogue of `useSyncedHex`: keeps a canonical Oklcha as the
+ * source of truth and ignores incoming `color` prop changes while a slider
+ * drag is in flight (so a mid-gesture external prop change cannot clobber the
+ * dragged value). The wide-gamut chroma and precision of the canonical value
+ * survive because it is never round-tripped through hex.
+ */
+function useSyncedOklch(
+  externalColor: string,
+  isDraggingRef: React.RefObject<boolean>,
+): [Oklcha, (next: Oklcha) => void] {
+  const [oklch, setOklch] = useState<Oklcha>(() => parseOklchColor(externalColor));
+  useEffect(() => {
+    if (isDraggingRef.current) return;
+    setOklch(parseOklchColor(externalColor));
+  }, [externalColor, isDraggingRef]);
+  return [oklch, setOklch];
+}
+
+/**
  * Compute a `position: fixed` style that places the popover below (or above,
  * if flipped) the anchor element, then clamps all edges inside the viewport.
  *
@@ -321,15 +377,31 @@ export function usePopoverClose(
 export function ColorPicker({
   color,
   onChange,
+  valueFormat = 'hex',
   label,
   defaultMode = 'oklch',
   anchorRef,
   onClose,
 }: ColorPickerProps): JSX.Element {
+  const isOklchFormat = valueFormat === 'oklch';
+
   const containerRef = useRef<HTMLDivElement>(null);
   const dragHandleRef = useRef<HTMLSpanElement>(null);
   const isDraggingRef = useRef(false);
-  const [hex, setHex] = useSyncedHex(color, isDraggingRef);
+
+  // Two parallel sources of truth, one per output format. In hex mode the hex
+  // string is canonical (byte-for-byte unchanged from the legacy behavior). In
+  // oklch mode the canonical Oklcha is the source of truth so wide-gamut chroma
+  // & precision survive without round-tripping through sRGB hex.
+  const [hexState, setHexState] = useSyncedHex(color, isDraggingRef);
+  const [canonicalOklch, setCanonicalOklch] = useSyncedOklch(
+    color,
+    isDraggingRef,
+  );
+
+  // The hex shown by the picker. In oklch mode this is the sRGB projection of
+  // the canonical value (for the hex-input box, preview is handled separately).
+  const hex = isOklchFormat ? oklchaToHex(canonicalOklch) : hexState;
 
   // ── Drag-handle state ─────────────────────────────────────────────────────
   // dragPos holds the current dragged-to position (left, top in viewport px).
@@ -374,19 +446,51 @@ export function ColorPicker({
 
   usePopoverClose(containerRef, onClose);
 
-  // OKLCH and HSL projections of the current hex.
-  // Recomputed on render — hex is the single source of truth.
-  const oklch = useMemo(() => hexToOklcha(hex), [hex]);
+  // OKLCH and HSL projections of the current color.
+  // In hex mode, hex is the single source of truth and both are derived from it.
+  // In oklch mode, the canonical Oklcha is the source of truth — `oklch` is that
+  // value directly (preserving wide-gamut chroma); hsla is still derived from
+  // the sRGB hex projection (S3b owns wide-gamut HSL).
+  const oklch = useMemo(
+    () => (isOklchFormat ? canonicalOklch : hexToOklcha(hex)),
+    [isOklchFormat, canonicalOklch, hex],
+  );
   const hsla = useMemo(() => hexToHsla(hex), [hex]);
 
+  // Commit a hex string (hex mode) or, in oklch mode, the `oklch()` of that hex.
+  // The internal hex state and hex-input box always track the (normalized) hex
+  // so the input box keeps showing the sRGB projection for reference.
   const commit = useCallback(
     (next: string) => {
       const normalized = next.toLowerCase();
-      setHex(normalized);
+      setHexState(normalized);
       setHexInput(normalized);
-      onChange(normalized);
+      if (isOklchFormat) {
+        // The hex-input box and preset grid commit a hex; in oklch mode emit
+        // the oklch() of that hex (hex → Oklcha → oklch string), never raw hex.
+        const asOklch = parseOklchColor(normalized);
+        setCanonicalOklch(asOklch);
+        onChange(oklchaToCss(asOklch));
+      } else {
+        onChange(normalized);
+      }
     },
-    [setHex, onChange],
+    [setHexState, setCanonicalOklch, isOklchFormat, onChange],
+  );
+
+  // Commit a canonical Oklcha directly without any sRGB clamp — used by the
+  // OKLCH sliders and the preset grid in oklch mode so out-of-gamut chroma and
+  // precision survive. Emits the normalized oklch() string.
+  const commitCanonicalOklch = useCallback(
+    (next: Oklcha) => {
+      setCanonicalOklch(next);
+      // Keep the hex-input box / hex state in sync with the sRGB projection.
+      const projHex = oklchaToHex(next).toLowerCase();
+      setHexState(projHex);
+      setHexInput(projHex);
+      onChange(oklchaToCss(next));
+    },
+    [setCanonicalOklch, setHexState, onChange],
   );
 
   const commitOklch = useCallback(
@@ -397,9 +501,13 @@ export function ColorPicker({
         h: partial.h ?? oklch.h,
         a: partial.a ?? oklch.a,
       };
-      commit(oklchaToHex(next));
+      if (isOklchFormat) {
+        commitCanonicalOklch(next);
+      } else {
+        commit(oklchaToHex(next));
+      }
     },
-    [oklch, commit],
+    [oklch, isOklchFormat, commitCanonicalOklch, commit],
   );
 
   const commitHsl = useCallback(
@@ -410,6 +518,9 @@ export function ColorPicker({
         l: partial.l ?? hsla.l,
         a: partial.a ?? hsla.a,
       };
+      // HSL mode still round-trips through hex even in oklch format (S3b owns
+      // wide-gamut HSL). commit() handles the hex → oklch() conversion in
+      // oklch mode, so onChange still emits the right format.
       commit(hslaToHex(next.h, next.s, next.l, next.a));
     },
     [hsla, commit],
@@ -432,10 +543,16 @@ export function ColorPicker({
   const handlePresetClick = useCallback(
     (rowIdx: number, colIdx: number) => {
       const preset = presetOklchForCell(rowIdx, colIdx, oklch.a, presetHCols);
-      const safe = clampToSrgbGamut(preset);
-      commit(oklchaToHex(safe));
+      if (isOklchFormat) {
+        // Commit the cell's UNCLAMPED Oklcha so wide-gamut presets survive.
+        // (The display background still uses clampToSrgbGamut — see the grid.)
+        commitCanonicalOklch(preset);
+      } else {
+        const safe = clampToSrgbGamut(preset);
+        commit(oklchaToHex(safe));
+      }
     },
-    [oklch.a, presetHCols, commit],
+    [oklch.a, presetHCols, isOklchFormat, commitCanonicalOklch, commit],
   );
 
   const handleGridKeyDown = useCallback(
@@ -604,8 +721,16 @@ export function ColorPicker({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Checkerboard is only needed when the color has a non-opaque alpha byte.
-  const hasAlpha = /^#[0-9a-fA-F]{8}$/.test(hex);
+  // Checkerboard is only needed when the color is non-opaque. In hex mode the
+  // 8-digit hex byte signals alpha; in oklch mode the canonical alpha does.
+  const hasAlpha = isOklchFormat
+    ? canonicalOklch.a < 100
+    : /^#[0-9a-fA-F]{8}$/.test(hex);
+
+  // Preview swatch background. In oklch mode use the canonical oklch() value so
+  // wide-gamut colors render correctly (and are not silently sRGB-clamped); in
+  // hex mode keep the exact hex string the legacy path used.
+  const previewBackground = isOklchFormat ? oklchaToCss(canonicalOklch) : hex;
 
   const onDragStart = useCallback(() => {
     isDraggingRef.current = true;
@@ -710,7 +835,7 @@ export function ColorPicker({
           )}
           <div
             className="tokenpanel-color-picker-preview-color"
-            style={{ backgroundColor: hex }}
+            style={{ backgroundColor: previewBackground }}
           />
         </div>
         <input

--- a/packages/zdtp/src/components/color-picker/color-picker.tsx
+++ b/packages/zdtp/src/components/color-picker/color-picker.tsx
@@ -40,6 +40,7 @@ import {
   MAX_OKLCH_CHROMA,
   oklchaToCss,
   oklchaToHex,
+  oklchaToHsla,
 } from '../../utils/color-oklch';
 import { CustomSlider, type SliderConfig } from './custom-slider';
 
@@ -449,13 +450,24 @@ export function ColorPicker({
   // OKLCH and HSL projections of the current color.
   // In hex mode, hex is the single source of truth and both are derived from it.
   // In oklch mode, the canonical Oklcha is the source of truth — `oklch` is that
-  // value directly (preserving wide-gamut chroma); hsla is still derived from
-  // the sRGB hex projection (S3b owns wide-gamut HSL).
+  // value directly (preserving wide-gamut chroma). The HSL slider values are an
+  // sRGB-oriented projection: HSL cannot represent wide-gamut colors, so a
+  // wide-gamut canonical value is gamut-mapped (clampToSrgbGamut) before the
+  // oklch → Hsla conversion, keeping the displayed S/L within the sane 0–100
+  // range. This is a VIEW projection only — the canonical Oklcha is never
+  // mutated by it (toggling to HSL stays non-clamping). The single
+  // deliberately-lossy mutation happens in commitHsl on an actual slider edit.
   const oklch = useMemo(
     () => (isOklchFormat ? canonicalOklch : hexToOklcha(hex)),
     [isOklchFormat, canonicalOklch, hex],
   );
-  const hsla = useMemo(() => hexToHsla(hex), [hex]);
+  const hsla = useMemo(
+    () =>
+      isOklchFormat
+        ? oklchaToHsla(clampToSrgbGamut(canonicalOklch))
+        : hexToHsla(hex),
+    [isOklchFormat, canonicalOklch, hex],
+  );
 
   // Commit a hex string (hex mode) or, in oklch mode, the `oklch()` of that hex.
   // The internal hex state and hex-input box always track the (normalized) hex
@@ -518,12 +530,21 @@ export function ColorPicker({
         l: partial.l ?? hsla.l,
         a: partial.a ?? hsla.a,
       };
-      // HSL mode still round-trips through hex even in oklch format (S3b owns
-      // wide-gamut HSL). commit() handles the hex → oklch() conversion in
-      // oklch mode, so onChange still emits the right format.
-      commit(hslaToHex(next.h, next.s, next.l, next.a));
+      if (isOklchFormat) {
+        // DELIBERATELY LOSSY PATH. HSL is an sRGB-oriented edit space: an HSL
+        // slider edit reinterprets the color through sRGB. Convert the edited
+        // HSL straight to the canonical Oklcha (hsl → Oklcha) and emit oklch(),
+        // so the format contract still holds while the value is sRGB-reanchored.
+        // A wide-gamut chroma the user was *viewing* in HSL mode is collapsed
+        // here — this is the single intentional precision-losing edit. (Merely
+        // toggling OKLCH↔HSL does NOT take this path; handleModeToggle never
+        // commits, so viewing in HSL alone never loses the wide-gamut value.)
+        commitCanonicalOklch(hslaToOklcha(next));
+      } else {
+        commit(hslaToHex(next.h, next.s, next.l, next.a));
+      }
     },
-    [hsla, commit],
+    [hsla, isOklchFormat, commitCanonicalOklch, commit],
   );
 
   const handleHexChange = (value: string) => {

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -415,6 +415,35 @@
   outline-offset: 2px;
 }
 
+/* ColorField — swatch-button used by GenericTab opt-in `format:'oklch'` color
+   items. It replaces the native <input type="color">, which has an intrinsic
+   box; a bare <div> has none, so explicit dimensions are required or the
+   affordance renders invisible/zero-size. Sized as an inline row control. */
+.tokenpanel-color-field {
+  display: inline-flex;
+}
+.tokenpanel-color-field-swatch {
+  display: block;
+  width: 2.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--tokentweak-color-muted);
+  border-radius: var(--radius-tokentweak);
+  cursor: pointer;
+  padding: 0;
+  transition: border-color 150ms ease;
+}
+.tokenpanel-color-field-swatch:hover {
+  border-color: var(--tokentweak-color-fg);
+}
+.tokenpanel-color-field-swatch:focus-visible {
+  outline: 2px solid var(--tokentweak-color-accent);
+  outline-offset: 2px;
+}
+.tokenpanel-color-field-swatch[aria-disabled='true'] {
+  cursor: default;
+  opacity: 0.6;
+}
+
 .tokenpanel-color-swatch-label-row {
   /* Flex row: label text + optional eye icon side by side, label truncates. */
   display: flex;

--- a/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
@@ -579,3 +579,183 @@ describe('GenericTab — rich tooltip on token-name labels', () => {
     expect(tooltip?.textContent).toBe('--test-easing-tab-open');
   });
 });
+
+// ---------------------------------------------------------------------------
+// S4 acceptance criteria: oklch color items route through ColorField (#378)
+// ---------------------------------------------------------------------------
+
+/** Tab with an oklch color item. */
+const OKLCH_COLOR_TAB: TabConfig = {
+  id: 'theme',
+  label: 'Theme',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base colors',
+      items: [
+        {
+          id: 'brand',
+          cssVar: '--test-brand',
+          label: 'Brand',
+          default: 'oklch(60% 0.2 240)',
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+/** Tab with a readonly oklch color item. */
+const READONLY_OKLCH_COLOR_TAB: TabConfig = {
+  id: 'theme-ro',
+  label: 'Theme RO',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base colors',
+      items: [
+        {
+          id: 'brand-ro',
+          cssVar: '--test-brand-ro',
+          label: 'Brand RO',
+          default: 'oklch(60% 0.2 240)',
+          type: { kind: 'color', format: 'oklch' },
+          readonly: true,
+        },
+      ],
+    },
+  ],
+};
+
+describe('GenericTab — oklch color items use ColorField (S4 #378)', () => {
+  it('renders ColorField swatch-button (not native <input type="color">) for oklch color items', async () => {
+    await renderGenericTab(OKLCH_COLOR_TAB);
+
+    const item = container.querySelector('[data-testid="tier-item-brand"]');
+    expect(item).not.toBeNull();
+
+    // Must NOT render a native color input
+    const nativeColorInput = item?.querySelector('input[type="color"]');
+    expect(nativeColorInput).toBeNull();
+
+    // Must render a ColorField swatch-button
+    const swatch = item?.querySelector('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+  });
+
+  it('oklch color swatch has role="button" and is keyboard accessible', async () => {
+    await renderGenericTab(OKLCH_COLOR_TAB);
+
+    const swatch = container.querySelector('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+    expect(swatch?.getAttribute('role')).toBe('button');
+    expect(swatch?.getAttribute('tabindex')).toBe('0');
+  });
+
+  it('clicking the swatch opens the ColorPicker for an oklch item', async () => {
+    await renderGenericTab(OKLCH_COLOR_TAB);
+
+    // Before click: no picker present
+    let picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+
+    act(() => {
+      swatch!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).not.toBeNull();
+  });
+
+  it('pressing Enter on the swatch opens the ColorPicker for an oklch item', async () => {
+    await renderGenericTab(OKLCH_COLOR_TAB);
+
+    let picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+
+    act(() => {
+      swatch!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).not.toBeNull();
+  });
+
+  it('pressing Space on the swatch opens the ColorPicker for an oklch item', async () => {
+    await renderGenericTab(OKLCH_COLOR_TAB);
+
+    let picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+
+    act(() => {
+      swatch!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+
+    picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).not.toBeNull();
+  });
+
+  it('plain hex color item still renders <input type="color">, not ColorField', async () => {
+    await renderGenericTab(MIXED_KINDS_TAB);
+
+    const item = container.querySelector('[data-testid="tier-item-color-item"]');
+    expect(item).not.toBeNull();
+
+    const nativeColorInput = item?.querySelector('input[type="color"]');
+    expect(nativeColorInput).not.toBeNull();
+
+    const swatch = item?.querySelector('[data-testid="color-field-swatch"]');
+    expect(swatch).toBeNull();
+  });
+
+  it('readonly oklch color item does NOT open the picker on click', async () => {
+    await renderGenericTab(READONLY_OKLCH_COLOR_TAB);
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+
+    act(() => {
+      swatch!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+  });
+
+  it('readonly oklch color item does NOT open the picker on Enter', async () => {
+    await renderGenericTab(READONLY_OKLCH_COLOR_TAB);
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+
+    act(() => {
+      swatch!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    const picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+  });
+
+  it('readonly oklch color item does NOT open the picker on Space', async () => {
+    await renderGenericTab(READONLY_OKLCH_COLOR_TAB);
+
+    const swatch = container.querySelector<HTMLElement>('[data-testid="color-field-swatch"]');
+    expect(swatch).not.toBeNull();
+
+    act(() => {
+      swatch!.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+
+    const picker = container.querySelector('.tokenpanel-color-picker');
+    expect(picker).toBeNull();
+  });
+});

--- a/packages/zdtp/src/tabs/_generic-item-editor.tsx
+++ b/packages/zdtp/src/tabs/_generic-item-editor.tsx
@@ -16,6 +16,7 @@ import { memo, useCallback, useEffect, useRef, useState } from 'preact/compat';
 import type { TierItem, TierValueKind } from '../tokens/tier-model';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import TokenLabel from '../controls/token-label';
+import ColorField from '../components/color-picker/color-field';
 
 export interface GenericItemEditorProps {
   item: TierItem;
@@ -189,6 +190,25 @@ function GenericItemEditorInner({ item, value, onChange }: GenericItemEditorProp
     }
 
     case 'color': {
+      if (type.format === 'oklch') {
+        const handleColorFieldChange = (next: string) => {
+          onChange(item.id, next);
+        };
+        return (
+          <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
+            <TokenLabel cssVar={item.cssVar} label={item.label} />
+            <ColorField
+              value={value}
+              onChange={handleColorFieldChange}
+              valueFormat="oklch"
+              label={item.label}
+              cssVar={item.cssVar}
+              readonly={isReadonly}
+            />
+            <HighlightToggleButton cssVar={item.cssVar} />
+          </div>
+        );
+      }
       const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         onChange(item.id, e.currentTarget.value);
       };

--- a/packages/zdtp/src/tabs/_generic-item-editor.tsx
+++ b/packages/zdtp/src/tabs/_generic-item-editor.tsx
@@ -6,6 +6,9 @@
  * For pill items (item.pill is set), a pill toggle is rendered above the
  * number input row.
  *
+ * For color items: native <input type="color"> by default; with format:'oklch' →
+ * OKLCH picker emitting oklch() (rendering wired in later sub-tasks).
+ *
  * This is an internal helper; not exported from the package index.
  */
 

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -9,7 +9,7 @@
  *   length / number → number input with unit suffix (numeric range)
  *   select          → native <select>
  *   text            → free-form text input
- *   color           → <input type="color"> (native OS color picker)
+ *   color           → native <input type="color"> by default; with format:'oklch' → OKLCH picker emitting oklch()
  *
  * For items in a tier with `referencesTier`, TierRefSelector is rendered
  * instead, so the user can either pick a tier-1 item id (emitted as

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -22,6 +22,7 @@ import { type TabOverrides, resolveTierItemValue } from '../apply/tier-resolver'
 import TierRefSelector from '../controls/tier-ref-selector';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import TokenLabel from '../controls/token-label';
+import ColorField from '../components/color-picker/color-field';
 
 // ---------------------------------------------------------------------------
 // Item editor dispatch
@@ -180,6 +181,25 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
     }
 
     case 'color': {
+      if (type.format === 'oklch') {
+        const handleColorFieldChange = (next: string) => {
+          onChange(item.id, next);
+        };
+        return (
+          <div className="tokenpanel-row" data-testid={`tier-item-${item.id}`}>
+            <TokenLabel cssVar={item.cssVar} label={item.label} />
+            <ColorField
+              value={value}
+              onChange={handleColorFieldChange}
+              valueFormat="oklch"
+              label={item.label}
+              cssVar={item.cssVar}
+              readonly={isReadonly}
+            />
+            <HighlightToggleButton cssVar={item.cssVar} />
+          </div>
+        );
+      }
       const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         onChange(item.id, e.currentTarget.value);
       };

--- a/packages/zdtp/src/tokens/tier-model.ts
+++ b/packages/zdtp/src/tokens/tier-model.ts
@@ -13,7 +13,12 @@ export type TierValueKind =
   | { kind: 'cursor' }
   | { kind: 'content' }
   | { kind: 'mask-image' }
-  | { kind: 'color' };
+  /**
+   * Omitting `format` (or passing `'hex'`) uses the native `<input type="color">`
+   * (today's behavior, emits a hex string). Passing `'oklch'` opts into the OKLCH
+   * picker that emits an `oklch(...)` string (rendering wired in later sub-tasks).
+   */
+  | { kind: 'color'; format?: 'hex' | 'oklch' };
 
 // ---------------------------------------------------------------------------
 // Narrowing helpers

--- a/packages/zdtp/src/utils/__tests__/color-oklch.test.ts
+++ b/packages/zdtp/src/utils/__tests__/color-oklch.test.ts
@@ -504,3 +504,35 @@ describe('cssToOklcha — round-trip with oklchaToCss', () => {
     });
   }
 });
+
+describe('cssToOklcha — rejects malformed channel tokens (codex review #380)', () => {
+  it('returns null when a channel has an invalid unit suffix (oklch(50px 0.1 120))', () => {
+    // Regression: the old global-regex tokenizer skipped the "px" and parsed
+    // "50" → l=5000. Must reject instead of silently truncating.
+    expect(cssToOklcha('oklch(50px 0.1 120)')).toBeNull();
+  });
+
+  it('returns null when chroma carries an angle unit (oklch(0.5 0.1deg 120))', () => {
+    expect(cssToOklcha('oklch(0.5 0.1deg 120)')).toBeNull();
+  });
+
+  it('returns null for trailing junk on lightness (oklch(0.5junk 0.1 120))', () => {
+    expect(cssToOklcha('oklch(0.5junk 0.1 120)')).toBeNull();
+  });
+
+  it('returns null for a malformed alpha token (oklch(0.5 0.1 120 / 50px))', () => {
+    expect(cssToOklcha('oklch(0.5 0.1 120 / 50px)')).toBeNull();
+  });
+
+  it('returns null when hue has a bogus unit (oklch(0.5 0.1 120px))', () => {
+    expect(cssToOklcha('oklch(0.5 0.1 120px)')).toBeNull();
+  });
+
+  it('still parses a fully-valid space-separated triple after the fix', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 120)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(50, 4);
+    expect(result!.c).toBeCloseTo(0.1, 5);
+    expect(result!.h).toBeCloseTo(120, 2);
+  });
+});

--- a/packages/zdtp/src/utils/__tests__/color-oklch.test.ts
+++ b/packages/zdtp/src/utils/__tests__/color-oklch.test.ts
@@ -14,6 +14,7 @@ import {
   hslaToOklcha,
   clampToSrgbGamut,
   isInSrgbGamut,
+  cssToOklcha,
   MAX_OKLCH_CHROMA,
   type Oklcha,
   type Hsla,
@@ -286,4 +287,220 @@ describe('MAX_OKLCH_CHROMA', () => {
   it('is 0.37', () => {
     expect(MAX_OKLCH_CHROMA).toBe(0.37);
   });
+});
+
+// ---------------------------------------------------------------------------
+// cssToOklcha
+// ---------------------------------------------------------------------------
+
+describe('cssToOklcha — null for non-oklch input', () => {
+  it('returns null for a hex string', () => {
+    expect(cssToOklcha('#aabbcc')).toBeNull();
+  });
+
+  it('returns null for named color "red"', () => {
+    expect(cssToOklcha('red')).toBeNull();
+  });
+
+  it('returns null for rgb()', () => {
+    expect(cssToOklcha('rgb(0,0,0)')).toBeNull();
+  });
+
+  it('returns null for hsl()', () => {
+    expect(cssToOklcha('hsl(0 0% 0%)')).toBeNull();
+  });
+
+  it('returns null for garbage input', () => {
+    expect(cssToOklcha('not a color')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(cssToOklcha('')).toBeNull();
+  });
+
+  it('returns null for oklch with wrong number of channels', () => {
+    expect(cssToOklcha('oklch(0.5 0.1)')).toBeNull();
+  });
+
+  it('returns null for oklch with too many channels', () => {
+    expect(cssToOklcha('oklch(0.5 0.1 120 200)')).toBeNull();
+  });
+});
+
+describe('cssToOklcha — basic numeric parsing', () => {
+  it('parses oklch(0.21 0.03 264)', () => {
+    const result = cssToOklcha('oklch(0.21 0.03 264)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(21, 4);
+    expect(result!.c).toBeCloseTo(0.03, 6);
+    expect(result!.h).toBeCloseTo(264, 4);
+    expect(result!.a).toBeCloseTo(100, 4);
+  });
+
+  it('parses oklch(0.5 0.1 120 / 0.5) — numeric alpha', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 120 / 0.5)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(50, 4);
+    expect(result!.c).toBeCloseTo(0.1, 6);
+    expect(result!.h).toBeCloseTo(120, 4);
+    expect(result!.a).toBeCloseTo(50, 4);
+  });
+
+  it('is case-insensitive (OKLCH uppercased)', () => {
+    const result = cssToOklcha('OKLCH(0.5 0.1 120)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(50, 4);
+  });
+
+  it('tolerates extra internal whitespace', () => {
+    const result = cssToOklcha('oklch(  0.5   0.1   120  )');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(50, 4);
+  });
+});
+
+describe('cssToOklcha — percentage L and A', () => {
+  it('parses oklch(93% 0.01 264deg / 50%) — percent L + angle unit + percent A', () => {
+    const result = cssToOklcha('oklch(93% 0.01 264deg / 50%)');
+    expect(result).not.toBeNull();
+    // 93% L → stored as 93
+    expect(result!.l).toBeCloseTo(93, 4);
+    expect(result!.c).toBeCloseTo(0.01, 6);
+    expect(result!.h).toBeCloseTo(264, 4);
+    // 50% A → stored as 50
+    expect(result!.a).toBeCloseTo(50, 4);
+  });
+
+  it('parses 0% L as l=0', () => {
+    const result = cssToOklcha('oklch(0% 0 0)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(0, 4);
+  });
+
+  it('parses 100% L as l=100', () => {
+    const result = cssToOklcha('oklch(100% 0 0)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(100, 4);
+  });
+});
+
+describe('cssToOklcha — chroma percentage (100% = 0.4)', () => {
+  it('parses oklch(0.6 50% 0.5turn) — chroma as percentage', () => {
+    const result = cssToOklcha('oklch(0.6 50% 0.5turn)');
+    expect(result).not.toBeNull();
+    // 50% chroma → 0.5 * 0.4 = 0.2
+    expect(result!.c).toBeCloseTo(0.2, 6);
+    // 0.5turn → 180 degrees
+    expect(result!.h).toBeCloseTo(180, 4);
+  });
+
+  it('parses 100% chroma as 0.4', () => {
+    const result = cssToOklcha('oklch(0.5 100% 120)');
+    expect(result).not.toBeNull();
+    expect(result!.c).toBeCloseTo(0.4, 6);
+  });
+
+  it('does NOT clamp wide-gamut chroma (chroma > 0.4 survives)', () => {
+    // Direct numeric chroma above the slider cap (MAX_OKLCH_CHROMA = 0.37)
+    const result = cssToOklcha('oklch(0.7 0.25 150)');
+    expect(result).not.toBeNull();
+    expect(result!.c).toBeCloseTo(0.25, 6);
+    // Also test percentage that exceeds 100% → chroma > 0.4
+    const result2 = cssToOklcha('oklch(0.7 150% 150)');
+    expect(result2).not.toBeNull();
+    expect(result2!.c).toBeCloseTo(0.6, 6);
+  });
+});
+
+describe('cssToOklcha — angle units', () => {
+  it('parses hue with deg unit', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 180deg)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(180, 4);
+  });
+
+  it('parses hue with rad unit', () => {
+    // Math.PI rad ≈ 180 degrees
+    const result = cssToOklcha(`oklch(0.5 0.1 ${Math.PI}rad)`);
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(180, 3);
+  });
+
+  it('parses hue with grad unit', () => {
+    // 200 gradians = 180 degrees
+    const result = cssToOklcha('oklch(0.5 0.1 200grad)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(180, 4);
+  });
+
+  it('parses hue with turn unit', () => {
+    // 0.5 turn = 180 degrees
+    const result = cssToOklcha('oklch(0.5 0.1 0.5turn)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(180, 4);
+  });
+});
+
+describe('cssToOklcha — hue normalization', () => {
+  it('normalizes negative hue: -30 → 330', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 -30)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(330, 4);
+  });
+
+  it('normalizes hue > 360: 400 → 40', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 400)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(40, 4);
+  });
+
+  it('normalizes 360 → 0', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 360)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(0, 4);
+  });
+});
+
+describe('cssToOklcha — none keyword', () => {
+  it('parses oklch(0.5 0.1 none) — none hue becomes 0', () => {
+    const result = cssToOklcha('oklch(0.5 0.1 none)');
+    expect(result).not.toBeNull();
+    expect(result!.h).toBeCloseTo(0, 4);
+  });
+
+  it('parses oklch(0.5 none 264 / none) — none chroma and none alpha', () => {
+    const result = cssToOklcha('oklch(0.5 none 264 / none)');
+    expect(result).not.toBeNull();
+    expect(result!.c).toBeCloseTo(0, 6);
+    expect(result!.h).toBeCloseTo(264, 4);
+    expect(result!.a).toBeCloseTo(0, 4);
+  });
+
+  it('parses none as L → l=0', () => {
+    const result = cssToOklcha('oklch(none 0.1 120)');
+    expect(result).not.toBeNull();
+    expect(result!.l).toBeCloseTo(0, 4);
+  });
+});
+
+describe('cssToOklcha — round-trip with oklchaToCss', () => {
+  const testCases: Array<{ label: string; o: Oklcha }> = [
+    { label: 'black', o: { l: 0, c: 0, h: 0, a: 100 } },
+    { label: 'white', o: { l: 100, c: 0, h: 0, a: 100 } },
+    { label: 'mid sRGB blue', o: { l: 50, c: 0.1, h: 264, a: 100 } },
+    { label: 'semi-transparent', o: { l: 70, c: 0.15, h: 120, a: 50 } },
+    { label: 'wide-gamut oklch(0.7 0.25 150)', o: { l: 70, c: 0.25, h: 150, a: 100 } },
+  ];
+
+  for (const { label, o } of testCases) {
+    it(`round-trips ${label}`, () => {
+      const css = oklchaToCss(o);
+      const parsed = cssToOklcha(css);
+      expect(parsed).not.toBeNull();
+      expect(parsed!.l).toBeCloseTo(o.l, 3);
+      expect(parsed!.c).toBeCloseTo(o.c, 5);
+      expect(parsed!.h).toBeCloseTo(o.h, 2);
+      expect(parsed!.a).toBeCloseTo(o.a, 3);
+    });
+  }
 });

--- a/packages/zdtp/src/utils/color-oklch.ts
+++ b/packages/zdtp/src/utils/color-oklch.ts
@@ -203,3 +203,125 @@ export function isInSrgbGamut(o: Oklcha): boolean {
   if (!rgb) return false;
   return isInSrgbGamutFn(rgb);
 }
+
+// ---------------------------------------------------------------------------
+// cssToOklcha
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an angle value (with optional unit) to degrees in [0, 360).
+ * Supported units: deg (default), rad, grad, turn.
+ */
+function parseAngleToDeg(value: string, unit: string): number {
+  const n = parseFloat(value);
+  let deg: number;
+  switch (unit.toLowerCase()) {
+    case 'rad':
+      deg = n * (180 / Math.PI);
+      break;
+    case 'grad':
+      // 400 gradians = 360 degrees
+      deg = n * (360 / 400);
+      break;
+    case 'turn':
+      deg = n * 360;
+      break;
+    default:
+      // 'deg' or no unit
+      deg = n;
+  }
+  // Normalize into [0, 360)
+  return ((deg % 360) + 360) % 360;
+}
+
+/**
+ * Parse a CSS Color 4 `oklch()` string into the panel's `Oklcha` shape.
+ *
+ * Supported syntax:
+ *   oklch(L C H)
+ *   oklch(L C H / A)
+ *
+ * L: number (0–1) or percentage (0%–100% → 0–1), stored as 0–100 internally.
+ * C: number in culori-native units, OR percentage where 100% = 0.4
+ *    (CSS Color 4 reference range). Wide-gamut chroma is NOT clamped.
+ * H: number (degrees) or angle with deg/rad/grad/turn unit; normalized to [0,360).
+ * A: number (0–1) or percentage (0%–100%); stored as 0–100 internally.
+ * `none` per channel is treated as 0.
+ *
+ * Returns null for non-oklch or unparseable input.
+ */
+export function cssToOklcha(css: string): Oklcha | null {
+  // Case-insensitive match on oklch( ... ) with optional whitespace
+  const trimmed = css.trim();
+  const outerMatch = trimmed.match(/^oklch\(\s*(.*?)\s*\)$/i);
+  if (!outerMatch) return null;
+
+  const inner = outerMatch[1];
+
+  // Split on '/' to separate color channels from alpha
+  const slashParts = inner.split('/');
+  if (slashParts.length > 2) return null;
+
+  const channelsPart = slashParts[0].trim();
+  const alphaPart = slashParts.length === 2 ? slashParts[1].trim() : null;
+
+  // Tokenize the channel part: values can be numbers, percentages, or angle values
+  // (e.g. "120deg", "1.5rad", "0.5turn", "200grad")
+  const TOKEN_RE = /none|[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?(%|deg|rad|grad|turn)?/gi;
+  const channelTokens = channelsPart.match(TOKEN_RE);
+  if (!channelTokens || channelTokens.length !== 3) return null;
+
+  // Helper: parse a single channel token
+  const parseValue = (token: string): { value: number; isPercent: boolean; unit: string } | null => {
+    if (token.toLowerCase() === 'none') return { value: 0, isPercent: false, unit: '' };
+    const m = token.match(/^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)(.*)?$/i);
+    if (!m) return null;
+    const num = parseFloat(m[1]);
+    if (isNaN(num)) return null;
+    const suffix = (m[2] ?? '').toLowerCase();
+    const isPercent = suffix === '%';
+    const unit = isPercent ? '%' : suffix;
+    return { value: num, isPercent, unit };
+  };
+
+  // Parse L
+  const lToken = parseValue(channelTokens[0]);
+  if (!lToken) return null;
+  // L stored 0–100; CSS L is 0–1 (number) or 0%–100% (percentage → /100 → still 0–1 → *100)
+  const lInternal = lToken.isPercent ? lToken.value : lToken.value * 100;
+
+  // Parse C
+  const cToken = parseValue(channelTokens[1]);
+  if (!cToken) return null;
+  // CSS Color 4: 100% chroma = 0.4 (reference range for chroma percentage)
+  const cInternal = cToken.isPercent ? (cToken.value / 100) * 0.4 : cToken.value;
+
+  // Parse H
+  const hRaw = channelTokens[2];
+  let hInternal: number;
+  if (hRaw.toLowerCase() === 'none') {
+    hInternal = 0;
+  } else {
+    const hMatch = hRaw.match(/^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)(deg|rad|grad|turn)?$/i);
+    if (!hMatch) return null;
+    const hNum = hMatch[1];
+    const hUnit = hMatch[2] ?? 'deg';
+    hInternal = parseAngleToDeg(hNum, hUnit);
+  }
+
+  // Parse A (optional)
+  let aInternal = 100; // default fully opaque
+  if (alphaPart !== null) {
+    const aToken = parseValue(alphaPart.trim());
+    if (!aToken) return null;
+    // A stored 0–100; CSS A is 0–1 (number) or 0%–100% (percentage)
+    aInternal = aToken.isPercent ? aToken.value : aToken.value * 100;
+  }
+
+  return {
+    l: lInternal,
+    c: cInternal,
+    h: hInternal,
+    a: aInternal,
+  };
+}

--- a/packages/zdtp/src/utils/color-oklch.ts
+++ b/packages/zdtp/src/utils/color-oklch.ts
@@ -265,23 +265,24 @@ export function cssToOklcha(css: string): Oklcha | null {
   const channelsPart = slashParts[0].trim();
   const alphaPart = slashParts.length === 2 ? slashParts[1].trim() : null;
 
-  // Tokenize the channel part: values can be numbers, percentages, or angle values
-  // (e.g. "120deg", "1.5rad", "0.5turn", "200grad")
-  const TOKEN_RE = /none|[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?(%|deg|rad|grad|turn)?/gi;
-  const channelTokens = channelsPart.match(TOKEN_RE);
-  if (!channelTokens || channelTokens.length !== 3) return null;
+  // CSS Color 4 oklch channels are whitespace-separated. Split on whitespace and
+  // require EXACTLY three fully-formed tokens — a global regex `.match()` would
+  // silently skip unmatched junk (e.g. tokenizing "50px 0.1 120" to ["50","0.1","120"]),
+  // so malformed channels must be rejected here rather than truncated to a bogus number.
+  const channelTokens = channelsPart.split(/\s+/).filter(Boolean);
+  if (channelTokens.length !== 3) return null;
 
-  // Helper: parse a single channel token
-  const parseValue = (token: string): { value: number; isPercent: boolean; unit: string } | null => {
-    if (token.toLowerCase() === 'none') return { value: 0, isPercent: false, unit: '' };
-    const m = token.match(/^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)(.*)?$/i);
+  // Helper: parse a single L/C/A channel token. Only a bare number or a percentage
+  // is valid — the regex is fully anchored, so any trailing junk (e.g. "50px",
+  // "0.1deg") yields null instead of a silently-truncated value. (H is parsed
+  // separately below with its own angle-aware anchored regex.)
+  const parseValue = (token: string): { value: number; isPercent: boolean } | null => {
+    if (token.toLowerCase() === 'none') return { value: 0, isPercent: false };
+    const m = token.match(/^([+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)(%?)$/i);
     if (!m) return null;
     const num = parseFloat(m[1]);
     if (isNaN(num)) return null;
-    const suffix = (m[2] ?? '').toLowerCase();
-    const isPercent = suffix === '%';
-    const unit = isPercent ? '%' : suffix;
-    return { value: num, isPercent, unit };
+    return { value: num, isPercent: m[2] === '%' };
   };
 
   // Parse L


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/373
    - https://github.com/Takazudo/zudo-design-token-panel/issues/372 (superseded)

---

## Summary

Implements epic #373 (supersedes #372). Opt-in `GenericTab` `{ kind: 'color' }` items can now render through the OKLCH/HSL `ColorPicker` and **edit/emit `oklch(...)` with no lossy sRGB hex round-trip**, so host/secondary panels can faithfully display and edit wide-gamut (oklch/P3) palette values.

**Additive & backward compatible:** the capability is gated behind a new `format?: 'hex' | 'oklch'` on the color tier item. Omitting it (or `'hex'`) keeps today's native `<input type="color">` exactly as before — existing hex consumers, `ColorTab`, and `highlight-settings-popover` are unaffected.

## What changed

- **`cssToOklcha` parser** (`utils/color-oklch.ts`) — parses CSS Color 4 `oklch()` (number/percentage L, chroma %, deg/rad/grad/turn hue, `none`, alpha); strict — rejects malformed channels. The apply/persistence path was already value-agnostic, so `oklch(...)` strings flow end-to-end with no serializer change.
- **`{ kind: 'color'; format?: 'hex' | 'oklch' }`** public type (`tokens/tier-model.ts`) + updated doc comments.
- **`ColorPicker` `valueFormat` contract** — canonical `Oklcha` source of truth in oklch mode; OKLCH sliders/presets/preview/hex-input emit wide-gamut `oklch(...)` unclamped; HSL mode stays available but is a documented, tested, sRGB-oriented (lossy) edit path while the mode toggle itself is emit-free; default hex path byte-for-byte unchanged.
- **Shared `ColorField`** (swatch-button → picker popover) wired into both generic item editors; readonly-aware; styled so the swatch is a visible row control.

## Sub-issues (all merged into the base)

#374 parser · #375 type+docs · #376 picker core · #377 picker HSL/alpha/preset hardening · #378 ColorField+routing · #379 integration confirm.

## Quality

- 1264 unit tests green, `tsc --noEmit` clean, `pnpm -F @takazudo/zdtp build` green, Invariant D (DOM hygiene) green.
- Codex deep-review surfaced 2 findings (invisible swatch CSS; lenient parser) — both fixed in-PR with regression tests.
- e2e test asserts dual-path oklch emit (panel `onChange` + apply path) and wide-gamut P3 (`oklch(0.7 0.25 150)`) surviving prop→edit→emit without sRGB clamping.