### PR TITLE
Panel: drag/move/resize on narrow windows + keep copy-selector working while closed

### DIFF
--- a/packages/zdtp/src/__tests__/elpath-enabled-mounts-while-closed.test.tsx
+++ b/packages/zdtp/src/__tests__/elpath-enabled-mounts-while-closed.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression test: the Element Path Copy inspector must work even while the
+ * panel is CLOSED.
+ *
+ * The Alt+click "copy selector" gesture lives in the InspectorOverlay, which
+ * is mounted by the ElementPathOrchestrator — and that orchestrator only runs
+ * while the Preact shell is mounted. The shell mounts lazily (first open). So
+ * on a page load where the user had previously enabled inspect mode but left
+ * the panel closed (and has no token overrides), nothing mounted the shell and
+ * the inspector silently did not work.
+ *
+ * Fix (`reapplyFromStorage` in index.tsx): when the persisted elpath-enabled
+ * flag is set, mount the shell CLOSED (via `hideInstance`) so the inspector
+ * overlay activates without opening the panel.
+ *
+ * This drives the real soft-nav trigger: `reapplyFromStorage` is bound to
+ * `astro:page-load` (the adapter's default lifecycle channel), so dispatching
+ * that event exercises the exact mount decision the fix changed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  panelRootId,
+  storageKey_visible,
+  getPanelConfig,
+} from '../config/panel-config';
+
+const PANEL_ROOT_ID = panelRootId(getPanelConfig());
+const STORAGE_KEY_VISIBLE = storageKey_visible(getPanelConfig());
+const ELPATH_ENABLED_KEY = `${getPanelConfig().storagePrefix}-elpath-enabled`;
+const OPEN_PANEL_HEADER_TEXT = 'Design Tokens';
+
+async function waitForEffectFlush(): Promise<void> {
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+}
+
+/** Re-import the adapter fresh so its module-init binds the astro lifecycle. */
+async function freshAdapterImport(): Promise<void> {
+  vi.resetModules();
+  const { __resetPanelConfigForTests } = await import('../config/panel-config');
+  __resetPanelConfigForTests();
+  await import('../index');
+}
+
+describe('adapter — Element Path Copy mounts the shell while closed', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = '';
+    const adapterWin = window as unknown as Record<string, unknown>;
+    delete adapterWin.__zudoDesignTokenPanelAdapter;
+    delete adapterWin.__zudoDesignTokenPanelLifecycle;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('mounts the shell CLOSED when elpath is enabled (no overrides, not visible)', async () => {
+    // Persisted inspect-mode ON; panel was never made visible; no overrides.
+    localStorage.setItem(ELPATH_ENABLED_KEY, '1');
+    expect(localStorage.getItem(STORAGE_KEY_VISIBLE)).toBeNull();
+
+    await freshAdapterImport();
+    // No mount yet — the shell is lazy.
+    expect(document.getElementById(PANEL_ROOT_ID)).toBeNull();
+
+    // A page load re-evaluates storage and decides what to mount.
+    document.dispatchEvent(new Event('astro:page-load'));
+    await waitForEffectFlush();
+
+    // The shell is mounted...
+    const root = document.getElementById(PANEL_ROOT_ID);
+    expect(root).not.toBeNull();
+    // ...but the panel itself stays CLOSED (no open header rendered).
+    expect(root!.textContent ?? '').not.toContain(OPEN_PANEL_HEADER_TEXT);
+  });
+
+  it('does NOT mount the shell when elpath is disabled (no overrides, not visible)', async () => {
+    localStorage.setItem(ELPATH_ENABLED_KEY, '0');
+
+    await freshAdapterImport();
+    document.dispatchEvent(new Event('astro:page-load'));
+    await waitForEffectFlush();
+
+    expect(document.getElementById(PANEL_ROOT_ID)).toBeNull();
+  });
+});

--- a/packages/zdtp/src/__tests__/load-size.test.ts
+++ b/packages/zdtp/src/__tests__/load-size.test.ts
@@ -56,6 +56,15 @@ describe('defaultSize', () => {
     expect(size.width).toBe(1200);
     expect(size.height).toBe(800);
   });
