### PR TITLE
OKLCH ColorTab: reserved color tab honors format:'oklch' + runtime preserves OKLCH

### DIFF
--- a/packages/zdtp/src/__tests__/oklch-color-cluster-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/oklch-color-cluster-e2e.test.tsx
@@ -1,0 +1,1046 @@
+// @vitest-environment jsdom
+
+/**
+ * OKLCH ColorTab cluster — end-to-end integration test (issue #437 Wave-2 confirm).
+ *
+ * Validates the full path on a CLUSTER-BASED color tab (`colorExtras` present)
+ * whose palette tier items are `format:'oklch'`, seeded from a scheme whose
+ * palette is `oklch(...)` including at least one WIDE-GAMUT / out-of-sRGB value.
+ *
+ * Assertions:
+ *  1. Seed → state.palette holds raw oklch() (not hex, not #000000)
+ *  2. jsdom #000000 guard: wide-gamut value does not collapse to black on seed
+ *  3. Apply path: CSS custom property receives oklch() value (not hex)
+ *  4. localStorage persist/hydrate round-trip preserves oklch() byte-for-byte
+ *  5. SerDe JSON round-trip (serialize → deserialize) preserves oklch()
+ *  6. UI: editing swatch via OKLCH editor emits oklch() through persistColor
+ *  7. HSL-edit caveat: toggling to HSL mode does NOT commit/clamp (OKLCH preserved);
+ *     actual HSL-slider edit emits oklch() but may sRGB-reanchor (intentional
+ *     lossy edit path — NOT an R4 violation, see issue #437 §Note)
+ *  8. Cluster-feature regression: scheme-preset swap, base-role mappings,
+ *     semantic→palette mappings resolve to OKLCH values, secondary cluster
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+import ColorTab from '../tabs/color-tab';
+import {
+  initColorFromSchemeData,
+  applyColorState,
+  loadPersistedState,
+  savePersistedState,
+  getStorageKeyV3,
+  getActivePrimaryCluster,
+  type ColorTweakState,
+  type TweakState,
+  type StorageLike,
+} from '../state/tweak-state';
+import { resolveColorClusterFromTab } from '../config/cluster-config';
+import { serialize, deserialize } from '../utils/design-token-serde';
+import {
+  configurePanel,
+  __resetPanelConfigForTests,
+  getPanelConfig,
+  type PanelConfig,
+} from '../config/panel-config';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from '../highlight/highlight-toggle-button';
+import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../highlight/highlight-state';
+import { TooltipProvider } from '../controls/tooltip';
+import type { TabConfig } from '../tokens/tier-model';
+import type { ColorScheme } from '../config/color-schemes';
+import type { PersistColor, PersistSecondary } from '../state/persist';
+
+// ---------------------------------------------------------------------------
+// PALETTE CONSTANTS
+// ---------------------------------------------------------------------------
+
+/**
+ * 4-slot OKLCH palette. Index 2 is WIDE-GAMUT (chroma 0.25 is out of sRGB at
+ * L≈0.7, H=150 — real P3 colour). The jsdom `#000000` guard specifically
+ * targets this slot: if seed eagerly clips via canvas, it collapses to black.
+ */
+const PALETTE_SIZE = 4;
+const WIDE_GAMUT_INDEX = 2; // --oklch-p2
+
+const OKLCH_PALETTE_STRINGS: readonly string[] = [
+  'oklch(0.21 0.03 264)', // 0 — dark blue
+  'oklch(0.50 0.12 150)', // 1 — mid green
+  'oklch(0.70 0.25 150)', // 2 — WIDE-GAMUT (P3 chroma, out of sRGB)
+  'oklch(0.90 0.02 100)', // 3 — near-white
+] as const;
+
+// ---------------------------------------------------------------------------
+// COLOR SCHEMES
+// ---------------------------------------------------------------------------
+
+/**
+ * Primary scheme: palette is all-oklch() including the wide-gamut slot.
+ * Cast to `unknown` first because `ColorScheme['palette']` is a 16-element
+ * tuple type and our test uses a 4-slot cluster whose scheme intentionally
+ * has 4 entries (matching the tab's paletteSize=4).
+ */
+const DEFAULT_OKLCH_SCHEME: ColorScheme = {
+  background: 0,
+  foreground: 3,
+  cursor: 1,
+  selectionBg: 0,
+  selectionFg: 3,
+  // paletteSize=4; cast via unknown to satisfy the 16-tuple type constraint
+  palette: OKLCH_PALETTE_STRINGS as unknown as ColorScheme['palette'],
+  semantic: { accent: 2, muted: 0 },
+};
+
+/** Alternate scheme: used for scheme-swap regression test. */
+const ALT_OKLCH_SCHEME: ColorScheme = {
+  background: 3,
+  foreground: 0,
+  cursor: 2,
+  selectionBg: 3,
+  selectionFg: 0,
+  palette: [
+    'oklch(0.10 0.01 200)',
+    'oklch(0.30 0.15 45)',
+    'oklch(0.60 0.20 300)',
+    'oklch(0.95 0.01 80)',
+  ] as unknown as ColorScheme['palette'],
+  semantic: { accent: 1, muted: 3 },
+};
+
+// ---------------------------------------------------------------------------
+// TAB CONFIGS
+// ---------------------------------------------------------------------------
+
+/** Primary OKLCH color tab. All palette items declare format:'oklch'. */
+const PRIMARY_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'oklch-cluster',
+    label: 'OKLCH Cluster',
+    baseRoles: {
+      background: '--oklch-cluster-bg',
+      foreground: '--oklch-cluster-fg',
+    },
+    baseDefaults: {
+      background: 0,
+      foreground: 3,
+      cursor: 1,
+      selectionBg: 0,
+      selectionFg: 3,
+    },
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {
+      'Default OKLCH': DEFAULT_OKLCH_SCHEME,
+      'Alt OKLCH': ALT_OKLCH_SCHEME,
+    },
+    panelSettings: { colorScheme: 'Default OKLCH', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: Array.from({ length: PALETTE_SIZE }, (_, i) => ({
+        id: `oklch-p${i}`,
+        cssVar: `--oklch-p${i}`,
+        label: `Palette ${i}`,
+        default: OKLCH_PALETTE_STRINGS[i],
+        type: { kind: 'color' as const, format: 'oklch' as const },
+      })),
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        {
+          id: 'accent',
+          cssVar: '--oklch-semantic-accent',
+          label: 'Accent',
+          default: 'oklch-p2', // → wide-gamut slot, index 2
+          type: { kind: 'color' as const },
+        },
+        {
+          id: 'muted',
+          cssVar: '--oklch-semantic-muted',
+          label: 'Muted',
+          default: 'oklch-p0', // → index 0
+          type: { kind: 'color' as const },
+        },
+      ],
+    },
+  ],
+};
+
+/**
+ * Secondary OKLCH color tab. Exercises the secondary cluster regression:
+ * both palette slots have format:'oklch', including one wide-gamut entry.
+ */
+const SECONDARY_COLOR_TAB: TabConfig = {
+  id: 'color-secondary',
+  label: 'Secondary Color',
+  colorExtras: {
+    id: 'oklch-secondary',
+    label: 'OKLCH Secondary',
+    baseRoles: {},
+    baseDefaults: {
+      background: 0,
+      foreground: 1,
+    },
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: [
+        {
+          id: 'sec-p0',
+          cssVar: '--sec-p0',
+          label: 'sec-p0',
+          default: 'oklch(0.20 0.05 270)',
+          type: { kind: 'color' as const, format: 'oklch' as const },
+        },
+        {
+          id: 'sec-p1',
+          cssVar: '--sec-p1',
+          label: 'sec-p1',
+          default: 'oklch(0.80 0.30 150)', // wide-gamut
+          type: { kind: 'color' as const, format: 'oklch' as const },
+        },
+      ],
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        {
+          id: 'highlight',
+          cssVar: '--sec-semantic-highlight',
+          label: 'Highlight',
+          default: 'sec-p1', // → index 1 (wide-gamut)
+          type: { kind: 'color' as const },
+        },
+      ],
+    },
+  ],
+};
+
+/** Panel config with OKLCH primary + secondary color tabs. */
+const OKLCH_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'oklch-e2e-test',
+  consoleNamespace: 'oklch-test',
+  modalClassPrefix: 'oklch-test-modal',
+  schemaId: 'zudo-design-tokens/v2',
+  exportFilenameBase: 'oklch-test-tokens',
+  tabs: [PRIMARY_COLOR_TAB, SECONDARY_COLOR_TAB],
+  colorPresets: {},
+};
+
+// ---------------------------------------------------------------------------
+// HELPERS
+// ---------------------------------------------------------------------------
+
+/** In-memory localStorage substitute for round-trip tests. */
+function makeStorage(
+  initial: Record<string, string> = {},
+): StorageLike & { entries: Record<string, string> } {
+  const entries: Record<string, string> = { ...initial };
+  return {
+    entries,
+    getItem: (k) => (k in entries ? entries[k] : null),
+    setItem: (k, v) => {
+      entries[k] = v;
+    },
+    removeItem: (k) => {
+      delete entries[k];
+    },
+  };
+}
+
+function makeOklchColorState(): ColorTweakState {
+  return {
+    palette: [...OKLCH_PALETTE_STRINGS],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { accent: 2, muted: 0 },
+    shikiTheme: 'dracula',
+  };
+}
+
+function makeSecondaryOklchState(): ColorTweakState {
+  return {
+    palette: ['oklch(0.20 0.05 270)', 'oklch(0.80 0.30 150)'],
+    background: 0,
+    foreground: 1,
+    cursor: 0,
+    selectionBg: 0,
+    selectionFg: 1,
+    semanticMappings: { highlight: 1 },
+    shikiTheme: 'dracula',
+  };
+}
+
+function makeHighlightState(): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    outlineWidth: 2,
+    active: {},
+  };
+}
+
+function makeCtx(
+  state: HighlightState,
+  toggle: (cssVar: string) => void,
+): HighlightContextValue {
+  return { state, toggle };
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+  configurePanel(OKLCH_PANEL_CONFIG);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  document.documentElement.removeAttribute('style');
+});
+
+afterEach(() => {
+  act(() => {
+    render(null, container);
+  });
+  document.body.removeChild(container);
+  document.documentElement.removeAttribute('style');
+  __resetPanelConfigForTests();
+  vi.restoreAllMocks();
+  localStorage.removeItem('tokenpanel.colorPicker.mode');
+});
+
+/** Render ColorTab wrapped in TooltipProvider and HighlightContext. */
+function renderColorTab(
+  opts: {
+    colorState?: ColorTweakState;
+    secondaryTab?: TabConfig | null;
+    secondaryState?: ColorTweakState | null;
+    persistColor?: PersistColor;
+    persistSecondary?: PersistSecondary;
+  } = {},
+): void {
+  const {
+    colorState = makeOklchColorState(),
+    secondaryTab = null,
+    secondaryState = null,
+    persistColor = vi.fn(),
+    persistSecondary = vi.fn(),
+  } = opts;
+  const ctx = makeCtx(makeHighlightState(), vi.fn());
+  act(() => {
+    render(
+      <TooltipProvider>
+        <HighlightContext.Provider value={ctx}>
+          <ColorTab
+            tab={PRIMARY_COLOR_TAB}
+            state={colorState}
+            persistColor={persistColor}
+            secondaryTab={secondaryTab}
+            secondaryState={secondaryState}
+            persistSecondary={persistSecondary}
+          />
+        </HighlightContext.Provider>
+      </TooltipProvider>,
+      container,
+    );
+  });
+}
+
+/** Open the first palette swatch picker. */
+function openFirstPaletteSwatch(section?: HTMLElement): void {
+  const root = section ?? container;
+  const grid = root.querySelector('.tokenpanel-color-palette-grid,.tokenpanel-color-palette-grid--secondary') as HTMLElement;
+  const btn = grid.querySelector('.tokenpanel-color-swatch-button') as HTMLElement;
+  expect(btn).not.toBeNull();
+  act(() => {
+    btn.click();
+  });
+}
+
+/** Open the first swatch in the secondary cluster palette section. */
+function openFirstSecondarySwatch(): void {
+  const secSection = container.querySelector(
+    '[data-testid="tokenpanel-secondary-palette-section"]',
+  ) as HTMLElement;
+  const btn = secSection.querySelector('.tokenpanel-color-swatch-button') as HTMLElement;
+  expect(btn).not.toBeNull();
+  act(() => {
+    btn.click();
+  });
+}
+
+/** Fire an arrow key on the first slider in the open picker dialog. */
+function fireFirstPickerSliderArrow(key = 'ArrowUp'): void {
+  const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+  if (!slider) throw new Error('no slider found in open picker dialog');
+  act(() => {
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. SEED PATH — state.palette holds raw oklch() (no eager hex clip)
+// ---------------------------------------------------------------------------
+
+describe('seed → state.palette holds raw oklch() (no eager hex clip)', () => {
+  it('stores all oklch palette entries VERBATIM (not hex, not #000000)', () => {
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(DEFAULT_OKLCH_SCHEME, cluster);
+
+    expect(state.palette).toEqual([...OKLCH_PALETTE_STRINGS]);
+    for (const entry of state.palette) {
+      expect(entry.startsWith('#')).toBe(false);
+      expect(entry).not.toBe('#000000');
+    }
+  });
+
+  it('jsdom #000000 guard: wide-gamut value at index 2 does NOT collapse to #000000', () => {
+    // jsdom canvas can't parse oklch() — the old map(cssColorToHex) would have
+    // turned palette[2] = 'oklch(0.70 0.25 150)' into '#000000'. The raw value
+    // must survive verbatim.
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(DEFAULT_OKLCH_SCHEME, cluster);
+
+    expect(state.palette[WIDE_GAMUT_INDEX]).toBe(OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX]);
+    expect(state.palette.includes('#000000')).toBe(false);
+    // Extra: chroma 0.25 is way out of sRGB gamut at L=0.7, so this specifically
+    // confirms R4 — "clamp to sRGB only at the hex-conversion boundary, never eagerly".
+    expect(state.palette[WIDE_GAMUT_INDEX]).toContain('0.25');
+  });
+
+  it('palette is a fresh array (not aliased to scheme.palette)', () => {
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(DEFAULT_OKLCH_SCHEME, cluster);
+    expect(state.palette).not.toBe(DEFAULT_OKLCH_SCHEME.palette);
+    expect(state.palette).toEqual([...OKLCH_PALETTE_STRINGS]);
+  });
+
+  it('semantic mappings resolve to correct palette indices from the oklch scheme', () => {
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(DEFAULT_OKLCH_SCHEME, cluster);
+    // accent: 2 from scheme.semantic, muted: 0
+    expect(state.semanticMappings['accent']).toBe(2);
+    expect(state.semanticMappings['muted']).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. APPLY PATH — CSS custom property gets oklch() value
+// ---------------------------------------------------------------------------
+
+describe('apply → CSS custom property receives oklch() value (not hex)', () => {
+  it('applyColorState writes oklch() string to the primary palette CSS vars', () => {
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const state = makeOklchColorState();
+    applyColorState(state, cluster);
+
+    for (let i = 0; i < PALETTE_SIZE; i++) {
+      const written = document.documentElement.style.getPropertyValue(`--oklch-p${i}`);
+      expect(written).toMatch(/^oklch\(/i);
+      expect(written).not.toBe('#000000');
+      expect(written).toBe(OKLCH_PALETTE_STRINGS[i]);
+    }
+  });
+
+  it('wide-gamut value at index 2 writes oklch() with chroma 0.25 preserved', () => {
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const state = makeOklchColorState();
+    applyColorState(state, cluster);
+
+    const wideGamut = document.documentElement.style.getPropertyValue(
+      `--oklch-p${WIDE_GAMUT_INDEX}`,
+    );
+    expect(wideGamut).toBe(OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX]);
+    expect(wideGamut).toContain('0.25'); // chroma must not be sRGB-clamped
+  });
+
+  it('base-role (background) CSS var gets the oklch() palette entry', () => {
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const state = makeOklchColorState(); // background: 0 → palette[0]
+    applyColorState(state, cluster);
+
+    const bg = document.documentElement.style.getPropertyValue('--oklch-cluster-bg');
+    expect(bg).toBe(OKLCH_PALETTE_STRINGS[0]);
+    expect(bg).toMatch(/^oklch\(/);
+  });
+
+  it('base-role (foreground) CSS var gets the oklch() palette entry', () => {
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const state = makeOklchColorState(); // foreground: 3 → palette[3]
+    applyColorState(state, cluster);
+
+    const fg = document.documentElement.style.getPropertyValue('--oklch-cluster-fg');
+    expect(fg).toBe(OKLCH_PALETTE_STRINGS[3]);
+    expect(fg).toMatch(/^oklch\(/);
+  });
+
+  it('semantic mapping accent=2 resolves to the wide-gamut OKLCH palette entry', () => {
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const state = makeOklchColorState(); // accent: 2 → palette[2] (wide-gamut)
+    applyColorState(state, cluster);
+
+    const accent = document.documentElement.style.getPropertyValue('--oklch-semantic-accent');
+    expect(accent).toBe(OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX]);
+    expect(accent).toMatch(/^oklch\(/);
+    expect(accent).toContain('0.25'); // wide-gamut chroma preserved
+  });
+
+  it('semantic mapping muted=0 resolves to palette[0] oklch() entry', () => {
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const state = makeOklchColorState();
+    applyColorState(state, cluster);
+
+    const muted = document.documentElement.style.getPropertyValue('--oklch-semantic-muted');
+    expect(muted).toBe(OKLCH_PALETTE_STRINGS[0]);
+    expect(muted).toMatch(/^oklch\(/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. LOCALSTORAGE PERSIST / HYDRATE ROUND-TRIP
+// ---------------------------------------------------------------------------
+
+describe('localStorage persist → hydrate preserves oklch() byte-for-byte', () => {
+  it('save + reload via savePersistedState / loadPersistedState preserves oklch() palette', () => {
+    const storage = makeStorage();
+    const colorState = makeOklchColorState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    savePersistedState(fullState, storage);
+
+    const cluster = getActivePrimaryCluster();
+    const loaded = loadPersistedState(storage, colorState, cluster);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.color.palette).toEqual([...OKLCH_PALETTE_STRINGS]);
+    expect(loaded!.color.palette.includes('#000000')).toBe(false);
+  });
+
+  it('wide-gamut entry survives localStorage round-trip byte-for-byte', () => {
+    const storage = makeStorage();
+    const colorState = makeOklchColorState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    savePersistedState(fullState, storage);
+    const cluster = getActivePrimaryCluster();
+    const loaded = loadPersistedState(storage, colorState, cluster);
+
+    expect(loaded!.color.palette[WIDE_GAMUT_INDEX]).toBe(
+      OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX],
+    );
+    // Sanity: nothing got collapsed to black anywhere in the palette
+    expect(loaded!.color.palette.every((c) => c !== '#000000')).toBe(true);
+  });
+
+  it('semantic mappings survive localStorage round-trip intact', () => {
+    const storage = makeStorage();
+    const colorState = makeOklchColorState(); // accent: 2, muted: 0
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    savePersistedState(fullState, storage);
+    const cluster = getActivePrimaryCluster();
+    const loaded = loadPersistedState(storage, colorState, cluster);
+
+    expect(loaded!.color.semanticMappings['accent']).toBe(2);
+    expect(loaded!.color.semanticMappings['muted']).toBe(0);
+  });
+
+  it('a pre-stored v3 envelope with oklch() palette loads unchanged', () => {
+    const storageKey = getStorageKeyV3();
+    const v3Payload = {
+      color: makeOklchColorState(),
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const storage = makeStorage({ [storageKey]: JSON.stringify(v3Payload) });
+
+    const cluster = getActivePrimaryCluster();
+    const loaded = loadPersistedState(storage, makeOklchColorState(), cluster);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.color.palette).toEqual([...OKLCH_PALETTE_STRINGS]);
+    expect(loaded!.color.palette[WIDE_GAMUT_INDEX]).toBe(
+      OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. SERDE JSON ROUND-TRIP
+// ---------------------------------------------------------------------------
+
+describe('SerDe JSON round-trip (serialize → deserialize) preserves oklch()', () => {
+  it('serialize emits oklch() strings under tabs.color.palette', () => {
+    const colorState = makeOklchColorState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cfg = getPanelConfig();
+
+    const json = serialize(fullState, { includeDefaults: true, colorDefaults: colorState }, cfg);
+
+    expect(json.tabs?.['color']?.['palette']).toBeDefined();
+    const palette = json.tabs!['color']!['palette'] as Record<string, string>;
+
+    // Every palette entry must be oklch(), not hex
+    for (let i = 0; i < PALETTE_SIZE; i++) {
+      const val = palette[`--oklch-p${i}`];
+      expect(val).toMatch(/^oklch\(/i);
+      expect(val).not.toMatch(/^#/);
+    }
+  });
+
+  it('serialize emits the wide-gamut value byte-for-byte', () => {
+    const colorState = makeOklchColorState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cfg = getPanelConfig();
+
+    const json = serialize(fullState, { includeDefaults: true, colorDefaults: colorState }, cfg);
+    const palette = json.tabs!['color']!['palette'] as Record<string, string>;
+
+    expect(palette[`--oklch-p${WIDE_GAMUT_INDEX}`]).toBe(
+      OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX],
+    );
+  });
+
+  it('deserialize restores oklch() palette from v2 JSON', () => {
+    const colorState = makeOklchColorState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cfg = getPanelConfig();
+
+    const json = serialize(fullState, { includeDefaults: true, colorDefaults: colorState }, cfg);
+    const result = deserialize(json, { colorDefaults: colorState }, cfg);
+
+    expect(result.state.color.palette).toEqual([...OKLCH_PALETTE_STRINGS]);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.unknownTokens).toHaveLength(0);
+  });
+
+  it('wide-gamut value survives the full serialize → deserialize cycle unchanged', () => {
+    const colorState = makeOklchColorState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cfg = getPanelConfig();
+
+    const json = serialize(fullState, { includeDefaults: true, colorDefaults: colorState }, cfg);
+    const result = deserialize(json, { colorDefaults: colorState }, cfg);
+
+    expect(result.state.color.palette[WIDE_GAMUT_INDEX]).toBe(
+      OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX],
+    );
+    // No collapse to black anywhere
+    expect(result.state.color.palette.includes('#000000')).toBe(false);
+  });
+
+  it('diff-only serialize still emits changed oklch() entries', () => {
+    // Simulate a user-edited swatch: palette[0] changed to a new oklch() value
+    const originalState = makeOklchColorState();
+    const editedState: ColorTweakState = {
+      ...originalState,
+      palette: [
+        'oklch(0.30 0.05 264)', // changed from 0.21 to 0.30
+        ...originalState.palette.slice(1),
+      ],
+    };
+    const fullState: TweakState = {
+      color: editedState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cfg = getPanelConfig();
+
+    // Diff against the original (only slot 0 changed)
+    const json = serialize(fullState, { colorDefaults: originalState }, cfg);
+
+    const palette = json.tabs?.['color']?.['palette'] as Record<string, string> | undefined;
+    expect(palette).toBeDefined();
+    // Slot 0 should be emitted (it changed)
+    expect(palette!['--oklch-p0']).toMatch(/^oklch\(/i);
+    // Deserialize should restore the edited value
+    const result = deserialize(json, { colorDefaults: originalState }, cfg);
+    expect(result.state.color.palette[0]).toBe('oklch(0.30 0.05 264)');
+    // The unchanged wide-gamut slot falls back to baseline (colorDefaults)
+    expect(result.state.color.palette[WIDE_GAMUT_INDEX]).toBe(
+      OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. UI — SWATCH EDIT PERSISTS oklch()
+// ---------------------------------------------------------------------------
+
+describe('ColorTab swatch edit → persistColor emits oklch()', () => {
+  beforeEach(() => {
+    // Pin the picker to OKLCH mode so the L/C/H sliders render deterministically.
+    localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+  });
+
+  it('clicking an oklch palette swatch opens the OKLCH color picker', () => {
+    renderColorTab();
+    openFirstPaletteSwatch();
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(
+      container.querySelector('[role="slider"][aria-label="Lightness"]'),
+    ).not.toBeNull();
+  });
+
+  it('editing an oklch palette swatch emits oklch(...) string via persistColor', () => {
+    const persistColor = vi.fn();
+    renderColorTab({ persistColor });
+
+    openFirstPaletteSwatch();
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeOklchColorState());
+
+    expect(result.palette[0]).toMatch(/^oklch\(/i);
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(result.palette[0])).toBe(false);
+  });
+
+  it('edited swatch value is NOT #000000 (wide-gamut path stays non-black)', () => {
+    const persistColor = vi.fn();
+    renderColorTab({ persistColor });
+
+    openFirstPaletteSwatch();
+    fireFirstPickerSliderArrow();
+
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeOklchColorState());
+    expect(result.palette[0]).not.toBe('#000000');
+  });
+
+  it('editing swatch 0 leaves the wide-gamut slot at index 2 unchanged', () => {
+    const persistColor = vi.fn();
+    renderColorTab({ persistColor });
+
+    openFirstPaletteSwatch(); // opens swatch 0
+    fireFirstPickerSliderArrow();
+
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeOklchColorState());
+    // Only slot 0 was edited; slot 2 must survive untouched
+    expect(result.palette[WIDE_GAMUT_INDEX]).toBe(OKLCH_PALETTE_STRINGS[WIDE_GAMUT_INDEX]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. HSL-EDIT CAVEAT
+// ---------------------------------------------------------------------------
+
+describe('HSL-edit caveat: toggle does NOT commit; HSL edit emits oklch() (may reanchor)', () => {
+  beforeEach(() => {
+    localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+  });
+
+  it('toggling picker to HSL mode does NOT call persistColor (no commit on mode toggle)', () => {
+    // Mode toggle is pure view-state — it must never trigger a color commit.
+    // This is the documented R4-safe invariant: toggling OKLCH↔HSL alone never
+    // loses the wide-gamut chroma value; only an HSL slider drag takes the lossy
+    // reanchor path.
+    const persistColor = vi.fn();
+    renderColorTab({ persistColor });
+
+    openFirstPaletteSwatch();
+
+    // The HSL mode button is aria-pressed=false when current mode is oklch
+    const hslBtn = container.querySelector<HTMLElement>(
+      '[aria-label="Color mode"] [aria-pressed="false"]',
+    );
+    expect(hslBtn).not.toBeNull();
+    act(() => {
+      hslBtn!.click();
+    });
+
+    // The toggle must NOT have emitted a color change
+    expect(persistColor).not.toHaveBeenCalled();
+  });
+
+  it('after HSL toggle, HSL-specific Saturation slider is visible (mode switch took effect)', () => {
+    // Saturation is present ONLY in HSL mode (not in OKLCH which uses Chroma instead).
+    // Checking for Saturation makes this test non-vacuous — it would fail if the toggle
+    // had no effect and the picker stayed in OKLCH mode.
+    renderColorTab();
+
+    openFirstPaletteSwatch();
+
+    const hslBtn = container.querySelector<HTMLElement>(
+      '[aria-label="Color mode"] [aria-pressed="false"]',
+    );
+    act(() => {
+      hslBtn!.click();
+    });
+
+    // HSL mode exposes Saturation; OKLCH mode does not (it uses Chroma instead)
+    const satSlider = container.querySelector<HTMLElement>(
+      '[role="slider"][aria-label="Saturation"]',
+    );
+    expect(satSlider).not.toBeNull();
+  });
+
+  it('after HSL toggle, OKLCH sliders are gone (mode is now HSL)', () => {
+    renderColorTab();
+
+    openFirstPaletteSwatch();
+
+    const hslBtn = container.querySelector<HTMLElement>(
+      '[aria-label="Color mode"] [aria-pressed="false"]',
+    );
+    act(() => {
+      hslBtn!.click();
+    });
+
+    // OKLCH-only sliders (Chroma) must be absent in HSL mode
+    const chromaSlider = container.querySelector<HTMLElement>(
+      '[role="slider"][aria-label="Chroma"]',
+    );
+    expect(chromaSlider).toBeNull();
+  });
+
+  it('HSL slider edit emits oklch() even in HSL mode (valueFormat drives the output format)', () => {
+    // In valueFormat='oklch' mode the picker always emits oklch() regardless of
+    // display mode. An HSL edit performs an HSL→oklch conversion which may sRGB-
+    // reanchor wide-gamut chroma — this is the ONE documented intentional lossy
+    // path (NOT an R4 violation; R4 forbids the eager background clip, not a
+    // user-initiated HSL edit).
+    const persistColor = vi.fn();
+    renderColorTab({ persistColor });
+
+    openFirstPaletteSwatch();
+
+    // Switch to HSL mode (non-committing)
+    const hslBtn = container.querySelector<HTMLElement>(
+      '[aria-label="Color mode"] [aria-pressed="false"]',
+    );
+    act(() => {
+      hslBtn!.click();
+    });
+
+    // Fire an HSL slider keydown — this IS a committing edit
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeOklchColorState());
+
+    // The output format is always oklch() when valueFormat='oklch', even from HSL edit
+    expect(result.palette[0]).toMatch(/^oklch\(/i);
+    expect(result.palette[0]).not.toMatch(/^#/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. CLUSTER-FEATURE REGRESSION WITH OKLCH PALETTE
+// ---------------------------------------------------------------------------
+
+describe('Cluster-feature regression: all cluster features work with an OKLCH palette', () => {
+  beforeEach(() => {
+    localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+  });
+
+  it('Scheme... dropdown renders and lists both bundled OKLCH schemes', () => {
+    renderColorTab();
+
+    const select = container.querySelector('.tokenpanel-color-preset-select');
+    expect(select).not.toBeNull();
+    expect(container.querySelector('option[value="Default OKLCH"]')).not.toBeNull();
+    expect(container.querySelector('option[value="Alt OKLCH"]')).not.toBeNull();
+  });
+
+  it('scheme-preset swap via initColorFromSchemeData produces all-oklch() palette', () => {
+    const cluster = getActivePrimaryCluster();
+    const altState = initColorFromSchemeData(ALT_OKLCH_SCHEME, cluster);
+
+    expect(altState.palette.every((c) => c.startsWith('oklch('))).toBe(true);
+    expect(altState.palette.includes('#000000')).toBe(false);
+    // Alt scheme has 4 oklch() entries
+    expect(altState.palette).toHaveLength(PALETTE_SIZE);
+  });
+
+  it('base-role (background=3) resolves to palette[3] oklch() on apply', () => {
+    // backgroundIndex=3 in altState — applying must write palette[3] not #000000
+    const cluster = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    const altState: ColorTweakState = {
+      ...makeOklchColorState(),
+      background: 3, // foreground background swapped
+      palette: [
+        'oklch(0.10 0.01 200)',
+        'oklch(0.30 0.15 45)',
+        'oklch(0.60 0.20 300)',
+        'oklch(0.95 0.01 80)',
+      ],
+    };
+    applyColorState(altState, cluster);
+
+    const bg = document.documentElement.style.getPropertyValue('--oklch-cluster-bg');
+    expect(bg).toBe('oklch(0.95 0.01 80)'); // palette[3]
+    expect(bg).toMatch(/^oklch\(/);
+  });
+
+  it('semantic→palette mapping still resolves OKLCH after a scheme swap', () => {
+    const cluster = getActivePrimaryCluster();
+    const altState = initColorFromSchemeData(ALT_OKLCH_SCHEME, cluster);
+    // accent: 1 (from ALT_OKLCH_SCHEME.semantic.accent)
+    expect(altState.semanticMappings['accent']).toBe(1);
+
+    // Apply and verify CSS var
+    const clusterFromTab = resolveColorClusterFromTab(PRIMARY_COLOR_TAB)!;
+    applyColorState(altState, clusterFromTab);
+
+    const accentVal = document.documentElement.style.getPropertyValue('--oklch-semantic-accent');
+    expect(accentVal).toBe(ALT_OKLCH_SCHEME.palette[1]);
+    expect(accentVal).toMatch(/^oklch\(/);
+  });
+
+  it('Base section renders 2 PaletteSelector rows (background / foreground)', () => {
+    renderColorTab();
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const baseGrid = baseGrids[0] as HTMLElement;
+    expect(baseGrid).not.toBeNull();
+    const selectors = baseGrid.querySelectorAll('.tokenpanel-palette-selector');
+    expect(selectors.length).toBe(2);
+  });
+
+  it('Semantic section renders 2 PaletteSelector rows (accent / muted)', () => {
+    renderColorTab();
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    expect(semanticGrid).not.toBeNull();
+    const selectors = semanticGrid.querySelectorAll('.tokenpanel-palette-selector');
+    expect(selectors.length).toBe(2);
+  });
+
+  it('secondary cluster palette section renders with 2 oklch swatches', () => {
+    renderColorTab({
+      secondaryTab: SECONDARY_COLOR_TAB,
+      secondaryState: makeSecondaryOklchState(),
+    });
+
+    const secSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-palette-section"]',
+    );
+    expect(secSection).not.toBeNull();
+    const swatches = secSection!.querySelectorAll('.tokenpanel-color-swatch-button');
+    expect(swatches.length).toBe(2);
+  });
+
+  it('secondary cluster semantic section renders', () => {
+    renderColorTab({
+      secondaryTab: SECONDARY_COLOR_TAB,
+      secondaryState: makeSecondaryOklchState(),
+    });
+
+    const secSemanticSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-semantic-section"]',
+    );
+    expect(secSemanticSection).not.toBeNull();
+    const selectors = secSemanticSection!.querySelectorAll('.tokenpanel-palette-selector');
+    expect(selectors.length).toBe(1); // one semantic row: highlight
+  });
+
+  it('secondary cluster swatch edit persists oklch() via persistSecondary', () => {
+    const persistSecondary = vi.fn();
+    renderColorTab({
+      secondaryTab: SECONDARY_COLOR_TAB,
+      secondaryState: makeSecondaryOklchState(),
+      persistSecondary,
+    });
+
+    openFirstSecondarySwatch();
+    fireFirstPickerSliderArrow();
+
+    expect(persistSecondary).toHaveBeenCalled();
+    const updater = persistSecondary.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState | undefined,
+    ) => ColorTweakState | undefined;
+    const result = updater(makeSecondaryOklchState());
+
+    expect(result).not.toBeUndefined();
+    expect(result!.palette[0]).toMatch(/^oklch\(/i);
+    expect(result!.palette[0]).not.toMatch(/^#/);
+  });
+
+  it('primary palette swatch is a color-swatch-button, NOT <input type="color"> (oklch format)', () => {
+    renderColorTab();
+
+    const grid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    // No native color input should appear — oklch items use the custom swatch
+    expect(grid.querySelector('input[type="color"]')).toBeNull();
+    // The custom swatch button must be present
+    const swatches = grid.querySelectorAll('.tokenpanel-color-swatch-button');
+    expect(swatches.length).toBe(PALETTE_SIZE);
+  });
+
+  it('no <button> elements rendered in the cluster color tab (hostile-host policy)', () => {
+    renderColorTab({
+      secondaryTab: SECONDARY_COLOR_TAB,
+      secondaryState: makeSecondaryOklchState(),
+    });
+
+    expect(container.querySelector('button')).toBeNull();
+  });
+});

--- a/packages/zdtp/src/apply/build-apply-overrides.ts
+++ b/packages/zdtp/src/apply/build-apply-overrides.ts
@@ -6,7 +6,8 @@
  * Consumes the `TweakState` shape directly:
  *
  * Color tokens:
- *   - `state.color.palette: string[]` — palette hex values
+ *   - `state.color.palette: string[]` — palette color values (hex, or
+ *     `oklch(...)` when the palette tier declares `type.format: 'oklch'`)
  *   - `state.color.semanticMappings: Record<string, number | 'bg' | 'fg'>` —
  *     semantic-token → palette-index map
  *   - `state.color.background` / `foreground` — palette indices used when a
@@ -27,7 +28,8 @@
  * Specifically:
  *
  *   - Palette slots (resolved via `resolvePaletteCssVar(cluster, i)`) —
- *     EMITTED as hex values.
+ *     EMITTED as the stored color value (hex, or `oklch(...)` for
+ *     oklch-format palettes).
  *   - Semantic tokens (`cluster.semanticCssNames` entries) — EMITTED as
  *     `var(--<paletteSlotName>)` so the rewrite preserves the indirection
  *     that the hand-authored CSS relies on.

--- a/packages/zdtp/src/state/__tests__/oklch-runtime-seed.test.ts
+++ b/packages/zdtp/src/state/__tests__/oklch-runtime-seed.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+/**
+ * Runtime OKLCH preservation (issue #435 / #433 part 2).
+ *
+ * `state.palette` must carry RAW color strings (hex OR `oklch(...)`) instead of
+ * being eagerly clipped to sRGB hex on seed. The jsdom environment here is
+ * load-bearing: jsdom's canvas `getContext('2d')` returns null, so the
+ * `cssColorToHex` canvas round-trip is unavailable and the OLD seed code
+ * (`scheme.palette.map(cssColorToHex)`) collapsed every `oklch()` entry to
+ * '#000000'. These tests pin the post-fix behavior: oklch survives verbatim.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  colorRefToIndex,
+  getActivePrimaryCluster,
+  getStorageKeyV3,
+  initColorFromSchemeData,
+  loadPersistedState,
+  type ColorTweakState,
+  type StorageLike,
+} from '../tweak-state';
+import type { ColorScheme } from '../../config/color-schemes';
+import { __resetPanelConfigForTests } from '../../config/panel-config';
+import { installFixturePanelConfig } from '../../__tests__/_test-helpers';
+
+/** 16 distinct oklch palette entries; index 15 is wide-gamut (out of sRGB). */
+const oklchPalette: string[] = [
+  'oklch(0.20 0.02 0)', // 0
+  'oklch(0.30 0.04 30)', // 1
+  'oklch(0.50 0.12 250)', // 2
+  'oklch(0.40 0.06 90)', // 3
+  'oklch(0.55 0.10 140)', // 4
+  'oklch(0.60 0.14 200)', // 5
+  'oklch(0.65 0.18 300)', // 6
+  'oklch(0.70 0.20 350)', // 7
+  'oklch(0.45 0.08 60)', // 8
+  'oklch(0.50 0.10 120)', // 9
+  'oklch(0.58 0.16 180)', // 10
+  'oklch(0.62 0.12 220)', // 11
+  'oklch(0.68 0.22 320)', // 12
+  'oklch(0.72 0.24 40)', // 13
+  'oklch(0.75 0.15 160)', // 14
+  'oklch(0.70 0.37 30)', // 15 — wide-gamut chroma, outside sRGB
+];
+
+const hexPalette16 = Array.from(
+  { length: 16 },
+  (_, i) => `#${i.toString(16).padStart(2, '0').repeat(3)}`,
+);
+
+function makeOklchScheme(overrides: Partial<ColorScheme> = {}): ColorScheme {
+  return {
+    background: 0,
+    foreground: 15,
+    cursor: 6,
+    selectionBg: 0,
+    selectionFg: 15,
+    palette: oklchPalette as ColorScheme['palette'],
+    ...overrides,
+  };
+}
+
+function makeStorage(initial: Record<string, string> = {}): StorageLike & {
+  entries: Record<string, string>;
+} {
+  const entries: Record<string, string> = { ...initial };
+  return {
+    entries,
+    getItem: (k) => (k in entries ? entries[k] : null),
+    setItem: (k, v) => {
+      entries[k] = v;
+    },
+    removeItem: (k) => {
+      delete entries[k];
+    },
+  };
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  installFixturePanelConfig();
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  __resetPanelConfigForTests();
+  warnSpy.mockRestore();
+});
+
+describe('initColorFromSchemeData — raw OKLCH seed (no eager hex clip)', () => {
+  it('stores oklch palette entries VERBATIM (no hex, no #000000)', () => {
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(makeOklchScheme(), cluster);
+
+    expect(state.palette).toEqual(oklchPalette);
+    // Defensive: nothing got clipped to hex and nothing collapsed to black.
+    for (const entry of state.palette) {
+      expect(entry.startsWith('#')).toBe(false);
+      expect(entry).not.toBe('#000000');
+    }
+  });
+
+  it('seeds a wide-gamut oklch() entry under jsdom without collapsing to #000000', () => {
+    // jsdom canvas can't parse oklch — the OLD map(cssColorToHex) would have
+    // turned the wide-gamut p15 into '#000000'. The raw value must survive.
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromSchemeData(makeOklchScheme(), cluster);
+
+    expect(state.palette[15]).toBe('oklch(0.70 0.37 30)');
+    expect(state.palette.includes('#000000')).toBe(false);
+  });
+
+  it('returns a fresh palette array (not aliased to scheme.palette)', () => {
+    const scheme = makeOklchScheme();
+    const state = initColorFromSchemeData(scheme, getActivePrimaryCluster());
+    expect(state.palette).not.toBe(scheme.palette);
+    expect(state.palette).toEqual([...scheme.palette]);
+  });
+
+  it('resolves an oklch base ref to the correct palette index during seed', () => {
+    // background ref is the same color as p2 but serialized differently — it
+    // must resolve to index 2 via the OKLCH-aware match, not collapse to 0.
+    const state = initColorFromSchemeData(
+      makeOklchScheme({ background: 'oklch(0.500 0.1200 250.00)' }),
+      getActivePrimaryCluster(),
+    );
+    expect(state.background).toBe(2);
+  });
+
+  it('re-seeds verbatim through the Scheme-dropdown path (default cluster)', () => {
+    // Mirrors color-tab.tsx:548 handleLoadPreset → initColorFromSchemeData(scheme)
+    // with no explicit cluster (resolves getActivePrimaryCluster()).
+    const state = initColorFromSchemeData(makeOklchScheme());
+    expect(state.palette).toEqual(oklchPalette);
+    expect(state.palette.includes('#000000')).toBe(false);
+  });
+});
+
+describe('colorRefToIndex — OKLCH format-tolerance + alpha-awareness', () => {
+  it('matches a differently-serialized oklch ref by canonical epsilon', () => {
+    const idx = colorRefToIndex('oklch(0.500 0.1200 250.00)', oklchPalette, 0);
+    expect(idx).toBe(2);
+  });
+
+  it('disambiguates same-L/C/H but DIFFERENT alpha (alpha included in epsilon)', () => {
+    // Two slots differ only in alpha; refs must bind to the matching alpha,
+    // never collapse to the wrong slot.
+    const palette = [
+      'oklch(0.60 0.10 120)', // 0 — opaque
+      'oklch(0.60 0.10 120 / 0.5)', // 1 — 50% alpha
+    ];
+    // Differently-serialized opaque ref → slot 0 (a=100), not slot 1 (a=50).
+    expect(colorRefToIndex('oklch(0.600 0.100 120.0)', palette, 9)).toBe(0);
+    // Differently-serialized 50%-alpha ref → slot 1, not slot 0.
+    expect(colorRefToIndex('oklch(0.600 0.100 120.0 / 0.50)', palette, 9)).toBe(1);
+  });
+
+  it('uses a circular hue delta so ~360° and ~0° are adjacent', () => {
+    const palette = ['oklch(0.6 0.1 0.0003)', 'oklch(0.5 0.2 200)'];
+    expect(colorRefToIndex('oklch(0.6 0.1 359.9999)', palette, 9)).toBe(0);
+  });
+
+  it('does NOT merge genuinely different oklch colors', () => {
+    const palette = ['oklch(0.6 0.1 120)', 'oklch(0.601 0.1 120)'];
+    expect(colorRefToIndex('oklch(0.601 0.1 120)', palette, 9)).toBe(1);
+    expect(colorRefToIndex('oklch(0.6 0.1 120)', palette, 9)).toBe(0);
+  });
+});
+
+describe('colorRefToIndex — existing hex/rgb behavior unchanged', () => {
+  it('returns a numeric ref as-is', () => {
+    expect(colorRefToIndex(7, hexPalette16, 0)).toBe(7);
+  });
+
+  it('exact-matches a raw hex ref', () => {
+    expect(colorRefToIndex('#0a0a0a', hexPalette16, 0)).toBe(10);
+  });
+
+  it('matches equivalent notations via canonical hex (rgba vs #rrggbbaa)', () => {
+    const palette = ['#ffffff', '#ff000080', '#000000'];
+    expect(colorRefToIndex('rgba(255,0,0,0.5)', palette, 0)).toBe(1);
+  });
+
+  it('falls back to nearest base-RGB color when no exact match exists', () => {
+    const palette = ['#000000', '#ff0000', '#00ff00', '#0000ff'];
+    // Closest to a slightly-off red is the red slot.
+    expect(colorRefToIndex('#fe0101', palette, 0)).toBe(1);
+  });
+
+  it('returns the fallback only when ref is undefined', () => {
+    expect(colorRefToIndex(undefined, hexPalette16, 4)).toBe(4);
+  });
+});
+
+describe('persist → hydrate round-trip preserves oklch() byte-for-byte', () => {
+  it('loads a v3 envelope with an oklch palette unchanged', () => {
+    const defaults: ColorTweakState = {
+      palette: hexPalette16,
+      background: 0,
+      foreground: 15,
+      cursor: 6,
+      selectionBg: 0,
+      selectionFg: 15,
+      semanticMappings: { accent: 6, muted: 8, active: 14 },
+      shikiTheme: 'dracula',
+    };
+    const v3 = {
+      color: {
+        palette: oklchPalette,
+        background: 2,
+        foreground: 15,
+        cursor: 6,
+        selectionBg: 0,
+        selectionFg: 15,
+        semanticMappings: { accent: 6, muted: 8, active: 14 },
+        shikiTheme: 'dracula',
+      },
+    };
+    const storage = makeStorage({ [getStorageKeyV3()]: JSON.stringify(v3) });
+
+    const result = loadPersistedState(storage, defaults);
+
+    expect(result).not.toBeNull();
+    expect(result!.color.palette).toEqual(oklchPalette);
+    // Byte-for-byte: the wide-gamut entry is preserved, not clamped.
+    expect(result!.color.palette[15]).toBe('oklch(0.70 0.37 30)');
+  });
+});

--- a/packages/zdtp/src/state/__tests__/oklch-runtime-seed.test.ts
+++ b/packages/zdtp/src/state/__tests__/oklch-runtime-seed.test.ts
@@ -227,3 +227,37 @@ describe('persist → hydrate round-trip preserves oklch() byte-for-byte', () =>
     expect(result!.color.palette[15]).toBe('oklch(0.70 0.37 30)');
   });
 });
+
+describe('initColorFromSchemeData — non-oklch entries are sanitised (regression)', () => {
+  it('normalises an invalid non-color palette entry to a safe #000000 instead of leaking it', () => {
+    // The bundled `Default Dark` scheme carries a stray non-color slot — `"18"` at
+    // index 9, referenced by `background: 9`. Preserving palette entries verbatim
+    // for the OKLCH feature must NOT regress this: an unparseable string has to be
+    // sanitised (cssColorToHex → '#000000') rather than written to a CSS custom
+    // property as the literal `18`.
+    const cluster = getActivePrimaryCluster();
+    const mixed = [...oklchPalette];
+    mixed[9] = '18';
+    const state = initColorFromSchemeData(
+      makeOklchScheme({ palette: mixed as ColorScheme['palette'] }),
+      cluster,
+    );
+
+    expect(state.palette[9]).toBe('#000000');
+    // …while the real oklch entries alongside it are still preserved raw.
+    expect(state.palette[0]).toBe(oklchPalette[0]);
+    expect(state.palette[15]).toBe(oklchPalette[15]);
+  });
+
+  it('canonicalises a valid shorthand hex entry rather than dropping it', () => {
+    const cluster = getActivePrimaryCluster();
+    const mixed = [...oklchPalette];
+    mixed[2] = '#abc';
+    const state = initColorFromSchemeData(
+      makeOklchScheme({ palette: mixed as ColorScheme['palette'] }),
+      cluster,
+    );
+
+    expect(state.palette[2]).toBe('#aabbcc');
+  });
+});

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -863,18 +863,31 @@ export function initColorFromScheme(
   return initColorFromSchemeData(scheme, cluster);
 }
 
+/**
+ * Seed-time palette sanitiser. Raw `oklch(...)` values are preserved verbatim so
+ * wide-gamut chroma survives (and they never touch the canvas → no '#000000'
+ * under jsdom / engines whose 2D canvas can't parse oklch). Every NON-oklch entry
+ * goes through cssColorToHex() — the exact pre-OKLCH behaviour — which
+ * canonicalises valid hex/rgb and, crucially, turns an unparseable string into a
+ * safe '#000000' rather than leaking it into a CSS custom property. Without this,
+ * a bundled scheme's stray non-color entry (e.g. `Default Dark`'s slot-9 `"18"`,
+ * referenced by `background: 9`) would reach the apply path verbatim.
+ */
+function normalizeSchemePaletteEntry(value: string): string {
+  return cssToOklcha(value) ? value : cssColorToHex(value);
+}
+
 export function initColorFromSchemeData(
   scheme: ColorScheme,
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
 ): ColorTweakState {
-  // Store each seeded palette entry VERBATIM — hex OR raw `oklch(...)`. The
-  // string is self-describing and the apply path writes it straight to a CSS
-  // custom property (browsers parse oklch natively), so we must NOT clip to
-  // sRGB hex here. Eagerly normalising via cssColorToHex() would discard
-  // wide-gamut chroma and, worse, collapse every entry to '#000000' under
-  // jsdom / engines whose canvas can't parse oklch. sRGB clamping belongs only
-  // at a true hex-conversion boundary (native <input type="color">, hex box).
-  const palette = [...scheme.palette];
+  // Preserve raw `oklch(...)` losslessly (wide-gamut chroma survives; never
+  // collapses to '#000000' under jsdom). Every other entry is sanitised through
+  // cssColorToHex() exactly as before this OKLCH work — canonicalises valid
+  // hex/rgb and turns invalid bundled-scheme strings (e.g. Default Dark's "18")
+  // into a safe '#000000' instead of leaking them to apply. sRGB clamping for
+  // oklch still happens only at a true hex-conversion boundary.
+  const palette = scheme.palette.map(normalizeSchemePaletteEntry);
   const semanticMappings: Record<string, number | 'bg' | 'fg'> = {};
   for (const [key, defaultVal] of Object.entries(cluster.semanticDefaults)) {
     const schemeVal = scheme.semantic?.[key as keyof typeof scheme.semantic];

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -71,6 +71,7 @@ import {
   emitTierItemCssValue,
   resolveTierItemValue,
 } from '../apply/tier-resolver';
+import { cssToOklcha, type Oklcha } from '../utils/color-oklch';
 
 // Re-export the cluster types under their historical names so existing call
 // sites (build-apply-overrides.ts, apply-modal.tsx, tests) keep compiling.
@@ -709,9 +710,44 @@ export function setCssVar(name: string, value: string) {
 }
 
 /**
+ * Compare two canonical `Oklcha` values for equality within a per-channel
+ * epsilon. Alpha is INCLUDED so two entries with the same L/C/H but different
+ * alpha are treated as distinct. Hue uses a CIRCULAR delta so 359.999° and
+ * 0.001° are recognised as adjacent.
+ *
+ * Epsilons (against `cssToOklcha`'s internal scale — l/a on 0–100, c native,
+ * h in degrees): l ≤ 1e-3, c ≤ 1e-5, h ≤ 1e-3°, a ≤ 1e-3. These only absorb
+ * serialization/float noise — genuinely different colors differ by far more.
+ */
+function oklchaApproxEqual(a: Oklcha, b: Oklcha): boolean {
+  let dh = Math.abs(a.h - b.h) % 360;
+  if (dh > 180) dh = 360 - dh;
+  return (
+    Math.abs(a.l - b.l) <= 1e-3 &&
+    Math.abs(a.c - b.c) <= 1e-5 &&
+    dh <= 1e-3 &&
+    Math.abs(a.a - b.a) <= 1e-3
+  );
+}
+
+/**
  * Resolve a `ColorRef` to a palette index. If it's already a number, use it.
  * If it's a string, find an exact palette match or the nearest color by RGB
  * distance. `fallback` is returned only when `ref` is undefined.
+ *
+ * Match order (format-tolerant + alpha-aware):
+ *  (a) exact raw-string match — preserves byte-for-byte `oklch()`/hex refs
+ *      without any lossy normalization (palette refs are usually canonical);
+ *  (b) OKLCH-aware match — when the ref AND a palette entry both parse as CSS
+ *      Color 4 `oklch()`, compare canonical `cssToOklcha` forms with a
+ *      per-channel epsilon (alpha included). This keeps a wide-gamut oklch ref
+ *      from collapsing to '#000000' under the hex path (jsdom / engines whose
+ *      canvas can't parse oklch) and keeps a same-L/C/H-different-alpha ref
+ *      bound to the correct slot;
+ *  (c) hex fallback — normalize ref + palette to canonical hex for an exact
+ *      match, else nearest color by base-RGB distance. This is the path for
+ *      genuine hex/rgb refs; the nearest-distance step intentionally drops
+ *      alpha, so the exact matches above must run first when alpha matters.
  */
 export function colorRefToIndex(
   ref: ColorRef | undefined,
@@ -720,18 +756,20 @@ export function colorRefToIndex(
 ): number {
   if (ref === undefined) return fallback;
   if (typeof ref === 'number') return ref;
-  // Normalize the ref and every palette entry to a canonical hex form before
-  // exact-match lookup. Without this, equivalent notations miss each other
-  // (e.g. ref `rgba(255,0,0,0.5)` vs palette `#ff000080`) and fall through to
-  // the distance fallback below, which intentionally ignores alpha — that
-  // would silently bind to the wrong slot when the palette holds multiple
-  // entries with the same RGB but different alpha.
-  const refHex = cssColorToHex(ref);
-  const normalized: string[] = palette.map((p) => cssColorToHex(p));
-  // First try the raw string for backwards compatibility (palette refs are
-  // usually already canonical), then the normalized form.
+  // (a) Exact raw-string match first.
   const rawIdx = palette.indexOf(ref);
   if (rawIdx >= 0) return rawIdx;
+  // (b) OKLCH-aware match — only when both sides parse as oklch().
+  const refOklch = cssToOklcha(ref);
+  if (refOklch) {
+    for (let i = 0; i < palette.length; i++) {
+      const pOklch = cssToOklcha(palette[i]);
+      if (pOklch && oklchaApproxEqual(refOklch, pOklch)) return i;
+    }
+  }
+  // (c) Hex fallback for genuine hex/rgb refs.
+  const refHex = cssColorToHex(ref);
+  const normalized: string[] = palette.map((p) => cssColorToHex(p));
   const normIdx = normalized.indexOf(refHex);
   if (normIdx >= 0) return normIdx;
   // No exact match — find nearest palette color by RGB distance.
@@ -829,7 +867,14 @@ export function initColorFromSchemeData(
   scheme: ColorScheme,
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
 ): ColorTweakState {
-  const palette = scheme.palette.map((c) => cssColorToHex(c));
+  // Store each seeded palette entry VERBATIM — hex OR raw `oklch(...)`. The
+  // string is self-describing and the apply path writes it straight to a CSS
+  // custom property (browsers parse oklch natively), so we must NOT clip to
+  // sRGB hex here. Eagerly normalising via cssColorToHex() would discard
+  // wide-gamut chroma and, worse, collapse every entry to '#000000' under
+  // jsdom / engines whose canvas can't parse oklch. sRGB clamping belongs only
+  // at a true hex-conversion boundary (native <input type="color">, hex box).
+  const palette = [...scheme.palette];
   const semanticMappings: Record<string, number | 'bg' | 'fg'> = {};
   for (const [key, defaultVal] of Object.entries(cluster.semanticDefaults)) {
     const schemeVal = scheme.semantic?.[key as keyof typeof scheme.semantic];

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -36,6 +36,7 @@ import ColorTab from '../color-tab';
 import { TooltipProvider } from '../../controls/tooltip';
 import type { TabConfig } from '../../tokens/tier-model';
 import type { ColorTweakState } from '../../state/tweak-state';
+import type { PersistColor, PersistSecondary } from '../../state/persist';
 import {
   installFixturePanelConfig,
   FIXTURE_CLUSTER,
@@ -160,6 +161,8 @@ function renderColorTab(
     colorState?: ColorTweakState;
     secondaryTab?: TabConfig | null;
     secondaryState?: ColorTweakState | null;
+    persistColor?: PersistColor;
+    persistSecondary?: PersistSecondary;
   } = {},
 ): void {
   const {
@@ -167,6 +170,8 @@ function renderColorTab(
     colorState = makeColorState(),
     secondaryTab = null,
     secondaryState = null,
+    persistColor = noop,
+    persistSecondary = noop,
   } = opts;
   act(() => {
     render(
@@ -175,10 +180,10 @@ function renderColorTab(
           <ColorTab
             tab={tab}
             state={colorState}
-            persistColor={noop}
+            persistColor={persistColor}
             secondaryTab={secondaryTab}
             secondaryState={secondaryState}
-            persistSecondary={noop}
+            persistSecondary={persistSecondary}
           />
         </HighlightContext.Provider>
       </TooltipProvider>,
@@ -716,5 +721,227 @@ describe('S4 — no native title attribute on tooltip triggers', () => {
 
     const trigger = container.querySelector('.tokenpanel-palette-trigger') as HTMLElement;
     expect(trigger.getAttribute('aria-label')).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #436 — palette tier `type.format: 'oklch'` routes swatch edits through the
+// lossless OKLCH editor, while every cluster feature still renders. Semantic /
+// base rows stay index-based (they reference palette slots, so they inherit
+// OKLCH transitively) and are NOT converted to direct color editors.
+// ---------------------------------------------------------------------------
+
+/** Primary color tab whose palette tier items declare format:'oklch'. */
+const OKLCH_PRIMARY_TAB: TabConfig = {
+  ...PRIMARY_COLOR_TAB,
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: Array.from({ length: PALETTE_SIZE }, (_, i) => ({
+        id: `fixture-p${i}`,
+        cssVar: `--fixture-p${i}`,
+        label: `Palette ${i}`,
+        default: 'oklch(0.5 0.1 250)',
+        type: { kind: 'color' as const, format: 'oklch' as const },
+      })),
+    },
+    // Semantic tier is unchanged — it references the palette tier.
+    PRIMARY_COLOR_TAB.tiers[1],
+  ],
+};
+
+/** Secondary color tab whose palette tier items declare format:'oklch'. */
+const OKLCH_SECONDARY_TAB: TabConfig = {
+  ...SECONDARY_TAB,
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: [
+        { id: 'sec-p0', cssVar: '--sec-p0', label: 'sec-p0', default: 'oklch(0.5 0.1 250)', type: { kind: 'color' as const, format: 'oklch' as const } },
+        { id: 'sec-p1', cssVar: '--sec-p1', label: 'sec-p1', default: 'oklch(0.7 0.05 120)', type: { kind: 'color' as const, format: 'oklch' as const } },
+      ],
+    },
+    SECONDARY_TAB.tiers[1],
+  ],
+};
+
+function makeOklchColorState(): ColorTweakState {
+  return {
+    ...makeColorState(),
+    palette: ['oklch(0.5 0.1 250)', 'oklch(0.6 0.12 200)', 'oklch(0.7 0.08 120)'],
+  };
+}
+
+function makeOklchSecondaryState(): ColorTweakState {
+  return {
+    ...makeSecondaryState(),
+    palette: ['oklch(0.5 0.1 250)', 'oklch(0.7 0.05 120)'],
+  };
+}
+
+/** Click the first palette swatch button within a section to open its picker. */
+function openFirstSwatch(section: HTMLElement): void {
+  const btn = section.querySelector('.tokenpanel-color-swatch-button') as HTMLElement;
+  expect(btn).not.toBeNull();
+  act(() => btn.click());
+}
+
+/**
+ * Nudge the first slider in the open picker with a keyboard arrow. The slider's
+ * pointer path is inert in jsdom; the keydown path commits directly, so this is
+ * the deterministic way to drive a swatch edit through to onChange.
+ */
+function fireFirstPickerSliderArrow(key = 'ArrowUp'): void {
+  const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+  if (!slider) throw new Error('no slider in open picker');
+  act(() => {
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+describe('ColorTab — palette format:"oklch" routing (#436)', () => {
+  beforeEach(() => {
+    // Pin the in-picker display mode so the OKLCH (L/C/H) sliders render
+    // deterministically rather than a persisted HSL mode from another run.
+    localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+  });
+  afterEach(() => {
+    localStorage.removeItem('tokenpanel.colorPicker.mode');
+  });
+
+  it('clicking an oklch palette swatch opens the OKLCH color picker', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: OKLCH_PRIMARY_TAB, colorState: makeOklchColorState() });
+
+    const grid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    openFirstSwatch(grid);
+
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    // OKLCH editor → Lightness/Chroma/Hue sliders are present.
+    expect(
+      container.querySelector('[role="slider"][aria-label="Lightness"]'),
+    ).not.toBeNull();
+  });
+
+  it('editing an oklch palette swatch persists an oklch(...) string, not hex', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: OKLCH_PRIMARY_TAB,
+      colorState: makeOklchColorState(),
+      persistColor,
+    });
+
+    const grid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    openFirstSwatch(grid);
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeOklchColorState());
+    expect(result.palette[0]).toMatch(/^oklch\(/);
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(result.palette[0])).toBe(false);
+  });
+
+  it('with no format, editing a palette swatch persists a hex string (backward compatible)', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    // Default PRIMARY_COLOR_TAB has no `format` on its palette items.
+    renderColorTab(ctx, { persistColor });
+
+    const grid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    openFirstSwatch(grid);
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeColorState());
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(result.palette[0])).toBe(true);
+    expect(result.palette[0].startsWith('oklch(')).toBe(false);
+  });
+
+  it('renders every cluster feature with an oklch palette (preset dropdown, Base, Semantic, secondary)', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      tab: OKLCH_PRIMARY_TAB,
+      colorState: makeOklchColorState(),
+      secondaryTab: OKLCH_SECONDARY_TAB,
+      secondaryState: makeOklchSecondaryState(),
+    });
+
+    // "Scheme…" preset dropdown.
+    expect(container.querySelector('.tokenpanel-color-preset-select')).not.toBeNull();
+    // Base (bg/fg) + Semantic (accent/muted) stay index-based PaletteSelectors.
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    expect(baseGrids.length).toBeGreaterThanOrEqual(2);
+    expect(
+      (baseGrids[0] as HTMLElement).querySelectorAll('.tokenpanel-palette-selector').length,
+    ).toBe(2);
+    expect(
+      (baseGrids[1] as HTMLElement).querySelectorAll('.tokenpanel-palette-selector').length,
+    ).toBe(2);
+    // Secondary cluster sections render.
+    expect(
+      container.querySelector('[data-testid="tokenpanel-secondary-palette-section"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="tokenpanel-secondary-semantic-section"]'),
+    ).not.toBeNull();
+  });
+
+  it('secondary oklch palette swatch persists an oklch(...) string', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistSecondary = vi.fn();
+    renderColorTab(ctx, {
+      tab: OKLCH_PRIMARY_TAB,
+      colorState: makeOklchColorState(),
+      secondaryTab: OKLCH_SECONDARY_TAB,
+      secondaryState: makeOklchSecondaryState(),
+      persistSecondary,
+    });
+
+    const secSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-palette-section"]',
+    ) as HTMLElement;
+    openFirstSwatch(secSection);
+    fireFirstPickerSliderArrow();
+
+    expect(persistSecondary).toHaveBeenCalled();
+    const updater = persistSecondary.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState | undefined,
+    ) => ColorTweakState | undefined;
+    const result = updater(makeOklchSecondaryState());
+    expect(result).not.toBeUndefined();
+    expect(result!.palette[0]).toMatch(/^oklch\(/);
+  });
+
+  it('secondary palette stays hex when its tier declares no format', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistSecondary = vi.fn();
+    renderColorTab(ctx, {
+      secondaryTab: SECONDARY_TAB, // no format on palette items
+      secondaryState: makeSecondaryState(),
+      persistSecondary,
+    });
+
+    const secSection = container.querySelector(
+      '[data-testid="tokenpanel-secondary-palette-section"]',
+    ) as HTMLElement;
+    openFirstSwatch(secSection);
+    fireFirstPickerSliderArrow();
+
+    expect(persistSecondary).toHaveBeenCalled();
+    const updater = persistSecondary.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState | undefined,
+    ) => ColorTweakState | undefined;
+    const result = updater(makeSecondaryState());
+    expect(result).not.toBeUndefined();
+    expect(/^#[0-9a-fA-F]{6,8}$/.test(result!.palette[0])).toBe(true);
   });
 });

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -11,10 +11,13 @@
  *
  * Acceptance criterion (rejection-fix): every Base / Semantic Tokens row is
  * a `PaletteSelector` — the only way to edit those values is to pick a
- * palette index (p0–p15) or one of the `bg`/`fg` extras. The 16 Palette
- * swatches themselves are the only inputs that edit a hex via the HSL
- * popover. No raw-color inputs (rgb / hex text field / lab) are
- * exposed for Base or Semantic rows.
+ * palette index (p0–p15) or one of the `bg`/`fg` extras. The Palette
+ * swatches themselves are the only inputs that edit a color directly — a
+ * hex by default, or an `oklch(...)` string when the palette tier declares
+ * `type.format: 'oklch'` — via the color-picker popover. No raw-color
+ * inputs (rgb / hex text field / lab) are exposed for Base or Semantic rows;
+ * those rows reference palette slots, so they inherit OKLCH transitively the
+ * moment the palette holds `oklch()` values.
  *
  * Shiki integration is out of scope — the `shikiTheme` field stays on
  * state + persist + serde for envelope round-tripping with upstream
@@ -35,6 +38,7 @@
 import { memo, useState, useEffect, useCallback, useMemo, useRef } from 'preact/compat';
 import type { ColorScheme } from '../config/color-schemes';
 import ColorPicker from '../components/color-picker';
+import type { ColorPickerValueFormat } from '../components/color-picker/color-picker';
 import {
   type ColorTweakState,
   applyShikiTheme,
@@ -43,7 +47,7 @@ import {
 } from '../state/tweak-state';
 import { getPanelConfig } from '../config/panel-config';
 import { resolveColorClusterFromTab } from '../config/cluster-config';
-import type { TabConfig } from '../tokens/tier-model';
+import type { TabConfig, TierConfig } from '../tokens/tier-model';
 import type { PersistColor, PersistSecondary } from '../state/persist';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { useTooltip } from '../controls/tooltip';
@@ -135,16 +139,49 @@ function getFixedPopoverStyle(
   return style;
 }
 
+// --- Palette format resolution ---
+
+/**
+ * Find the palette tier in a color tab: the first non-reference tier whose
+ * items are color-kind. Mirrors the palette-tier detection in
+ * `resolveColorClusterFromTab`, so the format lookup keys off the SAME tier the
+ * cluster was flattened from. `resolveColorClusterFromTab` drops the per-item
+ * `type.format`, so the swatch grid must recover it from the tier here.
+ */
+function findPaletteTier(tab: TabConfig): TierConfig | undefined {
+  return tab.tiers.find(
+    (t) => !t.referencesTier && t.items.length > 0 && t.items[0].type.kind === 'color',
+  );
+}
+
+/**
+ * Resolve the ColorPicker value format for the palette slot at `index`.
+ * Returns `'oklch'` when the palette tier item declares
+ * `type.format: 'oklch'`, otherwise `'hex'` (the back-compatible default —
+ * `format` is optional, added 0.3.3).
+ */
+function resolvePaletteFormat(
+  paletteTier: TierConfig | undefined,
+  index: number,
+): ColorPickerValueFormat {
+  const item = paletteTier?.items[index];
+  if (item && item.type.kind === 'color' && item.type.format === 'oklch') {
+    return 'oklch';
+  }
+  return 'hex';
+}
+
 // --- UI Components ---
 
 /**
- * Single palette swatch with HSL popover.
+ * Single palette swatch with color-picker popover.
  *
- * `onChange` is `(index, hex)` — the swatch passes its own palette `index`
+ * `onChange` is `(index, value)` — the swatch passes its own palette `index`
  * back so the parent can use a single stable handler across every cell,
- * keeping React.memo effective. The same component is reused by both the
- * primary and secondary palettes because the `onChange` shape is
- * parameterised on the parent's per-cluster handler.
+ * keeping React.memo effective. `value` is a hex string by default, or an
+ * `oklch(...)` string when `valueFormat` is `'oklch'`. The same component is
+ * reused by both the primary and secondary palettes because the `onChange`
+ * shape is parameterised on the parent's per-cluster handler.
  */
 const ColorSwatch = memo(function ColorSwatch({
   color,
@@ -152,21 +189,26 @@ const ColorSwatch = memo(function ColorSwatch({
   index,
   label,
   cssVar,
+  valueFormat = 'hex',
 }: {
   color: string;
-  onChange: (index: number, hex: string) => void;
+  onChange: (index: number, value: string) => void;
   index: number;
   label: string;
   /** CSS custom property name (e.g. `--zd-p3`) used to wire the eye toggle.
    *  When present, a HighlightToggleButton appears in the swatch label row. */
   cssVar?: string;
+  /** Output format for the swatch's ColorPicker. `'oklch'` routes the edit
+   *  through the lossless OKLCH editor (emits `oklch(...)`); `'hex'` (default)
+   *  keeps the native hex behavior. */
+  valueFormat?: ColorPickerValueFormat;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const buttonRef = useRef<HTMLDivElement>(null);
   const handleClose = useCallback(() => setIsOpen(false), []);
-  const handleHexChange = useCallback(
-    (hex: string) => {
-      onChange(index, hex);
+  const handleColorChange = useCallback(
+    (value: string) => {
+      onChange(index, value);
     },
     [onChange, index],
   );
@@ -194,7 +236,9 @@ const ColorSwatch = memo(function ColorSwatch({
       {isOpen && (
         <ColorPicker
           color={color}
-          onChange={handleHexChange}
+          onChange={handleColorChange}
+          valueFormat={valueFormat}
+          label={label}
           onClose={handleClose}
           anchorRef={buttonRef}
         />
@@ -472,11 +516,20 @@ export default function ColorTab({
     [secondaryCluster],
   );
 
+  // The palette tier carries the per-slot `type.format` that
+  // `resolveColorClusterFromTab` flattens away — recover it here so the swatch
+  // grid can route oklch-format slots through the lossless OKLCH editor.
+  const paletteTier = useMemo(() => findPaletteTier(tab), [tab]);
+  const secondaryPaletteTier = useMemo(
+    () => (secondaryTab ? findPaletteTier(secondaryTab) : undefined),
+    [secondaryTab],
+  );
+
   const handlePaletteChange = useCallback(
-    (index: number, hex: string) => {
+    (index: number, value: string) => {
       persistColor((prev) => ({
         ...prev,
-        palette: prev.palette.map((c, i) => (i === index ? hex : c)),
+        palette: prev.palette.map((c, i) => (i === index ? value : c)),
       }));
     },
     [persistColor],
@@ -488,12 +541,12 @@ export default function ColorTab({
   // `secondaryState` would force a fresh callback identity on every state
   // change, defeating the React.memo wrapping further down the tree.
   const handleSecondaryPaletteChange = useCallback(
-    (index: number, hex: string) => {
+    (index: number, value: string) => {
       persistSecondary((prev) => {
         if (!prev) return prev;
         return {
           ...prev,
-          palette: prev.palette.map((c, i) => (i === index ? hex : c)),
+          palette: prev.palette.map((c, i) => (i === index ? value : c)),
         };
       });
     },
@@ -602,15 +655,17 @@ export default function ColorTab({
         </div>
         <div className="tokenpanel-color-palette-grid">
           {state.palette.map((color, i) => (
-            // ColorSwatch passes `i` back via its (index, hex) onChange so we
+            // ColorSwatch passes `i` back via its (index, value) onChange so we
             // hand `handlePaletteChange` directly — no inline arrow, memo
-            // stays effective.
+            // stays effective. `valueFormat` routes oklch-format slots through
+            // the lossless OKLCH editor; absent/`'hex'` slots stay hex.
             <ColorSwatch
               key={i}
               color={color}
               index={i}
               label={resolvePaletteCssVar(safeCluster, i)}
               cssVar={resolvePaletteCssVar(safeCluster, i)}
+              valueFormat={resolvePaletteFormat(paletteTier, i)}
               onChange={handlePaletteChange}
             />
           ))}
@@ -709,6 +764,7 @@ export default function ColorTab({
                     index={i}
                     label={resolvePaletteCssVar(secondaryCluster, i)}
                     cssVar={resolvePaletteCssVar(secondaryCluster, i)}
+                    valueFormat={resolvePaletteFormat(secondaryPaletteTier, i)}
                     onChange={handleSecondaryPaletteChange}
                   />
                 ))}

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -9,7 +9,7 @@
  *   length / number → number input with unit suffix (numeric range)
  *   select          → native <select>
  *   text            → free-form text input
- *   color           → native <input type="color"> by default; with format:'oklch' → OKLCH picker emitting oklch()
+ *   color           → native <input type="color"> by default (emits hex); with format:'oklch' → OKLCH picker emitting an oklch() string. Color values therefore persist as hex OR oklch(), not hex-only.
  *
  * For items in a tier with `referencesTier`, TierRefSelector is rendered
  * instead, so the user can either pick a tier-1 item id (emitted as

--- a/packages/zdtp/src/utils/design-token-serde.ts
+++ b/packages/zdtp/src/utils/design-token-serde.ts
@@ -238,7 +238,8 @@ export interface DesignTokenJson {
  *
  * For token tiers (spacing/font/size raw): values are CSS length/value strings.
  * For reference tiers (font semantic, etc.): values are `var(--tier1-cssvar)` strings.
- * For color palette: values are hex color strings.
+ * For color palette: values are color strings — hex, or `oklch(...)` when the
+ * palette tier declares `type.format: 'oklch'`.
  * For color semantic: values are palette-index integers.
  */
 export type V2TierMap = Record<string, string | number>;


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/434

---

## Summary

Implements the **"Wave 5" reserved-color-tab OKLCH migration** (epic #434, supersedes #433). The reserved `color` tab can now edit a cluster-based palette losslessly in OKLCH while keeping every color-cluster feature, and the runtime preserves `oklch()` end to end instead of clipping the palette to sRGB hex on seed.

### Part 1 — `ColorTab` honors `format:'oklch'` (#436)
- `ColorTab` reads `type.format` from the palette tier in `tab.tiers` (via `findPaletteTier` / `resolvePaletteFormat`) — `resolveColorClusterFromTab()` flattens the cluster and drops per-item format, so the tier is consulted directly.
- Palette swatches with `format:'oklch'` route through `ColorSwatch → ColorPicker` with `valueFormat='oklch'`, emitting raw `oklch(...)`. Primary **and** secondary cluster palettes honor it. Absent/`'hex'` format keeps the existing hex behavior (backward compatible — `format` is optional, added 0.3.3).
- Semantic/base rows stay index-based (they reference palette slots and inherit OKLCH transitively).

### Part 2 — runtime preserves OKLCH (#435)
- `initColorFromSchemeData` no longer eagerly maps the palette through `cssColorToHex`. Raw `oklch(...)` is preserved losslessly (wide-gamut survives; no `#000000` under jsdom / engines whose canvas can't parse oklch). Non-oklch entries still pass through `cssColorToHex` (`normalizeSchemePaletteEntry`) so invalid bundled-scheme strings are sanitized rather than leaked.
- `colorRefToIndex` is now format-tolerant + alpha-aware: exact match → OKLCH epsilon compare (circular hue, alpha included) → legacy hex/nearest fallback.
- Apply / persist / hydrate already pass strings verbatim, so OKLCH round-trips seed → edit → persist → reload → apply.

### Part 3 — confirm + docs (#437)
- New 38-case jsdom integration test (`oklch-color-cluster-e2e.test.tsx`): full cluster round-trip incl. wide-gamut, jsdom `#000000` guard, localStorage + SerDe-JSON persistence, HSL-edit caveat, and cluster-feature regression.
- Stale "palette values are hex" docs updated in `generic-tab.tsx`, `build-apply-overrides.ts`, `design-token-serde.ts`.

### Review fix
- Codex review caught a regression: `Default Dark`'s stray slot-9 `"18"` (used by `background: 9`) would have reached apply verbatim. Fixed by `normalizeSchemePaletteEntry` + 2 regression tests.

## Tests
- 1452 node-project tests green locally; full CI (incl. Playwright browser project) green.
- Additive & backward-compatible — no public type change (`format?: 'hex'|'oklch'` predates this in 0.3.3).

## Sub-issues
- #435 Runtime preserves OKLCH (Wave 1)
- #436 ColorTab routes format:'oklch' palette items (Wave 1)
- #437 Confirm OKLCH survives seed→edit→persist→apply (Wave 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
