### PR TITLE
fix(doc): restore project color scheme on docs pages + 404 (host-owned routes)

### DIFF
--- a/doc/pages/404.tsx
+++ b/doc/pages/404.tsx
@@ -1,0 +1,54 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Host route entrypoint: /404 — static route, emitted as dist/404.html.
+//
+// Host-owned override of the package-injected 404 route
+// (.zudo-doc/routes-src/404.tsx); see pages/docs/[[...slug]].tsx for the override
+// rationale. Mirrors the package stub's markup but wires the host chrome
+// (HeadWithDefaults / BodyEndIslands from pages/lib) so the page renders with the
+// project color scheme and the real body-end islands, exactly like pages/index.tsx.
+
+import type { JSX } from "preact";
+import { DocLayoutWithDefaults } from "@takazudo/zudo-doc/doclayout";
+import { settings } from "@/config/settings";
+import { defaultLocale } from "@/config/i18n";
+import { withBase } from "@/utils/base";
+import { HeadWithDefaults } from "./lib/_head-with-defaults";
+import { HeaderWithDefaults } from "./lib/_header-with-defaults";
+import { FooterWithDefaults } from "./lib/_footer-with-defaults";
+import { BodyEndIslands } from "./lib/_body-end-islands";
+import { composeMetaTitle } from "./lib/_compose-meta-title";
+
+export const frontmatter = { title: "404" };
+
+export default function NotFoundPage(): JSX.Element {
+  const locale = defaultLocale;
+  const title = "Page Not Found";
+
+  return (
+    <DocLayoutWithDefaults
+      title={composeMetaTitle(title)}
+      head={<HeadWithDefaults title={title} />}
+      lang={locale}
+      noindex={true}
+      hideSidebar={true}
+      hideToc={true}
+      sidebarOverride={<></>}
+      headerOverride={<HeaderWithDefaults lang={locale} />}
+      footerOverride={<FooterWithDefaults lang={locale} />}
+      bodyEndComponents={<BodyEndIslands basePath={settings.base ?? "/"} />}
+      enableClientRouter={settings.dynamicPageTransition}
+    >
+      <div class="min-h-[60vh] flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl">
+        <h1 class="text-display font-bold mb-vsp-md">404</h1>
+        <p class="text-title text-muted mb-vsp-xl">Page not found.</p>
+        <a
+          href={withBase("/")}
+          class="bg-accent px-hsp-lg py-vsp-xs font-medium text-bg hover:bg-accent-hover"
+        >
+          Back to Home
+        </a>
+      </div>
+    </DocLayoutWithDefaults>
+  );
+}

--- a/doc/pages/[locale]/docs/[[...slug]].tsx
+++ b/doc/pages/[locale]/docs/[[...slug]].tsx
@@ -1,0 +1,73 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Host route entrypoint: /[locale]/docs/[[...slug]] — non-default-locale catch-all.
+//
+// Host-owned override of the package-injected route
+// (.zudo-doc/routes-src/locale-docs-slug.tsx); see pages/docs/[[...slug]].tsx for
+// the override rationale. paths() enumerates one route per (non-default locale,
+// slug) with the locale-first + base-EN-fallback merge, then renders through the
+// host pages/lib toolkit so the project color scheme applies.
+
+import type { JSX } from "preact";
+import type { DocPageEntryProps, DocPageAutoIndexProps } from "@takazudo/zudo-doc/doc-page-props";
+import { settings } from "@/config/settings";
+import { getLocaleConfig, type Locale } from "@/config/i18n";
+import { resolveNavSource } from "../../lib/_nav-source-docs";
+import { buildDocRouteEntries } from "../../lib/_doc-route-entries";
+import { renderDocPage } from "../../lib/_doc-page-renderer";
+
+export const frontmatter = { title: "Docs" };
+
+interface LocaleDocPageExtra {
+  contentDir: string;
+  isFallback: boolean;
+}
+
+type DocPageProps =
+  | (DocPageEntryProps & LocaleDocPageExtra)
+  | (DocPageAutoIndexProps & LocaleDocPageExtra);
+
+export function paths(): Array<{
+  params: { locale: string; slug: string[] };
+  props: DocPageProps;
+}> {
+  const result: Array<{
+    params: { locale: string; slug: string[] };
+    props: DocPageProps;
+  }> = [];
+
+  for (const locale of Object.keys(settings.locales)) {
+    const contentDir = getLocaleConfig(locale)?.dir ?? settings.docsDir;
+    const source = resolveNavSource(locale as Locale, undefined, {
+      applyDefaultLocaleOnlyFilter: true,
+      keepUnlisted: true,
+    });
+
+    for (const item of buildDocRouteEntries({
+      source,
+      locale,
+      routeSig: `locale-docs;${locale}`,
+    })) {
+      const extra: LocaleDocPageExtra = {
+        contentDir: item.isFallback ? settings.docsDir : contentDir,
+        isFallback: item.isFallback,
+      };
+      result.push({
+        params: { locale, slug: item.slugParams },
+        props: { ...(item.props as DocPageProps), ...extra },
+      });
+    }
+  }
+
+  return result;
+}
+
+type PageArgs = DocPageProps & { params: { locale: string; slug: string[] } };
+
+export default function LocaleDocsPage(props: PageArgs): JSX.Element {
+  return renderDocPage(props, {
+    locale: props.params.locale,
+    isFallback: props.isFallback,
+    docHistoryContentDir: props.contentDir,
+  });
+}