+
+  it('clamps up to the MIN_PANEL floor on a phone-width viewport (375×667)', () => {
+    // 0.8 * 375 = 300, below MIN_PANEL_WIDTH (320) — the panel stays usable
+    // and draggable/resizable at this width since narrow mode was removed.
+    setViewport(375, 667);
+    const size = defaultSize();
+    expect(size.width).toBe(MIN_PANEL_WIDTH);
+    expect(size.height).toBeCloseTo(0.8 * 667); // 533.6, above MIN_PANEL_HEIGHT
+  });
 });
 
 describe('loadSize', () => {

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -67,6 +67,7 @@ import {
   toggleEventName,
   type PanelConfig,
 } from './config/panel-config';
+import { loadElementPathEnabled } from './element-path/element-path-state';
 
 // ---------------------------------------------------------------------------
 // Public DOM contract (kept in sync with astro/host-adapter.ts)
@@ -482,8 +483,12 @@ function unmountForSwap(): void {
 
 /**
  * Re-materialise the shell on a page load when either (a) the user had the
- * panel visible before navigation, or (b) overrides are persisted and need
- * reapplying even while the panel stays hidden.
+ * panel visible before navigation, (b) overrides are persisted and need
+ * reapplying even while the panel stays hidden, or (c) the Element Path Copy
+ * inspector is enabled — its Alt+click "copy selector" gesture must work even
+ * when the panel is closed, and the inspector overlay only runs while the
+ * Preact shell (and its ElementPathOrchestrator) is mounted. Cases (b) and (c)
+ * mount the shell CLOSED via `hideInstance`.
  *
  * Overrides are applied to `:root` first (cheap, no Preact render) so the
  * post-swap paint uses the persisted values immediately instead of waiting
@@ -495,7 +500,7 @@ function reapplyFromStorage(): void {
   reapplyPersistedOverrides();
   if (wasVisible(cfg)) {
     showInstance(cfg);
-  } else if (hasPersistedOverrides(cfg)) {
+  } else if (hasPersistedOverrides(cfg) || loadElementPathEnabled()) {
     hideInstance(cfg);
   }
 }

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -62,32 +62,20 @@ const DEFAULT_TAB_ID: ReservedTabId = 'color';
 
 // --- Panel sizing ---
 
-/** Below this width the panel switches to narrow mode (non-draggable, centered, capped width). */
-const NARROW_BREAKPOINT = 900;
-
-function computePanelSize(
-  viewportW: number,
-  _viewportH: number,
-  storedSize: PanelSize,
-): {
-  width: number | string;
-  height: number | string;
-  narrow: boolean;
+/**
+ * The panel is always draggable, movable, and resizable — on any viewport
+ * width. `loadSize` / `defaultSize` already clamp the stored size to the
+ * viewport (down to MIN_PANEL_WIDTH/HEIGHT), and `clampPosition` keeps a
+ * visible slice on-screen, so a fixed-px panel stays usable on narrow windows
+ * without a separate centered/locked layout.
+ */
+function computePanelSize(storedSize: PanelSize): {
+  width: number;
+  height: number;
 } {
-  const narrow = viewportW < NARROW_BREAKPOINT;
-  if (narrow) {
-    return {
-      width: `min(calc(100vw - 16px), 500px)`,
-      height: `min(800px, calc(100vh - 32px))`,
-      narrow,
-    };
-  }
-  // Wide mode: fixed px sourced from user-resizable state. `loadSize` /
-  // `defaultSize` already clamp to viewport, so we can trust the values here.
   return {
     width: storedSize.width,
     height: storedSize.height,
-    narrow,
   };
 }
 
@@ -161,7 +149,6 @@ export default function DesignTokenTweakPanel({
   const [position, setPosition] = useState<PanelPosition>(DEFAULT_POSITION);
   const [size, setSize] = useState<PanelSize>(defaultSize);
   const [density, setDensity] = useState<PanelDensity>(DEFAULT_DENSITY);
-  const [isNarrow, setIsNarrow] = useState(false);
   const panelRef = useRef<HTMLDivElement>(null);
   // tabRefs is now keyed by string to support host-supplied tab ids.
   const tabRefs = useRef<Record<string, HTMLDivElement | null>>({
@@ -197,8 +184,6 @@ export default function DesignTokenTweakPanel({
     setSize(loadedSize);
     sizeRef.current = loadedSize;
     setDensity(loadDensity(instanceConfig));
-    // Initial narrow-check
-    setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -343,8 +328,6 @@ export default function DesignTokenTweakPanel({
 
   // Drag handler for panel header (stable — reads position from ref)
   const handleDragStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    // Drag disabled on narrow viewports.
-    if (window.innerWidth < NARROW_BREAKPOINT) return;
     // Skip if target is a button (or role=button/tab div), select, or inside one
     const target = e.target as HTMLElement;
     if (target.closest("button, select, option, [role='tab'], [role='button']")) return;
@@ -398,9 +381,6 @@ export default function DesignTokenTweakPanel({
   // re-renders of the whole panel) and commits the final value to React
   // state + localStorage on mouseup.
   const handleResizeStart = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    // Resize disabled on narrow viewports — the panel is centered and the
-    // grip is hidden anyway, but guard defensively.
-    if (window.innerWidth < NARROW_BREAKPOINT) return;
     e.preventDefault();
     e.stopPropagation();
     const startX = e.clientX;
@@ -460,10 +440,10 @@ export default function DesignTokenTweakPanel({
     };
   }, []);
 
-  // Re-clamp position + size on window resize, update narrow-mode flag
+  // Re-clamp position + size on window resize so a viewport shrink keeps the
+  // panel within bounds.
   useEffect(() => {
     function handleResize() {
-      setIsNarrow(window.innerWidth < NARROW_BREAKPOINT);
       // Re-clamp size first — a viewport shrink might force a smaller panel,
       // and the new dimensions feed into the position clamp below.
       setSize((prev) => {
@@ -566,27 +546,9 @@ export default function DesignTokenTweakPanel({
       <ElementPathOrchestrator>
       <TooltipProvider>
       {open && (() => {
-        const {
-          width: panelW,
-          height: panelH,
-          narrow,
-        } = computePanelSize(
-          typeof window !== 'undefined' ? window.innerWidth : 1024,
-          typeof window !== 'undefined' ? window.innerHeight : 768,
-          size,
-        );
+        const { width: panelW, height: panelH } = computePanelSize(size);
 
-        // In narrow mode, ignore saved position — center safely near the top.
-        const panelPos =
-          narrow || isNarrow
-            ? {
-                position: 'fixed' as const,
-                top: 16,
-                left: '50%',
-                transform: 'translateX(-50%)',
-                right: 'auto' as const,
-              }
-            : { position: 'fixed' as const, top: position.top, left: position.left };
+        const panelPos = { position: 'fixed' as const, top: position.top, left: position.left };
 
         return (
           <>
@@ -604,10 +566,10 @@ export default function DesignTokenTweakPanel({
           ['--tokenpanel-grid-min' as string]: densityToGridMin(density),
         }}
       >
-        {/* Header row (expert/reset) — draggable on desktop only */}
+        {/* Header row (expert/reset) — drag to move the panel */}
         <div
           className="tokenpanel-header"
-          style={{ cursor: narrow || isNarrow ? 'default' : 'move' }}
+          style={{ cursor: 'move' }}
           onMouseDown={handleDragStart}
         >
           <span className="tokenpanel-title">Design Tokens</span>
@@ -837,22 +799,18 @@ export default function DesignTokenTweakPanel({
           })}
         </div>
 
-        {/* Bottom-right resize grip. Hidden in narrow (centered) mode where
-            the panel is sized by CSS expressions and dragging would conflict
-            with the touch-first layout.
+        {/* Bottom-right resize grip — available on every viewport width.
 
             ARIA: `role="separator"` would imply a 1D resizer between two
             regions; this grip resizes the panel on both axes, which has no
             standard role. We keep just `aria-label` for SR users — keyboard
             resize is intentionally out of scope. */}
-        {!(narrow || isNarrow) && (
-          <div
-            className="tokenpanel-resize-handle"
-            onMouseDown={handleResizeStart}
-            aria-label="Resize panel"
-            title="Drag to resize"
-          />
-        )}
+        <div
+          className="tokenpanel-resize-handle"
+          onMouseDown={handleResizeStart}
+          aria-label="Resize panel"
+          title="Drag to resize"
+        />
       </div>
 
       {showExport && state && (

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -233,14 +233,17 @@ export const DEFAULT_SIZE: PanelSize = { width: 1024 * 0.8, height: 768 * 0.8 };
 /**
  * Compute the first-open panel size in px. Mirrors the historical CSS
  * `min(1200, 0.8 * vw)` × `min(800, 0.8 * vh)` rule so existing users
- * experience the same default size after this PR ships.
+ * experience the same default size, then clamps through `clampSize` so the
+ * result respects the MIN_PANEL_* floor and the viewport cap. The floor only
+ * bites on phone-width viewports (e.g. 375px → 0.8*375 = 300, raised to the
+ * 320 min); on normal viewports the clamp is a no-op.
  */
 export function defaultSize(): PanelSize {
   if (typeof window === 'undefined') return DEFAULT_SIZE;
-  return {
-    width: Math.min(1200, 0.8 * window.innerWidth),
-    height: Math.min(800, 0.8 * window.innerHeight),
-  };
+  return clampSize(
+    Math.min(1200, 0.8 * window.innerWidth),
+    Math.min(800, 0.8 * window.innerHeight),
+  );
 }
 
 /** Margin kept around the panel when clamping size against the viewport. */

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -55,9 +55,9 @@
 /* ===========================================================================
  * Resize grip (bottom-right corner)
  *
- * Windows-style diagonal-stripes hint, hidden in narrow (touch) mode by the
- * panel component skipping the element altogether. The three stripes are
- * drawn with `repeating-linear-gradient` so no SVG or extra DOM is needed.
+ * Windows-style diagonal-stripes hint, shown on every viewport width. The
+ * three stripes are drawn with `repeating-linear-gradient` so no SVG or extra
+ * DOM is needed.
  * ========================================================================= */
 
 .tokenpanel-resize-handle {


### PR DESCRIPTION
## Summary

Two panel UX fixes:

1. **Drag / move / resize on narrow windows.** The panel previously switched to a locked "narrow mode" below a 900px viewport (`NARROW_BREAKPOINT`): centered, non-draggable, non-resizable, with the resize grip hidden. On a narrow window a developer could not move or resize it. The lockout is removed so drag/move/resize work at every viewport width. The existing `clampSize` (floors at 320px, caps at viewport − margin) and `clampPosition` (always keeps a visible slice on-screen) already keep a fixed-px panel usable on small viewports, so no separate centered layout is needed.

2. **Copy-selector (Element Path Copy) works while the panel is closed.** The Alt+click → copy element path gesture lives in the `ElementPathOrchestrator`, which only runs while the Preact shell is mounted. The shell mounts lazily on first open, so on a page load where the user had enabled inspect mode but left the panel closed (and had no token overrides) nothing mounted the shell and Alt+click silently did nothing. `reapplyFromStorage` already mounts the shell *closed* to reapply persisted token overrides; that condition is extended to also mount (closed) when the persisted `elpath-enabled` flag is set.

## Changes

- `packages/zdtp/src/panel.tsx` — remove `NARROW_BREAKPOINT`, the `computePanelSize` narrow branch, `isNarrow` state, the narrow guards in the drag/resize handlers, the centered position branch, the conditional header cursor, and the grip-hiding. The header is always `cursor: move` and the resize grip always renders.
- `packages/zdtp/src/styles/panel.css` — update the resize-grip comment (no longer hidden in narrow mode).
- `packages/zdtp/src/state/tweak-state.ts` — route `defaultSize()` through `clampSize` so first-open on a phone-width viewport respects the `MIN_PANEL_WIDTH` floor (no-op on normal viewports).
- `packages/zdtp/src/index.tsx` — `reapplyFromStorage` mounts the shell closed when `loadElementPathEnabled()` is set.
- Tests: phone-width `defaultSize` floor; `elpath-enabled-mounts-while-closed` (mounts closed when enabled, stays unmounted when disabled).

## Test Plan

- `pnpm -F @takazudo/zdtp exec tsc --noEmit` — clean.
- `pnpm -F @takazudo/zdtp test --run` — 1339 passed, 6 skipped. (The one unrelated error is a Playwright headless-shell browser-launch limitation in the cloud container, not a code failure.)
- Visual drag/resize on a narrow window and Alt+click-while-closed should be confirmed on a real browser (see the `mac` follow-up note) — these can't be verified headless in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QueqxeRhNHHhDApXTsVsUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QueqxeRhNHHhDApXTsVsUJ)_