--- a/doc/pages/docs/[[...slug]].tsx
+++ b/doc/pages/docs/[[...slug]].tsx
@@ -1,0 +1,47 @@
+/** @jsxRuntime automatic */
+/** @jsxImportSource preact */
+// Host route entrypoint: /docs/[[...slug]] — default-locale (EN) catch-all.
+//
+// This is the host-owned override of the package-injected docs catch-all
+// (.zudo-doc/routes-src/docs-slug.tsx). With `packageOwnedRoutes: true` the
+// @takazudo/zudo-doc routes plugin injects this route bound to the package's
+// grey-ramp DEFAULT_SCHEME chrome (_chrome.tsx); zfb drops that injected route
+// wherever a host pages/ file claims the same URL shape ("user pages/ wins"),
+// so rendering here flows through the host pages/lib toolkit and the project
+// color scheme — exactly as pages/index.tsx overrides the injected `/` route.
+// The zudo-doc 1.1.0 rescaffold scaffolded the pages/lib toolkit but omitted
+// this entrypoint, leaving docs pages on the package stub scheme.
+
+import type { JSX } from "preact";
+import type { DocPageEntryProps, DocPageAutoIndexProps } from "@takazudo/zudo-doc/doc-page-props";
+import { settings } from "@/config/settings";
+import { defaultLocale } from "@/config/i18n";
+import { resolveNavSource } from "../lib/_nav-source-docs";
+import { buildDocRouteEntries } from "../lib/_doc-route-entries";
+import { renderDocPage } from "../lib/_doc-page-renderer";
+
+export const frontmatter = { title: "Docs" };
+
+type DocPageProps = DocPageEntryProps | DocPageAutoIndexProps;
+
+export function paths(): Array<{ params: { slug: string[] }; props: DocPageProps }> {
+  const locale = defaultLocale;
+  const source = resolveNavSource(locale, undefined);
+  return buildDocRouteEntries({
+    source,
+    locale,
+    routeSig: `docs;${locale}`,
+  }).map((item) => ({
+    params: { slug: item.slugParams },
+    props: item.props as DocPageProps,
+  }));
+}
+
+type PageArgs = DocPageProps & { params: { slug: string[] } };
+
+export default function DocsPage(props: PageArgs): JSX.Element {
+  return renderDocPage(props, {
+    locale: defaultLocale,
+    docHistoryContentDir: settings.docsDir,
+  });
+}


### PR DESCRIPTION
## Summary

After the zudo-doc 1.1.0 rescaffold (commit `801e5b9`), every `/docs/**` page and `404.html` rendered with a wrong grey/black high-contrast color scheme — inline code showed as unreadable solid blocks (code-bg ≈ code-fg). Only the two locale index pages rendered correctly.

**Root cause:** the rescaffold enabled `packageOwnedRoutes: true` (so `@takazudo/zudo-doc`'s routes plugin injects the docs/404 routes) and scaffolded the full host doc-rendering toolkit under `doc/pages/lib/`, but **never created the host route entrypoint files that import it**. zfb gives host `pages/` files precedence over a package-injected route of the same URL shape ("user pages/ wins"). The host shipped only `pages/index.tsx` + `pages/[locale]/index.tsx`, so only `/` and `/[locale]` were overridden with the project scheme; every docs/404 route fell back to the package-injected stub routes, whose `_chrome.tsx` binds `HeadWithDefaults` to a grey-ramp `DEFAULT_SCHEME` (`#000000`/`#ffffff`/`#cccccc`…).

**Fix:** add the three missing host-owned route files, mirroring the generated stubs (`doc/.zudo-doc/routes-src/{docs-slug,locale-docs-slug,404}.tsx`) but importing the host `doc/pages/lib` toolkit (correct project scheme via `getActiveScheme()`). zfb now drops the injected stubs in favour of these. `packageOwnedRoutes` stays `true`.

This also restores, on docs pages, the project translations, the design-token-panel / image-enlarge body-end islands, and doc-history — all of which the stub chrome had nulled out.

## Changes
- `doc/pages/docs/[[...slug]].tsx` — host-owned default-locale (EN) docs catch-all → `/docs/[[...slug]]`
- `doc/pages/[locale]/docs/[[...slug]].tsx` — host-owned non-default-locale docs catch-all → `/[locale]/docs/[[...slug]]`
- `doc/pages/404.tsx` — host-owned 404 → `dist/404.html`

Each is a thin wrapper: `paths()` enumerates via the host `_doc-route-entries` / `_nav-source-docs`, and rendering goes through the host `_doc-page-renderer` / chrome.

## Test Plan
- `pnpm build` — build log confirms `package route /docs/[[...slug]]`, `/[locale]/docs/[[...slug]]`, `/404` are now "shadowed by a user pages/ route (user wins); skipping"; 59 pages built, no errors
- Built-output assertion: `dist/docs/**`, `dist/ja/docs/**`, `dist/404.html` all now emit `--zd-bg: light-dark(#e2ddda,#181818)` with readable code tokens (`#ece9e9`/`#303030`); **zero** pages remain on the `#000000` fallback
- `pnpm check` (tsc) clean; `pnpm check:html` and `check:asset-prefix` clean
- Headless computed-style probe (light mode): docs page body `rgb(48,48,48)` on `rgb(226,221,218)` — identical to index; inline code bg `#ece9e9` ≠ fg `#303030` (readable pill, not solid block)
- Codex review: no regressions found