### PR TITLE
[Ramp Tier2 Editor] Ramp-native Tier-2 color editor: semantic marker + cross-tab refs + literal + per-mode (#459)

### DIFF
--- a/doc/src/content/docs/reference/color-cluster.mdx
+++ b/doc/src/content/docs/reference/color-cluster.mdx
@@ -230,7 +230,7 @@ brand   -> --zd-brand:   var(--palette-accent-1)
 
 In the panel UI, a row on a `referencesRamps` tier renders as a grouped `<select>` — one `<optgroup>` per declared ramp source (`Base`, `Accent`) — plus a `"Literal…"` option that switches the row to a standalone literal color (see the next section). Picking a different ramp option persists a new `{ ref }` mapping; picking `"Literal…"` persists a `{ literal }` mapping seeded from the row's currently-resolved color.
 
-## `SemanticValue` — the mapping shapes
+## `SemanticValue` mapping shapes
 
 Every item in a semantic tier (`referencesTier`-style OR `semantic: true`) resolves to one `SemanticValue`:
 
@@ -503,7 +503,7 @@ When the user clicks Apply for the Color tab, the pipeline:
 
 1. Iterates palette items (palette tier, when one exists — a lone `semantic: true` tab has none): writes `paletteTier.items[i].cssVar` ← `palette[i]` for each slot.
 2. Iterates `baseRoles`: writes `cssName` ← `palette[state[roleKey]]`. Absent roles emit no writes.
-3. Iterates semantic items: resolves each item's `SemanticValue` mapping and emits per the table in [`SemanticValue` — the mapping shapes](#semanticvalue--the-mapping-shapes) above — `var(...)` for an index or `{ ref }` mapping, the literal string verbatim for `{ literal }`, or `light-dark(<light>, <dark>)` (plus `color-scheme: light dark` on the applied root) for a per-mode `{ literal: { light, dark } }`.
+3. Iterates semantic items: resolves each item's `SemanticValue` mapping and emits per the table in [`SemanticValue` mapping shapes](#semanticvalue-mapping-shapes) above — `var(...)` for an index or `{ ref }` mapping, the literal string verbatim for `{ literal }`, or `light-dark(<light>, <dark>)` (plus `color-scheme: light dark` on the applied root) for a per-mode `{ literal: { light, dark } }`.
 
 `clearAppliedStyles` removes every CSS property that the cluster could have set (palette + base roles + semantic + any `color-scheme` a per-mode literal left behind).
 

--- a/doc/src/content/docs/reference/color-cluster.mdx
+++ b/doc/src/content/docs/reference/color-cluster.mdx
@@ -81,6 +81,276 @@ export const colorTab: TabConfig = {
 };
 ```
 
+## Semantic-only tier (`semantic: true`)
+
+The palette tier above is detected **structurally** — the first tier with no `referencesTier` whose items are `kind: 'color'`. That heuristic breaks for a design system that ships only named semantic tokens (`--zd-danger`, `--zd-warning`, `--zd-info`, …) with no numbered palette slots at all: the semantic tier's own `kind: 'color'` items would otherwise be mistaken for a malformed palette (issue #458).
+
+Setting `TierConfig.semantic: true` opts a tier out of palette-tier detection everywhere — validation, `resolveColorClusterFromTab`, and the internal `findPaletteTier` helper never treat it as the palette, even though its items are color-kind. A Color `TabConfig` whose only tier is `semantic: true` is a **lone semantic tier**:
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+export const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true, // no palette tier anywhere in this TabConfig
+      items: [
+        { id: 'danger',  cssVar: '--zd-danger',  label: 'Danger',  default: 'oklch(0.55 0.22 25)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'warning', cssVar: '--zd-warning', label: 'Warning', default: 'oklch(0.75 0.18 80)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'info',    cssVar: '--zd-info',    label: 'Info',    default: 'oklch(0.6 0.1 230)',  type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+```
+
+Consequences for a lone semantic tier — `resolveColorClusterFromTab` reports `paletteSize: 0` — and the Color tab renders accordingly:
+
+| Before #459 (bug, issue #458) | After #459 |
+| --- | --- |
+| `configurePanel` threw — the F4 palette-cssVar contiguity check mistook the semantic tier's non-contiguous named cssVars for a malformed palette. | `configurePanel` accepts it — F4 never fires on a `semantic: true` tier. |
+| The "Semantic Tokens" section rendered grayscale `PaletteSelector` dropdowns pointing at a synthetic 1-slot palette. | Each row renders an editable OKLCH `ColorField` swatch directly — there is no palette to select from, so there is nothing to select. |
+| The "Scheme…" preset dropdown rendered as a dead control. | No scheme dropdown is rendered at all when `colorSchemes` is empty. |
+
+A lone semantic tier can also mix in `referencesRamps` to source some (or all) of its rows from a palette living on another tab — see the next section.
+
+## Cross-tab ramp references (`referencesRamps`)
+
+A `semantic: true` tier is not limited to standalone literals. `TierConfig.referencesRamps` declares one or more *ramp sources* — tiers (optionally on another tab) whose items the semantic tier's rows may reference:
+
+```ts
+referencesRamps?: readonly { tab?: string; tier: string }[];
+```
+
+Each entry names a tier `id` and an optional `tab` id (omitted `tab` means "this tab"). `assertValidPanelConfig` validates every declared source up front — an unknown tab or tier throws a clear configure-time error, before any row renders.
+
+### Worked example: a Palette tab feeding a Color tab's semantic tier
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+// The ramp source — a standalone Palette tab (no colorExtras: see
+// [Grouped palette tab](../recipes/grouped-palette-tab.mdx) for the full
+// rationale). Two ramps, "base" and "accent".
+export const paletteTab: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.7 0 0)',  type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.2 0 0)',  type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-0', cssVar: '--palette-accent-0', label: 'Accent 0', default: 'oklch(0.65 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-1', cssVar: '--palette-accent-1', label: 'Accent 1', default: 'oklch(0.45 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+// The Color tab: a lone semantic tier that references BOTH of the Palette
+// tab's ramps.
+export const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [
+        { tab: 'palette', tier: 'base' },   // ramp source #1 (the default)
+        { tab: 'palette', tier: 'accent' }, // ramp source #2
+      ],
+      items: [
+        {
+          id: 'surface',
+          cssVar: '--zd-surface',
+          label: 'Surface',
+          // A bare ramp-item id resolves against the FIRST declared ramp
+          // source (referencesRamps[0] — here, "base").
+          default: 'base-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'brand',
+          cssVar: '--zd-brand',
+          label: 'Brand',
+          // "tierId:itemId" picks a NON-first ramp source by name.
+          default: 'accent:accent-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+```
+
+`resolveColorClusterFromTab` derives each row's manifest default into a `{ ref }` `SemanticValue`:
+
+```ts
+cluster.semanticDefaults['surface'] === { ref: { tab: 'palette', tier: 'base',   item: 'base-1' } }
+cluster.semanticDefaults['brand']   === { ref: { tab: 'palette', tier: 'accent', item: 'accent-1' } }
+```
+
+The apply pipeline emits a **live** `var(...)` reference for each — never a resolved snapshot — so tweaking `--palette-accent-1` on the Palette tab re-colors `--zd-brand` immediately, with no re-apply needed:
+
+```
+surface -> --zd-surface: var(--palette-base-1)
+brand   -> --zd-brand:   var(--palette-accent-1)
+```
+
+In the panel UI, a row on a `referencesRamps` tier renders as a grouped `<select>` — one `<optgroup>` per declared ramp source (`Base`, `Accent`) — plus a `"Literal…"` option that switches the row to a standalone literal color (see the next section). Picking a different ramp option persists a new `{ ref }` mapping; picking `"Literal…"` persists a `{ literal }` mapping seeded from the row's currently-resolved color.
+
+## `SemanticValue` — the mapping shapes
+
+Every item in a semantic tier (`referencesTier`-style OR `semantic: true`) resolves to one `SemanticValue`:
+
+```ts
+export type SemanticValue =
+  | number
+  | 'bg'
+  | 'fg'
+  | { literal: string }
+  | { literal: { light: string; dark: string } }
+  | { ref: { tab?: string; tier: string; item: string } };
+```
+
+| Shape | Meaning | Manifest default | Apply emission |
+| --- | --- | --- | --- |
+| `number` | Palette-index mapping (the conventional `referencesTier` shape at the top of this page). | The id of a palette item, looked up to its index. | `var(--palette-item-cssVar)` |
+| `'bg'` / `'fg'` | Legacy aliases — resolve to the scheme's current background/foreground palette index. | Rare as a manifest default; mostly a v1-import artifact. | `var(--palette-item-cssVar)` for whichever index `'bg'`/`'fg'` currently resolves to. |
+| `{ literal: string }` | A standalone color, independent of any palette. | A literal CSS color string (e.g. `'oklch(0.6 0.1 230)'`). | The literal string verbatim. |
+| `{ literal: { light, dark } }` | The **per-mode literal** (#472/#473) — two independently-edited colors, one per color-scheme mode. | Never — `TierItem.default` is always a plain string, so this shape can only arise at RUNTIME (the panel's "Per-mode" editor checkbox, or a hand-built `ColorTweakState` / imported `SCHEMA_V3` JSON). | `light-dark(<light>, <dark>)`, and the apply pipeline additionally sets `color-scheme: light dark` on the applied root (cleared again on Reset) so the browser can pick a side. |
+| `{ ref: { tab?, tier, item } }` | A cross-tab/tier **ramp reference** (#467/#468) — only legal on a tier that declares `referencesRamps` naming the target tier. | The `"itemId"` (bare, first declared source) or `"tierId:itemId"` (named source) shorthand — see the worked example above. | `var(--target-item-cssVar)` — a live reference, re-resolved by the browser on every change to the ramp source, never a baked snapshot. |
+
+### Per-mode literal and `colorMode.defaultMode`
+
+`ClusterPanelSettings.colorMode.defaultMode` (documented below) gains a second job once a per-mode literal is in play: it selects which side (`'light'` or `'dark'`) is used for the panel's own swatch preview and as the flat fallback anywhere `light-dark()` cannot be resolved by a real browser (an export preview, an SSR seed). It does **not** change what gets emitted — `applyColorState` / `buildApplyOverrides` always emit the full `light-dark(<light>, <dark>)` function; `defaultMode` only affects which value the panel itself displays or falls back to.
+
+```ts
+panelSettings: {
+  colorScheme: 'default',
+  colorMode: { defaultMode: 'dark', lightScheme: 'Light', darkScheme: 'Dark' },
+},
+```
+
+### Regression: pre-#459 shapes are unaffected
+
+A conventional 2-tier palette + semantic cluster (the `referencesTier`-driven shape documented earlier on this page) keeps working unchanged — `number` index mappings still render as `PaletteSelector` dropdowns and still emit `var(--palette-item-cssVar)`. `semantic: true` and `referencesRamps` are purely additive: a tab that never sets them behaves exactly as it did before #459.
+
+## Minimal end-to-end example
+
+The snippet below wires a `configurePanel({...})` call with a grouped Palette tab (`base` / `accent` ramps) and a Color tab whose lone `semantic: true` tier exercises all three post-#459 `SemanticValue` shapes side by side — a cross-tab `{ ref }`, a standalone `{ literal }`, and (via a runtime state hand-edit, since `TierItem.default` cannot express it) the per-mode `{ literal: { light, dark } }`:
+
+```ts
+import { configurePanel } from '@takazudo/zdtp';
+import type { TabConfig, PanelConfig } from '@takazudo/zdtp';
+
+const paletteTab: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.7 0 0)',  type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-0', cssVar: '--palette-accent-0', label: 'Accent 0', default: 'oklch(0.65 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [{ tab: 'palette', tier: 'base' }, { tab: 'palette', tier: 'accent' }],
+      items: [
+        // { ref } — bare id resolves against the first ramp source ("base").
+        { id: 'brand', cssVar: '--zd-brand', label: 'Brand', default: 'base-1', type: { kind: 'color', format: 'oklch' } },
+        // { literal } — a standalone color, unrelated to any ramp.
+        { id: 'info', cssVar: '--zd-info', label: 'Info', default: 'oklch(0.6 0.1 230)', type: { kind: 'color', format: 'oklch' } },
+        // Manifest default is a single-mode literal; the per-mode pair below
+        // is layered on top of the seeded state at runtime.
+        { id: 'danger', cssVar: '--zd-danger', label: 'Danger', default: 'oklch(0.55 0.22 25)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+const config: PanelConfig = {
+  storagePrefix: 'myapp-design-token-panel',
+  consoleNamespace: 'myapp',
+  modalClassPrefix: 'myapp-design-token-panel-modal',
+  schemaId: 'myapp-design-tokens/v1',
+  exportFilenameBase: 'myapp-design-tokens',
+  tabs: [paletteTab, colorTab],
+};
+
+configurePanel(config);
+
+// Optional: seed "danger" with a per-mode literal, exactly as the panel's own
+// "Per-mode" editor checkbox would produce it. (Sketch — the real call site
+// reads the current state via the panel's persisted-state helpers rather than
+// constructing ColorTweakState by hand.)
+// state.color.semanticMappings.danger = {
+//   literal: { light: 'oklch(0.55 0.22 25)', dark: 'oklch(0.7 0.19 25)' },
+// };
+```
+
+<Tip title="Runnable fixture in the package's own test suite">
+This exact shape (Palette tab + lone `semantic: true` Color tab with a `{ ref }`, a `{ literal }`, and a runtime `{ literal: { light, dark } }` override on top) is a real, `configurePanel`-validated fixture in the package's own repo — `packages/zdtp/src/__tests__/_example-ramp-native-tier2.ts` — exercised by `manifest-cascade-verification.test.ts`'s Invariant H.
+</Tip>
+
 ## `ColorClusterExtras`
 
 The `colorExtras` field on a color `TabConfig` carries every piece of metadata that does not fit into the tier model.
@@ -231,11 +501,11 @@ See [`setPanelColorPresets`](/docs/reference/configure-panel#setpanelcolorpreset
 
 When the user clicks Apply for the Color tab, the pipeline:
 
-1. Iterates palette items (palette tier): writes `paletteTier.items[i].cssVar` ← `palette[i]` for each slot.
+1. Iterates palette items (palette tier, when one exists — a lone `semantic: true` tab has none): writes `paletteTier.items[i].cssVar` ← `palette[i]` for each slot.
 2. Iterates `baseRoles`: writes `cssName` ← `palette[state[roleKey]]`. Absent roles emit no writes.
-3. Iterates semantic items: resolves each item's override (a palette item id) to the palette item's `cssVar`, emits `var(--that-cssVar)` into the semantic slot.
+3. Iterates semantic items: resolves each item's `SemanticValue` mapping and emits per the table in [`SemanticValue` — the mapping shapes](#semanticvalue--the-mapping-shapes) above — `var(...)` for an index or `{ ref }` mapping, the literal string verbatim for `{ literal }`, or `light-dark(<light>, <dark>)` (plus `color-scheme: light dark` on the applied root) for a per-mode `{ literal: { light, dark } }`.
 
-`clearAppliedStyles` removes every CSS property that the cluster could have set (palette + base roles + semantic).
+`clearAppliedStyles` removes every CSS property that the cluster could have set (palette + base roles + semantic + any `color-scheme` a per-mode literal left behind).
 
 ## Cross-references
 

--- a/doc/src/content/docs/reference/token-manifest.mdx
+++ b/doc/src/content/docs/reference/token-manifest.mdx
@@ -70,8 +70,6 @@ export interface TierItem {
   cssVar: string;
   /** Human-visible label rendered in the panel row. */
   label: string;
-  /** Optional group id — used by some tab components for section headers. */
-  group?: string;
   /** Default CSS string value — used when no override is active. */
   default: string;
   /** Discriminated union controlling the edit widget. */
@@ -83,6 +81,10 @@ export interface TierItem {
 }
 ```
 
+<Note title="No `group` field">
+`TierItem.group` (a sub-heading key inside a tier) was removed in #148 — the panel's [one-tier-one-heading policy](/docs/reference/architecture) requires each tier to render exactly one section heading. A tier that conceptually needs sub-grouping is split into multiple `TierConfig` entries instead. Example manifests must not reference `group`.
+</Note>
+
 ### Field reference
 
 | Field | Required | Notes |
@@ -90,7 +92,6 @@ export interface TierItem {
 | `id` | yes | Stable key in the persisted override map. Renaming breaks existing user state unless `legacyIdRenameMap` is configured. |
 | `cssVar` | yes | The CSS custom property written to `:root`. Must start with `--` and be non-empty after the prefix; validated by `assertValidPanelConfig`. |
 | `label` | yes | Display label inside the panel row. |
-| `group` | no | Section header grouping key. Some tab components render a heading for each unique group value. |
 | `default` | yes | Fallback CSS string emitted when no override is active. |
 | `type` | yes | Controls which editor renders for this row. |
 | `pill` | no | Adds an opt-in sentinel toggle alongside the main editor. |
@@ -115,10 +116,33 @@ export interface TierConfig {
    * `var(--that-tier-item-cssVar)` rather than the raw value string.
    */
   referencesTier?: string;
+  /**
+   * Marks this tier as a SEMANTIC tier on the Color tab — its items hold
+   * `SemanticValue` mappings (index, literal, per-mode literal, or a
+   * cross-tab ramp reference) rather than raw palette entries, so the
+   * panel never mistakes it for the palette tier even when its items are
+   * `kind: 'color'`. A tier with `semantic: true` and no sibling palette
+   * tier is a **lone semantic tier** — the Color tab renders it with no
+   * palette grid at all. Additive: omitting `semantic` preserves the
+   * pre-#459 structural palette-detection behavior.
+   */
+  semantic?: true;
+  /**
+   * Cross-tab ramp-source declaration for a `semantic: true` tier: the ramp
+   * tier(s) this tier's `{ ref }` mappings are allowed to point into. Each
+   * entry names a tier `id` and an optional `tab` id (omitted `tab` means
+   * "this tab"). Validated up front by `assertValidPanelConfig` — an
+   * unknown tab or tier throws at configure time, before any row renders.
+   */
+  referencesRamps?: readonly { tab?: string; tier: string }[];
 }
 ```
 
 A tier with `referencesTier` is called a **reference tier**. Its items don't hold direct CSS values — they hold the id of a *source* item in another (literal) tier. The `referencesTier` value must be the `id` of a tier that exists in the same `TabConfig`. The tier kinds must match (e.g. both `'color'` or both `'length'`).
+
+<Info title="semantic + referencesRamps are Color-tab concepts">
+`semantic` and `referencesRamps` are only meaningful on a tier inside a `'color'` / `'color-secondary'` `TabConfig` (a tier the Color tab's `resolveColorClusterFromTab` bridge reads). For the full behavioral contract — the `SemanticValue` union, how a lone semantic tier renders, and a worked cross-tab example — see [Color cluster § Semantic-only tier](/docs/reference/color-cluster#semantic-only-tier-semantic-true).
+</Info>
 
 ## `TabConfig`
 
@@ -133,17 +157,16 @@ export interface TabConfig {
   /** Ordered tiers rendered inside the tab. */
   tiers: readonly TierConfig[];
   /**
-   * Optional list of tier ids hidden behind the per-tab "Advanced" disclosure.
-   * Any tier id listed here is rendered inside a collapsed `<details>` element.
-   */
-  advancedTiers?: readonly string[];
-  /**
    * Color-tab metadata. Required for the reserved `'color'` and
    * `'color-secondary'` ids — ignored (and unnecessary) for all other ids.
    */
   colorExtras?: ColorClusterExtras;
 }
 ```
+
+<Note title="No `advancedTiers` field">
+`TabConfig.advancedTiers` (a per-tab "Advanced" `<details>` disclosure) was removed in #148 — the panel's [no-progressive-disclosure policy](/docs/reference/architecture) requires every tier to render flat, with no collapsed sections. If a tab has many tokens, render them flat in tier-section order instead. Example manifests must not reference `advancedTiers`.
+</Note>
 
 ### Reserved tab ids
 
@@ -238,7 +261,6 @@ export const easingTab: TabConfig = {
       ],
     },
   ],
-  advancedTiers: ['semantic'],
 };
 ```
 

--- a/packages/zdtp/CLAUDE.md
+++ b/packages/zdtp/CLAUDE.md
@@ -135,6 +135,22 @@ The companion CSS rule is unchanged — the selector targets the class, not the 
 
 This swap is purely structural: it removes the tag-level styling hook without touching the class-based visual styling.
 
+## Ramp-native Tier-2 color editor (`semantic` / `referencesRamps`, epic #459)
+
+The tier model (`tokens/tier-model.ts`) gained two additive `TierConfig` fields for the Color tab:
+
+- `semantic?: true` — marks a tier as holding `SemanticValue` mappings (index, literal, per-mode literal, or a cross-tab ramp `{ ref }`) instead of raw palette entries. A tier marked `semantic: true` is NEVER treated as the palette tier, even when its items are `kind: 'color'` — this lets a Color `TabConfig` ship with a **lone semantic tier** and no palette tier at all (issue #458).
+- `referencesRamps?: readonly { tab?: string; tier: string }[]` — declares which ramp tier(s) (optionally on another tab) a `semantic: true` tier's `{ ref }` rows may point into. Validated up front by `assertValidPanelConfig`.
+
+Full behavioral documentation (the `SemanticValue` union, the per-mode `light-dark()` emission, the worked cross-tab example) lives in `doc/src/content/docs/reference/color-cluster.mdx` — this section only covers what changed for the panel's OWN DOM-hygiene rules above.
+
+**No new tag exemptions were needed.** The two new interactive pieces this feature added both reuse the existing permitted-form-control exemptions, not new markup:
+
+- The grouped ref-or-literal picker (`controls/tier-ref-selector.tsx`) is a native `<select>` with one `<optgroup>` per declared ramp source and a trailing `"Literal…"` `<option>`.
+- The "Per-mode" toggle that expands a literal row into an independently-editable light/dark `ColorField` pair is a native `<label><input type="checkbox"></label>`.
+
+Both `select`/`optgroup`/`option` and `input`/`label` are already on the permitted-form-controls list above. `color-tab.tsx`'s semantic rows (whether `PaletteSelector`, `SemanticLiteralRow`, or the grouped `TierRefSelector`) still render exactly one tier-section heading (`<div role="heading" aria-level={3}>` per the one-tier-one-heading policy) — the new value shapes only change what's inside a row, not the tier's own heading structure.
+
 ## Hostile-host test page
 
 A verification harness page lives at `doc/src/content/docs/internal/hostile-host.mdx`. It is marked `unlisted: true` (not indexed, not in sidebar) and documents the hostile-host test scenario for the Panel Hardening epic (#145).
@@ -177,6 +193,7 @@ After merging changes that affect the tier model, manifest structure, or token n
 
 - **Invariant D** — the panel tabs and `components/color-picker/` source contain no `<h4`, `<details`, `<summary`, `<button`, or `<table` elements (the hostile-host policy above).
 - **Invariant F** — the panel CSS sources (`panel-tokens.css` and `panel.css`) do not read host `--color-*` or `--font-mono` vars, and declare their baked-in dark `--tokentweak-*` chrome tokens.
+- **Invariant H** (#459/#475) — the ramp-native Tier-2 example manifest (`_example-ramp-native-tier2.ts`) is a real, `configurePanel`-valid `PanelConfig`; `semantic: true`, `referencesRamps`, and every `SemanticValue` shape (index-free `{ ref }`, `{ literal }`, and a runtime-built per-mode `{ literal: { light, dark } }`) resolve and emit correctly.
 
 > **Historical note — Invariants A, B, C, E.** Earlier waves asserted Invariant A (`TierItem.group` removed in #148) and Invariant B (`TabConfig.advancedTiers` removed in #148) by grepping every example manifest source for those object-keys. After the panel types removed those fields, TypeScript at panel-compile time covers both. Invariant C (zfb-tailwind Spacing tab tier count) and Invariant E (`examples/zfb-tailwind/styles/global.css` re-exports spacing variables as Tailwind theme tokens) were exercised by reading example source files directly. After the Wave-2 example-move (epic #202) those files left this monorepo, so Invariants C and E are now exercised in the external [`zudo-design-token-panel-example-zfb-tailwind`](https://github.com/Takazudo/zudo-design-token-panel-example-zfb-tailwind) repo's own CI on each panel SHA bump.
 

--- a/packages/zdtp/src/__tests__/_example-ramp-native-tier2.ts
+++ b/packages/zdtp/src/__tests__/_example-ramp-native-tier2.ts
@@ -1,0 +1,153 @@
+/**
+ * Example manifest — ramp-native Tier-2 color editor (epic #459, S14/#475).
+ *
+ * A minimal, realistic `PanelConfig` fixture that exercises every #459
+ * addition side by side, in the shape a real host would actually ship:
+ *
+ *   - `TierConfig.semantic: true`   — the Color tab's only tier is a lone
+ *     semantic tier (no palette tier of its own); it is never mistaken for
+ *     the palette (#461).
+ *   - `TierConfig.referencesRamps`  — the semantic tier declares two ramp
+ *     sources living on a SEPARATE `palette` tab: `base` and `accent` (#467).
+ *   - `SemanticValue` `{ ref }`     — `surface` uses the bare-id form
+ *     (resolves against the FIRST declared ramp source, `base`); `brand`
+ *     uses the `"tierId:itemId"` form to pick the non-first `accent` source
+ *     (#467/#468).
+ *   - `SemanticValue` `{ literal }` — `info` is a standalone literal OKLCH
+ *     color, unrelated to any ramp (#464/#465).
+ *
+ * `danger`'s MANIFEST default is a single-mode literal string — `TierItem.default`
+ * is always a plain string, so the `{ literal: { light, dark } }` per-mode shape
+ * can only ever arise as a RUNTIME override (via the panel's "Per-mode" editor
+ * checkbox, or a hand-built `ColorTweakState`), never as a manifest default
+ * (#472/#473). `EXAMPLE_DANGER_LIGHT` / `EXAMPLE_DANGER_DARK` below are the pair
+ * `manifest-cascade-verification.test.ts`'s Invariant H layers on top of this
+ * manifest's cluster to exercise that shape end-to-end.
+ *
+ * Consumed by:
+ *   - `manifest-cascade-verification.test.ts` (Invariant H) — asserts the
+ *     manifest is valid and exercises the tier-model fields above.
+ *   - `doc/src/content/docs/reference/color-cluster.mdx` ("Semantic value
+ *     shapes" worked example) — the doc's `configurePanel({...})` snippet
+ *     transcribes this fixture's shape.
+ */
+
+import type { PanelConfig } from '../config/panel-config';
+import type { TabConfig } from '../tokens/tier-model';
+
+// ---------------------------------------------------------------------------
+// Ramp source — a standalone Palette tab (no colorExtras: it is never itself
+// a color cluster's primary tab, only a source of ramp items for the Color
+// tab's semantic tier). Two tiers so the grouped picker's two ramp sources
+// are genuinely distinct groups, not a single-source degenerate case.
+// ---------------------------------------------------------------------------
+
+export const EXAMPLE_PALETTE_TAB: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.85 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.7 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-3', cssVar: '--palette-base-3', label: 'Base 3', default: 'oklch(0.2 0 0)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-0', cssVar: '--palette-accent-0', label: 'Accent 0', default: 'oklch(0.65 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-1', cssVar: '--palette-accent-1', label: 'Accent 1', default: 'oklch(0.55 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-2', cssVar: '--palette-accent-2', label: 'Accent 2', default: 'oklch(0.45 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// The Color tab — a lone `semantic: true` tier referencing both of the
+// Palette tab's ramps, plus a standalone literal row.
+// ---------------------------------------------------------------------------
+
+/** Manifest default for `danger` — a single-mode literal (see file header). */
+export const EXAMPLE_DANGER_LIGHT = 'oklch(0.55 0.22 25)';
+/** Dark-mode counterpart used only by the Invariant H runtime-state check. */
+export const EXAMPLE_DANGER_DARK = 'oklch(0.7 0.19 25)';
+
+export const EXAMPLE_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'ramp-native-example',
+    label: 'Example',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    // A non-empty colorScheme is required by assertValidPanelConfig even
+    // though it is functionally unused here (colorSchemes is empty, so
+    // initColorFromScheme short-circuits to initSecondaryDefaults).
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [
+        { tab: 'palette', tier: 'base' },
+        { tab: 'palette', tier: 'accent' },
+      ],
+      items: [
+        {
+          id: 'surface',
+          cssVar: '--zd-surface',
+          label: 'Surface',
+          // Bare ramp-item id -> resolves against the FIRST declared ramp
+          // source (referencesRamps[0] = base).
+          default: 'base-2',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'brand',
+          cssVar: '--zd-brand',
+          label: 'Brand',
+          // "tierId:itemId" form -> picks a NON-first ramp source by name.
+          default: 'accent:accent-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'info',
+          cssVar: '--zd-info',
+          label: 'Info',
+          // Standalone literal, unrelated to any ramp.
+          default: 'oklch(0.6 0.1 230)',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'danger',
+          cssVar: '--zd-danger',
+          label: 'Danger',
+          default: EXAMPLE_DANGER_LIGHT,
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+export const EXAMPLE_TABS: readonly TabConfig[] = [EXAMPLE_PALETTE_TAB, EXAMPLE_COLOR_TAB];
+
+export const EXAMPLE_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'zdtp-example-ramp-native',
+  consoleNamespace: 'zdtpExample',
+  modalClassPrefix: 'zdtp-example-ramp-native-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'zdtp-example-ramp-native-tokens',
+  tabs: EXAMPLE_TABS,
+  colorPresets: {},
+};

--- a/packages/zdtp/src/__tests__/apply-sink.test.ts
+++ b/packages/zdtp/src/__tests__/apply-sink.test.ts
@@ -278,6 +278,20 @@ describe('clearAppliedColorStyles with sink', () => {
     expect(cleared).toContain('--fixture-p0');
     expect(cleared).toContain('--fixture-semantic-accent');
   });
+
+  // #474 (S13) — a per-mode literal apply (#472) may have routed
+  // `color-scheme: light dark` through this same sink to its own target
+  // root. The clear must include it so a Reset on a sink instance doesn't
+  // leave it lingering there either.
+  it('includes "color-scheme" in the sink clear batch so it never lingers on the sink target root', () => {
+    const sink = makeSinkSpy();
+    installFixturePanelConfig({ applySink: sink });
+
+    clearAppliedColorStyles([FIXTURE_CLUSTER], sink);
+
+    const cleared = flatClearNames(sink.clearCalls);
+    expect(cleared).toContain('color-scheme');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/zdtp/src/__tests__/clear-applied-styles.test.ts
+++ b/packages/zdtp/src/__tests__/clear-applied-styles.test.ts
@@ -74,4 +74,26 @@ describe('clearAppliedColorStyles / clearAppliedStyles split (#347)', () => {
       expect(readVar(v)).toBe('');
     }
   });
+
+  // #474 (S13) — a per-mode literal semantic value (#472) causes the apply
+  // path to set `color-scheme: light dark` on :root. Neither clear path
+  // removed it before this fix, leaving it lingering after a Reset even
+  // though every color var it was serving had just been wiped.
+  it('clearAppliedColorStyles also removes a lingering color-scheme left by a per-mode literal apply', () => {
+    seedAppliedVars();
+    document.documentElement.style.setProperty('color-scheme', 'light dark');
+
+    clearAppliedColorStyles();
+
+    expect(readVar('color-scheme')).toBe('');
+  });
+
+  it('clearAppliedStyles also removes a lingering color-scheme left by a per-mode literal apply', () => {
+    seedAppliedVars();
+    document.documentElement.style.setProperty('color-scheme', 'light dark');
+
+    clearAppliedStyles();
+
+    expect(readVar('color-scheme')).toBe('');
+  });
 });

--- a/packages/zdtp/src/__tests__/issue-458-lone-semantic-tier-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-458-lone-semantic-tier-e2e.test.tsx
@@ -1,0 +1,605 @@
+// @vitest-environment jsdom
+
+/**
+ * Lone `semantic: true` OKLCH tier — end-to-end confirm (issue #458, Wave-2
+ * confirm, S6, #466).
+ *
+ * Issue #458 reported three symptoms for a color tab that ships ONLY a
+ * `semantic: true` tier of named literal OKLCH tokens (no palette tier at
+ * all — e.g. a design system with `--zd-danger`, `--zd-warning`, `--zd-info`
+ * but no numbered palette slots):
+ *
+ *   1. `configurePanel` threw — F4's palette-cssVar contiguity check
+ *      mistook the semantic tier's non-contiguous named cssVars for a
+ *      malformed palette.
+ *   2. The Semantic Tokens section rendered N grayscale `PaletteSelector`
+ *      dropdowns (pointing at a synthetic 1-slot grayscale palette) instead
+ *      of editable color swatches — there was no palette to select from.
+ *   3. The "Scheme…" preset dropdown rendered as a dead control (no bundled
+ *      schemes, no host presets) with no indication it does nothing.
+ *
+ * Wave 2 (#460-#465) fixed the data model end to end:
+ *   - `TierConfig.semantic?: true` opts a tier out of palette-tier detection
+ *     everywhere (F4 validation, `resolveColorClusterFromTab`,
+ *     `findPaletteTier`).
+ *   - `resolveColorClusterFromTab` derives `semanticDefaults[id] = { literal }`
+ *     for each item instead of a palette index.
+ *   - `color-tab.tsx` renders `{ literal: string }` mappings through
+ *     `SemanticLiteralRow` (an editable OKLCH `ColorField` swatch) instead of
+ *     `PaletteSelector`.
+ *   - Both emitters (`buildApplyOverrides` disk, `applyColorState` DOM via
+ *     `resolveSemanticCssValue`) emit the literal CSS value verbatim.
+ *   - `SCHEMA_V3` + the persist hydrator round-trip every `SemanticValue`
+ *     variant, including `{ literal: string }`.
+ *
+ * This test proves the fix end-to-end for the all-literal, single-mode case
+ * — the exact shape #458 reported — through configure → render → edit →
+ * serde/persist round-trip → apply (disk + DOM, checked for parity), plus a
+ * scheme-dropdown dead-control check and a conventional 2-tier regression.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+
+import ColorTab from '../tabs/color-tab';
+import {
+  __resetPanelConfigForTests,
+  configurePanel,
+  getPanelConfig,
+  type PanelConfig,
+} from '../config/panel-config';
+import { resolveColorClusterFromTab } from '../config/cluster-config';
+import {
+  applyColorState,
+  getActivePrimaryCluster,
+  getStorageKeyV3,
+  initColorFromScheme,
+  loadPersistedState,
+  savePersistedState,
+  type ColorTweakState,
+  type StorageLike,
+  type TweakState,
+} from '../state/tweak-state';
+import { buildApplyOverrides } from '../apply/build-apply-overrides';
+import { serialize, deserialize, SCHEMA_V3 } from '../utils/design-token-serde';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from '../highlight/highlight-toggle-button';
+import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../highlight/highlight-state';
+import { TooltipProvider } from '../controls/tooltip';
+import type { TabConfig } from '../tokens/tier-model';
+import type { PersistColor, PersistSecondary } from '../state/persist';
+import { FIXTURE_TABS, FIXTURE_PANEL_CONFIG } from './_test-helpers';
+
+// ---------------------------------------------------------------------------
+// FIXTURE — lone semantic:true OKLCH tier, no palette tier, no schemes
+// ---------------------------------------------------------------------------
+
+/** Semantic token ids, in declaration order — used as the "N" throughout. */
+const SEMANTIC_IDS = ['danger', 'warning', 'info'] as const;
+
+const SEMANTIC_LITERALS: Record<(typeof SEMANTIC_IDS)[number], string> = {
+  danger: 'oklch(0.55 0.22 25)',
+  warning: 'oklch(0.75 0.15 80)',
+  // No trailing zeros (0.6, not 0.60) — jsdom's cssstyle parser canonicalizes
+  // `background-color` (a real CSS property, unlike a custom property) and
+  // strips them, which would otherwise desync this literal from the
+  // rendered swatch's `style.backgroundColor` in the "seeded default"
+  // assertion below.
+  info: 'oklch(0.6 0.1 230)',
+};
+
+const SEMANTIC_CSS_VARS: Record<(typeof SEMANTIC_IDS)[number], string> = {
+  danger: '--zd-danger',
+  warning: '--zd-warning',
+  info: '--zd-info',
+};
+
+/** The lone semantic tier: named cssVars, non-contiguous, kind:'color'/'oklch'. */
+const LONE_SEMANTIC_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'lone-semantic',
+    label: 'Lone Semantic',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      items: SEMANTIC_IDS.map((id) => ({
+        id,
+        cssVar: SEMANTIC_CSS_VARS[id],
+        label: id,
+        default: SEMANTIC_LITERALS[id],
+        type: { kind: 'color' as const, format: 'oklch' as const },
+      })),
+    },
+  ],
+};
+
+const LONE_SEMANTIC_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'issue-458-e2e',
+  consoleNamespace: 'issue-458-e2e',
+  modalClassPrefix: 'issue-458-e2e-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'issue-458-e2e-tokens',
+  tabs: [LONE_SEMANTIC_TAB],
+  colorPresets: {},
+};
+
+// ---------------------------------------------------------------------------
+// HELPERS
+// ---------------------------------------------------------------------------
+
+function makeStorage(
+  initial: Record<string, string> = {},
+): StorageLike & { entries: Record<string, string> } {
+  const entries: Record<string, string> = { ...initial };
+  return {
+    entries,
+    getItem: (k) => (k in entries ? entries[k] : null),
+    setItem: (k, v) => {
+      entries[k] = v;
+    },
+    removeItem: (k) => {
+      delete entries[k];
+    },
+  };
+}
+
+function makeHighlightState(): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    outlineWidth: 2,
+    active: {},
+  };
+}
+
+function makeCtx(state: HighlightState, toggle: (cssVar: string) => void): HighlightContextValue {
+  return { state, toggle };
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+  configurePanel(LONE_SEMANTIC_PANEL_CONFIG);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  document.documentElement.removeAttribute('style');
+  // Pin the picker to OKLCH mode so the L/C/H sliders render deterministically.
+  localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+});
+
+afterEach(() => {
+  act(() => {
+    render(null, container);
+  });
+  document.body.removeChild(container);
+  document.documentElement.removeAttribute('style');
+  __resetPanelConfigForTests();
+  vi.restoreAllMocks();
+  localStorage.removeItem('tokenpanel.colorPicker.mode');
+});
+
+/** Render ColorTab wrapped in TooltipProvider and HighlightContext. */
+function renderColorTab(
+  tab: TabConfig,
+  state: ColorTweakState,
+  opts: { persistColor?: PersistColor; persistSecondary?: PersistSecondary } = {},
+): void {
+  const { persistColor = vi.fn(), persistSecondary = vi.fn() } = opts;
+  const ctx = makeCtx(makeHighlightState(), vi.fn());
+  act(() => {
+    render(
+      <TooltipProvider>
+        <HighlightContext.Provider value={ctx}>
+          <ColorTab
+            tab={tab}
+            state={state}
+            persistColor={persistColor}
+            secondaryTab={null}
+            secondaryState={null}
+            persistSecondary={persistSecondary}
+          />
+        </HighlightContext.Provider>
+      </TooltipProvider>,
+      container,
+    );
+  });
+}
+
+/** The Semantic Tokens grid is the 2nd `.tokenpanel-color-base-grid` (Base is 1st). */
+function getSemanticGrid(): HTMLElement {
+  const grids = container.querySelectorAll('.tokenpanel-color-base-grid');
+  expect(grids.length).toBeGreaterThanOrEqual(2);
+  return grids[1] as HTMLElement;
+}
+
+/** Open the first literal-semantic swatch (a `ColorField`) in the semantic grid. */
+function openFirstSemanticLiteralSwatch(): void {
+  const swatch = getSemanticGrid().querySelector(
+    '.tokenpanel-color-field-swatch',
+  ) as HTMLElement;
+  expect(swatch).not.toBeNull();
+  act(() => {
+    swatch.click();
+  });
+}
+
+/** Fire an arrow key on the first slider in the open picker dialog. */
+function fireFirstPickerSliderArrow(key = 'ArrowUp'): void {
+  const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+  if (!slider) throw new Error('no slider found in open picker dialog');
+  act(() => {
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+function makeLoneSemanticState(): ColorTweakState {
+  const cluster = getActivePrimaryCluster();
+  return initColorFromScheme(cluster);
+}
+
+// ---------------------------------------------------------------------------
+// 1. configurePanel accepts the lone semantic:true tier
+// ---------------------------------------------------------------------------
+
+describe('1. configurePanel accepts a lone semantic:true OKLCH tier', () => {
+  it('does NOT throw (F4 no longer fires on named, non-contiguous cssVars)', () => {
+    __resetPanelConfigForTests();
+    expect(() => configurePanel(LONE_SEMANTIC_PANEL_CONFIG)).not.toThrow();
+  });
+
+  it('resolveColorClusterFromTab derives a { literal } SemanticValue per item, paletteSize 0', () => {
+    const cluster = resolveColorClusterFromTab(LONE_SEMANTIC_TAB)!;
+    expect(cluster).toBeDefined();
+    expect(cluster.paletteSize).toBe(0);
+    for (const id of SEMANTIC_IDS) {
+      expect(cluster.semanticDefaults[id]).toEqual({ literal: SEMANTIC_LITERALS[id] });
+      expect(cluster.semanticCssNames[id]).toBe(SEMANTIC_CSS_VARS[id]);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Rendering — literal ColorField swatches, not grayscale PaletteSelectors
+// ---------------------------------------------------------------------------
+
+describe('2. rendering shows editable literal swatches, not palette-index dropdowns', () => {
+  it('Semantic Tokens grid renders N SemanticLiteralRow swatches (data-testid marker)', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    const semanticGrid = getSemanticGrid();
+
+    for (const id of SEMANTIC_IDS) {
+      expect(
+        semanticGrid.querySelector(`[data-testid="tokenpanel-semantic-literal-${id}"]`),
+      ).not.toBeNull();
+    }
+    expect(
+      semanticGrid.querySelectorAll('[data-testid^="tokenpanel-semantic-literal-"]').length,
+    ).toBe(SEMANTIC_IDS.length);
+  });
+
+  it('Semantic Tokens grid renders ZERO PaletteSelector (index-dropdown) rows', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    const semanticGrid = getSemanticGrid();
+    expect(semanticGrid.querySelectorAll('.tokenpanel-palette-selector').length).toBe(0);
+  });
+
+  it('the "Semantic Tokens" section heading is present and the section is non-empty', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    const headings = Array.from(
+      container.querySelectorAll('[role="heading"][aria-level="3"]'),
+    );
+    const semanticHeading = headings.find((h) => (h.textContent ?? '').includes('Semantic Tokens'));
+    expect(semanticHeading).not.toBeUndefined();
+
+    const semanticGrid = getSemanticGrid();
+    expect(semanticGrid.children.length).toBeGreaterThan(0);
+  });
+
+  it('each literal swatch shows its seeded oklch() default as the swatch background', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    const semanticGrid = getSemanticGrid();
+    for (const id of SEMANTIC_IDS) {
+      const row = semanticGrid.querySelector(`[data-testid="tokenpanel-semantic-literal-${id}"]`)!;
+      const swatch = row.querySelector('.tokenpanel-color-field-swatch') as HTMLElement;
+      expect(swatch).not.toBeNull();
+      // jsdom keeps the inline style value as authored (no color-space resolution).
+      expect(swatch.style.backgroundColor).toBe(SEMANTIC_LITERALS[id]);
+    }
+  });
+
+  it('the raw Palette section does not surface any of the named semantic cssVars as swatches', () => {
+    // The Palette section (Section A) maps over `state.palette` directly; it
+    // must not expose the semantic tokens as if they were palette slots.
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    expect(paletteGrid).not.toBeNull();
+    const labels = Array.from(
+      paletteGrid.querySelectorAll('.tokenpanel-color-swatch-label'),
+    ).map((el) => el.textContent);
+    for (const id of SEMANTIC_IDS) {
+      expect(labels).not.toContain(SEMANTIC_CSS_VARS[id]);
+    }
+    // Crucially, the palette grid never shows N (one per semantic token)
+    // swatches — there is no palette backing this lone-semantic-tier cluster.
+    expect(paletteGrid.querySelectorAll('.tokenpanel-color-swatch-button').length).not.toBe(
+      SEMANTIC_IDS.length,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Editing a semantic swatch — state update + serde/persist round-trip
+// ---------------------------------------------------------------------------
+
+describe('3. editing a semantic swatch updates state to { literal } and survives round-trips', () => {
+  it('editing the first semantic swatch calls persistColor with a { literal: <newValue> } updater', () => {
+    const persistColor = vi.fn();
+    const baseState = makeLoneSemanticState();
+    renderColorTab(LONE_SEMANTIC_TAB, baseState, { persistColor });
+
+    openFirstSemanticLiteralSwatch();
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(baseState);
+
+    const edited = result.semanticMappings['danger'];
+    expect(edited).toBeTypeOf('object');
+    expect((edited as { literal: string }).literal).toMatch(/^oklch\(/i);
+    // The edit must actually change the value (arrow key nudges Lightness).
+    expect((edited as { literal: string }).literal).not.toBe(SEMANTIC_LITERALS.danger);
+  });
+
+  it('the edited { literal } value survives a serialize -> deserialize round-trip', () => {
+    const persistColor = vi.fn();
+    const baseState = makeLoneSemanticState();
+    renderColorTab(LONE_SEMANTIC_TAB, baseState, { persistColor });
+
+    openFirstSemanticLiteralSwatch();
+    fireFirstPickerSliderArrow();
+
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const editedColorState = updater(baseState);
+    const editedLiteral = (editedColorState.semanticMappings['danger'] as { literal: string })
+      .literal;
+
+    const fullState: TweakState = {
+      color: editedColorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cfg = getPanelConfig();
+
+    const json = serialize(fullState, { colorDefaults: baseState }, cfg);
+    // A { literal } mapping can't be expressed in v2's number-only leaf, so
+    // serialize() must upgrade to SCHEMA_V3.
+    expect(json.$schema).toBe(SCHEMA_V3);
+
+    const semanticOut = json.tabs?.['color']?.['semantic'] as Record<string, unknown> | undefined;
+    expect(semanticOut).toBeDefined();
+    expect(semanticOut!['--zd-danger']).toEqual({ literal: editedLiteral });
+
+    const result = deserialize(json, { colorDefaults: baseState }, cfg);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.unknownTokens).toHaveLength(0);
+    expect(result.state.color.semanticMappings['danger']).toEqual({ literal: editedLiteral });
+    // Untouched semantic entries fall back to the baseline unchanged.
+    expect(result.state.color.semanticMappings['warning']).toEqual({
+      literal: SEMANTIC_LITERALS.warning,
+    });
+  });
+
+  it('the edited { literal } value survives a localStorage persist -> hydrate round-trip', () => {
+    const persistColor = vi.fn();
+    const baseState = makeLoneSemanticState();
+    renderColorTab(LONE_SEMANTIC_TAB, baseState, { persistColor });
+
+    openFirstSemanticLiteralSwatch();
+    fireFirstPickerSliderArrow();
+
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const editedColorState = updater(baseState);
+    const editedLiteral = (editedColorState.semanticMappings['danger'] as { literal: string })
+      .literal;
+
+    const storage = makeStorage();
+    const fullState: TweakState = {
+      color: editedColorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    savePersistedState(fullState, storage);
+
+    const cluster = getActivePrimaryCluster();
+    const loaded = loadPersistedState(storage, baseState, cluster);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.color.semanticMappings['danger']).toEqual({ literal: editedLiteral });
+  });
+
+  it('a pre-stored v3 envelope with a { literal } semantic mapping loads unchanged', () => {
+    const storageKey = getStorageKeyV3();
+    const baseState = makeLoneSemanticState();
+    const editedColorState: ColorTweakState = {
+      ...baseState,
+      semanticMappings: {
+        ...baseState.semanticMappings,
+        danger: { literal: 'oklch(0.40 0.18 20)' },
+      },
+    };
+    const v3Payload = {
+      color: editedColorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const storage = makeStorage({ [storageKey]: JSON.stringify(v3Payload) });
+
+    const cluster = getActivePrimaryCluster();
+    const loaded = loadPersistedState(storage, baseState, cluster);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.color.semanticMappings['danger']).toEqual({ literal: 'oklch(0.40 0.18 20)' });
+    // Untouched entries still hydrate from the manifest defaults merge.
+    expect(loaded!.color.semanticMappings['info']).toEqual({ literal: SEMANTIC_LITERALS.info });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Apply — literal verbatim on BOTH the disk emitter and the DOM emitter
+// ---------------------------------------------------------------------------
+
+describe('4. apply writes each --zd-* verbatim on disk (buildApplyOverrides) and DOM (applyColorState)', () => {
+  it('buildApplyOverrides emits the literal oklch() string verbatim for every semantic cssVar', () => {
+    const colorState = makeLoneSemanticState();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const cluster = getActivePrimaryCluster();
+
+    // colorDefaults: undefined forces the whole color block into the diff
+    // (per buildApplyOverrides' documented contract), so every semantic
+    // entry is emitted regardless of baseline comparison.
+    const out = buildApplyOverrides(fullState, undefined, cluster, getPanelConfig().tabs);
+
+    for (const id of SEMANTIC_IDS) {
+      expect(out[SEMANTIC_CSS_VARS[id]]).toBe(SEMANTIC_LITERALS[id]);
+    }
+  });
+
+  it('applyColorState writes the literal oklch() string verbatim to document.documentElement', () => {
+    const colorState = makeLoneSemanticState();
+    const cluster = getActivePrimaryCluster();
+
+    applyColorState(colorState, cluster);
+
+    for (const id of SEMANTIC_IDS) {
+      const written = document.documentElement.style.getPropertyValue(SEMANTIC_CSS_VARS[id]);
+      expect(written).toBe(SEMANTIC_LITERALS[id]);
+    }
+  });
+
+  it('emitter parity: the disk map and the DOM inline style agree byte-for-byte for every semantic cssVar', () => {
+    const colorState = makeLoneSemanticState();
+    const cluster = getActivePrimaryCluster();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, getPanelConfig().tabs);
+    applyColorState(colorState, cluster);
+
+    for (const id of SEMANTIC_IDS) {
+      const cssVar = SEMANTIC_CSS_VARS[id];
+      const domValue = document.documentElement.style.getPropertyValue(cssVar);
+      expect(diskMap[cssVar]).toBe(domValue);
+      expect(diskMap[cssVar]).toBe(SEMANTIC_LITERALS[id]);
+    }
+  });
+
+  it('emitter parity holds for an EDITED literal value too (not just the seeded default)', () => {
+    const baseState = makeLoneSemanticState();
+    const editedColorState: ColorTweakState = {
+      ...baseState,
+      semanticMappings: {
+        ...baseState.semanticMappings,
+        danger: { literal: 'oklch(0.33 0.19 15)' },
+      },
+    };
+    const cluster = getActivePrimaryCluster();
+    const fullState: TweakState = {
+      color: editedColorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    const diskMap = buildApplyOverrides(fullState, baseState, cluster, getPanelConfig().tabs);
+    applyColorState(editedColorState, cluster);
+
+    const domValue = document.documentElement.style.getPropertyValue('--zd-danger');
+    expect(domValue).toBe('oklch(0.33 0.19 15)');
+    expect(diskMap['--zd-danger']).toBe('oklch(0.33 0.19 15)');
+    expect(diskMap['--zd-danger']).toBe(domValue);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Scheme dropdown — no dead functional control for a scheme-less cluster
+// ---------------------------------------------------------------------------
+
+describe('5. Scheme… dropdown has no functional options for a scheme-less lone-tier cluster', () => {
+  it('the preset <select> carries no enabled options beyond the disabled placeholder', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+
+    const select = container.querySelector('.tokenpanel-color-preset-select');
+    // Either the control is absent entirely, or -- if present -- it must not
+    // offer any functional (enabled, selectable) option: only the disabled
+    // "Scheme..." placeholder may exist.
+    if (select === null) {
+      expect(select).toBeNull();
+      return;
+    }
+    const options = Array.from(select.querySelectorAll('option'));
+    const enabledOptions = options.filter((o) => !(o as HTMLOptionElement).disabled);
+    expect(enabledOptions).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Regression — conventional palette+semantic 2-tier color tab unaffected
+// ---------------------------------------------------------------------------
+
+describe('6. regression: a conventional palette+semantic 2-tier color tab is unaffected', () => {
+  it('still renders palette swatches AND index-based PaletteSelector semantic rows', () => {
+    __resetPanelConfigForTests();
+    configurePanel(FIXTURE_PANEL_CONFIG);
+
+    const colorTab = FIXTURE_TABS.find((t) => t.id === 'color')!;
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromScheme(cluster);
+
+    renderColorTab(colorTab, state);
+
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    expect(paletteGrid).not.toBeNull();
+    // FIXTURE_CLUSTER declares a 16-slot palette.
+    expect(paletteGrid.querySelectorAll('.tokenpanel-color-swatch-button').length).toBe(16);
+
+    const semanticGrid = getSemanticGrid();
+    // FIXTURE_CLUSTER declares 3 semantic entries (accent / muted / active),
+    // all legacy palette-index mappings -> all render as PaletteSelector.
+    expect(semanticGrid.querySelectorAll('.tokenpanel-palette-selector').length).toBe(3);
+    expect(semanticGrid.querySelectorAll('[data-testid^="tokenpanel-semantic-literal-"]').length).toBe(
+      0,
+    );
+  });
+});

--- a/packages/zdtp/src/__tests__/issue-458-lone-semantic-tier-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-458-lone-semantic-tier-e2e.test.tsx
@@ -218,11 +218,25 @@ function renderColorTab(
   });
 }
 
-/** The Semantic Tokens grid is the 2nd `.tokenpanel-color-base-grid` (Base is 1st). */
+/**
+ * Locate the Semantic Tokens grid by its section heading rather than a fixed
+ * grid index — the Base section (and its `.tokenpanel-color-base-grid`) is
+ * gated on a non-empty palette (#466 follow-up) and does not render at all
+ * for the lone-semantic-tier fixture, so "2nd base-grid" is no longer a
+ * stable locator for every fixture in this file.
+ */
 function getSemanticGrid(): HTMLElement {
-  const grids = container.querySelectorAll('.tokenpanel-color-base-grid');
-  expect(grids.length).toBeGreaterThanOrEqual(2);
-  return grids[1] as HTMLElement;
+  const headings = Array.from(
+    container.querySelectorAll('[role="heading"][aria-level="3"]'),
+  );
+  const semanticHeading = headings.find((h) =>
+    (h.textContent ?? '').includes('Semantic Tokens'),
+  );
+  expect(semanticHeading).not.toBeUndefined();
+  const section = semanticHeading!.parentElement as HTMLElement;
+  const grid = section.querySelector('.tokenpanel-color-base-grid') as HTMLElement | null;
+  expect(grid).not.toBeNull();
+  return grid!;
 }
 
 /** Open the first literal-semantic swatch (a `ColorField`) in the semantic grid. */
@@ -324,19 +338,48 @@ describe('2. rendering shows editable literal swatches, not palette-index dropdo
     // The Palette section (Section A) maps over `state.palette` directly; it
     // must not expose the semantic tokens as if they were palette slots.
     renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
-    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
-    expect(paletteGrid).not.toBeNull();
-    const labels = Array.from(
-      paletteGrid.querySelectorAll('.tokenpanel-color-swatch-label'),
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement | null;
+    // A lone-semantic-tier cluster has paletteSize 0, so Section A (Palette)
+    // is gated off entirely (#466 follow-up) — there is no grid, not merely
+    // an empty one.
+    expect(paletteGrid).toBeNull();
+  });
+
+  it('#466 follow-up: paletteSize 0 seeds an EMPTY palette, not a phantom 1-slot grayscale', () => {
+    const state = makeLoneSemanticState();
+    expect(state.palette).toEqual([]);
+    expect(state.palette.length).toBe(0);
+  });
+
+  it('#466 follow-up: no phantom --zudo-stub-p0 swatch renders anywhere in the panel', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    // Neither Section A (Palette) nor Section B (Base) renders for a
+    // palette-less cluster, so no swatch/label carries the stub template's
+    // cssVar or references a stub palette slot.
+    const allLabels = Array.from(
+      container.querySelectorAll('.tokenpanel-color-swatch-label'),
     ).map((el) => el.textContent);
-    for (const id of SEMANTIC_IDS) {
-      expect(labels).not.toContain(SEMANTIC_CSS_VARS[id]);
-    }
-    // Crucially, the palette grid never shows N (one per semantic token)
-    // swatches — there is no palette backing this lone-semantic-tier cluster.
-    expect(paletteGrid.querySelectorAll('.tokenpanel-color-swatch-button').length).not.toBe(
-      SEMANTIC_IDS.length,
-    );
+    expect(allLabels.some((l) => (l ?? '').includes('--zudo-stub-p'))).toBe(false);
+    expect(container.querySelectorAll('.tokenpanel-color-palette-grid').length).toBe(0);
+    expect(container.querySelectorAll('.tokenpanel-color-base-grid').length).toBe(1); // Semantic Tokens grid only — no Base grid.
+  });
+
+  it('#466 follow-up: neither emitter (disk / DOM) writes a --zudo-stub-p* key', () => {
+    const colorState = makeLoneSemanticState();
+    const cluster = getActivePrimaryCluster();
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, getPanelConfig().tabs);
+    expect(Object.keys(diskMap).some((k) => k.startsWith('--zudo-stub-p'))).toBe(false);
+
+    applyColorState(colorState, cluster);
+    const inlineStyle = document.documentElement.getAttribute('style') ?? '';
+    expect(inlineStyle).not.toMatch(/--zudo-stub-p\d/);
   });
 });
 

--- a/packages/zdtp/src/__tests__/issue-459-crosstab-ref-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-459-crosstab-ref-e2e.test.tsx
@@ -577,7 +577,7 @@ describe('5. validation: a bad referencesRamps source or a bad per-row ref throw
     ).toThrow(/item "no-such-item" not found in tier "base"/);
   });
 
-  it('an unresolvable per-row { ref } degrades gracefully at apply time: skipped on disk, #000000 fallback in the DOM', () => {
+  it('an unresolvable per-row { ref } degrades gracefully at apply time: skipped on BOTH disk and DOM (no black paint)', () => {
     const baseState = makeCrosstabState();
     const badState: ColorTweakState = {
       ...baseState,
@@ -592,8 +592,12 @@ describe('5. validation: a bad referencesRamps source or a bad per-row ref throw
     const diskMap = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
     expect(diskMap['--zd-surface']).toBeUndefined();
 
+    // Isolate from any residue a sibling test left on the shared documentElement.
+    document.documentElement.style.removeProperty('--zd-surface');
     applyColorState(badState, cluster, undefined, COLOR_TAB, ALL_TABS);
-    expect(document.documentElement.style.getPropertyValue('--zd-surface')).toBe('#000000');
+    // DOM now skips the unresolvable ref too — token stays at its default,
+    // never painted black — matching the disk emitter (review fix).
+    expect(document.documentElement.style.getPropertyValue('--zd-surface')).toBe('');
   });
 });
 

--- a/packages/zdtp/src/__tests__/issue-459-crosstab-ref-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-459-crosstab-ref-e2e.test.tsx
@@ -1,0 +1,677 @@
+// @vitest-environment jsdom
+
+/**
+ * Cross-tab semantic ref cascade — end-to-end confirm (S10, #471, closing out
+ * the Wave-3 sequence for epic #459).
+ *
+ * Wave 3 (#467-#470) added the ability for a `semantic: true` tier to point a
+ * mapping at a ramp item living in ANOTHER tab (typically a grouped Palette
+ * tab), instead of only a literal color or an intra-tab palette index:
+ *
+ *   - `TierConfig.referencesRamps` declares which ramp tier(s) (optionally in
+ *     another tab) a semantic tier's `{ ref }` mappings may point into (#467).
+ *   - `SemanticValue` gained the `{ ref: { tab?, tier, item } }` variant, and
+ *     `resolveRefToCssVar` (`apply/tier-resolver.ts`) resolves it to the
+ *     target item's bare `cssVar` (#467).
+ *   - Both emitters — the disk emitter (`buildApplyOverrides`) and the DOM
+ *     emitter (`applyColorState`/`resolveSemanticCssValue`) — wrap that
+ *     cssVar in `var(...)` so the written custom property is a live CSS
+ *     reference, not a snapshot (#468).
+ *   - `configurePanel` validates every `referencesRamps` SOURCE declaration up
+ *     front — unknown tab/tier throws a clear configure-time error (#469).
+ *   - `TierRefSelector` renders a grouped ref-or-literal `<select>` (one
+ *     `<optgroup>` per declared ramp source) and `color-tab.tsx` routes a
+ *     `referencesRamps`-declaring tier's rows through it via
+ *     `SemanticRefOrLiteralRow` (#470).
+ *
+ * Each of #467-#470 has its own unit-level test file (`tier-resolver.test.ts`,
+ * `build-apply-overrides.test.ts`'s S7b section, `panel-config.test.ts`,
+ * `tier-ref-selector.test.tsx`). This file is the S10 confirm: it proves the
+ * whole stack works together — configure -> resolve -> render -> apply (disk
+ * + DOM, parity) -> the actual var()-indirection cascade -> validation -> the
+ * pre-existing literal/legacy paths are unaffected — through one fixture that
+ * ships BOTH a grouped Palette tab (the ramp source) and a Color tab whose
+ * semantic tier declares `referencesRamps` into it, wired through
+ * `configurePanel` exactly as a real host would.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+
+import ColorTab from '../tabs/color-tab';
+import {
+  __resetPanelConfigForTests,
+  assertValidPanelConfig,
+  configurePanel,
+  getPanelConfig,
+  type PanelConfig,
+} from '../config/panel-config';
+import { resolveColorClusterFromTab } from '../config/cluster-config';
+import {
+  applyColorState,
+  applyFullState,
+  getActivePrimaryCluster,
+  initColorFromScheme,
+  type ColorTweakState,
+  type TweakState,
+} from '../state/tweak-state';
+import { buildApplyOverrides } from '../apply/build-apply-overrides';
+import { resolveRefToCssVar, TierResolverError } from '../apply/tier-resolver';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from '../highlight/highlight-toggle-button';
+import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../highlight/highlight-state';
+import { TooltipProvider } from '../controls/tooltip';
+import type { TabConfig } from '../tokens/tier-model';
+import type { PersistColor, PersistSecondary } from '../state/persist';
+import { FIXTURE_TABS, FIXTURE_PANEL_CONFIG } from './_test-helpers';
+
+// ---------------------------------------------------------------------------
+// FIXTURE — a grouped Palette tab (ramp source) + a Color tab whose semantic
+// tier declares referencesRamps into it (3 sources: base/accent/state).
+// ---------------------------------------------------------------------------
+
+/**
+ * The ramp-source tab. No `colorExtras` — it is never itself a color
+ * cluster's primary tab, only a source of ramp items for another tab's
+ * semantic tier. Three tiers so the grouped picker renders three distinct
+ * `<optgroup>`s (base/accent/state), matching real-world "palette split into
+ * named ramps" manifests.
+ */
+const PALETTE_TAB: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.9 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.8 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-3', cssVar: '--palette-base-3', label: 'Base 3', default: 'oklch(0.7 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-4', cssVar: '--palette-base-4', label: 'Base 4', default: 'oklch(0.2 0 0)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-0', cssVar: '--palette-accent-0', label: 'Accent 0', default: 'oklch(0.65 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-1', cssVar: '--palette-accent-1', label: 'Accent 1', default: 'oklch(0.55 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-2', cssVar: '--palette-accent-2', label: 'Accent 2', default: 'oklch(0.45 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'state',
+      label: 'State',
+      items: [
+        { id: 'state-0', cssVar: '--palette-state-0', label: 'State 0', default: 'oklch(0.6 0.22 25)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'state-1', cssVar: '--palette-state-1', label: 'State 1', default: 'oklch(0.75 0.15 140)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+/**
+ * The Color tab: a lone `semantic: true` tier (no palette tier of its own —
+ * every mapping either references the Palette tab's ramps or is a standalone
+ * literal). Three semantic rows exercise the three `SemanticValue` shapes
+ * that can appear side by side on a `referencesRamps` tier:
+ *
+ *   - `surface` — `default: 'base-3'`, a bare ramp-item id. Convention: a bare
+ *     id (no `tierId:` prefix) resolves against the tier's FIRST declared
+ *     ramp source (`referencesRamps[0]` = base) — see
+ *     `deriveRampRef`/`deriveSemanticValue` in `config/cluster-config.ts`.
+ *   - `brand` — `default: 'accent:accent-1'`, the `"tierId:itemId"` form that
+ *     picks a NON-first ramp source by name.
+ *   - `danger` — `default: 'oklch(0.55 0.22 25)'`, a literal color. Proves a
+ *     `referencesRamps`-declaring tier still supports plain literal rows
+ *     side by side with ref rows (the #464 literal path is not disturbed by
+ *     Wave 3).
+ */
+const COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'crosstab-e2e',
+    label: 'Crosstab E2E',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [
+        { tab: 'palette', tier: 'base' },
+        { tab: 'palette', tier: 'accent' },
+        { tab: 'palette', tier: 'state' },
+      ],
+      items: [
+        {
+          id: 'surface',
+          cssVar: '--zd-surface',
+          label: 'Surface',
+          default: 'base-3',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'brand',
+          cssVar: '--zd-brand',
+          label: 'Brand',
+          default: 'accent:accent-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'danger',
+          cssVar: '--zd-danger',
+          label: 'Danger',
+          default: 'oklch(0.55 0.22 25)',
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+const ALL_TABS: readonly TabConfig[] = [PALETTE_TAB, COLOR_TAB];
+
+const CROSSTAB_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'issue-459-e2e',
+  consoleNamespace: 'issue-459-e2e',
+  modalClassPrefix: 'issue-459-e2e-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'issue-459-e2e-tokens',
+  tabs: ALL_TABS,
+  colorPresets: {},
+};
+
+// ---------------------------------------------------------------------------
+// HELPERS
+// ---------------------------------------------------------------------------
+
+function makeHighlightState(): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    outlineWidth: 2,
+    active: {},
+  };
+}
+
+function makeCtx(state: HighlightState, toggle: (cssVar: string) => void): HighlightContextValue {
+  return { state, toggle };
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+  configurePanel(CROSSTAB_PANEL_CONFIG);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  document.documentElement.removeAttribute('style');
+});
+
+afterEach(() => {
+  act(() => {
+    render(null, container);
+  });
+  document.body.removeChild(container);
+  document.documentElement.removeAttribute('style');
+  __resetPanelConfigForTests();
+  vi.restoreAllMocks();
+});
+
+/** Render ColorTab wrapped in TooltipProvider and HighlightContext. */
+function renderColorTab(
+  tab: TabConfig,
+  state: ColorTweakState,
+  opts: { persistColor?: PersistColor; persistSecondary?: PersistSecondary } = {},
+): void {
+  const { persistColor = vi.fn(), persistSecondary = vi.fn() } = opts;
+  const ctx = makeCtx(makeHighlightState(), vi.fn());
+  act(() => {
+    render(
+      <TooltipProvider>
+        <HighlightContext.Provider value={ctx}>
+          <ColorTab
+            tab={tab}
+            state={state}
+            persistColor={persistColor}
+            secondaryTab={null}
+            secondaryState={null}
+            persistSecondary={persistSecondary}
+          />
+        </HighlightContext.Provider>
+      </TooltipProvider>,
+      container,
+    );
+  });
+}
+
+function makeCrosstabState(): ColorTweakState {
+  const cluster = getActivePrimaryCluster();
+  return initColorFromScheme(cluster);
+}
+
+/** Locate a semantic row's `<select>` by its row data-testid. */
+function getSemanticRefSelect(idKey: string): HTMLSelectElement {
+  const row = container.querySelector(`[data-testid="tokenpanel-semantic-ref-${idKey}"]`);
+  expect(row).not.toBeNull();
+  const select = row!.querySelector('select.tokenpanel-tier-ref-select') as HTMLSelectElement;
+  expect(select).not.toBeNull();
+  return select;
+}
+
+/** Fire a native change event on a select element, setting its value first. */
+function fireSelectChange(select: HTMLSelectElement, newValue: string) {
+  act(() => {
+    Object.defineProperty(select, 'value', { value: newValue, writable: true, configurable: true });
+    select.value = newValue;
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+/** Locate the "Semantic Tokens" grid by its section heading (not a fixed
+ * grid index — the Base section renders its own `.tokenpanel-color-base-grid`
+ * sibling with two more `.tokenpanel-palette-selector` rows of its own for
+ * the background/foreground base roles, so an unscoped count would double
+ * count them). Mirrors `issue-458-lone-semantic-tier-e2e.test.tsx`'s helper
+ * of the same name. */
+function getSemanticGrid(): HTMLElement {
+  const headings = Array.from(container.querySelectorAll('[role="heading"][aria-level="3"]'));
+  const semanticHeading = headings.find((h) => (h.textContent ?? '').includes('Semantic Tokens'));
+  expect(semanticHeading).not.toBeUndefined();
+  const section = semanticHeading!.parentElement as HTMLElement;
+  const grid = section.querySelector('.tokenpanel-color-base-grid') as HTMLElement | null;
+  expect(grid).not.toBeNull();
+  return grid!;
+}
+
+function findOptionByText(select: HTMLSelectElement, needle: string): HTMLOptionElement {
+  const opt = Array.from(select.querySelectorAll('option')).find((o) =>
+    (o.textContent ?? '').includes(needle),
+  );
+  if (!opt) throw new Error(`no option with text containing "${needle}" in select`);
+  return opt;
+}
+
+// ---------------------------------------------------------------------------
+// 1. configurePanel + resolveColorClusterFromTab
+// ---------------------------------------------------------------------------
+
+describe('1. configurePanel accepts the palette + referencesRamps color tab pair', () => {
+  it('does NOT throw', () => {
+    __resetPanelConfigForTests();
+    expect(() => configurePanel(CROSSTAB_PANEL_CONFIG)).not.toThrow();
+  });
+
+  it('resolves the bare-id ramp ref ("surface": "base-3") against the FIRST declared ramp source', () => {
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, ALL_TABS)!;
+    expect(cluster).toBeDefined();
+    expect(cluster.semanticDefaults['surface']).toEqual({
+      ref: { tab: 'palette', tier: 'base', item: 'base-3' },
+    });
+  });
+
+  it('resolves the "tierId:itemId" ramp ref ("brand": "accent:accent-1") against the NAMED ramp source', () => {
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, ALL_TABS)!;
+    expect(cluster.semanticDefaults['brand']).toEqual({
+      ref: { tab: 'palette', tier: 'accent', item: 'accent-1' },
+    });
+  });
+
+  it('resolves the literal default ("danger") to a { literal } SemanticValue, unaffected by referencesRamps', () => {
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, ALL_TABS)!;
+    expect(cluster.semanticDefaults['danger']).toEqual({ literal: 'oklch(0.55 0.22 25)' });
+  });
+
+  it('paletteSize is 0 for the lone-semantic Color tab (no palette tier of its own)', () => {
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, ALL_TABS)!;
+    expect(cluster.paletteSize).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Emitter parity — disk (buildApplyOverrides) vs. DOM (applyColorState)
+// ---------------------------------------------------------------------------
+
+describe('2. both emitters emit var(--palette-base-3) for the resolved cross-tab ref, and agree with each other', () => {
+  it('buildApplyOverrides emits var(...) for each ref row and the literal verbatim for the literal row', () => {
+    const colorState = makeCrosstabState();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+    const cluster = getActivePrimaryCluster();
+
+    const out = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
+
+    expect(out['--zd-surface']).toBe('var(--palette-base-3)');
+    expect(out['--zd-brand']).toBe('var(--palette-accent-1)');
+    expect(out['--zd-danger']).toBe('oklch(0.55 0.22 25)');
+  });
+
+  it('applyColorState writes the identical values to document.documentElement', () => {
+    const colorState = makeCrosstabState();
+    const cluster = getActivePrimaryCluster();
+
+    applyColorState(colorState, cluster, undefined, COLOR_TAB, ALL_TABS);
+
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue('--zd-surface')).toBe('var(--palette-base-3)');
+    expect(root.getPropertyValue('--zd-brand')).toBe('var(--palette-accent-1)');
+    expect(root.getPropertyValue('--zd-danger')).toBe('oklch(0.55 0.22 25)');
+  });
+
+  it('disk and DOM outputs agree byte-for-byte for every semantic cssVar (ref rows AND the literal row)', () => {
+    const colorState = makeCrosstabState();
+    const cluster = getActivePrimaryCluster();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
+    applyColorState(colorState, cluster, undefined, COLOR_TAB, ALL_TABS);
+
+    for (const cssVar of ['--zd-surface', '--zd-brand', '--zd-danger']) {
+      const domValue = document.documentElement.style.getPropertyValue(cssVar);
+      expect(diskMap[cssVar]).toBe(domValue);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Cascade — the var() indirection actually points at a live ramp value
+// ---------------------------------------------------------------------------
+
+describe('3. cascade: --zd-surface indirects through var(--palette-base-3) to the ramp value', () => {
+  it('applyFullState (the real apply path, resolving currentTab/tabs from panel config) writes the var() reference, not a resolved snapshot', () => {
+    const cluster = getActivePrimaryCluster();
+    const colorState = initColorFromScheme(cluster);
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+
+    expect(document.documentElement.style.getPropertyValue('--zd-surface')).toBe(
+      'var(--palette-base-3)',
+    );
+  });
+
+  it('jsdom cannot compute var() substitution on a consuming declaration (documented environment limit, not a panel bug)', () => {
+    // Sanity-check the fallback path this describe block relies on: jsdom's
+    // cssstyle engine returns the literal `var(...)` text for any property
+    // that references a custom property — it never substitutes the target's
+    // value. This is a jsdom limitation (confirmed independently), not
+    // something the panel's apply logic could paper over from inside jsdom.
+    document.documentElement.style.setProperty('--palette-base-3', 'oklch(0.5 0.1 30)');
+    const probe = document.createElement('div');
+    document.body.appendChild(probe);
+    probe.style.setProperty('background-color', 'var(--palette-base-3)');
+    expect(getComputedStyle(probe).backgroundColor).toBe('var(--palette-base-3)');
+    probe.remove();
+  });
+
+  it('changing --palette-base-3 on :root (documentElement) changes the RESOLUTION TARGET\'s value while the emitted reference form stays the same', () => {
+    const cluster = getActivePrimaryCluster();
+    const colorState = initColorFromScheme(cluster);
+
+    // Seed the ramp source to a known concrete value, then apply.
+    document.documentElement.style.setProperty('--palette-base-3', 'oklch(0.7 0 0)');
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+
+    // The written semantic token is the reference form...
+    expect(document.documentElement.style.getPropertyValue('--zd-surface')).toBe(
+      'var(--palette-base-3)',
+    );
+    // ...and the target it points at holds the seeded concrete value. jsdom
+    // correctly reports a custom property's OWN computed value even though it
+    // cannot substitute var() inside a consuming declaration (see the
+    // preceding test) — this is enough to prove the indirection targets a
+    // live, changeable value rather than a baked-in literal.
+    expect(
+      getComputedStyle(document.documentElement).getPropertyValue('--palette-base-3').trim(),
+    ).toBe('oklch(0.7 0 0)');
+
+    // Change the ramp source to a different concrete color and re-apply.
+    document.documentElement.style.setProperty('--palette-base-3', 'oklch(0.3 0.1 300)');
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+
+    // The reference form emitted for --zd-surface is UNCHANGED (still a live
+    // pointer, not re-baked per apply)...
+    expect(document.documentElement.style.getPropertyValue('--zd-surface')).toBe(
+      'var(--palette-base-3)',
+    );
+    // ...but the value the pointer resolves against has genuinely changed —
+    // this is the whole point of the var() indirection: --zd-surface's
+    // effective color changes whenever --palette-base-3 changes, with no
+    // further apply-side work required.
+    expect(
+      getComputedStyle(document.documentElement).getPropertyValue('--palette-base-3').trim(),
+    ).toBe('oklch(0.3 0.1 300)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Rendering — grouped picker shows optgroups per ramp tier; edits reflect
+// ---------------------------------------------------------------------------
+
+describe('4. the rendered grouped picker groups by ramp tier and reflects edits into state', () => {
+  it('the "surface" row selects the Base optgroup option matching its resolved ref (base-3)', () => {
+    renderColorTab(COLOR_TAB, makeCrosstabState());
+    const select = getSemanticRefSelect('surface');
+
+    const groups = Array.from(select.querySelectorAll('optgroup'));
+    expect(groups.map((g) => g.label)).toEqual(['Base', 'Accent', 'State']);
+    expect(groups[0].querySelectorAll('option').length).toBe(5); // base-0..4
+    expect(groups[1].querySelectorAll('option').length).toBe(3); // accent-0..2
+    expect(groups[2].querySelectorAll('option').length).toBe(2); // state-0..1
+
+    const selected = Array.from(select.querySelectorAll('option')).find((o) => o.selected);
+    expect(selected?.textContent).toContain('--palette-base-3');
+  });
+
+  it('the "brand" row selects the Accent optgroup option matching its resolved ref (accent-1)', () => {
+    renderColorTab(COLOR_TAB, makeCrosstabState());
+    const select = getSemanticRefSelect('brand');
+    const selected = Array.from(select.querySelectorAll('option')).find((o) => o.selected);
+    expect(selected?.textContent).toContain('--palette-accent-1');
+  });
+
+  it('the "danger" row (literal, on a referencesRamps tier) shows "Literal…" selected and an editable swatch', () => {
+    renderColorTab(COLOR_TAB, makeCrosstabState());
+    const select = getSemanticRefSelect('danger');
+    const selected = Array.from(select.querySelectorAll('option')).find((o) => o.selected);
+    expect(selected?.textContent).toContain('Literal');
+
+    const row = container.querySelector('[data-testid="tokenpanel-semantic-ref-danger"]')!;
+    const swatch = row.querySelector('.tokenpanel-color-field-swatch') as HTMLElement;
+    expect(swatch).not.toBeNull();
+    expect(swatch.style.backgroundColor).toBe('oklch(0.55 0.22 25)');
+  });
+
+  it('selecting a different ramp option for "surface" persists a new { ref } mapping', () => {
+    const persistColor = vi.fn();
+    const baseState = makeCrosstabState();
+    renderColorTab(COLOR_TAB, baseState, { persistColor });
+
+    const select = getSemanticRefSelect('surface');
+    fireSelectChange(select, findOptionByText(select, '--palette-accent-2').value);
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(baseState);
+    expect(result.semanticMappings['surface']).toEqual({
+      ref: { tab: 'palette', tier: 'accent', item: 'accent-2' },
+    });
+  });
+
+  it('selecting "Literal…" for "surface" persists a { literal } mapping seeded from the resolved preview', () => {
+    const persistColor = vi.fn();
+    const baseState = makeCrosstabState();
+    renderColorTab(COLOR_TAB, baseState, { persistColor });
+
+    const select = getSemanticRefSelect('surface');
+    fireSelectChange(select, findOptionByText(select, 'Literal').value);
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(baseState);
+    const mapping = result.semanticMappings['surface'];
+    expect(mapping).toEqual({ literal: expect.stringMatching(/^oklch\(/) });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Validation — bad referencesRamps sources / bad per-row refs throw
+// ---------------------------------------------------------------------------
+
+describe('5. validation: a bad referencesRamps source or a bad per-row ref throws a clear error', () => {
+  // Configure-time validation of the `referencesRamps` SOURCE declaration
+  // (as opposed to a per-row `{ ref }` VALUE, tested below) is performed by
+  // `assertValidPanelConfig` — the same trust-boundary validator #469's own
+  // tests exercise (`panel-config.test.ts`). `configurePanel` itself does
+  // NOT re-run this validation (it is invoked by the host-adapter at the
+  // untrusted-JSON boundary before `configurePanel` is ever called), so
+  // asserting against `configurePanel` here would not exercise #469 at all.
+  it('assertValidPanelConfig throws when referencesRamps names a tab that does not exist', () => {
+    const badColorTab: TabConfig = {
+      ...COLOR_TAB,
+      tiers: [
+        {
+          ...COLOR_TAB.tiers[0],
+          referencesRamps: [{ tab: 'no-such-tab', tier: 'base' }],
+        },
+      ],
+    };
+    expect(() =>
+      assertValidPanelConfig({ ...CROSSTAB_PANEL_CONFIG, tabs: [PALETTE_TAB, badColorTab] }),
+    ).toThrow(/tab "no-such-tab" does not exist/);
+  });
+
+  it('assertValidPanelConfig throws when referencesRamps names a tier that does not exist in the target tab', () => {
+    const badColorTab: TabConfig = {
+      ...COLOR_TAB,
+      tiers: [
+        {
+          ...COLOR_TAB.tiers[0],
+          referencesRamps: [{ tab: 'palette', tier: 'no-such-tier' }],
+        },
+      ],
+    };
+    expect(() =>
+      assertValidPanelConfig({ ...CROSSTAB_PANEL_CONFIG, tabs: [PALETTE_TAB, badColorTab] }),
+    ).toThrow(/tier "no-such-tier" does not exist in tab "palette"/);
+  });
+
+  it('resolveRefToCssVar throws when a per-row { ref } names an item that does not exist in the target tier', () => {
+    expect(() =>
+      resolveRefToCssVar({ tab: 'palette', tier: 'base', item: 'no-such-item' }, COLOR_TAB, ALL_TABS),
+    ).toThrow(TierResolverError);
+    expect(() =>
+      resolveRefToCssVar({ tab: 'palette', tier: 'base', item: 'no-such-item' }, COLOR_TAB, ALL_TABS),
+    ).toThrow(/item "no-such-item" not found in tier "base"/);
+  });
+
+  it('an unresolvable per-row { ref } degrades gracefully at apply time: skipped on disk, #000000 fallback in the DOM', () => {
+    const baseState = makeCrosstabState();
+    const badState: ColorTweakState = {
+      ...baseState,
+      semanticMappings: {
+        ...baseState.semanticMappings,
+        surface: { ref: { tab: 'palette', tier: 'base', item: 'no-such-item' } },
+      },
+    };
+    const fullState: TweakState = { color: badState, spacing: {}, typography: {}, size: {} };
+    const cluster = getActivePrimaryCluster();
+
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
+    expect(diskMap['--zd-surface']).toBeUndefined();
+
+    applyColorState(badState, cluster, undefined, COLOR_TAB, ALL_TABS);
+    expect(document.documentElement.style.getPropertyValue('--zd-surface')).toBe('#000000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Regression — literal semantic rows (#464) and the conventional
+// palette+semantic 2-tier cluster (legacy index mappings) still work.
+// ---------------------------------------------------------------------------
+
+describe('6. regression: pre-Wave-3 semantic mapping shapes are unaffected', () => {
+  it('a lone semantic:true tier with NO referencesRamps still renders literal rows through SemanticLiteralRow (#464)', () => {
+    __resetPanelConfigForTests();
+    const loneLiteralColorTab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_TAB.colorExtras,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          // No referencesRamps — this is the #458/#464 shape, not Wave 3's.
+          items: [
+            {
+              id: 'info',
+              cssVar: '--zd-info',
+              label: 'Info',
+              default: 'oklch(0.6 0.1 230)',
+              type: { kind: 'color', format: 'oklch' },
+            },
+          ],
+        },
+      ],
+    };
+    configurePanel({ ...CROSSTAB_PANEL_CONFIG, tabs: [loneLiteralColorTab] });
+
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromScheme(cluster);
+    renderColorTab(loneLiteralColorTab, state);
+
+    // Literal-only tier -> SemanticLiteralRow (data-testid marker), NOT the
+    // grouped ref-or-literal picker (no `tokenpanel-semantic-ref-*` row, no
+    // <select>).
+    expect(
+      container.querySelector('[data-testid="tokenpanel-semantic-literal-info"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="tokenpanel-semantic-ref-info"]'),
+    ).toBeNull();
+    expect(container.querySelector('select.tokenpanel-tier-ref-select')).toBeNull();
+  });
+
+  it('a conventional 2-tier palette+semantic color tab (legacy index mappings) still renders and applies unchanged', () => {
+    __resetPanelConfigForTests();
+    configurePanel(FIXTURE_PANEL_CONFIG);
+
+    const colorTab = FIXTURE_TABS.find((t) => t.id === 'color')!;
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromScheme(cluster);
+
+    renderColorTab(colorTab, state);
+
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    expect(paletteGrid).not.toBeNull();
+    expect(paletteGrid.querySelectorAll('.tokenpanel-color-swatch-button').length).toBe(16);
+
+    // Legacy index mappings -> PaletteSelector rows, not the grouped picker.
+    // FIXTURE_CLUSTER declares 3 semantic entries (accent / muted / active).
+    expect(getSemanticGrid().querySelectorAll('.tokenpanel-palette-selector').length).toBe(3);
+    expect(container.querySelectorAll('select.tokenpanel-tier-ref-select').length).toBe(0);
+
+    // Apply path: legacy index rows resolve straight to the palette color on
+    // disk AND in the DOM (no var() indirection involved for this shape).
+    const fullState: TweakState = { color: state, spacing: {}, typography: {}, size: {} };
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, getPanelConfig().tabs);
+    applyColorState(state, cluster);
+    expect(diskMap['--fixture-semantic-accent']).toBe('var(--fixture-p6)');
+    expect(document.documentElement.style.getPropertyValue('--fixture-semantic-accent')).toBe(
+      state.palette[6],
+    );
+  });
+});

--- a/packages/zdtp/src/__tests__/issue-459-per-mode-literal-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-459-per-mode-literal-e2e.test.tsx
@@ -1,0 +1,736 @@
+// @vitest-environment jsdom
+
+/**
+ * Per-mode literal light-dark() — end-to-end confirm (S13, #474, closing out
+ * the Wave-4 sequence for epic #459).
+ *
+ * Wave 4 (#472-#473) added a per-mode variant of the `{ literal }` semantic
+ * value:
+ *
+ *   - `SemanticValue` gained the `{ literal: { light: string; dark: string } }`
+ *     shape (in addition to the existing single-mode `{ literal: string }`
+ *     and cross-tab `{ ref }` variants).
+ *   - Both emitters — the disk emitter (`buildApplyOverrides`) and the DOM
+ *     emitter (`applyColorState`/`resolveSemanticCssValue`) — emit a CSS
+ *     `light-dark(<light>, <dark>)` function for this shape so the browser
+ *     resolves the correct side from the applied root's `color-scheme` (#472).
+ *   - `applyColorState` additionally writes `color-scheme: light dark` on the
+ *     applied root whenever any per-mode literal is present, routed through
+ *     the sink for a sink instance so it lands on the sink's own target root,
+ *     never a hardcoded `document.documentElement` (#472).
+ *   - `getClusterDefaultMode` / `resolvePerModeLiteral` /
+ *     `resolveSemanticPreviewColor` give `panelSettings.colorMode.defaultMode`
+ *     a real runtime effect: the flat fallback side used anywhere
+ *     `light-dark()` cannot resolve (a preview swatch, an SSR seed) (#472).
+ *   - `SemanticLiteralRow` (lone semantic tier, no `referencesRamps`) and
+ *     `SemanticRefOrLiteralRow`/`TierRefSelector` (a `referencesRamps`
+ *     tier) both render a "Per-mode" checkbox that expands a single literal
+ *     into an independently-editable light/dark `ColorField` pair (#473).
+ *   - `SCHEMA_V3` serialize/deserialize round-trips the per-mode shape
+ *     verbatim (#462, extended for the per-mode literal by #472/#473's own
+ *     unit suites).
+ *
+ * Each of #472/#473 has its own unit-level test file
+ * (`state/__tests__/per-mode-literal.test.ts`, `tabs/__tests__/color-tab.test.tsx`'s
+ * S12 section, `utils/__tests__/design-token-serde.test.ts`'s SCHEMA_V3 section).
+ * This file is the S13 confirm: it proves the whole stack works together —
+ * configure -> resolve -> render -> apply (disk + DOM, parity) ->
+ * color-scheme routing (normal AND sink instance) -> serde round-trip ->
+ * persist round-trip -> defaultMode fallback -> the pre-existing
+ * single-mode-literal / ref / index paths are unaffected — through one
+ * fixture that ships BOTH a grouped Palette tab (a ramp source, so the ref
+ * regression check is real, not a stub) and a Color tab whose semantic tier
+ * declares `referencesRamps` into it and carries all three post-Wave-4
+ * `SemanticValue` shapes side by side.
+ *
+ * IMPORTANT — jsdom cannot resolve `light-dark()` visually: jsdom's cssstyle
+ * engine returns CSS function values verbatim; it never evaluates
+ * `light-dark()` against a `color-scheme` the way a real browser's rendering
+ * engine does. Every assertion below is on the STRING FORM of the emitted
+ * `light-dark(...)` value and the `color-scheme` declaration that lets a real
+ * browser resolve it — not the resolved color. Actual browser-side resolution
+ * (does the swatch actually turn dark when `color-scheme: dark` is active?)
+ * is a browser/Mac verification concern, out of scope for this jsdom suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'preact';
+import { act } from 'preact/test-utils';
+
+import ColorTab from '../tabs/color-tab';
+import {
+  __resetPanelConfigForTests,
+  assertValidPanelConfig,
+  configurePanel,
+  getPanelConfig,
+  type ApplySink,
+  type PanelConfig,
+} from '../config/panel-config';
+import { resolveColorClusterFromTab } from '../config/cluster-config';
+import {
+  applyColorState,
+  applyFullState,
+  clearAppliedColorStyles,
+  clearAppliedStyles,
+  getActivePrimaryCluster,
+  getClusterDefaultMode,
+  initColorFromScheme,
+  isLiteralMapping,
+  isPerModeLiteral,
+  isRefMapping,
+  loadPersistedState,
+  resolvePerModeLiteral,
+  resolveSemanticPreviewColor,
+  savePersistedState,
+  type ColorTweakState,
+  type StorageLike,
+  type TweakState,
+} from '../state/tweak-state';
+import { buildApplyOverrides } from '../apply/build-apply-overrides';
+import {
+  deserialize,
+  serialize,
+  SCHEMA_V3,
+  type DesignTokenJsonV3,
+} from '../utils/design-token-serde';
+import {
+  HighlightContext,
+  type HighlightContextValue,
+} from '../highlight/highlight-toggle-button';
+import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../highlight/highlight-state';
+import { TooltipProvider } from '../controls/tooltip';
+import type { TabConfig } from '../tokens/tier-model';
+import type { PersistColor, PersistSecondary } from '../state/persist';
+import { FIXTURE_TABS, FIXTURE_PANEL_CONFIG } from './_test-helpers';
+
+// ---------------------------------------------------------------------------
+// FIXTURE — a grouped Palette tab (ramp source) + a Color tab whose lone
+// semantic:true tier declares referencesRamps into it, carrying all three
+// post-Wave-4 SemanticValue shapes side by side:
+//
+//   - `brand`  — { ref }, a cross-tab ramp reference (#468, unaffected by Wave 4)
+//   - `info`   — { literal: string }, a single-mode literal (#465, unaffected)
+//   - `danger` — { literal: { light, dark } }, the Wave-4 per-mode literal
+//
+// `colorMode.defaultMode: 'dark'` is deliberately NOT the library default
+// ('light') so a test asserting the dark side was picked can't pass by
+// accident from an unset/default fallback.
+// ---------------------------------------------------------------------------
+
+const PALETTE_TAB: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.8 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.6 0 0)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+const LIGHT_DANGER = 'oklch(0.505 0.213 27)';
+const DARK_DANGER = 'oklch(0.655 0.213 27)';
+
+const COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'per-mode-e2e',
+    label: 'Per-mode E2E',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: {
+      // Non-empty (though functionally unused — colorSchemes is empty, so
+      // initColorFromScheme short-circuits to initSecondaryDefaults) so this
+      // fixture also passes assertValidPanelConfig, the host-adapter trust
+      // boundary validator (F8), not just configurePanel itself.
+      colorScheme: 'default',
+      colorMode: { defaultMode: 'dark', lightScheme: 'L', darkScheme: 'D' },
+    },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [{ tab: 'palette', tier: 'base' }],
+      items: [
+        {
+          id: 'brand',
+          cssVar: '--zd-brand',
+          label: 'Brand',
+          default: 'base-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'info',
+          cssVar: '--zd-info',
+          label: 'Info',
+          default: 'oklch(0.6 0.1 230)',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'danger',
+          cssVar: '--zd-danger',
+          label: 'Danger',
+          // The manifest default is a single-mode literal (TierItem.default
+          // is a plain string — the per-mode shape only ever arises at
+          // runtime, via the "Per-mode" checkbox, never from a manifest
+          // default). Tests that need a per-mode STATE build it explicitly
+          // via `makePerModeState()` below, matching #472/#473's own suites.
+          default: LIGHT_DANGER,
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+const ALL_TABS: readonly TabConfig[] = [PALETTE_TAB, COLOR_TAB];
+
+const PER_MODE_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'issue-459-per-mode-e2e',
+  consoleNamespace: 'issue-459-per-mode-e2e',
+  modalClassPrefix: 'issue-459-per-mode-e2e-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'issue-459-per-mode-e2e-tokens',
+  tabs: ALL_TABS,
+  colorPresets: {},
+};
+
+// ---------------------------------------------------------------------------
+// HELPERS
+// ---------------------------------------------------------------------------
+
+function makeHighlightState(): HighlightState {
+  return {
+    slots: DEFAULT_HIGHLIGHT_SLOTS.map((s) => ({ ...s })),
+    outlineWidth: 2,
+    active: {},
+  };
+}
+
+function makeCtx(state: HighlightState, toggle: (cssVar: string) => void): HighlightContextValue {
+  return { state, toggle };
+}
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  __resetPanelConfigForTests();
+  configurePanel(PER_MODE_PANEL_CONFIG);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  document.documentElement.removeAttribute('style');
+  localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+});
+
+afterEach(() => {
+  act(() => {
+    render(null, container);
+  });
+  document.body.removeChild(container);
+  document.documentElement.removeAttribute('style');
+  __resetPanelConfigForTests();
+  localStorage.removeItem('tokenpanel.colorPicker.mode');
+  vi.restoreAllMocks();
+});
+
+/** Render ColorTab wrapped in TooltipProvider and HighlightContext. */
+function renderColorTab(
+  tab: TabConfig,
+  state: ColorTweakState,
+  opts: { persistColor?: PersistColor; persistSecondary?: PersistSecondary } = {},
+): void {
+  const { persistColor = vi.fn(), persistSecondary = vi.fn() } = opts;
+  const ctx = makeCtx(makeHighlightState(), vi.fn());
+  act(() => {
+    render(
+      <TooltipProvider>
+        <HighlightContext.Provider value={ctx}>
+          <ColorTab
+            tab={tab}
+            state={state}
+            persistColor={persistColor}
+            secondaryTab={null}
+            secondaryState={null}
+            persistSecondary={persistSecondary}
+          />
+        </HighlightContext.Provider>
+      </TooltipProvider>,
+      container,
+    );
+  });
+}
+
+function makeBaseState(): ColorTweakState {
+  const cluster = getActivePrimaryCluster();
+  return initColorFromScheme(cluster);
+}
+
+/** `makeBaseState()`, with `danger` overridden to the per-mode literal pair. */
+function makePerModeState(): ColorTweakState {
+  const base = makeBaseState();
+  return {
+    ...base,
+    semanticMappings: {
+      ...base.semanticMappings,
+      danger: { literal: { light: LIGHT_DANGER, dark: DARK_DANGER } },
+    },
+  };
+}
+
+function makeSinkSpy(): ApplySink & {
+  applyCalls: Array<ReadonlyArray<readonly [string, string]>>;
+  clearCalls: Array<readonly string[]>;
+} {
+  const applyCalls: Array<ReadonlyArray<readonly [string, string]>> = [];
+  const clearCalls: Array<readonly string[]> = [];
+  return {
+    applyCalls,
+    clearCalls,
+    apply(pairs) {
+      applyCalls.push(pairs);
+    },
+    clear(names) {
+      clearCalls.push(names);
+    },
+  };
+}
+
+function flatApplyPairs(
+  calls: Array<ReadonlyArray<readonly [string, string]>>,
+): Array<readonly [string, string]> {
+  return calls.flat();
+}
+
+function flatClearNames(calls: Array<readonly string[]>): string[] {
+  return calls.flat();
+}
+
+/** In-memory `StorageLike` double for persist round-trip tests (no real localStorage). */
+function makeStorage(): StorageLike & { entries: Record<string, string> } {
+  const entries: Record<string, string> = {};
+  return {
+    entries,
+    getItem: (k) => (k in entries ? entries[k] : null),
+    setItem: (k, v) => {
+      entries[k] = v;
+    },
+    removeItem: (k) => {
+      delete entries[k];
+    },
+  };
+}
+
+/** Locate a semantic row's `<select>` by its row data-testid (grouped/referencesRamps rows). */
+function getSemanticRefSelect(idKey: string): HTMLSelectElement {
+  const row = container.querySelector(`[data-testid="tokenpanel-semantic-ref-${idKey}"]`);
+  expect(row).not.toBeNull();
+  const select = row!.querySelector('select.tokenpanel-tier-ref-select') as HTMLSelectElement;
+  expect(select).not.toBeNull();
+  return select;
+}
+
+/** Nudge the first slider in the open picker with a keyboard arrow — the deterministic
+ *  way to drive a ColorField swatch edit through to onChange under jsdom (pointer
+ *  events on the slider are inert there). Mirrors color-tab.test.tsx's own helper. */
+function fireFirstPickerSliderArrow(key = 'ArrowUp'): void {
+  const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+  if (!slider) throw new Error('no slider in open picker');
+  act(() => {
+    slider.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. configurePanel + resolveColorClusterFromTab
+// ---------------------------------------------------------------------------
+
+describe('1. configurePanel accepts the palette + per-mode-literal color tab pair', () => {
+  it('does NOT throw', () => {
+    __resetPanelConfigForTests();
+    expect(() => configurePanel(PER_MODE_PANEL_CONFIG)).not.toThrow();
+  });
+
+  it('assertValidPanelConfig accepts it too (host-adapter trust boundary)', () => {
+    expect(() => assertValidPanelConfig(PER_MODE_PANEL_CONFIG)).not.toThrow();
+  });
+
+  it('resolves the "danger" manifest default to a single-mode { literal } (per-mode is a runtime-only state, #472/#473)', () => {
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, ALL_TABS)!;
+    expect(cluster.semanticDefaults['danger']).toEqual({ literal: LIGHT_DANGER });
+  });
+
+  it('getClusterDefaultMode reads the configured "dark" default from panelSettings.colorMode', () => {
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, ALL_TABS)!;
+    expect(getClusterDefaultMode(cluster)).toBe('dark');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Emitter parity — disk (buildApplyOverrides) vs. DOM (applyColorState)
+// ---------------------------------------------------------------------------
+
+describe('2. both emitters emit light-dark(...) for the per-mode literal, and agree with each other', () => {
+  it('buildApplyOverrides emits light-dark(<light>, <dark>) for danger, var(...) for the ref, and the literal verbatim for info', () => {
+    const colorState = makePerModeState();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+    const cluster = getActivePrimaryCluster();
+
+    const out = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
+
+    expect(out['--zd-danger']).toBe(`light-dark(${LIGHT_DANGER}, ${DARK_DANGER})`);
+    expect(out['--zd-brand']).toBe('var(--palette-base-1)');
+    expect(out['--zd-info']).toBe('oklch(0.6 0.1 230)');
+  });
+
+  it('applyColorState writes the identical values to document.documentElement', () => {
+    const colorState = makePerModeState();
+    const cluster = getActivePrimaryCluster();
+
+    applyColorState(colorState, cluster, undefined, COLOR_TAB, ALL_TABS);
+
+    const root = document.documentElement.style;
+    expect(root.getPropertyValue('--zd-danger')).toBe(`light-dark(${LIGHT_DANGER}, ${DARK_DANGER})`);
+    expect(root.getPropertyValue('--zd-brand')).toBe('var(--palette-base-1)');
+    expect(root.getPropertyValue('--zd-info')).toBe('oklch(0.6 0.1 230)');
+  });
+
+  it('disk and DOM outputs agree byte-for-byte for every semantic cssVar', () => {
+    const colorState = makePerModeState();
+    const cluster = getActivePrimaryCluster();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
+    applyColorState(colorState, cluster, undefined, COLOR_TAB, ALL_TABS);
+
+    for (const cssVar of ['--zd-danger', '--zd-brand', '--zd-info']) {
+      const domValue = document.documentElement.style.getPropertyValue(cssVar);
+      expect(diskMap[cssVar]).toBe(domValue);
+    }
+  });
+
+  it('the disk emitter never emits a "color-scheme" entry — that is a DOM-only apply-time concern', () => {
+    const colorState = makePerModeState();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+    const cluster = getActivePrimaryCluster();
+
+    const out = buildApplyOverrides(fullState, undefined, cluster, ALL_TABS);
+    expect(out['color-scheme']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. color-scheme routing — normal instance (documentElement) vs. sink instance
+// ---------------------------------------------------------------------------
+
+describe('3. color-scheme: light dark is set on the correct root', () => {
+  it('a normal instance sets color-scheme on document.documentElement', () => {
+    const colorState = makePerModeState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+  });
+
+  it('a state with only single-mode literals / refs (no per-mode) sets NO color-scheme', () => {
+    const colorState = makeBaseState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('a sink instance routes color-scheme through the sink to ITS OWN target root, never :root', () => {
+    const sink = makeSinkSpy();
+    const sinkCfg: PanelConfig = { ...PER_MODE_PANEL_CONFIG, applySink: sink };
+    __resetPanelConfigForTests();
+    configurePanel(sinkCfg);
+
+    const colorState = makePerModeState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} }, sinkCfg);
+
+    const colorScheme = flatApplyPairs(sink.applyCalls).find(([name]) => name === 'color-scheme');
+    expect(colorScheme).toEqual(['color-scheme', 'light dark']);
+
+    const danger = flatApplyPairs(sink.applyCalls).find(([name]) => name === '--zd-danger');
+    expect(danger?.[1]).toBe(`light-dark(${LIGHT_DANGER}, ${DARK_DANGER})`);
+
+    // :root (the host document) was never touched by the sink path.
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--zd-danger')).toBe('');
+
+    // Re-configure back to the non-sink fixture so afterEach's reset is clean.
+    __resetPanelConfigForTests();
+    configurePanel(PER_MODE_PANEL_CONFIG);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Serde round-trip (SCHEMA_V3) and persist round-trip (save -> load)
+// ---------------------------------------------------------------------------
+
+describe('4. per-mode literal round-trips through serde and persist', () => {
+  it('serialize upgrades to SCHEMA_V3 and emits the per-mode { literal: { light, dark } } leaf verbatim', () => {
+    const colorState = makePerModeState();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+
+    const json = serialize(fullState, { colorDefaults: makeBaseState() }) as DesignTokenJsonV3;
+    expect(json.$schema).toBe(SCHEMA_V3);
+    const semMap = json.tabs?.['color']?.['semantic'];
+    expect(semMap).toMatchObject({
+      '--zd-danger': { literal: { light: LIGHT_DANGER, dark: DARK_DANGER } },
+    });
+  });
+
+  it('deserialize reconstructs the identical per-mode mapping from the serialized JSON', () => {
+    const colorState = makePerModeState();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+    const colorDefaults = makeBaseState();
+
+    const json = serialize(fullState, { colorDefaults });
+    const { state, unknownTokens, warnings } = deserialize(JSON.parse(JSON.stringify(json)), {
+      colorDefaults,
+    });
+
+    expect(unknownTokens).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(state.color.semanticMappings.danger).toEqual({
+      literal: { light: LIGHT_DANGER, dark: DARK_DANGER },
+    });
+  });
+
+  it('savePersistedState -> loadPersistedState round-trips the per-mode mapping (no real localStorage involved)', () => {
+    const colorState = makePerModeState();
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+    const storage = makeStorage();
+
+    savePersistedState(fullState, storage);
+    const loaded = loadPersistedState(storage, colorState, getActivePrimaryCluster());
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.color.semanticMappings.danger).toEqual({
+      literal: { light: LIGHT_DANGER, dark: DARK_DANGER },
+    });
+    // The ref and single-mode-literal mappings persisted alongside it too.
+    expect(loaded!.color.semanticMappings.brand).toEqual({
+      ref: { tab: 'palette', tier: 'base', item: 'base-1' },
+    });
+    expect(loaded!.color.semanticMappings.info).toEqual({ literal: 'oklch(0.6 0.1 230)' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. defaultMode selects the correct preview / fallback color
+// ---------------------------------------------------------------------------
+
+describe('5. defaultMode (getClusterDefaultMode) selects the preview/fallback side', () => {
+  it('resolveSemanticPreviewColor collapses the per-mode literal to the cluster defaultMode side ("dark")', () => {
+    const colorState = makePerModeState();
+    const cluster = getActivePrimaryCluster();
+    const mapping = colorState.semanticMappings.danger;
+
+    const preview = resolveSemanticPreviewColor(mapping, colorState, cluster);
+    expect(preview).toBe(DARK_DANGER);
+  });
+
+  it('resolvePerModeLiteral selects either side directly, independent of defaultMode', () => {
+    const value = { literal: { light: LIGHT_DANGER, dark: DARK_DANGER } };
+    expect(resolvePerModeLiteral(value, 'light')).toBe(LIGHT_DANGER);
+    expect(resolvePerModeLiteral(value, 'dark')).toBe(DARK_DANGER);
+  });
+
+  it('a single-mode literal and a ref preview unaffected by defaultMode (regression)', () => {
+    const colorState = makePerModeState();
+    const cluster = getActivePrimaryCluster();
+    expect(
+      resolveSemanticPreviewColor(colorState.semanticMappings.info, colorState, cluster),
+    ).toBe('oklch(0.6 0.1 230)');
+    expect(
+      resolveSemanticPreviewColor(
+        colorState.semanticMappings.brand,
+        colorState,
+        cluster,
+        COLOR_TAB,
+        ALL_TABS,
+      ),
+    ).toBe('var(--palette-base-1)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Rendering — the per-mode row shows the light/dark editor; edits persist
+//    independently; sibling ref/literal rows are unaffected.
+// ---------------------------------------------------------------------------
+
+describe('6. rendering: the per-mode row shows a checked "Per-mode" toggle and two independently-editable swatches', () => {
+  it('the "danger" row (per-mode) shows a CHECKED Per-mode checkbox and two color-field swatches', () => {
+    renderColorTab(COLOR_TAB, makePerModeState());
+
+    const row = container.querySelector('[data-testid="tokenpanel-semantic-ref-danger"]')!;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(true);
+    expect(row.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(2);
+  });
+
+  it('editing the Light swatch persists only the light side, leaving dark untouched', () => {
+    const persistColor = vi.fn();
+    const baseState = makePerModeState();
+    renderColorTab(COLOR_TAB, baseState, { persistColor });
+
+    const row = container.querySelector('[data-testid="tokenpanel-semantic-ref-danger"]')!;
+    const lightSwatch = row.querySelector(
+      '[aria-label="--zd-danger (Light): --zd-danger"]',
+    ) as HTMLElement;
+    expect(lightSwatch).not.toBeNull();
+    act(() => lightSwatch.click());
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(baseState);
+    expect(result.semanticMappings.danger).toEqual({
+      literal: { light: expect.stringMatching(/^oklch\(/), dark: DARK_DANGER },
+    });
+  });
+
+  it('editing the Dark swatch persists only the dark side, leaving light untouched', () => {
+    const persistColor = vi.fn();
+    const baseState = makePerModeState();
+    renderColorTab(COLOR_TAB, baseState, { persistColor });
+
+    const row = container.querySelector('[data-testid="tokenpanel-semantic-ref-danger"]')!;
+    const darkSwatch = row.querySelector(
+      '[aria-label="--zd-danger (Dark): --zd-danger"]',
+    ) as HTMLElement;
+    expect(darkSwatch).not.toBeNull();
+    act(() => darkSwatch.click());
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(baseState);
+    expect(result.semanticMappings.danger).toEqual({
+      literal: { light: LIGHT_DANGER, dark: expect.stringMatching(/^oklch\(/) },
+    });
+  });
+
+  it('sibling rows are unaffected: "brand" still shows the resolved ramp option, "info" still shows a single unchecked swatch', () => {
+    renderColorTab(COLOR_TAB, makePerModeState());
+
+    // brand — ref row, grouped picker selects the Base optgroup option.
+    const brandSelect = getSemanticRefSelect('brand');
+    const selected = Array.from(brandSelect.querySelectorAll('option')).find((o) => o.selected);
+    expect(selected?.textContent).toContain('--palette-base-1');
+
+    // info — single-mode literal row on the SAME referencesRamps tier still
+    // renders through the grouped picker (S9/#470), with an UNCHECKED
+    // Per-mode toggle and exactly one swatch (regression: unaffected by Wave 4).
+    const infoRow = container.querySelector('[data-testid="tokenpanel-semantic-ref-info"]')!;
+    const infoCheckbox = infoRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(infoCheckbox.checked).toBe(false);
+    expect(infoRow.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Regression — a conventional palette+semantic 2-tier cluster (legacy
+// index mappings) still works unchanged (index rows unaffected by Wave 4).
+// ---------------------------------------------------------------------------
+
+describe('7. regression: legacy index-based semantic mappings still emit/behave as before', () => {
+  it('a conventional 2-tier palette+semantic color tab (index mappings) still renders and applies unchanged', () => {
+    __resetPanelConfigForTests();
+    configurePanel(FIXTURE_PANEL_CONFIG);
+
+    const colorTab = FIXTURE_TABS.find((t) => t.id === 'color')!;
+    const cluster = getActivePrimaryCluster();
+    const state = initColorFromScheme(cluster);
+
+    renderColorTab(colorTab, state);
+
+    const paletteGrid = container.querySelector('.tokenpanel-color-palette-grid') as HTMLElement;
+    expect(paletteGrid).not.toBeNull();
+    expect(paletteGrid.querySelectorAll('.tokenpanel-color-swatch-button').length).toBe(16);
+    expect(container.querySelectorAll('select.tokenpanel-tier-ref-select').length).toBe(0);
+
+    const fullState: TweakState = { color: state, spacing: {}, typography: {}, size: {} };
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, getPanelConfig().tabs);
+    applyColorState(state, cluster);
+    expect(diskMap['--fixture-semantic-accent']).toBe('var(--fixture-p6)');
+    expect(document.documentElement.style.getPropertyValue('--fixture-semantic-accent')).toBe(
+      state.palette[6],
+    );
+    // No per-mode literal anywhere in this fixture -> no color-scheme write.
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+
+    // Restore the per-mode fixture config for any subsequent test in this file.
+    __resetPanelConfigForTests();
+    configurePanel(PER_MODE_PANEL_CONFIG);
+  });
+
+  it('isPerModeLiteral / isLiteralMapping / isRefMapping narrow the three shapes correctly (sanity)', () => {
+    const state = makePerModeState();
+    expect(isPerModeLiteral(state.semanticMappings.danger)).toBe(true);
+    expect(isLiteralMapping(state.semanticMappings.info)).toBe(true);
+    expect(isPerModeLiteral(state.semanticMappings.info)).toBe(false);
+    expect(isRefMapping(state.semanticMappings.brand)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Part B — Reset clears a lingering color-scheme (#474 cleanup)
+// ---------------------------------------------------------------------------
+
+describe('8. Reset removes a lingering color-scheme left by a per-mode literal apply', () => {
+  it('clearAppliedColorStyles removes color-scheme from documentElement after a per-mode apply', () => {
+    const colorState = makePerModeState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+
+    clearAppliedColorStyles();
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+    // The semantic var itself is cleared too (pre-existing contract).
+    expect(document.documentElement.style.getPropertyValue('--zd-danger')).toBe('');
+  });
+
+  it('clearAppliedStyles (full panel Reset) also removes it', () => {
+    const colorState = makePerModeState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} });
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+
+    clearAppliedStyles();
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('on a sink instance, the clear routes "color-scheme" through the sink alongside the rest — never touching :root', () => {
+    const sink = makeSinkSpy();
+    const sinkCfg: PanelConfig = { ...PER_MODE_PANEL_CONFIG, applySink: sink };
+    __resetPanelConfigForTests();
+    configurePanel(sinkCfg);
+
+    const colorState = makePerModeState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} }, sinkCfg);
+    clearAppliedColorStyles(undefined, sink, sinkCfg);
+
+    const cleared = flatClearNames(sink.clearCalls);
+    expect(cleared).toContain('color-scheme');
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+
+    __resetPanelConfigForTests();
+    configurePanel(PER_MODE_PANEL_CONFIG);
+  });
+});

--- a/packages/zdtp/src/__tests__/manifest-cascade-verification.test.ts
+++ b/packages/zdtp/src/__tests__/manifest-cascade-verification.test.ts
@@ -21,6 +21,18 @@
  *      export and the self-injected `<style>` string) cannot diverge: all
  *      component CSS flows through a single `panel.css` `@import` aggregate,
  *      with no side-effect `.css` imports outside `index.tsx` (guards #413).
+ *   H. The ramp-native Tier-2 color editor's example manifest
+ *      (`_example-ramp-native-tier2.ts`, #459/#475) is a real, valid
+ *      `PanelConfig` — `semantic: true`, `referencesRamps`, and every
+ *      `SemanticValue` variant (index-free `{ ref }`, `{ literal }`, and a
+ *      runtime-built `{ literal: { light, dark } }`) resolve and emit
+ *      correctly through `configurePanel` / `resolveColorClusterFromTab` /
+ *      `buildApplyOverrides`. The new grouped ref-or-literal picker and
+ *      per-mode editor components (`controls/tier-ref-selector.tsx`,
+ *      `tabs/color-tab.tsx`) are already covered by Invariant D above (it
+ *      walks all of `src/**\/*.tsx`, not just the historical `tabs/` +
+ *      `components/color-picker/` set) — no separate DOM-hygiene invariant
+ *      is needed here.
  *
  * Historical Invariants A, B (no `group:` / `advancedTiers:` in example
  * manifests) are now enforced by TypeScript at panel-package compile time
@@ -32,12 +44,34 @@
  * exercised in that repo's CI.
  *
  * Browser-based cascade testing is deferred — see procedure in
- * packages/zdtp/CLAUDE.md.
+ * packages/zdtp/CLAUDE.md. For the ramp-native Tier-2 editor specifically,
+ * the actual visual cascade (grouped `<optgroup>` picker rendering, the
+ * "Per-mode" checkbox expanding into two swatches, `light-dark()` resolving
+ * against a real browser's `color-scheme`) can only be confirmed once the
+ * five external example repos and zudo-doc pick up this change via a panel
+ * SHA bump — that verification pass happens in those repos' own CI /
+ * `/verify-ui`, not here.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  __resetPanelConfigForTests,
+  assertValidPanelConfig,
+  configurePanel,
+} from '../config/panel-config';
+import { resolveColorClusterFromTab } from '../config/cluster-config';
+import { buildApplyOverrides } from '../apply/build-apply-overrides';
+import { getActivePrimaryCluster, initColorFromScheme, type ColorTweakState, type TweakState } from '../state/tweak-state';
+import {
+  EXAMPLE_COLOR_TAB,
+  EXAMPLE_DANGER_DARK,
+  EXAMPLE_DANGER_LIGHT,
+  EXAMPLE_PALETTE_TAB,
+  EXAMPLE_PANEL_CONFIG,
+  EXAMPLE_TABS,
+} from './_example-ramp-native-tier2';
 
 // ---------------------------------------------------------------------------
 // D. Panel source — no blocked semantic elements across ALL panel TSX files
@@ -245,5 +279,106 @@ describe('Invariant G — CSS self-inject and ./styles paths stay in sync', () =
       .filter((file) => !importTargets.includes(file))
       .map((file) => path.relative(SRC_DIR, file));
     expect(missing).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// H. Ramp-native Tier-2 example manifest (semantic + referencesRamps +
+//    every SemanticValue shape, #459/#475). See `_example-ramp-native-tier2.ts`
+//    for the fixture and its doc-page cross-reference.
+// ---------------------------------------------------------------------------
+
+describe('Invariant H — ramp-native Tier-2 example manifest is valid and exercises the new tier-model fields', () => {
+  afterEach(() => {
+    __resetPanelConfigForTests();
+  });
+
+  it('assertValidPanelConfig accepts the example manifest (host-adapter trust boundary)', () => {
+    expect(() => assertValidPanelConfig(EXAMPLE_PANEL_CONFIG)).not.toThrow();
+  });
+
+  it('configurePanel accepts the example manifest', () => {
+    __resetPanelConfigForTests();
+    expect(() => configurePanel(EXAMPLE_PANEL_CONFIG)).not.toThrow();
+  });
+
+  it('resolveColorClusterFromTab resolves the bare-id ref ("surface": "base-2") against the FIRST declared ramp source', () => {
+    const cluster = resolveColorClusterFromTab(EXAMPLE_COLOR_TAB, EXAMPLE_TABS)!;
+    expect(cluster).toBeDefined();
+    expect(cluster.semanticDefaults['surface']).toEqual({
+      ref: { tab: 'palette', tier: 'base', item: 'base-2' },
+    });
+  });
+
+  it('resolveColorClusterFromTab resolves the "tierId:itemId" ref ("brand": "accent:accent-1") against the NAMED ramp source', () => {
+    const cluster = resolveColorClusterFromTab(EXAMPLE_COLOR_TAB, EXAMPLE_TABS)!;
+    expect(cluster.semanticDefaults['brand']).toEqual({
+      ref: { tab: 'palette', tier: 'accent', item: 'accent-1' },
+    });
+  });
+
+  it('resolveColorClusterFromTab resolves the standalone literal ("info") to a { literal } SemanticValue', () => {
+    const cluster = resolveColorClusterFromTab(EXAMPLE_COLOR_TAB, EXAMPLE_TABS)!;
+    expect(cluster.semanticDefaults['info']).toEqual({ literal: 'oklch(0.6 0.1 230)' });
+  });
+
+  it('resolveColorClusterFromTab resolves the manifest-default literal ("danger") to a single-mode { literal }', () => {
+    const cluster = resolveColorClusterFromTab(EXAMPLE_COLOR_TAB, EXAMPLE_TABS)!;
+    expect(cluster.semanticDefaults['danger']).toEqual({ literal: EXAMPLE_DANGER_LIGHT });
+  });
+
+  it('paletteSize is 0 — the lone semantic:true tier has no palette tier of its own', () => {
+    const cluster = resolveColorClusterFromTab(EXAMPLE_COLOR_TAB, EXAMPLE_TABS)!;
+    expect(cluster.paletteSize).toBe(0);
+  });
+
+  it('buildApplyOverrides emits var(...) for both ref rows and the literal verbatim for "info"', () => {
+    __resetPanelConfigForTests();
+    configurePanel(EXAMPLE_PANEL_CONFIG);
+    const cluster = getActivePrimaryCluster();
+    const colorState = initColorFromScheme(cluster);
+    const fullState: TweakState = { color: colorState, spacing: {}, typography: {}, size: {} };
+
+    const out = buildApplyOverrides(fullState, undefined, cluster, EXAMPLE_TABS);
+
+    expect(out['--zd-surface']).toBe('var(--palette-base-2)');
+    expect(out['--zd-brand']).toBe('var(--palette-accent-1)');
+    expect(out['--zd-info']).toBe('oklch(0.6 0.1 230)');
+  });
+
+  it('buildApplyOverrides emits light-dark(<light>, <dark>) once "danger" carries a runtime per-mode literal override', () => {
+    // TierItem.default is always a plain string, so the { literal: { light,
+    // dark } } shape never appears as a manifest default (see the fixture's
+    // file header) — it is layered on top of the manifest-seeded state here,
+    // exactly as the panel's own "Per-mode" editor checkbox would produce it.
+    __resetPanelConfigForTests();
+    configurePanel(EXAMPLE_PANEL_CONFIG);
+    const cluster = getActivePrimaryCluster();
+    const baseState = initColorFromScheme(cluster);
+    const perModeState: ColorTweakState = {
+      ...baseState,
+      semanticMappings: {
+        ...baseState.semanticMappings,
+        danger: { literal: { light: EXAMPLE_DANGER_LIGHT, dark: EXAMPLE_DANGER_DARK } },
+      },
+    };
+    const fullState: TweakState = { color: perModeState, spacing: {}, typography: {}, size: {} };
+
+    const out = buildApplyOverrides(fullState, undefined, cluster, EXAMPLE_TABS);
+
+    expect(out['--zd-danger']).toBe(`light-dark(${EXAMPLE_DANGER_LIGHT}, ${EXAMPLE_DANGER_DARK})`);
+    // Sibling rows are unaffected by the per-mode override on "danger".
+    expect(out['--zd-surface']).toBe('var(--palette-base-2)');
+    expect(out['--zd-brand']).toBe('var(--palette-accent-1)');
+  });
+
+  it('EXAMPLE_PALETTE_TAB carries no palette-tier defaults that collide with EXAMPLE_COLOR_TAB\'s cssVars (sanity)', () => {
+    const paletteVars = new Set(
+      EXAMPLE_PALETTE_TAB.tiers.flatMap((t) => t.items.map((i) => i.cssVar)),
+    );
+    const colorVars = EXAMPLE_COLOR_TAB.tiers.flatMap((t) => t.items.map((i) => i.cssVar));
+    for (const v of colorVars) {
+      expect(paletteVars.has(v)).toBe(false);
+    }
   });
 });

--- a/packages/zdtp/src/__tests__/oklch-generic-tab-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/oklch-generic-tab-e2e.test.tsx
@@ -99,7 +99,7 @@ afterEach(() => {
 async function renderGenericTab(
   tab: TabConfig,
   overrides: TabOverrides = {},
-  onChange: (tierId: string, itemId: string, next: string) => void = () => undefined,
+  onChange: (tierId: string, itemId: string, next: string | undefined) => void = () => undefined,
 ): Promise<void> {
   await act(() => {
     render(<GenericTab tab={tab} overrides={overrides} onChange={onChange} />, container);

--- a/packages/zdtp/src/__tests__/panel-config.test.ts
+++ b/packages/zdtp/src/__tests__/panel-config.test.ts
@@ -788,6 +788,49 @@ describe('panel-config — assertValidPanelConfig host-tabs validation', () => {
     expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [tab] }))).not.toThrow();
   });
 
+  it('F4: skips a `semantic: true` tier — named, non-contiguous cssVars do not throw (#461)', () => {
+    // A lone semantic tier (no palette tier at all) with named cssVars like
+    // `--zd-danger` must not trip the "no trailing digit" guard: that guard
+    // only applies to the palette tier, and a semantic:true tier is never
+    // the palette (see cluster-config.ts / color-tab.ts findPaletteTier).
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: {
+        id: 'test',
+        defaultShikiTheme: 'dracula',
+        baseRoles: {},
+        baseDefaults: {},
+        colorSchemes: {},
+        panelSettings: { colorScheme: 'default', colorMode: false },
+      },
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: '#ff0000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'warning',
+              cssVar: '--zd-warning',
+              label: 'Warning',
+              default: '#ffaa00',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [tab] }))).not.toThrow();
+  });
+
   // F8: colorExtras deep validation (issue #440) ----------------------------
 
   function makeColorExtrasTab(overrides: Record<string, unknown> = {}): TabConfig {

--- a/packages/zdtp/src/__tests__/panel-config.test.ts
+++ b/packages/zdtp/src/__tests__/panel-config.test.ts
@@ -16,6 +16,7 @@ import {
   storageKey_visible,
   type PanelConfig,
 } from '../config/panel-config';
+import { TierResolverError, resolveRefToCssVar } from '../apply/tier-resolver';
 import type { TabConfig } from '../tokens/tier-model';
 
 /**
@@ -937,5 +938,326 @@ describe('panel-config — assertValidPanelConfig host-tabs validation', () => {
         }),
       ),
     ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S8 (#469): cross-tab ramp-source (`referencesRamps`) validation
+// ---------------------------------------------------------------------------
+//
+// `referencesRamps` (tier-level, on a `semantic: true` tier) is a DIFFERENT
+// mechanism from the same-tab `referencesTier` guard covered above: it is an
+// allow-list of ramp SOURCES — `{ tab?, tier }` — that per-row
+// `{ ref: { tab?, tier, item } }` VALUES are permitted to point into, and it
+// may legitimately name a tier in a DIFFERENT tab. See `TierConfig.referencesRamps`
+// in `tokens/tier-model.ts` and `resolveRefToCssVar` in `apply/tier-resolver.ts`
+// (#467/#468) for the runtime resolution counterpart.
+describe('panel-config — referencesRamps cross-tab source validation (S8, #469)', () => {
+  function makeBaseConfig(extra: Partial<PanelConfig> = {}): PanelConfig {
+    return {
+      storagePrefix: 'p',
+      consoleNamespace: 'p',
+      modalClassPrefix: 'p-modal',
+      schemaId: 'p/v1',
+      exportFilenameBase: 'p',
+      tabs: [],
+      ...extra,
+    };
+  }
+
+  /** The Palette tab: a plain color-kind ramp tier, no semantic/referencesTier. */
+  const PALETTE_TAB: TabConfig = {
+    id: 'palette',
+    label: 'Palette',
+    tiers: [
+      {
+        id: 'base',
+        label: 'Base',
+        items: [
+          {
+            id: 'base-1',
+            cssVar: '--palette-base-1',
+            label: 'Base 1',
+            default: '#111111',
+            type: { kind: 'color' },
+          },
+          {
+            id: 'base-2',
+            cssVar: '--palette-base-2',
+            label: 'Base 2',
+            default: '#222222',
+            type: { kind: 'color' },
+          },
+        ],
+      },
+      {
+        id: 'length-tier',
+        label: 'Not a color tier',
+        items: [
+          {
+            id: 'len-1',
+            cssVar: '--palette-len-1',
+            label: 'Len 1',
+            default: '4px',
+            type: { kind: 'length', step: 1, unit: 'px' },
+          },
+        ],
+      },
+    ],
+  };
+
+  /** A Color tab whose semantic tier declares a cross-tab ramp source. */
+  function makeSemanticColorTab(
+    referencesRamps: unknown,
+    overrides: Record<string, unknown> = {},
+  ): TabConfig {
+    return {
+      id: 'color',
+      label: 'Color',
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          referencesRamps,
+          items: [
+            {
+              id: 'surface',
+              cssVar: '--zd-surface',
+              label: 'Surface',
+              default: 'base-1',
+              type: { kind: 'color' },
+            },
+          ],
+          ...overrides,
+        },
+      ],
+    } as unknown as TabConfig;
+  }
+
+  it('accepts a valid referencesRamps declaration naming an existing tab + tier', () => {
+    const colorTab = makeSemanticColorTab([{ tab: 'palette', tier: 'base' }]);
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB] })),
+    ).not.toThrow();
+  });
+
+  it('accepts a referencesRamps entry with `tab` omitted (same-tab source)', () => {
+    // Same-tab source: a semantic tier referencing a ramp tier in ITS OWN tab.
+    const colorTab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      tiers: [
+        {
+          id: 'base',
+          label: 'Base',
+          items: [
+            {
+              id: 'base-1',
+              cssVar: '--color-base-1',
+              label: 'Base 1',
+              default: '#111111',
+              type: { kind: 'color' },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          referencesRamps: [{ tier: 'base' }],
+          items: [
+            {
+              id: 'surface',
+              cssVar: '--zd-surface',
+              label: 'Surface',
+              default: 'base-1',
+              type: { kind: 'color' },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab] }))).not.toThrow();
+  });
+
+  it('rejects a referencesRamps entry naming a missing tab, listing available tabs', () => {
+    const colorTab = makeSemanticColorTab([{ tab: 'no-such-tab', tier: 'base' }]);
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB] })),
+    ).toThrow(/tab "no-such-tab" does not exist. Available tabs: color, palette/);
+  });
+
+  it('rejects a referencesRamps entry naming a missing tier in an existing tab, listing available tiers', () => {
+    const colorTab = makeSemanticColorTab([{ tab: 'palette', tier: 'no-such-tier' }]);
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB] })),
+    ).toThrow(/tier "no-such-tier" does not exist in tab "palette". Available tiers: base, length-tier/);
+  });
+
+  it('rejects a cross-kind referencesRamps source (color semantic tier -> length ramp tier)', () => {
+    const colorTab = makeSemanticColorTab([{ tab: 'palette', tier: 'length-tier' }]);
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB] })),
+    ).toThrow(
+      /referencing semantic tier has kind "color" but target tier "length-tier" in tab "palette" has kind "length"/,
+    );
+  });
+
+  it('rejects referencesRamps declared on a tier that is not semantic: true', () => {
+    const colorTab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      tiers: [
+        {
+          id: 'base',
+          label: 'Base',
+          // Not `semantic: true` — referencesRamps has no business here.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          referencesRamps: [{ tier: 'base' }] as any,
+          items: [
+            {
+              id: 'base-1',
+              cssVar: '--color-base-1',
+              label: 'Base 1',
+              default: '#111111',
+              type: { kind: 'color' },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab] }))).toThrow(
+      /referencesRamps is only valid on a tier with semantic: true/,
+    );
+  });
+
+  it('rejects a referencesRamps entry missing the required `tier` field', () => {
+    const colorTab = makeSemanticColorTab([{ tab: 'palette' }]);
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB] })),
+    ).toThrow(/referencesRamps\[0\]\.tier must be a non-empty string/);
+  });
+
+  it('rejects a referencesRamps field that is not an array', () => {
+    const colorTab = makeSemanticColorTab({ tab: 'palette', tier: 'base' });
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB] })),
+    ).toThrow(/referencesRamps must be an array/);
+  });
+
+  it('keeps the existing same-tab referencesTier guard and F4 palette checks green alongside referencesRamps', () => {
+    // Sanity check: a tab using the unrelated same-tab referencesTier
+    // mechanism (no referencesRamps at all) still validates cleanly when a
+    // sibling tab in the array declares referencesRamps.
+    const spacingTab: TabConfig = {
+      id: 'spacing',
+      label: 'Spacing',
+      tiers: [
+        {
+          id: 'raw',
+          label: 'Raw',
+          items: [
+            {
+              id: 'space-1',
+              cssVar: '--my-spacing-space-1',
+              label: 'Space 1',
+              default: '4px',
+              type: { kind: 'length', step: 1, unit: 'px' },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'raw',
+          items: [
+            {
+              id: 'gap-sm',
+              cssVar: '--my-spacing-gap-sm',
+              label: 'Gap small',
+              default: 'space-1',
+              type: { kind: 'length', step: 1, unit: 'px' },
+            },
+          ],
+        },
+      ],
+    };
+    const colorTab = makeSemanticColorTab([{ tab: 'palette', tier: 'base' }]);
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [colorTab, PALETTE_TAB, spacingTab] })),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S8 (#469): per-row `{ ref }` to a missing item throws via resolveRefToCssVar
+// ---------------------------------------------------------------------------
+//
+// Per-row `{ ref: { tab?, tier, item } }` VALUES (the actual mappings stored
+// per semantic item, distinct from the tier-level `referencesRamps` source
+// declaration validated above) are resolved — and validated against real
+// items — at apply time by `resolveRefToCssVar` (#467/#468), not re-validated
+// eagerly by `assertValidPanelConfig`. This covers that a bad per-row ref
+// still surfaces a clear error, even though panel-config itself does not
+// re-check every row.
+describe('resolveRefToCssVar — per-row ref to a missing item throws (S8, #469)', () => {
+  const PALETTE_TAB_RESOLVER: TabConfig = {
+    id: 'palette',
+    label: 'Palette',
+    tiers: [
+      {
+        id: 'base',
+        label: 'Base',
+        items: [
+          {
+            id: 'base-1',
+            cssVar: '--palette-base-1',
+            label: 'Base 1',
+            default: '#111111',
+            type: { kind: 'color' },
+          },
+        ],
+      },
+    ],
+  };
+
+  const SEMANTIC_COLOR_TAB_RESOLVER: TabConfig = {
+    id: 'color',
+    label: 'Color',
+    tiers: [
+      {
+        id: 'semantic',
+        label: 'Semantic',
+        semantic: true,
+        referencesRamps: [{ tab: 'palette', tier: 'base' }],
+        items: [
+          {
+            id: 'surface',
+            cssVar: '--zd-surface',
+            label: 'Surface',
+            default: 'base-1',
+            type: { kind: 'color' },
+          },
+        ],
+      },
+    ],
+  };
+
+  it('throws a clear TierResolverError when a per-row ref names a missing item in an existing tab+tier', () => {
+    expect(() =>
+      resolveRefToCssVar(
+        { tab: 'palette', tier: 'base', item: 'no-such-item' },
+        SEMANTIC_COLOR_TAB_RESOLVER,
+        [SEMANTIC_COLOR_TAB_RESOLVER, PALETTE_TAB_RESOLVER],
+      ),
+    ).toThrow(TierResolverError);
+    expect(() =>
+      resolveRefToCssVar(
+        { tab: 'palette', tier: 'base', item: 'no-such-item' },
+        SEMANTIC_COLOR_TAB_RESOLVER,
+        [SEMANTIC_COLOR_TAB_RESOLVER, PALETTE_TAB_RESOLVER],
+      ),
+    ).toThrow(/no-such-item/);
   });
 });

--- a/packages/zdtp/src/__tests__/tweak-state.test.ts
+++ b/packages/zdtp/src/__tests__/tweak-state.test.ts
@@ -8,7 +8,9 @@ import {
   initColorFromSchemeData,
   type ColorTweakState,
   type StorageLike,
+  type TweakState,
   loadPersistedState,
+  savePersistedState,
 } from '../state/tweak-state';
 import type { ColorScheme } from '../config/color-schemes';
 import type { ColorClusterDataConfig } from '../config/cluster-config';
@@ -623,5 +625,122 @@ describe('#342 — ColorScheme.shikiTheme is optional', () => {
       cluster,
     );
     expect(state.shikiTheme).toBe('vitesse-dark');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #462 (S5) — persist-envelope round-trip for every SemanticValue variant
+// ---------------------------------------------------------------------------
+
+describe('savePersistedState / loadPersistedState — SemanticValue variant round-trips (#462)', () => {
+  function makeFullState(semanticMappings: ColorTweakState['semanticMappings']): TweakState {
+    return {
+      color: { ...defaults, semanticMappings },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+  }
+
+  it('round-trips a plain index (number) mapping unchanged', () => {
+    const storage = makeStorage();
+    const state = makeFullState({ accent: 9, muted: 8, active: 14 });
+    savePersistedState(state, storage);
+
+    const result = loadPersistedState(storage, defaults);
+    expect(result).not.toBeNull();
+    expect(result!.color.semanticMappings.accent).toBe(9);
+  });
+
+  it('round-trips a { literal: string } mapping', () => {
+    const storage = makeStorage();
+    const state = makeFullState({
+      accent: { literal: '#ff8800' },
+      muted: 8,
+      active: 14,
+    });
+    savePersistedState(state, storage);
+
+    const result = loadPersistedState(storage, defaults);
+    expect(result).not.toBeNull();
+    expect(result!.color.semanticMappings.accent).toEqual({ literal: '#ff8800' });
+  });
+
+  it('round-trips a { literal: { light, dark } } per-mode mapping', () => {
+    const storage = makeStorage();
+    const perMode = { literal: { light: '#111111', dark: '#eeeeee' } };
+    const state = makeFullState({ accent: 6, muted: perMode, active: 14 });
+    savePersistedState(state, storage);
+
+    const result = loadPersistedState(storage, defaults);
+    expect(result).not.toBeNull();
+    expect(result!.color.semanticMappings.muted).toEqual(perMode);
+  });
+
+  it('round-trips a { ref } mapping (with and without the optional tab field)', () => {
+    const storage = makeStorage();
+    const refWithTab = { ref: { tab: 'brand', tier: 'ramp', item: 'brand-500' } };
+    const refWithoutTab = { ref: { tier: 'ramp', item: 'brand-700' } };
+    const state = makeFullState({ accent: refWithTab, muted: refWithoutTab, active: 14 });
+    savePersistedState(state, storage);
+
+    const result = loadPersistedState(storage, defaults);
+    expect(result).not.toBeNull();
+    expect(result!.color.semanticMappings.accent).toEqual(refWithTab);
+    expect(result!.color.semanticMappings.muted).toEqual(refWithoutTab);
+  });
+
+  it('loads an OLD (pre-#459, index-only) persisted envelope without error under the widened hydrator', () => {
+    // Simulate a v3 envelope written by a build that predates #459/#462 — every
+    // semanticMappings value is a plain number (no object variants ever
+    // existed at persist time). Must hydrate byte-identical to before.
+    const legacyIndexOnlyV3 = {
+      color: {
+        palette: palette16,
+        background: 1,
+        foreground: 14,
+        cursor: 5,
+        selectionBg: 2,
+        selectionFg: 13,
+        semanticMappings: { accent: 6, muted: 8, active: 14 },
+        shikiTheme: 'tokyo-night',
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V3]: JSON.stringify(legacyIndexOnlyV3) });
+
+    const result = loadPersistedState(storage, defaults);
+    expect(result).not.toBeNull();
+    expect(result!.color.semanticMappings).toEqual({ accent: 6, muted: 8, active: 14 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('a malformed semantic-mapping value (neither index nor a recognized object shape) falls back to defaults instead of corrupting state', () => {
+    const corrupted = {
+      color: {
+        palette: palette16,
+        background: 1,
+        foreground: 14,
+        cursor: 5,
+        selectionBg: 2,
+        selectionFg: 13,
+        // `garbage` matches none of the SemanticValue variants.
+        semanticMappings: { accent: { garbage: true }, muted: 8, active: 14 },
+        shikiTheme: 'tokyo-night',
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const storage = makeStorage({ [STORAGE_KEY_V3]: JSON.stringify(corrupted) });
+
+    const result = loadPersistedState(storage, defaults);
+    expect(result).not.toBeNull();
+    // Falls back to the caller-supplied default for the corrupted key instead
+    // of admitting the arbitrary `{ garbage: true }` object into state.
+    expect(result!.color.semanticMappings.accent).toBe(defaults.semanticMappings.accent);
+    expect(result!.color.semanticMappings.muted).toBe(8);
   });
 });

--- a/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
+++ b/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
@@ -769,7 +769,7 @@ describe('buildApplyOverrides / applyColorState — emitter parity for a cross-t
     expect(applied['--zd-accent']).toBe('#222222');
   });
 
-  it('an unresolvable { ref } (unknown target item) is skipped on disk and falls back to #000000 in the DOM', () => {
+  it('an unresolvable { ref } (unknown target item) is skipped on BOTH disk and DOM — same-output contract, no black paint', () => {
     const color: ColorTweakState = {
       ...BASE_COLOR,
       semanticMappings: {
@@ -790,7 +790,9 @@ describe('buildApplyOverrides / applyColorState — emitter parity for a cross-t
       clear() {},
     };
     applyColorState(color, REF_CLUSTER, sink, COLOR_TAB, REF_TABS);
-    expect(applied['--zd-surface']).toBe('#000000');
+    // DOM now also skips (leaves the token at its stylesheet default) instead
+    // of painting it black — matching disk, per the review fix.
+    expect(applied['--zd-surface']).toBeUndefined();
   });
 });
 

--- a/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
+++ b/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
@@ -793,3 +793,121 @@ describe('buildApplyOverrides / applyColorState — emitter parity for a cross-t
     expect(applied['--zd-surface']).toBe('#000000');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — per-mode literal { literal: { light, dark } } → light-dark() (S11, #472)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — per-mode literal semantic value (S11, #472)', () => {
+  const PM_CLUSTER = {
+    id: 'permode-fixture',
+    label: 'Per-mode Fixture',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--pm-p{n}',
+    semanticDefaults: { danger: 1 },
+    semanticCssNames: { danger: '--zd-danger' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula' as const,
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  };
+
+  const PM_BASE_COLOR: ColorTweakState = {
+    palette: ['#000000', '#111111', '#222222', '#ffffff'],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { danger: 1 },
+    shikiTheme: 'dracula',
+  };
+
+  it('emits light-dark(<light>, <dark>) for a { literal: { light, dark } } mapping', () => {
+    const state: TweakState = {
+      color: {
+        ...PM_BASE_COLOR,
+        semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#990000' } } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, undefined, PM_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('light-dark(#ff0000, #990000)');
+  });
+
+  it('diff gate: does not re-emit a structurally-unchanged per-mode value', () => {
+    const baseline: ColorTweakState = {
+      ...PM_BASE_COLOR,
+      semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#990000' } } },
+    };
+    const state: TweakState = {
+      color: {
+        ...PM_BASE_COLOR,
+        // Distinct object reference, identical structural value.
+        semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#990000' } } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, baseline, PM_CLUSTER, []);
+    expect(result['--zd-danger']).toBeUndefined();
+  });
+
+  it('diff gate: DOES re-emit when either mode of the per-mode value changes', () => {
+    const baseline: ColorTweakState = {
+      ...PM_BASE_COLOR,
+      semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#990000' } } },
+    };
+    const state: TweakState = {
+      color: {
+        ...PM_BASE_COLOR,
+        semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#550000' } } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, baseline, PM_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('light-dark(#ff0000, #550000)');
+  });
+
+  it('disk output equals the DOM-applied (sink) value for a per-mode row (parity)', () => {
+    const color: ColorTweakState = {
+      ...PM_BASE_COLOR,
+      semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#990000' } } },
+    };
+    const state: TweakState = { color, spacing: {}, typography: {}, size: {} };
+
+    const diskResult = buildApplyOverrides(state, undefined, PM_CLUSTER, []);
+
+    const applied: Record<string, string> = {};
+    const sink: ApplySink = {
+      apply(pairs) {
+        for (const [name, value] of pairs) applied[name] = value;
+      },
+      clear() {},
+    };
+    applyColorState(color, PM_CLUSTER, sink);
+
+    expect(diskResult['--zd-danger']).toBe('light-dark(#ff0000, #990000)');
+    expect(applied['--zd-danger']).toBe(diskResult['--zd-danger']);
+  });
+
+  it('single-mode { literal: string } rows still emit a plain value (unchanged)', () => {
+    const state: TweakState = {
+      color: {
+        ...PM_BASE_COLOR,
+        semanticMappings: { danger: { literal: 'oklch(0.55 0.2 25)' } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, undefined, PM_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('oklch(0.55 0.2 25)');
+  });
+});

--- a/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
+++ b/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { buildApplyOverrides } from '../build-apply-overrides';
-import type { TweakState, ColorTweakState } from '../../state/tweak-state';
+import { applyColorState } from '../../state/tweak-state';
+import type { TweakState, ColorTweakState, ApplySink } from '../../state/tweak-state';
 import type { TabConfig } from '../../tokens/tier-model';
 
 // ---------------------------------------------------------------------------
@@ -472,5 +473,164 @@ describe('buildApplyOverrides — state.tabs generic tab overrides', () => {
     const result = buildApplyOverrides(state, undefined, STUB_CLUSTER, FIXTURE_TABS_WITH_PALETTE);
     expect(result['--zd-spacing-hgap-md']).toBe('24px');
     expect(result['--palette-gray-3']).toBe('#cccccc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — literal semantic value (S4, #465)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — literal semantic value (S4, #465)', () => {
+  const LITERAL_CLUSTER = {
+    id: 'literal-fixture',
+    label: 'Literal Fixture',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--literal-p{n}',
+    semanticDefaults: { accent: 1 },
+    semanticCssNames: { accent: '--zd-danger' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula' as const,
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  };
+
+  const LITERAL_BASE_COLOR: ColorTweakState = {
+    palette: ['#000000', '#111111', '#222222', '#ffffff'],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { accent: 1 },
+    shikiTheme: 'dracula',
+  };
+
+  it('emits a { literal: string } semantic mapping verbatim, not var(--palette-N)', () => {
+    const state: TweakState = {
+      color: {
+        ...LITERAL_BASE_COLOR,
+        semanticMappings: { accent: { literal: 'oklch(0.55 0.2 25)' } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, LITERAL_BASE_COLOR, LITERAL_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('oklch(0.55 0.2 25)');
+  });
+
+  it('legacy index/bg/fg mapping still emits var(--palette-N) (unchanged behavior)', () => {
+    const state: TweakState = {
+      color: { ...LITERAL_BASE_COLOR, semanticMappings: { accent: 2 } },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, LITERAL_BASE_COLOR, LITERAL_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('var(--literal-p2)');
+  });
+
+  it('emits the literal value when colorDefaults is undefined (no baseline)', () => {
+    const state: TweakState = {
+      color: {
+        ...LITERAL_BASE_COLOR,
+        semanticMappings: { accent: { literal: 'oklch(0.55 0.2 25)' } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, undefined, LITERAL_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('oklch(0.55 0.2 25)');
+  });
+
+  it('diff gate: does not re-emit a structurally-unchanged literal value', () => {
+    // The baseline and current mappings hold the SAME literal string but are
+    // distinct object references (as an immutable state update would produce).
+    // A reference-identity (`!==`) diff gate would treat this as "changed" and
+    // re-emit every time; the structural-equality gate must recognize no
+    // actual value change occurred.
+    const baseline: ColorTweakState = {
+      ...LITERAL_BASE_COLOR,
+      semanticMappings: { accent: { literal: 'oklch(0.55 0.2 25)' } },
+    };
+    const state: TweakState = {
+      color: {
+        ...LITERAL_BASE_COLOR,
+        semanticMappings: { accent: { literal: 'oklch(0.55 0.2 25)' } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, baseline, LITERAL_CLUSTER, []);
+    expect(result['--zd-danger']).toBeUndefined();
+  });
+
+  it('diff gate: DOES re-emit when the literal string actually changes', () => {
+    const baseline: ColorTweakState = {
+      ...LITERAL_BASE_COLOR,
+      semanticMappings: { accent: { literal: 'oklch(0.55 0.2 25)' } },
+    };
+    const state: TweakState = {
+      color: {
+        ...LITERAL_BASE_COLOR,
+        semanticMappings: { accent: { literal: 'oklch(0.9 0.1 100)' } },
+      },
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    const result = buildApplyOverrides(state, baseline, LITERAL_CLUSTER, []);
+    expect(result['--zd-danger']).toBe('oklch(0.9 0.1 100)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — emitter parity: disk output vs. DOM-applied value (S4, #465)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides / applyColorState — emitter parity for a literal semantic row', () => {
+  const PARITY_CLUSTER = {
+    id: 'parity-fixture',
+    label: 'Parity Fixture',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--parity-p{n}',
+    semanticDefaults: { danger: 1 },
+    semanticCssNames: { danger: '--zd-danger' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula' as const,
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  };
+
+  it('the disk cssVar value equals the DOM-applied (sink) value for a { literal } row', () => {
+    const color: ColorTweakState = {
+      palette: ['#000000', '#111111', '#222222', '#ffffff'],
+      background: 0,
+      foreground: 3,
+      cursor: 1,
+      selectionBg: 0,
+      selectionFg: 3,
+      semanticMappings: { danger: { literal: 'oklch(0.55 0.2 25)' } },
+      shikiTheme: 'dracula',
+    };
+    const state: TweakState = { color, spacing: {}, typography: {}, size: {} };
+
+    const diskResult = buildApplyOverrides(state, undefined, PARITY_CLUSTER, []);
+
+    const applied: Record<string, string> = {};
+    const sink: ApplySink = {
+      apply(pairs) {
+        for (const [name, value] of pairs) applied[name] = value;
+      },
+      clear() {},
+    };
+    applyColorState(color, PARITY_CLUSTER, sink);
+
+    expect(diskResult['--zd-danger']).toBe('oklch(0.55 0.2 25)');
+    expect(applied['--zd-danger']).toBe(diskResult['--zd-danger']);
   });
 });

--- a/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
+++ b/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
@@ -634,3 +634,162 @@ describe('buildApplyOverrides / applyColorState — emitter parity for a literal
     expect(applied['--zd-danger']).toBe(diskResult['--zd-danger']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — emitter parity: disk output vs. DOM-applied value for a cross-tab
+// { ref } semantic row (S7b, #468)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides / applyColorState — emitter parity for a cross-tab { ref } semantic row (S7b, #468)', () => {
+  // The color tab whose semantic tier holds the { ref } mapping. Empty tiers
+  // are fine here — buildApplyOverrides/applyColorState only need this tab to
+  // exist (by id 'color') so resolveRefToCssVar has a currentTab to resolve
+  // "tab omitted" refs against; the actual ref under test always names an
+  // explicit target tab ('palette').
+  const COLOR_TAB: TabConfig = {
+    id: 'color',
+    label: 'Color',
+    tiers: [],
+  };
+
+  // The grouped Palette tab: the ramp tier the { ref } points into.
+  const PALETTE_TAB: TabConfig = {
+    id: 'palette',
+    label: 'Palette',
+    tiers: [
+      {
+        id: 'base',
+        label: 'Base',
+        items: [
+          {
+            id: 'base-1',
+            cssVar: '--palette-base-1',
+            label: 'base-1',
+            default: '#111111',
+            type: { kind: 'color' },
+          },
+          {
+            id: 'base-3',
+            cssVar: '--palette-base-3',
+            label: 'base-3',
+            default: '#333333',
+            type: { kind: 'color' },
+          },
+        ],
+      },
+    ],
+  };
+
+  const REF_TABS: readonly TabConfig[] = [COLOR_TAB, PALETTE_TAB];
+
+  const REF_CLUSTER = {
+    id: 'ref-fixture',
+    label: 'Ref Fixture',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--ref-p{n}',
+    semanticDefaults: { surface: 1, danger: 1, accent: 1 },
+    semanticCssNames: { surface: '--zd-surface', danger: '--zd-danger', accent: '--zd-accent' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula' as const,
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  };
+
+  const BASE_COLOR: ColorTweakState = {
+    palette: ['#000000', '#111111', '#222222', '#ffffff'],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { surface: 1, danger: 1, accent: 1 },
+    shikiTheme: 'dracula',
+  };
+
+  it('a { ref: { tab: "palette", tier: "base", item: "base-3" } } row emits var(--palette-base-3) identically in both emitters', () => {
+    const color: ColorTweakState = {
+      ...BASE_COLOR,
+      semanticMappings: {
+        ...BASE_COLOR.semanticMappings,
+        surface: { ref: { tab: 'palette', tier: 'base', item: 'base-3' } },
+      },
+    };
+    const state: TweakState = { color, spacing: {}, typography: {}, size: {} };
+
+    const diskResult = buildApplyOverrides(state, undefined, REF_CLUSTER, REF_TABS);
+
+    const applied: Record<string, string> = {};
+    const sink: ApplySink = {
+      apply(pairs) {
+        for (const [name, value] of pairs) applied[name] = value;
+      },
+      clear() {},
+    };
+    applyColorState(color, REF_CLUSTER, sink, COLOR_TAB, REF_TABS);
+
+    expect(diskResult['--zd-surface']).toBe('var(--palette-base-3)');
+    expect(applied['--zd-surface']).toBe(diskResult['--zd-surface']);
+  });
+
+  it('index and literal rows alongside a { ref } row are unaffected (unchanged behavior)', () => {
+    const color: ColorTweakState = {
+      ...BASE_COLOR,
+      semanticMappings: {
+        surface: { ref: { tab: 'palette', tier: 'base', item: 'base-3' } },
+        danger: { literal: 'oklch(0.55 0.2 25)' },
+        accent: 2, // legacy palette-index mapping
+      },
+    };
+    const state: TweakState = { color, spacing: {}, typography: {}, size: {} };
+
+    const diskResult = buildApplyOverrides(state, undefined, REF_CLUSTER, REF_TABS);
+
+    const applied: Record<string, string> = {};
+    const sink: ApplySink = {
+      apply(pairs) {
+        for (const [name, value] of pairs) applied[name] = value;
+      },
+      clear() {},
+    };
+    applyColorState(color, REF_CLUSTER, sink, COLOR_TAB, REF_TABS);
+
+    // The { ref } and { literal } rows keep byte-identical disk/DOM output.
+    expect(diskResult['--zd-surface']).toBe('var(--palette-base-3)');
+    expect(diskResult['--zd-danger']).toBe('oklch(0.55 0.2 25)');
+    expect(applied['--zd-surface']).toBe(diskResult['--zd-surface']);
+    expect(applied['--zd-danger']).toBe(diskResult['--zd-danger']);
+
+    // The legacy index row keeps its PRE-EXISTING (intentional) disk/DOM
+    // divergence: disk emits an indirect var(--palette-N) reference, while
+    // the DOM path resolves straight to the palette's stored color value
+    // (see `resolveMapping`/the top-of-file doc comment) — { ref } support
+    // does not change this.
+    expect(diskResult['--zd-accent']).toBe('var(--ref-p2)');
+    expect(applied['--zd-accent']).toBe('#222222');
+  });
+
+  it('an unresolvable { ref } (unknown target item) is skipped on disk and falls back to #000000 in the DOM', () => {
+    const color: ColorTweakState = {
+      ...BASE_COLOR,
+      semanticMappings: {
+        ...BASE_COLOR.semanticMappings,
+        surface: { ref: { tab: 'palette', tier: 'base', item: 'no-such-item' } },
+      },
+    };
+    const state: TweakState = { color, spacing: {}, typography: {}, size: {} };
+
+    const diskResult = buildApplyOverrides(state, undefined, REF_CLUSTER, REF_TABS);
+    expect(diskResult['--zd-surface']).toBeUndefined();
+
+    const applied: Record<string, string> = {};
+    const sink: ApplySink = {
+      apply(pairs) {
+        for (const [name, value] of pairs) applied[name] = value;
+      },
+      clear() {},
+    };
+    applyColorState(color, REF_CLUSTER, sink, COLOR_TAB, REF_TABS);
+    expect(applied['--zd-surface']).toBe('#000000');
+  });
+});

--- a/packages/zdtp/src/apply/__tests__/tier-resolver.test.ts
+++ b/packages/zdtp/src/apply/__tests__/tier-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   resolveTierItemValue,
   emitTierItemCssValue,
+  resolveRefToCssVar,
   TierResolverError,
   type TabOverrides,
 } from '../tier-resolver';
@@ -556,5 +557,121 @@ describe('resolveTierItemValue — empty referenced tier', () => {
     expect(() =>
       resolveTierItemValue(tabWithEmptyRefTier, 'semantic', 'my-token', EMPTY_OVERRIDES),
     ).toThrow(/raw/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. resolveRefToCssVar — cross-tab ramp reference resolution (#467)
+// ---------------------------------------------------------------------------
+
+/** The grouped Palette tab: ramp tiers whose items have `--palette-<tier>-<n>` cssVars. */
+const PALETTE_TAB: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        colorItem('base-1', '--palette-base-1', 'oklch(0.98 0 0)'),
+        colorItem('base-2', '--palette-base-2', 'oklch(0.9 0 0)'),
+        colorItem('base-3', '--palette-base-3', 'oklch(0.8 0 0)'),
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [colorItem('accent-1', '--palette-accent-1', 'oklch(0.6 0.2 250)')],
+    },
+  ],
+};
+
+/** A semantic color tab that references ramp items living in PALETTE_TAB. */
+const SEMANTIC_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [{ tab: 'palette', tier: 'base' }],
+      items: [colorItem('surface', '--zd-surface', 'base-3')],
+    },
+  ],
+};
+
+describe('resolveRefToCssVar — cross-tab ramp reference (#467)', () => {
+  it('resolves a { tab, tier, item } ref to the Palette-tab item cssVar', () => {
+    const cssVar = resolveRefToCssVar(
+      { tab: 'palette', tier: 'base', item: 'base-3' },
+      SEMANTIC_COLOR_TAB,
+      [SEMANTIC_COLOR_TAB, PALETTE_TAB],
+    );
+    expect(cssVar).toBe('--palette-base-3');
+  });
+
+  it('feeds cleanly into emitTierItemCssValue as a var() ref (for #468)', () => {
+    const cssVar = resolveRefToCssVar(
+      { tab: 'palette', tier: 'accent', item: 'accent-1' },
+      SEMANTIC_COLOR_TAB,
+      [SEMANTIC_COLOR_TAB, PALETTE_TAB],
+    );
+    expect(emitTierItemCssValue({ kind: 'ref', targetCssVar: cssVar })).toBe(
+      'var(--palette-accent-1)',
+    );
+  });
+
+  it('resolves an intra-tab ref (tab omitted) within the current tab', () => {
+    const cssVar = resolveRefToCssVar(
+      { tier: 'base', item: 'base-2' },
+      PALETTE_TAB, // current tab is the palette tab itself
+    );
+    expect(cssVar).toBe('--palette-base-2');
+  });
+
+  it('resolves an intra-tab ref when tab equals the current tab id', () => {
+    const cssVar = resolveRefToCssVar(
+      { tab: 'palette', tier: 'accent', item: 'accent-1' },
+      PALETTE_TAB,
+    );
+    expect(cssVar).toBe('--palette-accent-1');
+  });
+
+  it('throws TierResolverError when the target tab does not exist', () => {
+    expect(() =>
+      resolveRefToCssVar(
+        { tab: 'no-such-tab', tier: 'base', item: 'base-3' },
+        SEMANTIC_COLOR_TAB,
+        [SEMANTIC_COLOR_TAB, PALETTE_TAB],
+      ),
+    ).toThrow(TierResolverError);
+    expect(() =>
+      resolveRefToCssVar(
+        { tab: 'no-such-tab', tier: 'base', item: 'base-3' },
+        SEMANTIC_COLOR_TAB,
+        [SEMANTIC_COLOR_TAB, PALETTE_TAB],
+      ),
+    ).toThrow(/no-such-tab/);
+  });
+
+  it('throws TierResolverError when the target tier does not exist', () => {
+    expect(() =>
+      resolveRefToCssVar(
+        { tab: 'palette', tier: 'no-such-tier', item: 'base-3' },
+        SEMANTIC_COLOR_TAB,
+        [SEMANTIC_COLOR_TAB, PALETTE_TAB],
+      ),
+    ).toThrow(/no-such-tier/);
+  });
+
+  it('throws TierResolverError when the target item does not exist', () => {
+    expect(() =>
+      resolveRefToCssVar(
+        { tab: 'palette', tier: 'base', item: 'base-99' },
+        SEMANTIC_COLOR_TAB,
+        [SEMANTIC_COLOR_TAB, PALETTE_TAB],
+      ),
+    ).toThrow(/base-99/);
   });
 });

--- a/packages/zdtp/src/apply/build-apply-overrides.ts
+++ b/packages/zdtp/src/apply/build-apply-overrides.ts
@@ -30,9 +30,13 @@
  *   - Palette slots (resolved via `resolvePaletteCssVar(cluster, i)`) —
  *     EMITTED as the stored color value (hex, or `oklch(...)` for
  *     oklch-format palettes).
- *   - Semantic tokens (`cluster.semanticCssNames` entries) — EMITTED as
- *     `var(--<paletteSlotName>)` so the rewrite preserves the indirection
- *     that the hand-authored CSS relies on.
+ *   - Semantic tokens (`cluster.semanticCssNames` entries) — a legacy
+ *     index/`bg`/`fg` mapping is EMITTED as `var(--<paletteSlotName>)` so the
+ *     rewrite preserves the indirection that the hand-authored CSS relies on.
+ *     A single-mode `{ literal: string }` mapping (#465) is instead EMITTED
+ *     VERBATIM as the literal CSS value — there is no palette slot to
+ *     reference. Per-mode `{ literal: { light, dark } }` (#472) and `{ ref }`
+ *     (#468) mappings are not resolved yet and are silently skipped.
  *   - Base roles (`cluster.baseRoles` entries) — NOT emitted. They do not
  *     belong to the apply pipeline's rewrite scope.
  *   - Spacing / typography / size — EMITTED when the corresponding
@@ -54,10 +58,17 @@
  */
 
 import type { ColorTweakState, TweakState, ColorClusterConfig, SemanticValue } from '../state/tweak-state';
-import { resolvePaletteCssVar, safeIndex, getActivePrimaryCluster } from '../state/tweak-state';
+import {
+  resolvePaletteCssVar,
+  safeIndex,
+  getActivePrimaryCluster,
+  isLiteralMapping,
+  isPerModeLiteral,
+} from '../state/tweak-state';
 import type { TabConfig } from '../tokens/tier-model';
 import { getPanelConfig } from '../config/panel-config';
 import { resolveTierItemValue, emitTierItemCssValue, type TabOverrides } from './tier-resolver';
+import { structuralEqual } from '../utils/structural-equal';
 
 /**
  * Produce the flat cssVar → value map for the dev-API handler.
@@ -102,8 +113,25 @@ export function buildApplyOverrides(
     const currentMapping = color.semanticMappings[key];
     if (currentMapping === undefined) continue;
     const baselineMapping = colorDefaults?.semanticMappings[key];
-    const changed = colorDefaults === undefined || currentMapping !== baselineMapping;
+    // Structural (not reference) equality: a `{ literal }` object produced by
+    // an immutable update is a fresh reference every time even when its value
+    // is unchanged. `!==` would always see it as "changed" and defeat the
+    // diff-only contract documented at the top of this file.
+    const changed = colorDefaults === undefined || !structuralEqual(currentMapping, baselineMapping);
     if (!changed) continue;
+
+    // `{ literal: string }` — single-mode literal color (#465, S4). Emit the
+    // stored CSS value verbatim rather than routing through a palette slot.
+    // Per-mode `{ literal: { light, dark } }` (#472) and `{ ref }` (#468) are
+    // NOT resolved here yet — they fall through to `resolveMappingIndex`
+    // below, which returns `null` for them, so the entry is silently skipped
+    // (see that function's doc comment). #472/#468 slot their branch in here,
+    // above the `resolveMappingIndex` call.
+    if (isLiteralMapping(currentMapping) && !isPerModeLiteral(currentMapping)) {
+      out[cssVar] = currentMapping.literal;
+      continue;
+    }
+
     const paletteIndex = resolveMappingIndex(currentMapping, color);
     if (paletteIndex === null) continue;
     // clamp out-of-range indices to a valid
@@ -211,11 +239,13 @@ function emitTabOverrides(
  * - `number`  → used as-is.
  * - `"bg"`    → the color state's current background index.
  * - `"fg"`    → the color state's current foreground index.
- * - anything else → `null` (caller skips the entry). This also covers the
- *   `{ literal }` / `{ ref }` `SemanticValue` variants (#459) — this
- *   disk-rewrite pipeline doesn't resolve them yet (downstream #467/#469),
- *   so they fall through to the existing "skip" behavior rather than a type
- *   error.
+ * - anything else → `null` (caller skips the entry).
+ *
+ * The single-mode `{ literal: string }` variant is resolved by the caller
+ * BEFORE this function runs (#465, S4) and never reaches here. The
+ * per-mode `{ literal: { light, dark } }` variant (#472) and the `{ ref }`
+ * variant (#468) still fall through to `null` — those resolvers are
+ * downstream work, not this function's job today.
  */
 function resolveMappingIndex(mapping: SemanticValue, color: ColorTweakState): number | null {
   if (mapping === 'bg') return color.background;

--- a/packages/zdtp/src/apply/build-apply-overrides.ts
+++ b/packages/zdtp/src/apply/build-apply-overrides.ts
@@ -35,8 +35,10 @@
  *     rewrite preserves the indirection that the hand-authored CSS relies on.
  *     A single-mode `{ literal: string }` mapping (#465) is instead EMITTED
  *     VERBATIM as the literal CSS value — there is no palette slot to
- *     reference. Per-mode `{ literal: { light, dark } }` (#472) and `{ ref }`
- *     (#468) mappings are not resolved yet and are silently skipped.
+ *     reference. A cross-tab/tier `{ ref }` mapping (#468) is resolved via
+ *     `resolveRefToCssVar` against the panel's full `tabs` array and EMITTED
+ *     as `var(--<resolved-target>)`. Per-mode `{ literal: { light, dark } }`
+ *     (#472) is not resolved yet and is silently skipped.
  *   - Base roles (`cluster.baseRoles` entries) — NOT emitted. They do not
  *     belong to the apply pipeline's rewrite scope.
  *   - Spacing / typography / size — EMITTED when the corresponding
@@ -64,10 +66,16 @@ import {
   getActivePrimaryCluster,
   isLiteralMapping,
   isPerModeLiteral,
+  isRefMapping,
 } from '../state/tweak-state';
 import type { TabConfig } from '../tokens/tier-model';
 import { getPanelConfig } from '../config/panel-config';
-import { resolveTierItemValue, emitTierItemCssValue, type TabOverrides } from './tier-resolver';
+import {
+  resolveTierItemValue,
+  emitTierItemCssValue,
+  resolveRefToCssVar,
+  type TabOverrides,
+} from './tier-resolver';
 import { structuralEqual } from '../utils/structural-equal';
 
 /**
@@ -122,13 +130,31 @@ export function buildApplyOverrides(
 
     // `{ literal: string }` — single-mode literal color (#465, S4). Emit the
     // stored CSS value verbatim rather than routing through a palette slot.
-    // Per-mode `{ literal: { light, dark } }` (#472) and `{ ref }` (#468) are
-    // NOT resolved here yet — they fall through to `resolveMappingIndex`
-    // below, which returns `null` for them, so the entry is silently skipped
-    // (see that function's doc comment). #472/#468 slot their branch in here,
-    // above the `resolveMappingIndex` call.
+    // Per-mode `{ literal: { light, dark } }` (#472) is NOT resolved here
+    // yet — it falls through to `resolveMappingIndex` below, which returns
+    // `null` for it, so the entry is silently skipped (see that function's
+    // doc comment). #472 slots its branch in here, above the `{ ref }` check.
     if (isLiteralMapping(currentMapping) && !isPerModeLiteral(currentMapping)) {
       out[cssVar] = currentMapping.literal;
+      continue;
+    }
+
+    // `{ ref: { tab?, tier, item } }` — cross-tab/tier ramp reference (#468).
+    // Resolve against the Color tab (the tier the semantic mapping lives on)
+    // using the panel's full `tabs` array so a ref pointing into another tab
+    // (e.g. the grouped Palette tab) resolves. A ref that fails to resolve
+    // (misconfigured manifest) is silently skipped rather than crashing the
+    // apply pipeline — up-front source validation is #469's job.
+    if (isRefMapping(currentMapping)) {
+      const colorTab = tabs.find((t) => t.id === 'color');
+      if (colorTab) {
+        try {
+          const targetCssVar = resolveRefToCssVar(currentMapping.ref, colorTab, tabs);
+          out[cssVar] = `var(${targetCssVar})`;
+        } catch {
+          // Unresolvable ref — skip rather than emit a broken var() reference.
+        }
+      }
       continue;
     }
 
@@ -241,11 +267,11 @@ function emitTabOverrides(
  * - `"fg"`    → the color state's current foreground index.
  * - anything else → `null` (caller skips the entry).
  *
- * The single-mode `{ literal: string }` variant is resolved by the caller
- * BEFORE this function runs (#465, S4) and never reaches here. The
- * per-mode `{ literal: { light, dark } }` variant (#472) and the `{ ref }`
- * variant (#468) still fall through to `null` — those resolvers are
- * downstream work, not this function's job today.
+ * The single-mode `{ literal: string }` variant (#465, S4) and the `{ ref }`
+ * variant (#468) are both resolved by the caller BEFORE this function runs
+ * and never reach here. The per-mode `{ literal: { light, dark } }` variant
+ * (#472) still falls through to `null` — that resolver is downstream work,
+ * not this function's job today.
  */
 function resolveMappingIndex(mapping: SemanticValue, color: ColorTweakState): number | null {
   if (mapping === 'bg') return color.background;

--- a/packages/zdtp/src/apply/build-apply-overrides.ts
+++ b/packages/zdtp/src/apply/build-apply-overrides.ts
@@ -53,7 +53,7 @@
  * Pure / no IO — safe to import anywhere (browser, Node, tests).
  */
 
-import type { ColorTweakState, TweakState, ColorClusterConfig } from '../state/tweak-state';
+import type { ColorTweakState, TweakState, ColorClusterConfig, SemanticValue } from '../state/tweak-state';
 import { resolvePaletteCssVar, safeIndex, getActivePrimaryCluster } from '../state/tweak-state';
 import type { TabConfig } from '../tokens/tier-model';
 import { getPanelConfig } from '../config/panel-config';
@@ -211,9 +211,13 @@ function emitTabOverrides(
  * - `number`  → used as-is.
  * - `"bg"`    → the color state's current background index.
  * - `"fg"`    → the color state's current foreground index.
- * - anything else → `null` (caller skips the entry).
+ * - anything else → `null` (caller skips the entry). This also covers the
+ *   `{ literal }` / `{ ref }` `SemanticValue` variants (#459) — this
+ *   disk-rewrite pipeline doesn't resolve them yet (downstream #467/#469),
+ *   so they fall through to the existing "skip" behavior rather than a type
+ *   error.
  */
-function resolveMappingIndex(mapping: number | 'bg' | 'fg', color: ColorTweakState): number | null {
+function resolveMappingIndex(mapping: SemanticValue, color: ColorTweakState): number | null {
   if (mapping === 'bg') return color.background;
   if (mapping === 'fg') return color.foreground;
   if (typeof mapping === 'number' && Number.isInteger(mapping)) return mapping;

--- a/packages/zdtp/src/apply/build-apply-overrides.ts
+++ b/packages/zdtp/src/apply/build-apply-overrides.ts
@@ -38,7 +38,9 @@
  *     reference. A cross-tab/tier `{ ref }` mapping (#468) is resolved via
  *     `resolveRefToCssVar` against the panel's full `tabs` array and EMITTED
  *     as `var(--<resolved-target>)`. Per-mode `{ literal: { light, dark } }`
- *     (#472) is not resolved yet and is silently skipped.
+ *     (#472) is EMITTED as `light-dark(<light>, <dark>)`, byte-identical to
+ *     the DOM emitter (the required `color-scheme: light dark` is NOT settable
+ *     via this pipeline — see the per-mode branch below for why).
  *   - Base roles (`cluster.baseRoles` entries) — NOT emitted. They do not
  *     belong to the apply pipeline's rewrite scope.
  *   - Spacing / typography / size — EMITTED when the corresponding
@@ -128,12 +130,24 @@ export function buildApplyOverrides(
     const changed = colorDefaults === undefined || !structuralEqual(currentMapping, baselineMapping);
     if (!changed) continue;
 
+    // Per-mode `{ literal: { light, dark } }` (#472). Emit a CSS
+    // `light-dark(<light>, <dark>)` — byte-identical to the DOM emitter
+    // (`resolveSemanticCssValue`) so disk and live-apply stay in parity. The
+    // browser resolves the correct side from the root's `color-scheme`.
+    //
+    // NOTE: this pipeline cannot ALSO set `color-scheme: light dark` on disk.
+    // `routeTokensToFiles` only rewrites entries shaped `--<prefix>-...`; a
+    // bare `color-scheme` property has no `--` prefix and no routing entry, so
+    // it would land in `rejected`. The host's tokens CSS is expected to declare
+    // `color-scheme` itself (see `generateLightDarkCssProperties`); the DOM
+    // apply path sets it at runtime for the live panel.
+    if (isPerModeLiteral(currentMapping)) {
+      out[cssVar] = `light-dark(${currentMapping.literal.light}, ${currentMapping.literal.dark})`;
+      continue;
+    }
+
     // `{ literal: string }` — single-mode literal color (#465, S4). Emit the
     // stored CSS value verbatim rather than routing through a palette slot.
-    // Per-mode `{ literal: { light, dark } }` (#472) is NOT resolved here
-    // yet — it falls through to `resolveMappingIndex` below, which returns
-    // `null` for it, so the entry is silently skipped (see that function's
-    // doc comment). #472 slots its branch in here, above the `{ ref }` check.
     if (isLiteralMapping(currentMapping) && !isPerModeLiteral(currentMapping)) {
       out[cssVar] = currentMapping.literal;
       continue;
@@ -267,11 +281,10 @@ function emitTabOverrides(
  * - `"fg"`    → the color state's current foreground index.
  * - anything else → `null` (caller skips the entry).
  *
- * The single-mode `{ literal: string }` variant (#465, S4) and the `{ ref }`
- * variant (#468) are both resolved by the caller BEFORE this function runs
- * and never reach here. The per-mode `{ literal: { light, dark } }` variant
- * (#472) still falls through to `null` — that resolver is downstream work,
- * not this function's job today.
+ * The single-mode `{ literal: string }` (#465, S4), per-mode
+ * `{ literal: { light, dark } }` (#472), and `{ ref }` (#468) variants are all
+ * resolved by the caller BEFORE this function runs and never reach here. Any
+ * other object shape still falls through to `null` (caller skips the entry).
  */
 function resolveMappingIndex(mapping: SemanticValue, color: ColorTweakState): number | null {
   if (mapping === 'bg') return color.background;

--- a/packages/zdtp/src/apply/tier-resolver.ts
+++ b/packages/zdtp/src/apply/tier-resolver.ts
@@ -184,3 +184,66 @@ export function emitTierItemCssValue(resolved: ResolvedTierItem): string {
   if (resolved.kind === 'literal') return resolved.value;
   return `var(${resolved.targetCssVar})`;
 }
+
+// ---------------------------------------------------------------------------
+// Cross-tab ref resolution (#467)
+// ---------------------------------------------------------------------------
+
+/**
+ * A `SemanticValue`'s cross-tab ramp reference: names a target ramp item by
+ * `{ tab?, tier, item }`. An omitted `tab` means "the current tab" (intra-tab,
+ * back-compat). Mirrors the `{ ref }` variant of `SemanticValue` in
+ * `tokens/tier-model.ts`.
+ */
+export type CrossTabRef = { tab?: string; tier: string; item: string };
+
+/**
+ * Resolve a `{ tab?, tier, item }` reference to the target item's `cssVar`
+ * so a downstream emitter (#468) can write `var(--target-cssvar)`.
+ *
+ * Resolution:
+ *   - `tab` omitted (or equal to `currentTab.id`) → resolve within
+ *     `currentTab` (intra-tab; keeps a lone-tab caller working with the
+ *     default `tabs = [currentTab]`).
+ *   - `tab` set → look the target tab up by id in `tabs` (the panel config's
+ *     full tabs array), then find `tier` in it, then `item` in that tier.
+ *
+ * Throws `TierResolverError` with a precise message when the target tab, tier,
+ * or item does not exist. This is the single reachable cross-tab lookup path;
+ * #468 wraps the returned cssVar in `var(...)` and #469 validates source
+ * declarations up front.
+ */
+export function resolveRefToCssVar(
+  ref: CrossTabRef,
+  currentTab: TabConfig,
+  tabs: readonly TabConfig[] = [currentTab],
+): string {
+  const targetTab =
+    ref.tab === undefined || ref.tab === currentTab.id
+      ? currentTab
+      : tabs.find((t) => t.id === ref.tab);
+  if (!targetTab) {
+    throw new TierResolverError(
+      `Cross-tab ref target tab "${ref.tab}" not found. ` +
+        `Available tabs: ${tabs.map((t) => t.id).join(', ')}.`,
+    );
+  }
+
+  const tier = findTier(targetTab, ref.tier);
+  if (!tier) {
+    throw new TierResolverError(
+      `Cross-tab ref target tier "${ref.tier}" not found in tab "${targetTab.id}". ` +
+        `Available tiers: ${targetTab.tiers.map((t) => t.id).join(', ')}.`,
+    );
+  }
+
+  const item = findItem(tier, ref.item);
+  if (!item) {
+    throw new TierResolverError(
+      `Cross-tab ref target item "${ref.item}" not found in tier "${ref.tier}" ` +
+        `of tab "${targetTab.id}". Available items: ${tier.items.map((i) => i.id).join(', ')}.`,
+    );
+  }
+
+  return item.cssVar;
+}

--- a/packages/zdtp/src/config/__tests__/cluster-config.test.ts
+++ b/packages/zdtp/src/config/__tests__/cluster-config.test.ts
@@ -152,3 +152,156 @@ describe('resolveColorClusterFromTab — palette vs. semantic disambiguation (#4
     expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
   });
 });
+
+/**
+ * Semantic-map derivation tests (#463, S2b). `resolveColorClusterFromTab`
+ * must populate `semanticDefaults`/`semanticCssNames` for a `semantic: true`
+ * tier in all three cluster shapes: lone semantic tier (no palette sibling),
+ * conventional palette+semantic, and palette-only (no semantic tier at all).
+ */
+describe('resolveColorClusterFromTab — semantic default derivation (#463)', () => {
+  it('derives `{ literal }` semantic defaults for a lone `semantic: true` tier with no palette sibling', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: 'oklch(0.6 0.2 25)',
+              type: { kind: 'color' as const, format: 'oklch' as const },
+            },
+            {
+              id: 'success',
+              cssVar: '--zd-success',
+              label: 'Success',
+              default: '#00cc66',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    expect(cluster?.paletteSize).toBe(0);
+    expect(cluster?.semanticCssNames).toEqual({
+      danger: '--zd-danger',
+      success: '--zd-success',
+    });
+    // Must be literal-wrapped, not the empty-stub `{}` nor a grayscale/index
+    // fallback (e.g. `{ danger: 0, success: 0 }`).
+    expect(cluster?.semanticDefaults).toEqual({
+      danger: { literal: 'oklch(0.6 0.2 25)' },
+      success: { literal: '#00cc66' },
+    });
+  });
+
+  it('keeps producing numeric palette indices for a conventional palette+semantic config', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p1',
+              cssVar: '--pal-1',
+              label: 'Palette 1',
+              default: '#ffffff',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p2',
+              cssVar: '--pal-2',
+              label: 'Palette 2',
+              default: '#ff00ff',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'palette',
+          items: [
+            {
+              id: 'accent',
+              cssVar: '--semantic-accent',
+              label: 'Accent',
+              default: 'p1',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'brand',
+              cssVar: '--semantic-brand',
+              label: 'Brand',
+              default: 'p2',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    expect(cluster?.paletteSize).toBe(3);
+    expect(cluster?.semanticDefaults).toEqual({ accent: 1, brand: 2 });
+  });
+
+  it('leaves semanticDefaults/semanticCssNames empty for a palette-only tab (no semantic tier)', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p1',
+              cssVar: '--pal-1',
+              label: 'Palette 1',
+              default: '#ffffff',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    expect(cluster?.paletteSize).toBe(2);
+    expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
+    expect(cluster?.semanticDefaults).toEqual({});
+    expect(cluster?.semanticCssNames).toEqual({});
+  });
+});

--- a/packages/zdtp/src/config/__tests__/cluster-config.test.ts
+++ b/packages/zdtp/src/config/__tests__/cluster-config.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { resolveColorClusterFromTab } from '../cluster-config';
+import type { TabConfig } from '../../tokens/tier-model';
+
+/**
+ * Disambiguation tests (#461, S2a): `TierConfig.semantic === true` must
+ * exclude a tier from palette-tier detection, even when its items happen to
+ * be `kind: 'color'`. Mirrors the same fixture shape used by the
+ * `cluster-config.ts` JSDoc and `color-tab.tsx`'s `findPaletteTier`.
+ */
+
+const COLOR_EXTRAS = {
+  id: 'test-cluster',
+  baseRoles: {},
+  baseDefaults: {},
+  defaultShikiTheme: 'dracula' as const,
+  colorSchemes: {},
+  panelSettings: { colorScheme: 'default', colorMode: false as const },
+};
+
+describe('resolveColorClusterFromTab — palette vs. semantic disambiguation (#461)', () => {
+  it('does NOT select a lone `semantic: true` color tier as the palette', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: '#ff0000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'warning',
+              cssVar: '--zd-warning',
+              label: 'Warning',
+              default: '#ffaa00',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    // No palette tier was found (the only tier is `semantic: true`), so the
+    // bridge falls back to the zero-palette stub — it must NOT report the
+    // semantic tier's 2 items as a 2-slot palette.
+    expect(cluster?.paletteSize).toBe(0);
+  });
+
+  it('still detects the palette tier as before in a conventional 2-tier palette+semantic config', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p1',
+              cssVar: '--pal-1',
+              label: 'Palette 1',
+              default: '#ffffff',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'palette',
+          items: [
+            {
+              id: 'accent',
+              cssVar: '--semantic-accent',
+              label: 'Accent',
+              default: 'p1',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    expect(cluster?.paletteSize).toBe(2);
+    expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
+    expect(cluster?.semanticCssNames).toEqual({ accent: '--semantic-accent' });
+    expect(cluster?.semanticDefaults).toEqual({ accent: 1 });
+  });
+
+  it('does not pick a `semantic: true` tier as the palette even when a real palette tier is also present', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: '#ff0000',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    // The `palette` tier (not the `semantic: true` tier) must be the one
+    // reported as the 1-slot palette.
+    expect(cluster?.paletteSize).toBe(1);
+    expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
+  });
+});

--- a/packages/zdtp/src/config/__tests__/cluster-config.test.ts
+++ b/packages/zdtp/src/config/__tests__/cluster-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { resolveColorClusterFromTab } from '../cluster-config';
+import { resolveRefToCssVar } from '../../apply/tier-resolver';
 import type { TabConfig } from '../../tokens/tier-model';
 
 /**
@@ -303,5 +304,73 @@ describe('resolveColorClusterFromTab — semantic default derivation (#463)', ()
     expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
     expect(cluster?.semanticDefaults).toEqual({});
     expect(cluster?.semanticCssNames).toEqual({});
+  });
+});
+
+/**
+ * Cross-tab ramp-reference derivation (#467, S7a). When a `semantic: true` tier
+ * declares `referencesRamps` pointing at a ramp tier in the grouped Palette tab
+ * (a DIFFERENT tab), `resolveColorClusterFromTab(colorTab, tabs)` must derive a
+ * `{ ref: { tab, tier, item } }` that actually names a real ramp item — i.e. one
+ * that `resolveRefToCssVar` can resolve to the ramp item's cssVar.
+ */
+describe('resolveColorClusterFromTab — cross-tab ramp ref derivation (#467)', () => {
+  const PALETTE_TAB: TabConfig = {
+    id: 'palette',
+    label: 'Palette',
+    tiers: [
+      {
+        id: 'base',
+        label: 'Base',
+        items: [
+          { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.98 0 0)', type: { kind: 'color' as const, format: 'oklch' as const } },
+          { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.9 0 0)', type: { kind: 'color' as const, format: 'oklch' as const } },
+          { id: 'base-3', cssVar: '--palette-base-3', label: 'Base 3', default: 'oklch(0.8 0 0)', type: { kind: 'color' as const, format: 'oklch' as const } },
+        ],
+      },
+    ],
+  };
+
+  const COLOR_TAB: TabConfig = {
+    id: 'color',
+    label: 'Color',
+    colorExtras: COLOR_EXTRAS,
+    tiers: [
+      {
+        id: 'semantic',
+        label: 'Semantic',
+        semantic: true,
+        referencesRamps: [{ tab: 'palette', tier: 'base' }],
+        items: [
+          { id: 'surface', cssVar: '--zd-surface', label: 'Surface', default: 'base-3', type: { kind: 'color' as const } },
+        ],
+      },
+    ],
+  };
+
+  it('derives a { ref } naming a real ramp item that resolves cross-tab to its cssVar', () => {
+    const tabs = [COLOR_TAB, PALETTE_TAB];
+    const cluster = resolveColorClusterFromTab(COLOR_TAB, tabs);
+    expect(cluster).toBeDefined();
+    expect(cluster?.paletteSize).toBe(0);
+    expect(cluster?.semanticCssNames).toEqual({ surface: '--zd-surface' });
+    expect(cluster?.semanticDefaults).toEqual({
+      surface: { ref: { tab: 'palette', tier: 'base', item: 'base-3' } },
+    });
+
+    // The derived ref must actually resolve against the Palette tab.
+    const derived = cluster?.semanticDefaults.surface as {
+      ref: { tab?: string; tier: string; item: string };
+    };
+    expect(resolveRefToCssVar(derived.ref, COLOR_TAB, tabs)).toBe('--palette-base-3');
+  });
+
+  it('back-compat: single-arg (lone-tab) call still derives the best-effort ref shape', () => {
+    // Without the Palette tab threaded in, the ref cannot be resolved but the
+    // shape is still produced (validation/throwing is #469's job).
+    const cluster = resolveColorClusterFromTab(COLOR_TAB);
+    expect(cluster?.semanticDefaults).toEqual({
+      surface: { ref: { tab: 'palette', tier: 'base', item: 'base-3' } },
+    });
   });
 });

--- a/packages/zdtp/src/config/cluster-config.ts
+++ b/packages/zdtp/src/config/cluster-config.ts
@@ -153,10 +153,13 @@ export function resolveColorClusterFromTab(
   const extras = tab.colorExtras;
   if (!extras) return undefined;
 
-  // Find the palette tier (first tier with kind: 'color' items).
+  // Find the palette tier (first tier with kind: 'color' items). A tier
+  // marked `semantic: true` is never the palette, even if its items happen
+  // to be color-kind — it holds SemanticValue mappings (#461).
   const paletteTier = tab.tiers.find(
     (t) =>
       !t.referencesTier &&
+      !t.semantic &&
       t.items.length > 0 &&
       t.items[0].type.kind === 'color',
   );
@@ -192,9 +195,14 @@ export function resolveColorClusterFromTab(
     paletteIdToIndex.set(paletteItems[i].id, i);
   }
 
-  // Find the semantic tier (first tier with referencesTier pointing to paletteTier).
+  // Find the semantic tier: either the first tier with referencesTier pointing
+  // at paletteTier (legacy shape), or a tier explicitly marked `semantic: true`
+  // (#461) — the latter may have no referencesTier at all (its mappings are
+  // SemanticValue, not necessarily plain palette indices). Literal/ref default
+  // derivation for a `semantic: true` tier is #463's job; this only stops it
+  // from being mis-detected as "no semantic tier".
   const semanticTier = tab.tiers.find(
-    (t) => t.referencesTier === paletteTier.id,
+    (t) => t.referencesTier === paletteTier.id || t.semantic === true,
   );
 
   const semanticDefaults: Record<string, number> = {};

--- a/packages/zdtp/src/config/cluster-config.ts
+++ b/packages/zdtp/src/config/cluster-config.ts
@@ -22,6 +22,11 @@
  */
 
 import type { ColorScheme } from './color-schemes';
+import type { SemanticValue } from '../tokens/tier-model';
+
+// Re-exported so callers that only import from `cluster-config` (rather than
+// `tokens/tier-model` or `state/tweak-state`) can still reach the type.
+export type { SemanticValue } from '../tokens/tier-model';
 
 /**
  * Base-role keys that a cluster may declare. Subset is allowed (a cluster may
@@ -76,8 +81,14 @@ export interface ColorClusterDataConfig {
    * `--brand-p{n}`, `--demo-palette-{n}`.
    */
   paletteCssVarTemplate: string;
-  /** Semantic token name → default palette index. */
-  semanticDefaults: Record<string, number>;
+  /**
+   * Semantic token name → default mapping. Historically always a palette
+   * index (`number`); widened to `SemanticValue` (#459) so a default can also
+   * be a literal color or a cross-tab ramp reference. `resolveColorClusterFromTab`
+   * still only ever produces `number` defaults today — the wider variants are
+   * populated by downstream sub-issues (#467/#469).
+   */
+  semanticDefaults: Record<string, SemanticValue>;
   /** Semantic token name → CSS custom-property name. */
   semanticCssNames: Record<string, string>;
   /** Fallback indices used when a scheme doesn't declare a base role. */

--- a/packages/zdtp/src/config/cluster-config.ts
+++ b/packages/zdtp/src/config/cluster-config.ts
@@ -85,8 +85,10 @@ export interface ColorClusterDataConfig {
    * Semantic token name → default mapping. Historically always a palette
    * index (`number`); widened to `SemanticValue` (#459) so a default can also
    * be a literal color or a cross-tab ramp reference. `resolveColorClusterFromTab`
-   * still only ever produces `number` defaults today — the wider variants are
-   * populated by downstream sub-issues (#467/#469).
+   * now derives the `{ literal }` / best-effort `{ ref }` variants too (#463)
+   * for a `semantic: true` tier; actually resolving a `{ ref }` against the
+   * ramp tier it names (rendering + apply) is still downstream work
+   * (#467/#469).
    */
   semanticDefaults: Record<string, SemanticValue>;
   /** Semantic token name → CSS custom-property name. */
@@ -126,22 +128,96 @@ export function resolvePaletteCssVar(
 // all need to be rewritten in one wave.
 // ---------------------------------------------------------------------------
 
-import type { TabConfig } from '../tokens/tier-model';
+import type { TabConfig, TierItem } from '../tokens/tier-model';
+
+/**
+ * True when `value` reads as a literal CSS color (e.g. `#fff`, `oklch(...)`,
+ * `rgb(...)`) rather than an id referencing another tier's item. Bare ids
+ * (palette-item ids, ramp-item ids) never start with `#` or contain `(`, so
+ * this is a cheap, reliable-enough discriminator for #463's best-effort
+ * literal-vs-ref split.
+ */
+function looksLikeColorLiteral(value: string): boolean {
+  return value.startsWith('#') || value.includes('(');
+}
+
+/**
+ * Build a best-effort `{ ref }` `SemanticValue` for a semantic item whose
+ * `default` names a ramp item rather than a literal color. Full cross-tab
+ * resolution (actually looking up the ramp item's color) is #467/#469's job —
+ * this only preserves the ref intent so it isn't silently dropped.
+ *
+ * Convention: `"tierId:itemId"` picks the matching `referencesRamps` entry by
+ * tier id; a bare `"itemId"` (no `:`) assumes the tier's first declared ramp.
+ */
+function deriveRampRef(
+  defaultId: string,
+  referencesRamps: readonly { tab?: string; tier: string }[],
+): { ref: { tab?: string; tier: string; item: string } } {
+  const sepIdx = defaultId.indexOf(':');
+  if (sepIdx !== -1) {
+    const tierId = defaultId.slice(0, sepIdx);
+    const itemId = defaultId.slice(sepIdx + 1);
+    const match = referencesRamps.find((r) => r.tier === tierId);
+    if (match) return { ref: { tab: match.tab, tier: match.tier, item: itemId } };
+  }
+  const [firstRamp] = referencesRamps;
+  return { ref: { tab: firstRamp.tab, tier: firstRamp.tier, item: defaultId } };
+}
+
+/**
+ * Derive the `SemanticValue` a semantic-tier item's `default` denotes.
+ *
+ * Branches (checked in order):
+ * 1. Legacy palette-index shape — `default` names a sibling palette item's
+ *    id (conventional 2-tier palette+semantic config, or a `semantic: true`
+ *    tier that still points at palette ids). Regression-critical: must keep
+ *    producing the exact numeric index as before.
+ * 2. `'bg'` / `'fg'` base-role sentinel aliases, passed through unchanged.
+ * 3. Cross-tab ramp reference — the tier declares `referencesRamps` and
+ *    `default` doesn't read as a literal color, so it's treated as naming a
+ *    ramp item (best-effort shape; see `deriveRampRef`).
+ * 4. Literal color default (e.g. an `oklch(...)`/hex string) — the common
+ *    case for a lone `semantic: true` tier with no palette sibling.
+ */
+function deriveSemanticValue(
+  item: TierItem,
+  paletteIdToIndex: ReadonlyMap<string, number>,
+  referencesRamps: readonly { tab?: string; tier: string }[] | undefined,
+): SemanticValue {
+  const paletteIdx = paletteIdToIndex.get(item.default);
+  if (paletteIdx !== undefined) return paletteIdx;
+
+  if (item.default === 'bg' || item.default === 'fg') return item.default;
+
+  if (referencesRamps && referencesRamps.length > 0 && !looksLikeColorLiteral(item.default)) {
+    return deriveRampRef(item.default, referencesRamps);
+  }
+
+  return { literal: item.default };
+}
 
 /**
  * Derive a `ColorClusterDataConfig` from a color `TabConfig`.
  *
- * - Palette items: the first tier whose items all have `kind: 'color'`.
- *   Each item's `cssVar` becomes a palette slot; `paletteCssVarTemplate` is
- *   synthesised as `"{item.cssVar}"` with `{n}` replaced by the slot index.
- *   Because item cssVars are explicit (e.g. `--zfb-palette-0`) rather
- *   than template-based, we derive the template from the first item by
- *   replacing the terminal digit sequence with `{n}`.
+ * - Palette items: the first tier whose items all have `kind: 'color'` and
+ *   are not `semantic: true`. Each item's `cssVar` becomes a palette slot;
+ *   `paletteCssVarTemplate` is synthesised as `"{item.cssVar}"` with `{n}`
+ *   replaced by the slot index. Because item cssVars are explicit (e.g.
+ *   `--zfb-palette-0`) rather than template-based, we derive the template
+ *   from the first item by replacing the terminal digit sequence with `{n}`.
  *
- * - Semantic items: the first tier with `referencesTier` set pointing at the
- *   palette tier. Each item's `id` → `cssVar` mapping becomes `semanticCssNames`;
- *   the item's `default` (a palette item id) is looked up to produce the index
- *   for `semanticDefaults`.
+ * - Semantic items: either the first tier with `referencesTier` set pointing
+ *   at the palette tier (legacy shape), or a tier explicitly marked
+ *   `semantic: true` (#461) — the latter may have no palette sibling at all.
+ *   Each item's `id` → `cssVar` mapping becomes `semanticCssNames`; the
+ *   item's `default` is resolved to a `SemanticValue` by
+ *   `deriveSemanticValue` (palette index / literal / ramp-ref — see there).
+ *
+ * - A tab with a semantic tier but NO palette tier still produces a usable
+ *   cluster: `paletteSize` is `0` (the palette-driven UI has nothing to
+ *   render) but `semanticDefaults`/`semanticCssNames` are populated from the
+ *   semantic tier so the Semantic Tokens section isn't left empty (#463).
  *
  * - Metadata comes from `tab.colorExtras` (required on a color tab).
  *
@@ -163,8 +239,17 @@ export function resolveColorClusterFromTab(
       t.items.length > 0 &&
       t.items[0].type.kind === 'color',
   );
-  if (!paletteTier) {
-    // No palette tier — return stub cluster with zero palette.
+
+  // Find the semantic tier: either the first tier with referencesTier pointing
+  // at paletteTier (legacy shape), or a tier explicitly marked `semantic: true`
+  // (#461) — the latter may have no referencesTier at all, and no palette
+  // sibling at all (#463).
+  const semanticTier = tab.tiers.find(
+    (t) => (paletteTier && t.referencesTier === paletteTier.id) || t.semantic === true,
+  );
+
+  if (!paletteTier && !semanticTier) {
+    // Genuinely no palette AND no semantic tier — return stub cluster.
     return {
       id: extras.id,
       label: extras.label,
@@ -180,14 +265,17 @@ export function resolveColorClusterFromTab(
     };
   }
 
-  const paletteItems = paletteTier.items;
+  const paletteItems = paletteTier?.items ?? [];
   const paletteSize = paletteItems.length;
 
   // Derive the palette CSS-var template from the first item's cssVar.
   // e.g. "--zfb-palette-0" → "--zfb-palette-{n}"
   // Strategy: replace the LAST run of digits in the cssVar with "{n}".
-  const firstCssVar = paletteItems[0]?.cssVar ?? '--palette-{n}';
-  const paletteCssVarTemplate = firstCssVar.replace(/\d+$/, '{n}');
+  // When there's no palette tier (lone semantic tier), fall back to the
+  // stub template — nothing reads it since paletteSize is 0.
+  const paletteCssVarTemplate = paletteItems[0]
+    ? paletteItems[0].cssVar.replace(/\d+$/, '{n}')
+    : '--zudo-stub-p{n}';
 
   // Build palette cssVar lookup for semantic default index resolution.
   const paletteIdToIndex = new Map<string, number>();
@@ -195,25 +283,17 @@ export function resolveColorClusterFromTab(
     paletteIdToIndex.set(paletteItems[i].id, i);
   }
 
-  // Find the semantic tier: either the first tier with referencesTier pointing
-  // at paletteTier (legacy shape), or a tier explicitly marked `semantic: true`
-  // (#461) — the latter may have no referencesTier at all (its mappings are
-  // SemanticValue, not necessarily plain palette indices). Literal/ref default
-  // derivation for a `semantic: true` tier is #463's job; this only stops it
-  // from being mis-detected as "no semantic tier".
-  const semanticTier = tab.tiers.find(
-    (t) => t.referencesTier === paletteTier.id || t.semantic === true,
-  );
-
-  const semanticDefaults: Record<string, number> = {};
+  const semanticDefaults: Record<string, SemanticValue> = {};
   const semanticCssNames: Record<string, string> = {};
 
   if (semanticTier) {
     for (const item of semanticTier.items) {
       semanticCssNames[item.id] = item.cssVar;
-      // item.default is the palette item id; look up its index.
-      const idx = paletteIdToIndex.get(item.default);
-      semanticDefaults[item.id] = idx ?? 0;
+      semanticDefaults[item.id] = deriveSemanticValue(
+        item,
+        paletteIdToIndex,
+        semanticTier.referencesRamps,
+      );
     }
   }
 

--- a/packages/zdtp/src/config/cluster-config.ts
+++ b/packages/zdtp/src/config/cluster-config.ts
@@ -129,6 +129,7 @@ export function resolvePaletteCssVar(
 // ---------------------------------------------------------------------------
 
 import type { TabConfig, TierItem } from '../tokens/tier-model';
+import { resolveRefToCssVar } from '../apply/tier-resolver';
 
 /**
  * True when `value` reads as a literal CSS color (e.g. `#fff`, `oklch(...)`,
@@ -142,27 +143,53 @@ function looksLikeColorLiteral(value: string): boolean {
 }
 
 /**
- * Build a best-effort `{ ref }` `SemanticValue` for a semantic item whose
- * `default` names a ramp item rather than a literal color. Full cross-tab
- * resolution (actually looking up the ramp item's color) is #467/#469's job —
- * this only preserves the ref intent so it isn't silently dropped.
+ * Build a `{ ref }` `SemanticValue` for a semantic item whose `default` names
+ * a ramp item rather than a literal color.
  *
  * Convention: `"tierId:itemId"` picks the matching `referencesRamps` entry by
  * tier id; a bare `"itemId"` (no `:`) assumes the tier's first declared ramp.
+ *
+ * When the panel's full `tabs` array is threaded in (via
+ * `resolveColorClusterFromTab(tab, tabs)`), each candidate ref is checked
+ * against the real ramp tier with `resolveRefToCssVar`, and the first ref that
+ * names an existing ramp item is chosen. This makes the derived ref actually
+ * resolvable cross-tab (the ramp typically lives in the Palette tab). When no
+ * candidate resolves — e.g. a lone-tab caller passing only `[tab]` — the
+ * best-effort shape is returned unchanged; up-front source validation (throwing
+ * on an unresolvable declaration) is #469's job.
  */
 function deriveRampRef(
   defaultId: string,
   referencesRamps: readonly { tab?: string; tier: string }[],
+  currentTab: TabConfig,
+  tabs: readonly TabConfig[],
 ): { ref: { tab?: string; tier: string; item: string } } {
+  const candidates: { tab?: string; tier: string; item: string }[] = [];
+
   const sepIdx = defaultId.indexOf(':');
   if (sepIdx !== -1) {
     const tierId = defaultId.slice(0, sepIdx);
     const itemId = defaultId.slice(sepIdx + 1);
     const match = referencesRamps.find((r) => r.tier === tierId);
-    if (match) return { ref: { tab: match.tab, tier: match.tier, item: itemId } };
+    if (match) candidates.push({ tab: match.tab, tier: match.tier, item: itemId });
   }
+
   const [firstRamp] = referencesRamps;
-  return { ref: { tab: firstRamp.tab, tier: firstRamp.tier, item: defaultId } };
+  candidates.push({ tab: firstRamp.tab, tier: firstRamp.tier, item: defaultId });
+
+  // Prefer the first candidate that resolves against a real ramp item.
+  for (const cand of candidates) {
+    try {
+      resolveRefToCssVar(cand, currentTab, tabs);
+      return { ref: cand };
+    } catch {
+      // Not resolvable against the supplied tabs — try the next candidate.
+    }
+  }
+
+  // Nothing resolved (lone-tab caller / ramp lives in a tab not passed).
+  // Return the best-effort shape; #469 owns up-front validation.
+  return { ref: candidates[0] };
 }
 
 /**
@@ -184,6 +211,8 @@ function deriveSemanticValue(
   item: TierItem,
   paletteIdToIndex: ReadonlyMap<string, number>,
   referencesRamps: readonly { tab?: string; tier: string }[] | undefined,
+  currentTab: TabConfig,
+  tabs: readonly TabConfig[],
 ): SemanticValue {
   const paletteIdx = paletteIdToIndex.get(item.default);
   if (paletteIdx !== undefined) return paletteIdx;
@@ -191,7 +220,7 @@ function deriveSemanticValue(
   if (item.default === 'bg' || item.default === 'fg') return item.default;
 
   if (referencesRamps && referencesRamps.length > 0 && !looksLikeColorLiteral(item.default)) {
-    return deriveRampRef(item.default, referencesRamps);
+    return deriveRampRef(item.default, referencesRamps, currentTab, tabs);
   }
 
   return { literal: item.default };
@@ -221,10 +250,17 @@ function deriveSemanticValue(
  *
  * - Metadata comes from `tab.colorExtras` (required on a color tab).
  *
+ * `tabs` is the panel config's full tabs array, used to resolve a semantic
+ * tier's cross-tab `{ ref }` mappings against a ramp tier living in ANOTHER
+ * tab (typically the grouped Palette tab). It defaults to `[tab]` so an
+ * existing single-argument call still works — intra-tab refs resolve, and a
+ * cross-tab ramp declaration falls back to its best-effort shape (#467).
+ *
  * Returns `undefined` when the tab has no `colorExtras` (not a color tab).
  */
 export function resolveColorClusterFromTab(
   tab: TabConfig,
+  tabs: readonly TabConfig[] = [tab],
 ): ColorClusterDataConfig | undefined {
   const extras = tab.colorExtras;
   if (!extras) return undefined;
@@ -293,6 +329,8 @@ export function resolveColorClusterFromTab(
         item,
         paletteIdToIndex,
         semanticTier.referencesRamps,
+        tab,
+        tabs,
       );
     }
   }
@@ -322,7 +360,7 @@ export function resolvePrimaryColorCluster(
 ): ColorClusterDataConfig | undefined {
   const colorTab = tabs.find((t) => t.id === 'color');
   if (!colorTab) return undefined;
-  return resolveColorClusterFromTab(colorTab);
+  return resolveColorClusterFromTab(colorTab, tabs);
 }
 
 /**
@@ -334,5 +372,5 @@ export function resolveSecondaryColorClusterFromTabs(
 ): ColorClusterDataConfig | null {
   const secondaryTab = tabs.find((t) => t.id === 'color-secondary');
   if (!secondaryTab) return null;
-  return resolveColorClusterFromTab(secondaryTab) ?? null;
+  return resolveColorClusterFromTab(secondaryTab, tabs) ?? null;
 }

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -1178,14 +1178,18 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
     }
 
     // F4: Palette cssVar 0-based contiguity check.
-    // Find the palette tier (first tier with kind:'color' items and no
-    // referencesTier) and verify that each item's cssVar matches the template
-    // derived from the first item at its expected 0-based index. A mismatch
-    // means the host used 1-based or non-numbered cssVars, which causes
-    // palette writes to land on the wrong variables at runtime.
+    // Find the palette tier (first tier with kind:'color' items, no
+    // referencesTier, and not marked `semantic: true`) and verify that each
+    // item's cssVar matches the template derived from the first item at its
+    // expected 0-based index. A mismatch means the host used 1-based or
+    // non-numbered cssVars, which causes palette writes to land on the wrong
+    // variables at runtime. A `semantic: true` tier is skipped here (#461) —
+    // it legitimately holds named, non-contiguous cssVars (e.g. `--zd-danger`)
+    // since its items are SemanticValue mappings, not palette slots.
     const tiers = tab.tiers as unknown as Array<Record<string, unknown>>;
     const paletteTier = tiers.find((t) => {
       if (t.referencesTier !== undefined) return false;
+      if (t.semantic === true) return false;
       const items = t.items;
       if (!Array.isArray(items) || items.length === 0) return false;
       const first = items[0];

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -938,7 +938,12 @@ function assertValidTabs(tabs: unknown): void {
       );
     }
     tabIds.add(t.id);
-    assertValidTab(t.id, t);
+    // Pass the full (raw, untyped) tabs array down so a tab can validate
+    // cross-tab references (S8, #469) against sibling tabs — including
+    // siblings that appear later in the array and have not been validated
+    // yet themselves. assertValidTab only reads shape (id/tiers/items) from
+    // those siblings defensively; it never assumes they are fully valid.
+    assertValidTab(t.id, t, tabs as unknown[]);
   }
 }
 
@@ -947,8 +952,12 @@ function assertValidTabs(tabs: unknown): void {
  * Checks tier-id uniqueness, item-id uniqueness across all tiers, cssVar
  * format, referencesTier existence (the referenced tier id must exist), and
  * cross-tier kind compatibility (Option 2-a narrowed guard — see below).
+ *
+ * `allTabs` is the raw, untyped `PanelConfig.tabs` array (every tab, including
+ * this one) — needed to validate cross-tab `referencesRamps` sources (S8,
+ * #469), which name a sibling tab by id.
  */
-function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
+function assertValidTab(tabId: string, tab: Record<string, unknown>, allTabs: unknown[]): void {
   if (!Array.isArray(tab.tiers)) {
     throw new Error(
       `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers must be an array`,
@@ -1099,6 +1108,135 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>): void {
         throw new Error(
           `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesTier: referencing tier has kind "${referencingKind}" but referenced tier "${refId}" has kind "${referencedKind}" (cross-kind reference is only allowed when the referencing tier has kind "text")`,
         );
+      }
+    }
+  }
+
+  // Rule: referencesRamps integrity (S8, #469) — a `semantic: true` tier's
+  // cross-tab ramp-source declaration must name an EXISTING tab (cross-tab;
+  // an omitted `tab` means "this tab") and an existing tier within it.
+  //
+  // This is a DIFFERENT mechanism from the same-tab `referencesTier` guard
+  // above: `referencesTier` names one tier a whole tier's items resolve
+  // against by id; `referencesRamps` is a tier-level allow-list of ramp
+  // SOURCES that per-row `{ ref: { tab?, tier, item } }` VALUES (see
+  // `SemanticValue` in `tokens/tier-model.ts`) are permitted to point into.
+  // Per-row `{ ref }` values are resolved (and validated against actual
+  // items) at apply time by `resolveRefToCssVar` in `apply/tier-resolver.ts`
+  // — this block only validates the declared sources, not every row.
+  for (const tier of tab.tiers) {
+    const ti = tier as Record<string, unknown>;
+    const tierId = ti.id as string;
+    if (ti.referencesRamps === undefined) continue;
+    if (ti.semantic !== true) {
+      throw new Error(
+        `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps is only valid on a tier with semantic: true`,
+      );
+    }
+    if (!Array.isArray(ti.referencesRamps)) {
+      throw new Error(
+        `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps must be an array`,
+      );
+    }
+    // Representative kind of THIS semantic tier, for the best-effort
+    // cross-kind compatibility check below (reuses the same tierKinds map
+    // built during the item loop earlier in this function).
+    const referencingKind = tierKinds.get(tierId);
+    const sources = ti.referencesRamps as unknown[];
+    for (let i = 0; i < sources.length; i++) {
+      const src = sources[i];
+      if (src === null || typeof src !== 'object' || Array.isArray(src)) {
+        throw new Error(
+          `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps[${i}] must be a non-null object`,
+        );
+      }
+      const s = src as Record<string, unknown>;
+      if (typeof s.tier !== 'string' || s.tier.length === 0) {
+        throw new Error(
+          `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps[${i}].tier must be a non-empty string`,
+        );
+      }
+      if (s.tab !== undefined && (typeof s.tab !== 'string' || s.tab.length === 0)) {
+        throw new Error(
+          `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps[${i}].tab must be a non-empty string when set`,
+        );
+      }
+      // Resolve the source tab: omitted (or equal to this tab's id) means
+      // "this tab" — mirrors resolveRefToCssVar's `ref.tab === undefined ||
+      // ref.tab === currentTab.id` rule in apply/tier-resolver.ts, so the
+      // declared allow-list stays in lockstep with actual row resolution.
+      const targetTabId = s.tab === undefined ? tabId : s.tab;
+      let targetTabRaw: Record<string, unknown>;
+      if (targetTabId === tabId) {
+        targetTabRaw = tab;
+      } else {
+        const found = allTabs.find(
+          (t) =>
+            t !== null &&
+            typeof t === 'object' &&
+            !Array.isArray(t) &&
+            (t as Record<string, unknown>).id === targetTabId,
+        );
+        if (!found) {
+          const availableTabs = allTabs
+            .filter((t) => t !== null && typeof t === 'object' && !Array.isArray(t))
+            .map((t) => (t as Record<string, unknown>).id)
+            .join(', ');
+          throw new Error(
+            `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps[${i}]: tab "${targetTabId}" does not exist. Available tabs: ${availableTabs}.`,
+          );
+        }
+        targetTabRaw = found as Record<string, unknown>;
+      }
+
+      // Find the target tier within the target tab. The target tab may be a
+      // sibling that has not gone through its own assertValidTab call yet
+      // (it can appear later in `allTabs`), so this reads its raw shape
+      // defensively instead of assuming full validity.
+      const targetTiers = Array.isArray(targetTabRaw.tiers)
+        ? (targetTabRaw.tiers as unknown[])
+        : [];
+      const targetTierIds: string[] = [];
+      let targetTierRaw: Record<string, unknown> | undefined;
+      for (const tt of targetTiers) {
+        if (tt === null || typeof tt !== 'object' || Array.isArray(tt)) continue;
+        const ttObj = tt as Record<string, unknown>;
+        if (typeof ttObj.id !== 'string') continue;
+        targetTierIds.push(ttObj.id);
+        if (ttObj.id === s.tier) targetTierRaw = ttObj;
+      }
+      if (!targetTierRaw) {
+        throw new Error(
+          `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps[${i}]: tier "${s.tier}" does not exist in tab "${targetTabId}". Available tiers: ${targetTierIds.join(', ')}.`,
+        );
+      }
+
+      // Best-effort cross-tab kind compatibility: a color semantic tier
+      // should reference color-kind ramp tiers, etc. Compute the target
+      // tier's representative kind directly from its raw items (the
+      // per-tab tierKinds map built earlier only covers THIS tab). Skip
+      // when either kind is unknown (empty tier, missing type.kind) to stay
+      // permissive — same precedent as the same-tab referencesTier guard.
+      if (referencingKind !== undefined) {
+        const targetItems = Array.isArray(targetTierRaw.items)
+          ? (targetTierRaw.items as unknown[])
+          : [];
+        let targetKind: string | undefined;
+        for (const rawItem of targetItems) {
+          if (rawItem === null || typeof rawItem !== 'object' || Array.isArray(rawItem)) continue;
+          const typeObj = (rawItem as Record<string, unknown>).type;
+          if (typeObj === null || typeof typeObj !== 'object' || Array.isArray(typeObj)) continue;
+          const kind = (typeObj as Record<string, unknown>).kind;
+          if (typeof kind === 'string') {
+            targetKind = kind;
+            break;
+          }
+        }
+        if (targetKind !== undefined && referencingKind !== targetKind) {
+          throw new Error(
+            `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${tierId}"].referencesRamps[${i}]: referencing semantic tier has kind "${referencingKind}" but target tier "${s.tier}" in tab "${targetTabId}" has kind "${targetKind}" (cross-tab ramp sources must share the semantic tier's kind)`,
+          );
+        }
       }
     }
   }

--- a/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
+++ b/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
@@ -187,6 +187,7 @@ function renderGroupedSelector(
   value: TierRefSelectorValue,
   onChange: (itemId: string, next: TierRefSelectorValue) => void,
   previewValueFor: (ref: TierRefTarget) => string = rampPreviewValueFor,
+  defaultMode?: 'light' | 'dark',
 ) {
   act(() => {
     render(
@@ -200,9 +201,18 @@ function renderGroupedSelector(
         previewValueFor={previewValueFor}
         label="Surface"
         cssVar="--zd-surface"
+        defaultMode={defaultMode}
       />,
       container,
     );
+  });
+}
+
+/** Fire a native change event on a checkbox, toggling its checked state. */
+function fireCheckboxToggle(checkbox: HTMLInputElement, checked: boolean) {
+  act(() => {
+    checkbox.checked = checked;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
   });
 }
 
@@ -434,7 +444,144 @@ describe('TierRefSelector — grouped ref-or-literal mode', () => {
 });
 
 // ===========================================================================
-// 3. DOM hygiene (CLAUDE.md panel policy)
+// 3. Per-mode (light/dark) literal editor (S12, #473)
+// ===========================================================================
+
+describe('TierRefSelector — per-mode literal editor', () => {
+  it('renders a "Per-mode" checkbox alongside a single-mode literal, unchecked', () => {
+    renderGroupedSelector({ literal: 'oklch(0.5 0.1 200)' }, vi.fn());
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(false);
+    // Still exactly one editable swatch (single-mode).
+    expect(container.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(1);
+  });
+
+  it('renders two ColorField swatches (Light / Dark), checkbox checked, for a per-mode value', () => {
+    renderGroupedSelector({ literal: { light: 'oklch(0.9 0 0)', dark: 'oklch(0.2 0 0)' } }, vi.fn());
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(container.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(2);
+    expect(
+      container.querySelector('[aria-label="Surface (Light): --zd-surface"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Surface (Dark): --zd-surface"]'),
+    ).not.toBeNull();
+  });
+
+  it('checking "Per-mode" on a single-mode literal seeds both sides from the current value', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector({ literal: 'oklch(0.5 0.1 200)' }, onChange);
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireCheckboxToggle(checkbox, true);
+
+    expect(onChange).toHaveBeenCalledWith('surface', {
+      literal: { light: 'oklch(0.5 0.1 200)', dark: 'oklch(0.5 0.1 200)' },
+    });
+  });
+
+  it('unchecking "Per-mode" collapses to the light side by default (defaultMode="light")', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector(
+      { literal: { light: 'oklch(0.9 0 0)', dark: 'oklch(0.2 0 0)' } },
+      onChange,
+    );
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireCheckboxToggle(checkbox, false);
+
+    expect(onChange).toHaveBeenCalledWith('surface', { literal: 'oklch(0.9 0 0)' });
+  });
+
+  it('unchecking "Per-mode" collapses to the dark side when defaultMode="dark"', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector(
+      { literal: { light: 'oklch(0.9 0 0)', dark: 'oklch(0.2 0 0)' } },
+      onChange,
+      undefined,
+      'dark',
+    );
+
+    const checkbox = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireCheckboxToggle(checkbox, false);
+
+    expect(onChange).toHaveBeenCalledWith('surface', { literal: 'oklch(0.2 0 0)' });
+  });
+
+  describe('editing the light/dark swatches independently', () => {
+    beforeEach(() => {
+      localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+    });
+    afterEach(() => {
+      localStorage.removeItem('tokenpanel.colorPicker.mode');
+    });
+
+    it('editing the Light swatch updates only the light side, leaving dark untouched', () => {
+      const onChange = vi.fn();
+      renderGroupedSelector(
+        { literal: { light: 'oklch(0.5 0.1 200)', dark: 'oklch(0.3 0.1 200)' } },
+        onChange,
+      );
+
+      const lightSwatch = container.querySelector(
+        '[aria-label="Surface (Light): --zd-surface"]',
+      ) as HTMLElement;
+      act(() => lightSwatch.click());
+      const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+      expect(slider).not.toBeNull();
+      act(() => {
+        slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      const [itemId, next] = onChange.mock.calls.at(-1)!;
+      expect(itemId).toBe('surface');
+      expect(next).toEqual({
+        literal: { light: expect.stringMatching(/^oklch\(/), dark: 'oklch(0.3 0.1 200)' },
+      });
+    });
+
+    it('editing the Dark swatch updates only the dark side, leaving light untouched', () => {
+      const onChange = vi.fn();
+      renderGroupedSelector(
+        { literal: { light: 'oklch(0.5 0.1 200)', dark: 'oklch(0.3 0.1 200)' } },
+        onChange,
+      );
+
+      const darkSwatch = container.querySelector(
+        '[aria-label="Surface (Dark): --zd-surface"]',
+      ) as HTMLElement;
+      act(() => darkSwatch.click());
+      const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+      expect(slider).not.toBeNull();
+      act(() => {
+        slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      const [itemId, next] = onChange.mock.calls.at(-1)!;
+      expect(itemId).toBe('surface');
+      expect(next).toEqual({
+        literal: { light: 'oklch(0.5 0.1 200)', dark: expect.stringMatching(/^oklch\(/) },
+      });
+    });
+  });
+
+  it('a ref-mode row (no literal value) shows no "Per-mode" checkbox', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
+    expect(container.querySelector('input[type="checkbox"]')).toBeNull();
+  });
+
+  it('flat/intra-tab mode never shows a "Per-mode" checkbox (grouped-only feature)', () => {
+    renderFlatSelector({ literal: 'whatever' }, vi.fn());
+    expect(container.querySelector('input[type="checkbox"]')).toBeNull();
+  });
+});
+
+// ===========================================================================
+// 4. DOM hygiene (CLAUDE.md panel policy)
 // ===========================================================================
 
 describe('TierRefSelector — DOM hygiene', () => {
@@ -448,9 +595,21 @@ describe('TierRefSelector — DOM hygiene', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
-  it('only uses permitted form-control tags (select/option/optgroup)', () => {
+  it('grouped mode renders no <button> elements with the per-mode fields open', () => {
+    renderGroupedSelector({ literal: { light: 'oklch(0.9 0 0)', dark: 'oklch(0.2 0 0)' } }, vi.fn());
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('only uses permitted form-control tags (select/option/optgroup/input/label)', () => {
     renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
     expect(getSelect().tagName.toLowerCase()).toBe('select');
     expect(getOptgroups().length).toBeGreaterThan(0);
+  });
+
+  it('renders no banned semantic tags with the per-mode fields open', () => {
+    renderGroupedSelector({ literal: { light: 'oklch(0.9 0 0)', dark: 'oklch(0.2 0 0)' } }, vi.fn());
+    expect(
+      container.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,li,table,a,details,summary'),
+    ).toBeNull();
   });
 });

--- a/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
+++ b/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
@@ -1,26 +1,33 @@
 // @vitest-environment jsdom
 
 /**
- * Unit tests for TierRefSelector (native <select> implementation).
+ * Unit tests for TierRefSelector — the grouped ref-or-literal control (S9,
+ * #470).
  *
  * Test structure:
- *  1. Rendering — renders a <select> with correct options
- *  2. Option labels — each option shows cssVar (resolved-value preview)
- *  3. Literal option — last option is "Literal…" with TIER_REF_LITERAL_SIGNAL value
- *  4. Selection change — fireEvent.change calls onChange with (itemId, refItemId)
- *  5. Literal selection — fireEvent.change with sentinel calls onChange correctly
- *  6. Value sync — overriding a tier-1 value via previewValueFor updates option labels
- *  7. TIER_REF_LITERAL_SIGNAL sentinel value is "__literal__"
+ *  1. Flat/intra-tab mode (font/spacing/size/generic-tab consumers) —
+ *     no `<optgroup>`, bare intra-tab ref options, "Literal…" is a
+ *     revert-to-default signal (no editor renders).
+ *  2. Grouped ref-or-literal mode (Color tab semantic tiers that declare
+ *     `referencesRamps`) — one `<optgroup>` per ramp source (cross-tab),
+ *     picking a ramp option emits `{ ref }`, picking "Literal…" (or already
+ *     being in literal mode) renders an editable OKLCH `ColorField` and
+ *     emits `{ literal }`.
+ *  3. DOM hygiene — native `<select>`/`<option>`/`<optgroup>` only, no
+ *     `role="listbox"`/`role="option"`, no `<button>`.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'preact';
 import { act } from 'preact/test-utils';
-import TierRefSelector, { TIER_REF_LITERAL_SIGNAL } from '../tier-ref-selector';
+import TierRefSelector, {
+  type TierRefSelectorValue,
+  type TierRefTarget,
+} from '../tier-ref-selector';
 import type { TabConfig } from '../../tokens/tier-model';
 
 // ---------------------------------------------------------------------------
-// Fixture tab config — 2-tier easing example
+// Fixture: 2-tier easing tab (flat / intra-tab mode)
 // ---------------------------------------------------------------------------
 
 const EASING_TAB: TabConfig = {
@@ -79,6 +86,52 @@ const EASING_TAB: TabConfig = {
 };
 
 // ---------------------------------------------------------------------------
+// Fixture: cross-tab ramp source (grouped ref-or-literal mode)
+// ---------------------------------------------------------------------------
+
+const RAMP_PALETTE_TAB: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.9 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-3', cssVar: '--palette-base-3', label: 'Base 3', default: 'oklch(0.8 0 0)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-1', cssVar: '--palette-accent-1', label: 'Accent 1', default: 'oklch(0.6 0.2 30)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-2', cssVar: '--palette-accent-2', label: 'Accent 2', default: 'oklch(0.5 0.2 30)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+const GROUPED_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [{ tab: 'palette', tier: 'base' }, { tab: 'palette', tier: 'accent' }],
+      items: [
+        { id: 'surface', cssVar: '--zd-surface', label: 'Surface', default: 'base-3', type: { kind: 'color' } },
+      ],
+    },
+  ],
+};
+
+const ALL_TABS: readonly TabConfig[] = [GROUPED_COLOR_TAB, RAMP_PALETTE_TAB];
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -96,17 +149,17 @@ afterEach(() => {
   container.remove();
 });
 
-/** Default previewValueFor — returns the item's manifest default. */
-function defaultPreviewValueFor(refItemId: string): string {
+/** Default previewValueFor for the flat/easing fixture — returns the raw item's manifest default. */
+function defaultPreviewValueFor(ref: TierRefTarget): string {
   const rawTier = EASING_TAB.tiers[0];
-  const item = rawTier.items.find((i) => i.id === refItemId);
-  return item?.default ?? refItemId;
+  const item = rawTier.items.find((i) => i.id === ref.item);
+  return item?.default ?? ref.item;
 }
 
-function renderSelector(
-  value: string,
-  onChange: (itemId: string, next: string) => void,
-  previewValueFor: (refItemId: string) => string = defaultPreviewValueFor,
+function renderFlatSelector(
+  value: TierRefSelectorValue,
+  onChange: (itemId: string, next: TierRefSelectorValue) => void,
+  previewValueFor: (ref: TierRefTarget) => string = defaultPreviewValueFor,
 ) {
   act(() => {
     render(
@@ -123,6 +176,36 @@ function renderSelector(
   });
 }
 
+/** previewValueFor for the grouped fixture — returns the ramp item's manifest default. */
+function rampPreviewValueFor(ref: TierRefTarget): string {
+  const targetTab = ref.tab ? ALL_TABS.find((t) => t.id === ref.tab) : GROUPED_COLOR_TAB;
+  const item = targetTab?.tiers.find((t) => t.id === ref.tier)?.items.find((i) => i.id === ref.item);
+  return item?.default ?? ref.item;
+}
+
+function renderGroupedSelector(
+  value: TierRefSelectorValue,
+  onChange: (itemId: string, next: TierRefSelectorValue) => void,
+  previewValueFor: (ref: TierRefTarget) => string = rampPreviewValueFor,
+) {
+  act(() => {
+    render(
+      <TierRefSelector
+        tab={GROUPED_COLOR_TAB}
+        tabs={ALL_TABS}
+        tierId="semantic"
+        itemId="surface"
+        value={value}
+        onChange={onChange}
+        previewValueFor={previewValueFor}
+        label="Surface"
+        cssVar="--zd-surface"
+      />,
+      container,
+    );
+  });
+}
+
 function getSelect(): HTMLSelectElement {
   const el = container.querySelector<HTMLSelectElement>('select.tokenpanel-tier-ref-select');
   if (!el) throw new Error('select.tokenpanel-tier-ref-select not found');
@@ -133,171 +216,241 @@ function getOptions(): HTMLOptionElement[] {
   return Array.from(getSelect().querySelectorAll('option'));
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+function getOptgroups(): HTMLOptGroupElement[] {
+  return Array.from(getSelect().querySelectorAll('optgroup'));
+}
 
-describe('TierRefSelector — rendering', () => {
-  it('renders a native <select> element', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(getSelect()).not.toBeNull();
-  });
-
-  it('renders one option per raw tier item plus the Literal option', () => {
-    renderSelector('ease-out', vi.fn());
-    // 3 raw items + 1 Literal sentinel = 4 options
-    expect(getOptions().length).toBe(4);
-  });
-
-  it('does NOT use role=listbox markup', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(container.querySelector('[role="listbox"]')).toBeNull();
-  });
-
-  it('does NOT use role=option markup', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(container.querySelector('[role="option"]')).toBeNull();
-  });
-
-  it('selected value matches the current ref item id', () => {
-    renderSelector('ease-out', vi.fn());
-    expect(getSelect().value).toBe('ease-out');
-  });
-
-  it('falls back to first item when value is unrecognised', () => {
-    renderSelector('unknown-id', vi.fn());
-    expect(getSelect().value).toBe('ease-in');
-  });
-});
-
-describe('TierRefSelector — option labels', () => {
-  it('each raw item option label includes cssVar and preview value', () => {
-    renderSelector('ease-out', vi.fn());
-    const options = getOptions();
-    const easeInOpt = options.find((o) => o.value === 'ease-in');
-    expect(easeInOpt).not.toBeUndefined();
-    // Label format: "--easing-ease-in (cubic-bezier(0.42, 0, 1, 1))"
-    expect(easeInOpt!.textContent).toContain('--easing-ease-in');
-    expect(easeInOpt!.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
-  });
-
-  it('truncates long preview values in option labels', () => {
-    // Provide a preview value that exceeds 28 chars.
-    const longValue = 'a'.repeat(40);
-    const previewValueFor = (refItemId: string) => (refItemId === 'ease-in' ? longValue : refItemId);
-    renderSelector('ease-out', vi.fn(), previewValueFor);
-
-    const options = getOptions();
-    const easeInOpt = options.find((o) => o.value === 'ease-in');
-    expect(easeInOpt).not.toBeUndefined();
-    // Truncated to 28 chars: 27 + '…'
-    const label = easeInOpt!.textContent ?? '';
-    expect(label).toContain('…');
-    // Original long value should not appear verbatim
-    expect(label).not.toContain(longValue);
-  });
-
-  it('Literal option is last with value TIER_REF_LITERAL_SIGNAL', () => {
-    renderSelector('ease-out', vi.fn());
-    const options = getOptions();
-    const last = options[options.length - 1];
-    expect(last.value).toBe(TIER_REF_LITERAL_SIGNAL);
-    expect(last.textContent).toContain('Literal');
-  });
-});
-
-describe('TierRefSelector — value sync (override-aware preview)', () => {
-  it('reflects overridden tier-1 value in option label', () => {
-    // Simulate a tier-1 override: ease-in now resolves to "custom-value".
-    const previewValueFor = (refItemId: string) =>
-      refItemId === 'ease-in' ? 'custom-value' : defaultPreviewValueFor(refItemId);
-
-    renderSelector('ease-out', vi.fn(), previewValueFor);
-
-    const options = getOptions();
-    const easeInOpt = options.find((o) => o.value === 'ease-in');
-    expect(easeInOpt).not.toBeUndefined();
-    expect(easeInOpt!.textContent).toContain('custom-value');
-    // Original manifest default should NOT appear when overridden
-    expect(easeInOpt!.textContent).not.toContain('cubic-bezier(0.42, 0, 1, 1)');
-  });
-
-  it('re-renders with updated option labels when previewValueFor changes', () => {
-    const onChange = vi.fn();
-
-    // First render: default previews.
-    renderSelector('ease-out', onChange, defaultPreviewValueFor);
-    let easeInOpt = getOptions().find((o) => o.value === 'ease-in')!;
-    expect(easeInOpt.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
-
-    // Second render: override ease-in to a new value.
-    const overriddenPreview = (refItemId: string) =>
-      refItemId === 'ease-in' ? '0.5s ease' : defaultPreviewValueFor(refItemId);
-    act(() => {
-      render(
-        <TierRefSelector
-          tab={EASING_TAB}
-          tierId="semantic"
-          itemId="tab-open"
-          value="ease-out"
-          onChange={onChange}
-          previewValueFor={overriddenPreview}
-        />,
-        container,
-      );
-    });
-
-    easeInOpt = getOptions().find((o) => o.value === 'ease-in')!;
-    expect(easeInOpt.textContent).toContain('0.5s ease');
-    expect(easeInOpt.textContent).not.toContain('cubic-bezier(0.42, 0, 1, 1)');
-  });
-});
+function findOptionByText(needle: string): HTMLOptionElement {
+  const opt = getOptions().find((o) => (o.textContent ?? '').includes(needle));
+  if (!opt) throw new Error(`no option with text containing "${needle}"`);
+  return opt;
+}
 
 /** Fire a native change event on a select element, setting its value first. */
 function fireSelectChange(select: HTMLSelectElement, newValue: string) {
   act(() => {
-    // Directly mutate the select's value so the event handler sees it.
     Object.defineProperty(select, 'value', { value: newValue, writable: true, configurable: true });
     select.value = newValue;
     select.dispatchEvent(new Event('change', { bubbles: true }));
   });
 }
 
-describe('TierRefSelector — selection via change event', () => {
-  it('calls onChange with (itemId, refItemId) when user changes selection', () => {
-    const onChange = vi.fn();
-    renderSelector('ease-in', onChange);
+// ===========================================================================
+// 1. Flat / intra-tab mode (font/spacing/size/generic-tab)
+// ===========================================================================
 
-    const select = getSelect();
-    fireSelectChange(select, 'ease-out');
+describe('TierRefSelector — flat/intra-tab mode', () => {
+  it('renders a native <select> element', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    expect(getSelect()).not.toBeNull();
+  });
+
+  it('renders one option per raw tier item plus the Literal option, with NO optgroup', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    // 3 raw items + 1 Literal sentinel = 4 options, flat (no grouping).
+    expect(getOptions().length).toBe(4);
+    expect(getOptgroups().length).toBe(0);
+  });
+
+  it('does NOT use role=listbox or role=option markup', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect(container.querySelector('[role="option"]')).toBeNull();
+  });
+
+  it('selected value matches the current ref item', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    const selected = getOptions().find((o) => o.selected);
+    expect(selected?.textContent).toContain('--easing-ease-out');
+  });
+
+  it('falls back to the first item when the ref is unrecognised', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'unknown-id' } }, vi.fn());
+    const selected = getOptions().find((o) => o.selected);
+    expect(selected?.textContent).toContain('--easing-ease-in');
+  });
+
+  it('each raw item option label includes cssVar and preview value', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    const opt = findOptionByText('--easing-ease-in');
+    expect(opt.textContent).toContain('cubic-bezier(0.42, 0, 1, 1)');
+  });
+
+  it('truncates long preview values in option labels', () => {
+    const longValue = 'a'.repeat(40);
+    const previewValueFor = (ref: TierRefTarget) => (ref.item === 'ease-in' ? longValue : ref.item);
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn(), previewValueFor);
+    const opt = findOptionByText('--easing-ease-in');
+    expect(opt.textContent).toContain('…');
+    expect(opt.textContent).not.toContain(longValue);
+  });
+
+  it('Literal option is last, labelled "Literal…"', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    const options = getOptions();
+    expect(options[options.length - 1].textContent).toContain('Literal');
+  });
+
+  it('does NOT render a literal editor even when the value is { literal } (flat mode has no editor)', () => {
+    renderFlatSelector({ literal: 'whatever' }, vi.fn());
+    expect(container.querySelector('[data-testid="color-field-swatch"]')).toBeNull();
+  });
+
+  it('calls onChange with { ref } when the user picks a different raw item', () => {
+    const onChange = vi.fn();
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-in' } }, onChange);
+
+    fireSelectChange(getSelect(), findOptionByText('--easing-ease-out').value);
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith('tab-open', 'ease-out');
+    expect(onChange).toHaveBeenCalledWith('tab-open', { ref: { tier: 'raw', item: 'ease-out' } });
   });
 
-  it('calls onChange with (itemId, linear) when linear is selected', () => {
+  it('calls onChange with { ref } when linear is selected', () => {
     const onChange = vi.fn();
-    renderSelector('ease-in', onChange);
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-in' } }, onChange);
 
-    const select = getSelect();
-    fireSelectChange(select, 'linear');
+    fireSelectChange(getSelect(), findOptionByText('--easing-linear').value);
 
-    expect(onChange).toHaveBeenCalledWith('tab-open', 'linear');
+    expect(onChange).toHaveBeenCalledWith('tab-open', { ref: { tier: 'raw', item: 'linear' } });
   });
 
-  it('calls onChange with TIER_REF_LITERAL_SIGNAL when Literal is selected', () => {
+  it('calls onChange with { literal } when "Literal…" is picked (consumer treats this as revert-to-default)', () => {
     const onChange = vi.fn();
-    renderSelector('ease-in', onChange);
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-in' } }, onChange);
 
-    const select = getSelect();
-    fireSelectChange(select, TIER_REF_LITERAL_SIGNAL);
+    fireSelectChange(getSelect(), findOptionByText('Literal').value);
 
-    expect(onChange).toHaveBeenCalledWith('tab-open', TIER_REF_LITERAL_SIGNAL);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [, next] = onChange.mock.calls[0]!;
+    expect('literal' in next).toBe(true);
   });
 });
 
-describe('TierRefSelector — TIER_REF_LITERAL_SIGNAL', () => {
-  it('TIER_REF_LITERAL_SIGNAL value is "__literal__"', () => {
-    expect(TIER_REF_LITERAL_SIGNAL).toBe('__literal__');
+// ===========================================================================
+// 2. Grouped ref-or-literal mode (Color tab cross-tab ramps, S9 #470)
+// ===========================================================================
+
+describe('TierRefSelector — grouped ref-or-literal mode', () => {
+  it('renders one <optgroup> per referencesRamps source, labelled by the source tier', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
+    const groups = getOptgroups();
+    expect(groups.length).toBe(2);
+    expect(groups.map((g) => g.label)).toEqual(['Base', 'Accent']);
+  });
+
+  it('each optgroup contains one option per ramp item, plus a trailing Literal option outside any group', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
+    const groups = getOptgroups();
+    expect(groups[0].querySelectorAll('option').length).toBe(3); // base-1/2/3
+    expect(groups[1].querySelectorAll('option').length).toBe(2); // accent-1/2
+    // Literal option lives directly under <select>, not inside an <optgroup>.
+    const select = getSelect();
+    const directOptions = Array.from(select.children).filter(
+      (c) => c.tagName.toLowerCase() === 'option',
+    );
+    expect(directOptions.length).toBe(1);
+    expect(directOptions[0].textContent).toContain('Literal');
+  });
+
+  it('ramp option labels include the item cssVar and its preview value', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
+    const opt = findOptionByText('--palette-accent-2');
+    expect(opt.textContent).toContain('oklch(0.5 0.2 30)');
+  });
+
+  it('selects the option matching the current { ref } value', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'accent', item: 'accent-2' } }, vi.fn());
+    const selected = getOptions().find((o) => o.selected);
+    expect(selected?.textContent).toContain('--palette-accent-2');
+  });
+
+  it('does NOT render a literal editor while a ramp ref is selected', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
+    expect(container.querySelector('[data-testid="color-field-swatch"]')).toBeNull();
+  });
+
+  it('selecting a ramp option emits { ref: { tab, tier, item } }', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-1' } }, onChange);
+
+    fireSelectChange(getSelect(), findOptionByText('--palette-accent-2').value);
+
+    expect(onChange).toHaveBeenCalledWith('surface', {
+      ref: { tab: 'palette', tier: 'accent', item: 'accent-2' },
+    });
+  });
+
+  it('selecting "Literal…" emits { literal } seeded from the currently resolved preview', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, onChange);
+
+    fireSelectChange(getSelect(), findOptionByText('Literal').value);
+
+    expect(onChange).toHaveBeenCalledWith('surface', { literal: 'oklch(0.8 0 0)' });
+  });
+
+  it('renders an editable OKLCH ColorField swatch when the value is already { literal }', () => {
+    renderGroupedSelector({ literal: 'oklch(0.5 0.1 200)' }, vi.fn());
+    const swatch = container.querySelector('[data-testid="color-field-swatch"]') as HTMLElement;
+    expect(swatch).not.toBeNull();
+    expect(swatch.style.backgroundColor).toContain('oklch');
+  });
+
+  it('the select shows "Literal…" selected when the value is { literal }', () => {
+    renderGroupedSelector({ literal: 'oklch(0.5 0.1 200)' }, vi.fn());
+    const selected = getOptions().find((o) => o.selected);
+    expect(selected?.textContent).toContain('Literal');
+  });
+
+  describe('editing the literal swatch', () => {
+    beforeEach(() => {
+      // Pin the in-picker display mode so the OKLCH (L/C/H) sliders render
+      // deterministically, mirroring the color-tab.test.tsx suite.
+      localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+    });
+    afterEach(() => {
+      localStorage.removeItem('tokenpanel.colorPicker.mode');
+    });
+
+    it('dispatches { literal: <new oklch string> } when the picker value changes', () => {
+      const onChange = vi.fn();
+      renderGroupedSelector({ literal: 'oklch(0.5 0.1 200)' }, onChange);
+
+      const swatchBtn = container.querySelector('[data-testid="color-field-swatch"]') as HTMLElement;
+      act(() => swatchBtn.click());
+      const slider = container.querySelector('[role="dialog"] [role="slider"]') as HTMLElement;
+      expect(slider).not.toBeNull();
+      act(() => {
+        slider.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      });
+
+      expect(onChange).toHaveBeenCalled();
+      const [itemId, next] = onChange.mock.calls.at(-1)!;
+      expect(itemId).toBe('surface');
+      expect(next).toEqual({ literal: expect.stringMatching(/^oklch\(/) });
+    });
+  });
+});
+
+// ===========================================================================
+// 3. DOM hygiene (CLAUDE.md panel policy)
+// ===========================================================================
+
+describe('TierRefSelector — DOM hygiene', () => {
+  it('flat mode renders no <button> elements', () => {
+    renderFlatSelector({ ref: { tier: 'raw', item: 'ease-out' } }, vi.fn());
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('grouped mode renders no <button> elements, even with the literal editor open', () => {
+    renderGroupedSelector({ literal: 'oklch(0.5 0.1 200)' }, vi.fn());
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('only uses permitted form-control tags (select/option/optgroup)', () => {
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
+    expect(getSelect().tagName.toLowerCase()).toBe('select');
+    expect(getOptgroups().length).toBeGreaterThan(0);
   });
 });

--- a/packages/zdtp/src/controls/tier-ref-selector.tsx
+++ b/packages/zdtp/src/controls/tier-ref-selector.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem } from '../tokens/tier-model';
 import ColorField from '../components/color-picker/color-field';
+import { resolvePerModeLiteral } from '../state/tweak-state';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -37,16 +38,22 @@ export interface TierRefTarget {
 
 /**
  * The value `TierRefSelector` reads and writes. Mirrors the `{ ref } | {
- * literal }` variants of `SemanticValue` (`tokens/tier-model.ts`) so the
+ * literal }` variants of `SemanticValue` (`tokens/tier-model.ts`) — including
+ * the per-mode `{ literal: { light, dark } }` shape (#472/#473) — so the
  * Color tab can pass a semantic mapping straight through. Flat/intra-tab
  * consumers (font/spacing/size/generic-tab) wrap their bare `TokenOverrides`
  * string into `{ ref: { tier, item } }` at the call site, and unwrap a
  * `{ literal }` response back into "drop the override" — see those tabs'
- * `onChange` handlers.
+ * `onChange` handlers. Those flat consumers never produce a per-mode literal.
  */
-export type TierRefSelectorValue = { ref: TierRefTarget } | { literal: string };
+export type TierRefSelectorValue =
+  | { ref: TierRefTarget }
+  | { literal: string }
+  | { literal: { light: string; dark: string } };
 
-function isLiteralValue(v: TierRefSelectorValue): v is { literal: string } {
+function isLiteralValue(
+  v: TierRefSelectorValue,
+): v is { literal: string } | { literal: { light: string; dark: string } } {
   return 'literal' in v;
 }
 
@@ -173,6 +180,12 @@ export interface TierRefSelectorProps {
    * editor for its `aria-label`, matching `SemanticLiteralRow`'s convention.
    */
   cssVar?: string;
+  /**
+   * The cluster's `getClusterDefaultMode()` result (#472) — used only when
+   * the user collapses a per-mode literal back to single-mode, to pick which
+   * side (`light` or `dark`) survives. Defaults to `'light'`.
+   */
+  defaultMode?: 'light' | 'dark';
 }
 
 // ---------------------------------------------------------------------------
@@ -189,6 +202,7 @@ function TierRefSelector({
   previewValueFor,
   label,
   cssVar,
+  defaultMode = 'light',
 }: TierRefSelectorProps) {
   // -------------------------------------------------------------------------
   // Derive mode (grouped cross-tab ramps vs. flat intra-tab ref) and options
@@ -229,9 +243,15 @@ function TierRefSelector({
     const key = e.currentTarget.value;
     if (key === LITERAL_OPTION_VALUE) {
       // Seed the literal editor from whatever was visible a moment ago, so
-      // the user starts from a real color rather than a blank field.
+      // the user starts from a real color rather than a blank field. Always
+      // seeds a single-mode string — picking "Literal…" starts single-mode;
+      // the user expands to per-mode via the "Per-mode" checkbox below. If
+      // the previous value was already a per-mode literal, collapse it to
+      // the cluster's default-mode side first.
       const seed = isLiteralValue(value)
-        ? value.literal
+        ? typeof value.literal === 'string'
+          ? value.literal
+          : resolvePerModeLiteral({ literal: value.literal }, defaultMode)
         : selectedOption
           ? (previewValueFor ? previewValueFor(selectedOption.ref) : selectedOption.item.default)
           : '';
@@ -245,6 +265,38 @@ function TierRefSelector({
 
   const handleLiteralChange = (next: string) => {
     onChange(itemId, { literal: next });
+  };
+
+  /**
+   * "Per-mode" checkbox (permitted `<label><input type="checkbox">`,
+   * CLAUDE.md) — expands a single-mode literal into a light/dark pair, or
+   * collapses a per-mode pair back to one value. Only meaningful while
+   * `value` is already a literal (the checkbox only renders in that state).
+   */
+  const handleTogglePerMode = () => {
+    if (!isLiteralValue(value)) return;
+    const current = value.literal;
+    if (typeof current === 'object' && current !== null) {
+      // Collapse — keep the cluster's default-mode side (#472).
+      onChange(itemId, { literal: resolvePerModeLiteral({ literal: current }, defaultMode) });
+    } else {
+      // Expand — seed both sides from the current single value.
+      onChange(itemId, { literal: { light: current, dark: current } });
+    }
+  };
+
+  const handleLightChange = (next: string) => {
+    if (!isLiteralValue(value)) return;
+    const current = value.literal;
+    if (typeof current !== 'object' || current === null) return;
+    onChange(itemId, { literal: { light: next, dark: current.dark } });
+  };
+
+  const handleDarkChange = (next: string) => {
+    if (!isLiteralValue(value)) return;
+    const current = value.literal;
+    if (typeof current !== 'object' || current === null) return;
+    onChange(itemId, { literal: { light: current.light, dark: next } });
   };
 
   // -------------------------------------------------------------------------
@@ -287,19 +339,50 @@ function TierRefSelector({
         <option value={LITERAL_OPTION_VALUE}>Literal…</option>
       </select>
       {/*
-       * The editable literal swatch only ever appears in grouped (ramp)
-       * mode — flat/intra-tab tiers (font/spacing/size/generic-tab) treat
+       * The editable literal swatch (single-mode, or the per-mode light/dark
+       * pair, S12 #473) only ever appears in grouped (ramp) mode —
+       * flat/intra-tab tiers (font/spacing/size/generic-tab) treat
        * "Literal…" as "revert to the tier's default ref", not a real
        * standalone value to edit (see those tabs' onChange handlers).
        */}
       {isGrouped && isLiteralValue(value) && (
-        <ColorField
-          value={value.literal}
-          onChange={handleLiteralChange}
-          valueFormat="oklch"
-          label={rowLabel}
-          cssVar={cssVar}
-        />
+        <div className="tokenpanel-per-mode-fields">
+          <label className="tokenpanel-per-mode-toggle">
+            <input
+              type="checkbox"
+              checked={typeof value.literal === 'object' && value.literal !== null}
+              onChange={handleTogglePerMode}
+              aria-label={`${rowLabel} per-mode (light/dark)`}
+            />
+            Per-mode
+          </label>
+          {typeof value.literal === 'object' && value.literal !== null ? (
+            <>
+              <ColorField
+                value={value.literal.light}
+                onChange={handleLightChange}
+                valueFormat="oklch"
+                label={`${rowLabel} (Light)`}
+                cssVar={cssVar}
+              />
+              <ColorField
+                value={value.literal.dark}
+                onChange={handleDarkChange}
+                valueFormat="oklch"
+                label={`${rowLabel} (Dark)`}
+                cssVar={cssVar}
+              />
+            </>
+          ) : (
+            <ColorField
+              value={value.literal}
+              onChange={handleLiteralChange}
+              valueFormat="oklch"
+              label={rowLabel}
+              cssVar={cssVar}
+            />
+          )}
+        </div>
       )}
     </div>
   );

--- a/packages/zdtp/src/controls/tier-ref-selector.tsx
+++ b/packages/zdtp/src/controls/tier-ref-selector.tsx
@@ -1,23 +1,54 @@
 import { memo } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem } from '../tokens/tier-model';
+import ColorField from '../components/color-picker/color-field';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 /**
- * Sentinel string passed to `onChange` when the user picks "Literal...".
- * The parent component interprets this as a request to flip the item back
- * into its kind-specific editor (slider / text / select) writing a literal
- * CSS override.
+ * `<select>` option value for the trailing "Literal…" choice. Purely an
+ * internal DOM detail — it never appears on the `onChange` payload, which
+ * always carries the structured `TierRefSelectorValue` union instead (see
+ * below).
  */
-export const TIER_REF_LITERAL_SIGNAL = '__literal__' as const;
+const LITERAL_OPTION_VALUE = '__literal__';
 
 /**
  * Maximum length of a value preview string shown in option labels.
  * Long values like cubic-bezier strings are truncated so the UI stays compact.
  */
 const PREVIEW_MAX_LEN = 28;
+
+// ---------------------------------------------------------------------------
+// Public value / target types
+// ---------------------------------------------------------------------------
+
+/**
+ * Names one item in a (possibly cross-tab) tier. `tab` omitted means "the tab
+ * `TierRefSelector` itself renders in" — the intra-tab case used by the
+ * font/spacing/size/generic-tab consumers, whose refs never cross tabs.
+ */
+export interface TierRefTarget {
+  tab?: string;
+  tier: string;
+  item: string;
+}
+
+/**
+ * The value `TierRefSelector` reads and writes. Mirrors the `{ ref } | {
+ * literal }` variants of `SemanticValue` (`tokens/tier-model.ts`) so the
+ * Color tab can pass a semantic mapping straight through. Flat/intra-tab
+ * consumers (font/spacing/size/generic-tab) wrap their bare `TokenOverrides`
+ * string into `{ ref: { tier, item } }` at the call site, and unwrap a
+ * `{ literal }` response back into "drop the override" — see those tabs'
+ * `onChange` handlers.
+ */
+export type TierRefSelectorValue = { ref: TierRefTarget } | { literal: string };
+
+function isLiteralValue(v: TierRefSelectorValue): v is { literal: string } {
+  return 'literal' in v;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,8 +63,69 @@ function findTier(tab: TabConfig, tierId: string): TierConfig | undefined {
   return tab.tiers.find((t) => t.id === tierId);
 }
 
-function findItem(tier: TierConfig, itemId: string): TierItem | undefined {
-  return tier.items.find((i) => i.id === itemId);
+function refsEqual(a: TierRefTarget, b: TierRefTarget): boolean {
+  return (a.tab ?? '') === (b.tab ?? '') && a.tier === b.tier && a.item === b.item;
+}
+
+/** One flattened, selectable ramp/ref option. */
+interface RefOption {
+  /**
+   * Unique `<option value>` — a stable per-render index string, NOT the ref
+   * itself, so duplicate item ids across different ramp tiers/tabs never
+   * collide in the native `<select>`.
+   */
+  key: string;
+  ref: TierRefTarget;
+  item: TierItem;
+}
+
+interface RefGroup {
+  label: string;
+  options: RefOption[];
+}
+
+/**
+ * Build the grouped ramp option list for a `referencesRamps`-declaring tier:
+ * one `<optgroup>` per declared ramp source, each populated from that
+ * source's tier items (cross-tab when the source names a different `tab`).
+ * A source that doesn't resolve (unknown tab/tier) is silently skipped —
+ * up-front validation of `referencesRamps` declarations is out of scope here.
+ */
+function buildRampGroups(
+  rampSources: readonly { tab?: string; tier: string }[],
+  currentTab: TabConfig,
+  tabs: readonly TabConfig[],
+): RefGroup[] {
+  const groups: RefGroup[] = [];
+  let counter = 0;
+  for (const src of rampSources) {
+    const sourceTab =
+      src.tab === undefined || src.tab === currentTab.id
+        ? currentTab
+        : tabs.find((t) => t.id === src.tab);
+    const sourceTier = sourceTab && findTier(sourceTab, src.tier);
+    if (!sourceTier) continue;
+    const options: RefOption[] = sourceTier.items.map((item) => ({
+      key: `r${counter++}`,
+      ref: { tab: src.tab, tier: src.tier, item: item.id },
+      item,
+    }));
+    groups.push({ label: sourceTier.label, options });
+  }
+  return groups;
+}
+
+/**
+ * Build the flat (non-grouped) intra-tab option list for a `referencesTier`
+ * tier — the font/spacing/size/generic-tab path. Unchanged from the
+ * pre-grouped rendering: no `<optgroup>`, one option per tier-1 item.
+ */
+function buildFlatOptions(refTier: TierConfig): RefOption[] {
+  return refTier.items.map((item, i) => ({
+    key: `r${i}`,
+    ref: { tier: refTier.id, item: item.id },
+    item,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -41,60 +133,118 @@ function findItem(tier: TierConfig, itemId: string): TierItem | undefined {
 // ---------------------------------------------------------------------------
 
 export interface TierRefSelectorProps {
-  /** Full tab config — needed to look up the referenced tier and its items. */
+  /** The tab this row belongs to — provides the semantic/reference tier
+   *  config and doubles as the default "current tab" for intra-tab refs. */
   tab: TabConfig;
-  /** The tier whose item is being edited (the "semantic" / reference tier). */
+  /**
+   * Full panel tabs array, needed to resolve a grouped tier's cross-tab ramp
+   * sources. Defaults to `[tab]` — fine for intra-tab (flat) callers, which
+   * never reference another tab.
+   */
+  tabs?: readonly TabConfig[];
+  /** The tier whose item is being edited (the semantic / reference tier). */
   tierId: string;
   /** The item being edited within `tierId`. */
   itemId: string;
+  /** Current value — a ramp/ref target, or a literal color/CSS string. */
+  value: TierRefSelectorValue;
   /**
-   * The current stored value for this item — an item id within the
-   * referenced (tier-1) tier. Empty string or an unrecognised id is treated
-   * as "pick the first item" (mirrors resolver fallback).
-   */
-  value: string;
-  /**
-   * Called when the user commits a selection.
+   * Called when the user commits a selection or edits the literal value.
    *
-   * - Picking a tier-1 item: `onChange(itemId, selectedRefItemId)`
-   * - Picking "Literal...": `onChange(itemId, TIER_REF_LITERAL_SIGNAL)`
+   * - Picking a ramp/ref option: `onChange(itemId, { ref: {...} })`
+   * - Picking "Literal…" or editing the literal swatch (grouped mode only):
+   *   `onChange(itemId, { literal: <value> })`
    */
-  onChange: (itemId: string, next: string) => void;
+  onChange: (itemId: string, next: TierRefSelectorValue) => void;
   /**
-   * Returns the resolved (override-aware) preview string for a tier-1 item id.
-   * Each option label is formatted as `${item.cssVar} (${truncated preview})`.
-   * Pass a wrapper around resolveTierItemValue using the current tweak-state map.
+   * Returns the resolved (override-aware) preview string for a ramp/ref
+   * target. Each option label is formatted as `${item.cssVar} (${truncated
+   * preview})`. Falls back to the target item's manifest `default` when
+   * omitted.
    */
-  previewValueFor: (refItemId: string) => string;
+  previewValueFor?: (ref: TierRefTarget) => string;
+  /**
+   * Friendly label used for the literal-mode `ColorField` editor (grouped
+   * mode only) and the select's `aria-label`. Defaults to `itemId`.
+   */
+  label?: string;
+  /**
+   * The row's own cssVar — threaded into the literal-mode `ColorField`
+   * editor for its `aria-label`, matching `SemanticLiteralRow`'s convention.
+   */
+  cssVar?: string;
 }
 
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
-function TierRefSelector({ tab, tierId, itemId, value, onChange, previewValueFor }: TierRefSelectorProps) {
+function TierRefSelector({
+  tab,
+  tabs,
+  tierId,
+  itemId,
+  value,
+  onChange,
+  previewValueFor,
+  label,
+  cssVar,
+}: TierRefSelectorProps) {
   // -------------------------------------------------------------------------
-  // Derive ref tier and options
+  // Derive mode (grouped cross-tab ramps vs. flat intra-tab ref) and options
   // -------------------------------------------------------------------------
 
   const thisTier = findTier(tab, tierId);
-  const refTierId = thisTier?.referencesTier ?? '';
-  const refTier = refTierId ? findTier(tab, refTierId) : undefined;
+  const rampSources = thisTier?.referencesRamps;
+  const isGrouped = !!rampSources && rampSources.length > 0;
+  const tabsList = tabs ?? [tab];
 
-  const refItems: readonly TierItem[] = refTier?.items ?? [];
+  const groups: RefGroup[] = isGrouped
+    ? buildRampGroups(rampSources!, tab, tabsList)
+    : (() => {
+        const refTierId = thisTier?.referencesTier ?? '';
+        const refTier = refTierId ? findTier(tab, refTierId) : undefined;
+        return refTier ? [{ label: refTier.label, options: buildFlatOptions(refTier) }] : [];
+      })();
 
-  // Determine the currently selected value — fall back to first item if unrecognised.
-  const selectedRefItemId = (() => {
-    if (refTier && findItem(refTier, value)) return value;
-    return refItems[0]?.id ?? '';
-  })();
+  const allOptions = groups.flatMap((g) => g.options);
+
+  // Determine the currently selected option — fall back to the first option
+  // when the value is a ref that doesn't (or no longer) resolve.
+  const selectedOption = isLiteralValue(value)
+    ? undefined
+    : (allOptions.find((o) => refsEqual(o.ref, value.ref)) ?? allOptions[0]);
+
+  const selectedKey = isLiteralValue(value)
+    ? LITERAL_OPTION_VALUE
+    : (selectedOption?.key ?? LITERAL_OPTION_VALUE);
+
+  const rowLabel = label ?? itemId;
 
   // -------------------------------------------------------------------------
-  // Handler
+  // Handlers
   // -------------------------------------------------------------------------
 
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    onChange(itemId, e.currentTarget.value);
+  const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const key = e.currentTarget.value;
+    if (key === LITERAL_OPTION_VALUE) {
+      // Seed the literal editor from whatever was visible a moment ago, so
+      // the user starts from a real color rather than a blank field.
+      const seed = isLiteralValue(value)
+        ? value.literal
+        : selectedOption
+          ? (previewValueFor ? previewValueFor(selectedOption.ref) : selectedOption.item.default)
+          : '';
+      onChange(itemId, { literal: seed });
+      return;
+    }
+    const opt = allOptions.find((o) => o.key === key);
+    if (!opt) return;
+    onChange(itemId, { ref: opt.ref });
+  };
+
+  const handleLiteralChange = (next: string) => {
+    onChange(itemId, { literal: next });
   };
 
   // -------------------------------------------------------------------------
@@ -105,20 +255,52 @@ function TierRefSelector({ tab, tierId, itemId, value, onChange, previewValueFor
     <div className="tokenpanel-tier-ref-selector">
       <select
         className="tokenpanel-tier-ref-select"
-        value={selectedRefItemId === '' ? TIER_REF_LITERAL_SIGNAL : selectedRefItemId}
-        onChange={handleChange}
-        aria-label={`${itemId} tier reference`}
+        value={selectedKey}
+        onChange={handleSelectChange}
+        aria-label={`${rowLabel} tier reference`}
       >
-        {refItems.map((item) => {
-          const preview = truncatePreview(previewValueFor(item.id));
-          return (
-            <option key={item.id} value={item.id}>
-              {item.cssVar} ({preview})
-            </option>
-          );
-        })}
-        <option value={TIER_REF_LITERAL_SIGNAL}>Literal…</option>
+        {isGrouped
+          ? groups.map((group) => (
+              <optgroup key={group.label} label={group.label}>
+                {group.options.map((opt) => {
+                  const preview = truncatePreview(
+                    previewValueFor ? previewValueFor(opt.ref) : opt.item.default,
+                  );
+                  return (
+                    <option key={opt.key} value={opt.key}>
+                      {opt.item.cssVar} ({preview})
+                    </option>
+                  );
+                })}
+              </optgroup>
+            ))
+          : allOptions.map((opt) => {
+              const preview = truncatePreview(
+                previewValueFor ? previewValueFor(opt.ref) : opt.item.default,
+              );
+              return (
+                <option key={opt.key} value={opt.key}>
+                  {opt.item.cssVar} ({preview})
+                </option>
+              );
+            })}
+        <option value={LITERAL_OPTION_VALUE}>Literal…</option>
       </select>
+      {/*
+       * The editable literal swatch only ever appears in grouped (ramp)
+       * mode — flat/intra-tab tiers (font/spacing/size/generic-tab) treat
+       * "Literal…" as "revert to the tier's default ref", not a real
+       * standalone value to edit (see those tabs' onChange handlers).
+       */}
+      {isGrouped && isLiteralValue(value) && (
+        <ColorField
+          value={value.literal}
+          onChange={handleLiteralChange}
+          valueFormat="oklch"
+          label={rowLabel}
+          cssVar={cssVar}
+        />
+      )}
     </div>
   );
 }

--- a/packages/zdtp/src/index.tsx
+++ b/packages/zdtp/src/index.tsx
@@ -367,6 +367,16 @@ export {
 // avoids isolatedModules surprises; `emptyOverrides` is a runtime value.
 export type { TweakState } from './state/tweak-state';
 export { emptyOverrides } from './state/tweak-state';
+// Per-mode literal helpers (#472). `getClusterDefaultMode` reads the cluster's
+// `colorMode.defaultMode`; `resolvePerModeLiteral` / `resolveSemanticPreviewColor`
+// collapse a `{ literal: { light, dark } }` value to a single concrete color for
+// preview/seed contexts where CSS `light-dark()` cannot resolve. Consumed by the
+// per-mode editor UI (#473).
+export {
+  getClusterDefaultMode,
+  resolvePerModeLiteral,
+  resolveSemanticPreviewColor,
+} from './state/tweak-state';
 
 /**
  * Show ONE instance's panel. Internal per-instance core shared by the public

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -830,13 +830,24 @@ export default function DesignTokenTweakPanel({
                     tab={tabConfigById[tab.id]}
                     overrides={state.tabs?.[tab.id] ?? {}}
                     onChange={(tierId, itemId, next) => {
-                      persistTab(tab.id, (prev) => ({
-                        ...prev,
-                        [tierId]: {
-                          ...(prev[tierId] ?? {}),
-                          [itemId]: next,
-                        },
-                      }));
+                      // `next === undefined` (ref-tier "Literal…" pick, #470)
+                      // means drop the stored override entirely so the item
+                      // reverts to its tier's default ref, matching the
+                      // font/spacing/size tabs' delete-the-key behavior.
+                      persistTab(tab.id, (prev) => {
+                        if (next === undefined) {
+                          const tierPrev = { ...prev[tierId] };
+                          delete tierPrev[itemId];
+                          return { ...prev, [tierId]: tierPrev };
+                        }
+                        return {
+                          ...prev,
+                          [tierId]: {
+                            ...prev[tierId],
+                            [itemId]: next,
+                          },
+                        };
+                      });
                     }}
                   />
                 )}

--- a/packages/zdtp/src/state/__tests__/per-mode-literal.test.ts
+++ b/packages/zdtp/src/state/__tests__/per-mode-literal.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+/**
+ * Per-mode literal light-dark() emission + color-scheme routing + defaultMode
+ * runtime (S11, #472).
+ *
+ * Covers:
+ *  - The DOM emitter writes `--zd-danger: light-dark(<light>, <dark>)` for a
+ *    `{ literal: { light, dark } }` semantic mapping.
+ *  - `color-scheme: light dark` is set on the correct root: `documentElement`
+ *    for a normal instance, and routed through the sink (never `:root`) for a
+ *    sink instance.
+ *  - No `color-scheme` is emitted when no per-mode literal is present.
+ *  - Single-mode literals emit a plain value (unchanged).
+ *  - `defaultMode` (`getClusterDefaultMode` / `resolvePerModeLiteral` /
+ *    `resolveSemanticPreviewColor`) selects the documented flat fallback.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  applyColorState,
+  getClusterDefaultMode,
+  resolvePerModeLiteral,
+  resolveSemanticPreviewColor,
+  type ApplySink,
+  type ColorClusterDataConfig,
+  type ColorTweakState,
+} from '../tweak-state';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeCluster(
+  colorMode: ColorClusterDataConfig['panelSettings']['colorMode'] = false,
+): ColorClusterDataConfig {
+  return {
+    id: 'pm',
+    label: 'Per-mode',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--pm-p{n}',
+    semanticDefaults: { danger: 1 },
+    semanticCssNames: { danger: '--zd-danger' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode },
+  };
+}
+
+const BASE_COLOR: ColorTweakState = {
+  palette: ['#000000', '#111111', '#222222', '#ffffff'],
+  background: 0,
+  foreground: 3,
+  cursor: 1,
+  selectionBg: 0,
+  selectionFg: 3,
+  semanticMappings: { danger: 1 },
+  shikiTheme: 'dracula',
+};
+
+const PER_MODE_COLOR: ColorTweakState = {
+  ...BASE_COLOR,
+  semanticMappings: { danger: { literal: { light: '#ff0000', dark: '#990000' } } },
+};
+
+function makeSinkSpy(): ApplySink & { pairs: Array<readonly [string, string]> } {
+  const pairs: Array<readonly [string, string]> = [];
+  return {
+    pairs,
+    apply(applied) {
+      for (const p of applied) pairs.push(p);
+    },
+    clear() {},
+  };
+}
+
+beforeEach(() => {
+  document.documentElement.removeAttribute('style');
+});
+
+afterEach(() => {
+  document.documentElement.removeAttribute('style');
+});
+
+// ---------------------------------------------------------------------------
+// DOM emission + color-scheme (normal instance)
+// ---------------------------------------------------------------------------
+
+describe('applyColorState — per-mode literal (normal instance)', () => {
+  it('emits light-dark() for the semantic var and sets color-scheme on documentElement', () => {
+    applyColorState(PER_MODE_COLOR, makeCluster());
+
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--zd-danger')).toBe('light-dark(#ff0000, #990000)');
+    expect(style.getPropertyValue('color-scheme')).toBe('light dark');
+  });
+
+  it('does NOT set color-scheme when no per-mode literal is present', () => {
+    applyColorState(BASE_COLOR, makeCluster());
+
+    const style = document.documentElement.style;
+    // Legacy index mapping resolves to the palette color, no light-dark().
+    expect(style.getPropertyValue('--zd-danger')).toBe('#111111');
+    expect(style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('single-mode { literal: string } emits a plain value and no color-scheme', () => {
+    const single: ColorTweakState = {
+      ...BASE_COLOR,
+      semanticMappings: { danger: { literal: 'oklch(0.55 0.2 25)' } },
+    };
+    applyColorState(single, makeCluster());
+
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--zd-danger')).toBe('oklch(0.55 0.2 25)');
+    expect(style.getPropertyValue('color-scheme')).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// color-scheme routing (sink instance)
+// ---------------------------------------------------------------------------
+
+describe('applyColorState — per-mode literal (sink instance)', () => {
+  it('routes color-scheme through the sink and never touches documentElement', () => {
+    const sink = makeSinkSpy();
+    applyColorState(PER_MODE_COLOR, makeCluster(), sink);
+
+    // color-scheme is in the sink batch, targeting the sink's own root.
+    const colorScheme = sink.pairs.find(([name]) => name === 'color-scheme');
+    expect(colorScheme).toEqual(['color-scheme', 'light dark']);
+
+    // The semantic var emits light-dark() through the sink too.
+    const danger = sink.pairs.find(([name]) => name === '--zd-danger');
+    expect(danger?.[1]).toBe('light-dark(#ff0000, #990000)');
+
+    // :root was not touched by the sink path.
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--zd-danger')).toBe('');
+  });
+
+  it('does NOT push color-scheme into the sink batch when no per-mode literal exists', () => {
+    const sink = makeSinkSpy();
+    applyColorState(BASE_COLOR, makeCluster(), sink);
+    expect(sink.pairs.some(([name]) => name === 'color-scheme')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultMode runtime (#472)
+// ---------------------------------------------------------------------------
+
+describe('defaultMode runtime — getClusterDefaultMode / resolvePerModeLiteral', () => {
+  it('getClusterDefaultMode returns the configured defaultMode', () => {
+    const cluster = makeCluster({
+      defaultMode: 'dark',
+      lightScheme: 'L',
+      darkScheme: 'D',
+    });
+    expect(getClusterDefaultMode(cluster)).toBe('dark');
+  });
+
+  it('getClusterDefaultMode falls back to "light" when colorMode is false', () => {
+    expect(getClusterDefaultMode(makeCluster())).toBe('light');
+  });
+
+  it('resolvePerModeLiteral selects the given mode side', () => {
+    const value = { literal: { light: '#ff0000', dark: '#990000' } };
+    expect(resolvePerModeLiteral(value, 'light')).toBe('#ff0000');
+    expect(resolvePerModeLiteral(value, 'dark')).toBe('#990000');
+  });
+});
+
+describe('resolveSemanticPreviewColor — flat value using defaultMode', () => {
+  it('collapses a per-mode literal to the cluster defaultMode side (dark)', () => {
+    const cluster = makeCluster({ defaultMode: 'dark', lightScheme: 'L', darkScheme: 'D' });
+    const preview = resolveSemanticPreviewColor(
+      { literal: { light: '#ff0000', dark: '#990000' } },
+      PER_MODE_COLOR,
+      cluster,
+    );
+    expect(preview).toBe('#990000');
+  });
+
+  it('collapses to the light side when colorMode is false (defaultMode → light)', () => {
+    const preview = resolveSemanticPreviewColor(
+      { literal: { light: '#ff0000', dark: '#990000' } },
+      PER_MODE_COLOR,
+      makeCluster(),
+    );
+    expect(preview).toBe('#ff0000');
+  });
+
+  it('passes through a single-mode literal and an index mapping unchanged', () => {
+    const cluster = makeCluster();
+    expect(
+      resolveSemanticPreviewColor({ literal: 'oklch(0.55 0.2 25)' }, BASE_COLOR, cluster),
+    ).toBe('oklch(0.55 0.2 25)');
+    // Index 2 → palette[2].
+    expect(resolveSemanticPreviewColor(2, BASE_COLOR, cluster)).toBe('#222222');
+  });
+});

--- a/packages/zdtp/src/state/__tests__/semantic-value.test.ts
+++ b/packages/zdtp/src/state/__tests__/semantic-value.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isIndexMapping,
+  isLiteralMapping,
+  isPerModeLiteral,
+  isRefMapping,
+  type SemanticValue,
+} from '../tweak-state';
+
+describe('SemanticValue narrowing helpers', () => {
+  describe('isIndexMapping', () => {
+    it('is true for a palette-index number', () => {
+      expect(isIndexMapping(3)).toBe(true);
+      expect(isIndexMapping(0)).toBe(true);
+    });
+
+    it('is true for the "bg" / "fg" aliases', () => {
+      expect(isIndexMapping('bg')).toBe(true);
+      expect(isIndexMapping('fg')).toBe(true);
+    });
+
+    it('is false for literal and ref variants', () => {
+      expect(isIndexMapping({ literal: '#ff0000' })).toBe(false);
+      expect(isIndexMapping({ literal: { light: '#fff', dark: '#000' } })).toBe(false);
+      expect(isIndexMapping({ ref: { tier: 'ramp', item: 'blue-500' } })).toBe(false);
+    });
+  });
+
+  describe('isLiteralMapping', () => {
+    it('is true for a plain string literal', () => {
+      expect(isLiteralMapping({ literal: '#112233' })).toBe(true);
+    });
+
+    it('is true for a light/dark literal pair', () => {
+      expect(isLiteralMapping({ literal: { light: '#fff', dark: '#000' } })).toBe(true);
+    });
+
+    it('is false for index mappings and ref mappings', () => {
+      expect(isLiteralMapping(2)).toBe(false);
+      expect(isLiteralMapping('bg')).toBe(false);
+      expect(isLiteralMapping({ ref: { tier: 'ramp', item: 'blue-500' } })).toBe(false);
+    });
+  });
+
+  describe('isPerModeLiteral', () => {
+    it('is true only for the light/dark literal variant', () => {
+      expect(isPerModeLiteral({ literal: { light: '#fff', dark: '#000' } })).toBe(true);
+    });
+
+    it('is false for a plain string literal', () => {
+      expect(isPerModeLiteral({ literal: '#112233' })).toBe(false);
+    });
+
+    it('is false for index mappings and ref mappings', () => {
+      expect(isPerModeLiteral(1)).toBe(false);
+      expect(isPerModeLiteral({ ref: { tab: 'other', tier: 'ramp', item: 'blue-500' } })).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('isRefMapping', () => {
+    it('is true for a ramp-item reference, with or without a tab', () => {
+      expect(isRefMapping({ ref: { tier: 'ramp', item: 'blue-500' } })).toBe(true);
+      expect(isRefMapping({ ref: { tab: 'colors', tier: 'ramp', item: 'blue-500' } })).toBe(true);
+    });
+
+    it('is false for index and literal mappings', () => {
+      expect(isRefMapping(0)).toBe(false);
+      expect(isRefMapping('fg')).toBe(false);
+      expect(isRefMapping({ literal: '#112233' })).toBe(false);
+    });
+  });
+
+  it('every legacy value is still assignable to SemanticValue (widening is additive)', () => {
+    const legacyValues: SemanticValue[] = [0, 5, 'bg', 'fg'];
+    for (const v of legacyValues) {
+      expect(isIndexMapping(v)).toBe(true);
+    }
+  });
+});

--- a/packages/zdtp/src/state/persist.ts
+++ b/packages/zdtp/src/state/persist.ts
@@ -11,6 +11,13 @@
  * Framework-agnostic wrt. the setState function: pass any
  * `(updater) => void` that propagates `updater(prev)` to the caller's state.
  * In practice the panel passes Preact's `setState` from `useState`.
+ *
+ * `persistColor`'s updater is `(prev: ColorTweakState) => ColorTweakState`, so
+ * the widened `ColorTweakState.semanticMappings: Record<string, SemanticValue>`
+ * (#459) — including the `{ literal }` / `{ ref }` object variants added for
+ * #462 — already flows through this hook's generic pass-through unchanged; the
+ * actual validating hydrate/round-trip logic for those variants lives in
+ * `tweak-state.ts` (`hydrateSemanticMappings` / `savePersistedState`), not here.
  */
 
 import { useCallback } from 'preact/hooks';

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -47,6 +47,14 @@ import {
   type ColorClusterDataConfig,
   resolvePaletteCssVar,
 } from '../config/cluster-config';
+import type { SemanticValue } from '../tokens/tier-model';
+
+// Re-export so callers that already import from `state/tweak-state` (the
+// historical home of `ColorTweakState`) can reach the mapping-value type
+// without a second import from `tokens/tier-model`. Defined in tier-model.ts
+// to avoid a type-only import cycle with `config/cluster-config.ts` — see the
+// doc comment on `SemanticValue` there.
+export type { SemanticValue } from '../tokens/tier-model';
 import {
   getPanelConfig,
   resolveSecondaryColorCluster,
@@ -469,8 +477,50 @@ export interface ColorTweakState {
   cursor: number;
   selectionBg: number;
   selectionFg: number;
-  semanticMappings: Record<string, number | 'bg' | 'fg'>;
+  /**
+   * Semantic token name → mapping. Widened from `Record<string, number | 'bg'
+   * | 'fg'>` to `Record<string, SemanticValue>` (#459 S1). This is additive
+   * for readers of the type (every legacy value is still a valid
+   * `SemanticValue`), but it BREAKS any exhaustive `switch`/equality check
+   * written against the old narrow union — callers that pattern-match on a
+   * mapping value must now also handle the new `{ literal }` / `{ ref }`
+   * object variants (see `isIndexMapping` / `isLiteralMapping` /
+   * `isPerModeLiteral` / `isRefMapping` below). `resolveMapping` (exported)
+   * still only resolves the legacy `number | 'bg' | 'fg'` shape — resolving
+   * the new variants is downstream work (#467/#469).
+   */
+  semanticMappings: Record<string, SemanticValue>;
   shikiTheme: string;
+}
+
+// ---------------------------------------------------------------------------
+// SemanticValue narrowing helpers
+// ---------------------------------------------------------------------------
+
+/** True when `v` is a legacy index-style mapping (palette index or bg/fg alias). */
+export function isIndexMapping(v: SemanticValue): v is number | 'bg' | 'fg' {
+  return typeof v === 'number' || v === 'bg' || v === 'fg';
+}
+
+/** True when `v` is either literal-color variant (plain string or light/dark pair). */
+export function isLiteralMapping(
+  v: SemanticValue,
+): v is { literal: string } | { literal: { light: string; dark: string } } {
+  return typeof v === 'object' && v !== null && 'literal' in v;
+}
+
+/** True when `v` is specifically the light/dark literal-color variant. */
+export function isPerModeLiteral(
+  v: SemanticValue,
+): v is { literal: { light: string; dark: string } } {
+  return isLiteralMapping(v) && typeof v.literal === 'object' && v.literal !== null;
+}
+
+/** True when `v` is a cross-tab/tier ramp-item reference. */
+export function isRefMapping(
+  v: SemanticValue,
+): v is { ref: { tab?: string; tier: string; item: string } } {
+  return typeof v === 'object' && v !== null && 'ref' in v;
 }
 
 /**
@@ -911,16 +961,23 @@ export function initColorFromSchemeData(
   // into a safe '#000000' instead of leaking them to apply. sRGB clamping for
   // oklch still happens only at a true hex-conversion boundary.
   const palette = scheme.palette.map(normalizeSchemePaletteEntry);
-  const semanticMappings: Record<string, number | 'bg' | 'fg'> = {};
+  const semanticMappings: Record<string, SemanticValue> = {};
   for (const [key, defaultVal] of Object.entries(cluster.semanticDefaults)) {
+    // `cluster.semanticDefaults` is `SemanticValue`-typed (#459), but every
+    // default this function has ever produced is a plain palette-index number
+    // — the `'bg'`/`'fg'` aliases and the `{ literal }` / `{ ref }` variants
+    // are populated by downstream sub-issues (#467/#469), not resolved here.
+    // Fall back to 0 for a non-numeric default so this stays total over the
+    // widened type; `colorRefToIndex`'s `fallback` param is `number`-only.
+    const indexDefault = typeof defaultVal === 'number' ? defaultVal : 0;
     const schemeVal = scheme.semantic?.[key as keyof typeof scheme.semantic];
     if (schemeVal === undefined) {
-      semanticMappings[key] = defaultVal;
+      semanticMappings[key] = indexDefault;
     } else if (typeof schemeVal === 'number') {
       semanticMappings[key] = schemeVal;
     } else {
       // String value — find in palette or nearest match.
-      semanticMappings[key] = colorRefToIndex(schemeVal, scheme.palette, defaultVal);
+      semanticMappings[key] = colorRefToIndex(schemeVal, scheme.palette, indexDefault);
     }
   }
 
@@ -956,7 +1013,16 @@ export function initColorFromSchemeData(
 // Apply / clear
 // ---------------------------------------------------------------------------
 
-/** Resolve a semantic mapping to an actual color (bounds-checked). */
+/**
+ * Resolve a semantic mapping to an actual color (bounds-checked).
+ *
+ * Only handles the legacy `number | 'bg' | 'fg'` index shape — the narrower
+ * type this function accepted before `ColorTweakState.semanticMappings` /
+ * `ColorClusterDataConfig.semanticDefaults` were widened to `SemanticValue`
+ * (#459 S1). Callers holding a `SemanticValue` must narrow with
+ * `isIndexMapping()` first; resolving the `{ literal }` / `{ ref }` variants
+ * is downstream work (#467/#469), not this function's job today.
+ */
 export function resolveMapping(
   mapping: number | 'bg' | 'fg',
   palette: string[],
@@ -971,6 +1037,23 @@ export function resolveMapping(
 
 export function safeIndex(index: number, len: number): number {
   return index >= 0 && index < len ? index : 0;
+}
+
+/**
+ * Resolve a `SemanticValue` to an actual color for the apply path. Delegates
+ * to `resolveMapping` for the legacy index shape (every mapping produced by
+ * the panel today). The `{ literal }` / `{ ref }` variants are not resolved
+ * yet — that lands with #467/#469 — so they fall back to `'#000000'` rather
+ * than throwing, keeping `applyColorState` total over the widened type.
+ */
+function resolveSemanticCssValue(
+  mapping: SemanticValue,
+  palette: string[],
+  bgIndex: number,
+  fgIndex: number,
+): string {
+  if (isIndexMapping(mapping)) return resolveMapping(mapping, palette, bgIndex, fgIndex);
+  return '#000000';
 }
 
 /** Apply a single `ColorTweakState` to the DOM using the given cluster config. */
@@ -994,7 +1077,10 @@ export function applyColorState(
     }
     for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
       const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
-      pairs.push([cssName, resolveMapping(mapping, state.palette, state.background, state.foreground)]);
+      pairs.push([
+        cssName,
+        resolveSemanticCssValue(mapping, state.palette, state.background, state.foreground),
+      ]);
     }
     try {
       sink.apply(pairs);
@@ -1020,7 +1106,10 @@ export function applyColorState(
   // Semantic.
   for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
     const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
-    setCssVar(cssName, resolveMapping(mapping, state.palette, state.background, state.foreground));
+    setCssVar(
+      cssName,
+      resolveSemanticCssValue(mapping, state.palette, state.background, state.foreground),
+    );
   }
 }
 

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -1062,10 +1062,15 @@ export function safeIndex(index: number, len: number): number {
  * resolve (misconfigured manifest), falls back to `'#000000'` rather than
  * throwing — up-front source validation is #469's job, not this function's.
  *
- * The per-mode `{ literal: { light, dark } }` variant (#472) is not resolved
- * yet — that branch slots in here, above the final `'#000000'` fallback —
- * so it currently falls back to `'#000000'`, keeping `applyColorState` total
- * over the widened type.
+ * The per-mode `{ literal: { light, dark } }` variant (#472) emits a CSS
+ * `light-dark(<light>, <dark>)` function so the browser resolves the correct
+ * side automatically from the applied root's `color-scheme` (set by
+ * `applyColorState` whenever any per-mode literal is present). When the
+ * optional `perModeMode` is supplied — a preview / seed / non-browser context
+ * where `light-dark()` cannot resolve — the branch instead collapses to that
+ * single mode's literal. `perModeMode` is the cluster's
+ * `panelSettings.colorMode.defaultMode` (via `getClusterDefaultMode`), giving
+ * that previously-inert field a real runtime effect.
  */
 function resolveSemanticCssValue(
   mapping: SemanticValue,
@@ -1074,8 +1079,18 @@ function resolveSemanticCssValue(
   fgIndex: number,
   currentTab?: TabConfig,
   tabs?: readonly TabConfig[],
+  perModeMode?: 'light' | 'dark',
 ): string {
   if (isIndexMapping(mapping)) return resolveMapping(mapping, palette, bgIndex, fgIndex);
+  if (isLiteralMapping(mapping) && isPerModeLiteral(mapping)) {
+    // #472 — per-mode literal. Emit `light-dark()` so the browser picks the
+    // side matching the applied root's used color-scheme; or, when a concrete
+    // single value is requested (preview/seed, no `light-dark()` support),
+    // collapse to `perModeMode`'s literal.
+    return perModeMode
+      ? mapping.literal[perModeMode]
+      : `light-dark(${mapping.literal.light}, ${mapping.literal.dark})`;
+  }
   if (isLiteralMapping(mapping) && !isPerModeLiteral(mapping)) return mapping.literal;
   if (isRefMapping(mapping) && currentTab) {
     try {
@@ -1087,6 +1102,93 @@ function resolveSemanticCssValue(
     }
   }
   return '#000000';
+}
+
+/**
+ * The cluster's configured default light/dark mode, or `'light'` when the
+ * cluster declares no `colorMode` (`colorMode === false`).
+ *
+ * This is the single runtime reader of `ClusterPanelSettings.colorMode.defaultMode`
+ * (#472). The field validates but was previously never read at runtime; this
+ * helper (consumed by `resolveSemanticPreviewColor`) gives it a real effect —
+ * it selects which side of a per-mode `{ literal: { light, dark } }` pair is the
+ * fallback when `light-dark()` cannot resolve.
+ */
+export function getClusterDefaultMode(
+  cluster: ColorClusterDataConfig,
+): 'light' | 'dark' {
+  const cm = cluster.panelSettings.colorMode;
+  return cm ? cm.defaultMode : 'light';
+}
+
+/**
+ * Resolve a per-mode literal to a single concrete CSS color for `mode`.
+ *
+ * Used wherever CSS `light-dark()` cannot be used — a preview swatch, an SSR
+ * seed, or any non-browser consumer that needs one flat value rather than a
+ * `light-dark(...)` function. The emitters (`applyColorState`,
+ * `buildApplyOverrides`) deliberately do NOT call this; they emit
+ * `light-dark()` and let the browser choose.
+ */
+export function resolvePerModeLiteral(
+  value: { literal: { light: string; dark: string } },
+  mode: 'light' | 'dark',
+): string {
+  return value.literal[mode];
+}
+
+/**
+ * Resolve a semantic mapping to a single concrete CSS color suitable for a
+ * PREVIEW swatch — a flat value, never a `light-dark()` function. Mirrors the
+ * internal apply-path resolver, except a per-mode `{ literal: { light, dark } }`
+ * value collapses to `getClusterDefaultMode(cluster)`'s side (#472).
+ *
+ * This is the "preview/seed" consumer referenced by #472/#473: the per-mode
+ * editor UI (#473) renders its swatch from this so the user sees the cluster's
+ * default-mode color, while the applied CSS var still emits `light-dark()`.
+ */
+export function resolveSemanticPreviewColor(
+  mapping: SemanticValue,
+  state: ColorTweakState,
+  cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
+  currentTab?: TabConfig,
+  tabs?: readonly TabConfig[],
+): string {
+  return resolveSemanticCssValue(
+    mapping,
+    state.palette,
+    state.background,
+    state.foreground,
+    currentTab,
+    tabs,
+    getClusterDefaultMode(cluster),
+  );
+}
+
+/**
+ * Inline CSS property (NOT a custom property) written to the applied root when
+ * a cluster emits any per-mode `light-dark()` value, so that function resolves
+ * against a defined color-scheme instead of silently falling back. Emitted as
+ * a plain `[name, value]` pair through the same write path (sink batch or
+ * `document.documentElement`) as every other var, per #472.
+ */
+const COLOR_SCHEME_PROP = 'color-scheme';
+const COLOR_SCHEME_LIGHT_DARK = 'light dark';
+
+/**
+ * True when applying `state` against `cluster` would emit at least one per-mode
+ * `light-dark()` semantic value — i.e. the applied root needs
+ * `color-scheme: light dark` for those values to resolve.
+ */
+function hasPerModeLiteralSemantic(
+  state: ColorTweakState,
+  cluster: ColorClusterDataConfig,
+): boolean {
+  for (const key of Object.keys(cluster.semanticCssNames)) {
+    const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
+    if (mapping !== undefined && isPerModeLiteral(mapping)) return true;
+  }
+  return false;
 }
 
 /**
@@ -1135,6 +1237,13 @@ export function applyColorState(
         ),
       ]);
     }
+    // #472 — when any semantic value emits `light-dark()`, the applied root
+    // needs `color-scheme: light dark` for it to resolve. Route it through the
+    // SAME sink so it lands on the sink's own target root, never a hardcoded
+    // `document.documentElement`.
+    if (hasPerModeLiteralSemantic(state, cluster)) {
+      pairs.push([COLOR_SCHEME_PROP, COLOR_SCHEME_LIGHT_DARK]);
+    }
     try {
       sink.apply(pairs);
     } catch (err) {
@@ -1170,6 +1279,13 @@ export function applyColorState(
         tabs,
       ),
     );
+  }
+  // #472 — set `color-scheme: light dark` on the applied root so any emitted
+  // `light-dark()` semantic value resolves. `setCssVar` writes to
+  // `document.documentElement` (the default, no-sink path's root). This is a
+  // plain CSS property, not a custom property, but `setProperty` handles both.
+  if (hasPerModeLiteralSemantic(state, cluster)) {
+    setCssVar(COLOR_SCHEME_PROP, COLOR_SCHEME_LIGHT_DARK);
   }
 }
 

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -1042,8 +1042,14 @@ export function safeIndex(index: number, len: number): number {
 /**
  * Resolve a `SemanticValue` to an actual color for the apply path. Delegates
  * to `resolveMapping` for the legacy index shape (every mapping produced by
- * the panel today). The `{ literal }` / `{ ref }` variants are not resolved
- * yet — that lands with #467/#469 — so they fall back to `'#000000'` rather
+ * the panel today), and returns the raw CSS value verbatim for a single-mode
+ * `{ literal: string }` mapping (#465, S4) — the DOM value for a literal row
+ * must equal what `build-apply-overrides.ts`'s disk emitter writes for the
+ * same mapping.
+ *
+ * The per-mode `{ literal: { light, dark } }` variant (#472) and the `{ ref }`
+ * variant (#468) are not resolved yet — those branches slot in here, above
+ * the final `'#000000'` fallback — so they fall back to `'#000000'` rather
  * than throwing, keeping `applyColorState` total over the widened type.
  */
 function resolveSemanticCssValue(
@@ -1053,6 +1059,7 @@ function resolveSemanticCssValue(
   fgIndex: number,
 ): string {
   if (isIndexMapping(mapping)) return resolveMapping(mapping, palette, bgIndex, fgIndex);
+  if (isLiteralMapping(mapping) && !isPerModeLiteral(mapping)) return mapping.literal;
   return '#000000';
 }
 

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -1586,6 +1586,12 @@ function clearAppliedColorStylesImpl(
     for (const cluster of clusters) {
       names.push(...clusterVarNames(cluster));
     }
+    // #474 — the apply path may have set `color-scheme: light dark` on this
+    // sink's target root (whenever any per-mode literal was present, #472).
+    // Clear it alongside the palette/base-role/semantic vars so a Reset
+    // doesn't leave it lingering. Harmless when it was never set — clearing
+    // an absent property is a no-op.
+    if (clusters.length > 0) names.push(COLOR_SCHEME_PROP);
     if (names.length > 0) {
       try {
         sink.clear(names);
@@ -1607,6 +1613,9 @@ function clearAppliedColorStylesImpl(
       root.style.removeProperty(cssName);
     }
   }
+  // #474 — same rationale as the sink branch above: remove a lingering
+  // `color-scheme: light dark` set by the apply path for a per-mode literal.
+  if (clusters.length > 0) root.style.removeProperty(COLOR_SCHEME_PROP);
 }
 
 /**

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -1508,6 +1508,97 @@ function isValidColorShape(s: unknown, paletteSize: number): s is Partial<ColorT
   );
 }
 
+/**
+ * Validate+narrow a single persisted `semanticMappings` entry into a
+ * `SemanticValue`, or return `undefined` when the shape matches none of the
+ * known variants.
+ *
+ * Accepts every shape `ColorTweakState.semanticMappings` has ever held:
+ * the legacy index mapping (`number` / `'bg'` / `'fg'`, pre-#459) plus the
+ * `{ literal }` / `{ literal: { light, dark } }` / `{ ref }` object variants
+ * added in #459 and carried through the external serde in #462.
+ */
+function parsePersistedSemanticValue(val: unknown): SemanticValue | undefined {
+  if (typeof val === 'number') return val;
+  if (val === 'bg' || val === 'fg') return val;
+  if (!val || typeof val !== 'object' || Array.isArray(val)) return undefined;
+
+  const o = val as Record<string, unknown>;
+
+  if ('literal' in o) {
+    const lit = o.literal;
+    if (typeof lit === 'string') return { literal: lit };
+    if (lit && typeof lit === 'object' && !Array.isArray(lit)) {
+      const lo = lit as Record<string, unknown>;
+      if (typeof lo.light === 'string' && typeof lo.dark === 'string') {
+        return { literal: { light: lo.light, dark: lo.dark } };
+      }
+    }
+    return undefined;
+  }
+
+  if ('ref' in o) {
+    const ref = o.ref;
+    if (ref && typeof ref === 'object' && !Array.isArray(ref)) {
+      const ro = ref as Record<string, unknown>;
+      if (typeof ro.tier === 'string' && typeof ro.item === 'string') {
+        return {
+          ref: {
+            tier: ro.tier,
+            item: ro.item,
+            ...(typeof ro.tab === 'string' ? { tab: ro.tab } : {}),
+          },
+        };
+      }
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Hydrate a persisted `semanticMappings` object into a validated
+ * `Record<string, SemanticValue>`, merged over `defaults` (so keys the
+ * manifest has grown since the payload was written still backfill — see the
+ * "fills in missing semantic keys from defaults" test).
+ *
+ * This is the persist-envelope "tolerant reader" for #462: an OLD payload
+ * (pre-#459, index-only — every value a `number` / `'bg'` / `'fg'`) hydrates
+ * byte-identical to before, because every one of those values already
+ * satisfies `parsePersistedSemanticValue`. A NEWER payload may additionally
+ * carry the `{ literal }` / `{ ref }` object variants, which round-trip too.
+ * Any entry whose shape matches NEITHER — a corrupted key, or a foreign
+ * localStorage value — falls back to whatever `defaults[key]` already holds
+ * instead of being merged in verbatim, so malformed persisted data can't
+ * inject an arbitrary object into runtime state.
+ *
+ * No storage-key version bump was needed for this: `getStorageKeyV3()` /
+ * `storageKey_stateV3()` are also read directly by `astro/host-adapter.ts`
+ * (autoload) and `index.tsx` (`hasPersistedOverrides`) outside this module.
+ * Renaming the key here alone would desync those "does persisted state
+ * exist" checks from where new saves actually land — the v3 envelope shape
+ * was already wide enough (untyped at the JSON boundary) to carry the new
+ * variants, so widening what THIS function accepts is the migration; the key
+ * itself doesn't need to change.
+ */
+function hydrateSemanticMappings(
+  raw: unknown,
+  defaults: Record<string, SemanticValue>,
+): Record<string, SemanticValue> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { ...defaults };
+  const out: Record<string, SemanticValue> = { ...defaults };
+  for (const [key, val] of Object.entries(raw as Record<string, unknown>)) {
+    const parsed = parsePersistedSemanticValue(val);
+    if (parsed !== undefined) {
+      out[key] = parsed;
+    }
+    // else: an unrecognized shape — keep whatever `defaults[key]` already
+    // provided (possibly nothing) rather than merging garbage into state.
+  }
+  return out;
+}
+
 /** Fill missing fields on a `ColorTweakState`-shaped object using defaults. */
 function hydrateColorState(
   partial: Partial<ColorTweakState>,
@@ -1543,10 +1634,7 @@ function hydrateColorState(
       typeof partial.selectionBg === 'number' ? partial.selectionBg : defaults.selectionBg,
     selectionFg:
       typeof partial.selectionFg === 'number' ? partial.selectionFg : defaults.selectionFg,
-    semanticMappings:
-      partial.semanticMappings && typeof partial.semanticMappings === 'object'
-        ? { ...defaults.semanticMappings, ...partial.semanticMappings }
-        : defaults.semanticMappings,
+    semanticMappings: hydrateSemanticMappings(partial.semanticMappings, defaults.semanticMappings),
     shikiTheme:
       typeof partial.shikiTheme === 'string' && partial.shikiTheme.length > 0
         ? partial.shikiTheme

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -78,6 +78,7 @@ import {
   type TabOverrides,
   emitTierItemCssValue,
   resolveTierItemValue,
+  resolveRefToCssVar,
 } from '../apply/tier-resolver';
 import { cssToOklcha, type Oklcha } from '../utils/color-oklch';
 
@@ -1048,32 +1049,64 @@ export function safeIndex(index: number, len: number): number {
 /**
  * Resolve a `SemanticValue` to an actual color for the apply path. Delegates
  * to `resolveMapping` for the legacy index shape (every mapping produced by
- * the panel today), and returns the raw CSS value verbatim for a single-mode
+ * the panel today), returns the raw CSS value verbatim for a single-mode
  * `{ literal: string }` mapping (#465, S4) — the DOM value for a literal row
  * must equal what `build-apply-overrides.ts`'s disk emitter writes for the
- * same mapping.
+ * same mapping — and resolves a cross-tab/tier `{ ref }` mapping (#468) via
+ * `resolveRefToCssVar` into a `var(--target)` string, again matching the disk
+ * emitter's output for the same mapping.
  *
- * The per-mode `{ literal: { light, dark } }` variant (#472) and the `{ ref }`
- * variant (#468) are not resolved yet — those branches slot in here, above
- * the final `'#000000'` fallback — so they fall back to `'#000000'` rather
- * than throwing, keeping `applyColorState` total over the widened type.
+ * `currentTab` / `tabs` are optional so existing callers that have no tab
+ * context (or only ever produce index/literal mappings) keep compiling. A
+ * `{ ref }` mapping with no `currentTab` supplied, or one that fails to
+ * resolve (misconfigured manifest), falls back to `'#000000'` rather than
+ * throwing — up-front source validation is #469's job, not this function's.
+ *
+ * The per-mode `{ literal: { light, dark } }` variant (#472) is not resolved
+ * yet — that branch slots in here, above the final `'#000000'` fallback —
+ * so it currently falls back to `'#000000'`, keeping `applyColorState` total
+ * over the widened type.
  */
 function resolveSemanticCssValue(
   mapping: SemanticValue,
   palette: string[],
   bgIndex: number,
   fgIndex: number,
+  currentTab?: TabConfig,
+  tabs?: readonly TabConfig[],
 ): string {
   if (isIndexMapping(mapping)) return resolveMapping(mapping, palette, bgIndex, fgIndex);
   if (isLiteralMapping(mapping) && !isPerModeLiteral(mapping)) return mapping.literal;
+  if (isRefMapping(mapping) && currentTab) {
+    try {
+      const targetCssVar = resolveRefToCssVar(mapping.ref, currentTab, tabs ?? [currentTab]);
+      return `var(${targetCssVar})`;
+    } catch {
+      // Unresolvable ref (misconfigured manifest) — fall through to the
+      // '#000000' fallback below rather than throwing.
+    }
+  }
   return '#000000';
 }
 
-/** Apply a single `ColorTweakState` to the DOM using the given cluster config. */
+/**
+ * Apply a single `ColorTweakState` to the DOM using the given cluster config.
+ *
+ * `currentTab` / `tabs` are optional and exist so a cross-tab/tier `{ ref }`
+ * semantic mapping (#468) can resolve: `currentTab` should be the color
+ * TabConfig this cluster was derived from (id `'color'` or
+ * `'color-secondary'`), and `tabs` the panel's full tabs array so a ref
+ * pointing into another tab (e.g. the grouped Palette tab) resolves. Callers
+ * that never hold `{ ref }` mappings (or have no tab context, e.g. most
+ * existing tests) can omit both — `resolveSemanticCssValue` falls back to
+ * `'#000000'` for an unresolvable ref rather than throwing.
+ */
 export function applyColorState(
   state: ColorTweakState,
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
   sink?: ApplySink,
+  currentTab?: TabConfig,
+  tabs?: readonly TabConfig[],
 ) {
   const len = state.palette.length;
   if (sink) {
@@ -1092,7 +1125,14 @@ export function applyColorState(
       const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
       pairs.push([
         cssName,
-        resolveSemanticCssValue(mapping, state.palette, state.background, state.foreground),
+        resolveSemanticCssValue(
+          mapping,
+          state.palette,
+          state.background,
+          state.foreground,
+          currentTab,
+          tabs,
+        ),
       ]);
     }
     try {
@@ -1121,7 +1161,14 @@ export function applyColorState(
     const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
     setCssVar(
       cssName,
-      resolveSemanticCssValue(mapping, state.palette, state.background, state.foreground),
+      resolveSemanticCssValue(
+        mapping,
+        state.palette,
+        state.background,
+        state.foreground,
+        currentTab,
+        tabs,
+      ),
     );
   }
 }
@@ -1194,8 +1241,12 @@ export function applyTokenOverrides(
 export function applyFullState(state: TweakState, cfg?: PanelConfig) {
   const config = cfg ?? getPanelConfig();
   const sink = config.applySink;
-  // Primary color cluster is derived from the color TabConfig.
-  applyColorState(state.color, getActivePrimaryCluster(config), sink);
+  // Primary color cluster is derived from the color TabConfig. Thread the
+  // color tab + the full tabs array through so a cross-tab `{ ref }` semantic
+  // mapping (#468) resolves against a ramp tier living in another tab (e.g.
+  // the grouped Palette tab).
+  const colorTab = config.tabs.find((t) => t.id === 'color');
+  applyColorState(state.color, getActivePrimaryCluster(config), sink, colorTab, config.tabs);
   // Apply spacing / typography / size from tabs[] (required field post-Wave-5).
   applyTabOverridesFlat(config.tabs, 'spacing', state.spacing, sink);
   applyTabOverridesFlat(config.tabs, 'font', state.typography, sink);
@@ -1204,7 +1255,8 @@ export function applyFullState(state: TweakState, cfg?: PanelConfig) {
   // When no such tab is configured, skip the secondary apply pass entirely.
   const secondaryCluster = resolveSecondaryColorCluster(config);
   if (secondaryCluster && state.secondary) {
-    applyColorState(state.secondary, secondaryCluster, sink);
+    const secondaryColorTab = config.tabs.find((t) => t.id === 'color-secondary');
+    applyColorState(state.secondary, secondaryCluster, sink, secondaryColorTab, config.tabs);
   }
   // Apply generic tab overrides (v3 envelope tabs field).
   // The `tabs` field stores `TabOverrides` (tierId → { itemId → value }).

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -1080,7 +1080,12 @@ function resolveSemanticCssValue(
   currentTab?: TabConfig,
   tabs?: readonly TabConfig[],
   perModeMode?: 'light' | 'dark',
-): string {
+): string | null {
+  // Returns `null` to mean "emit nothing" — an unresolvable `{ ref }` or an
+  // unrecognized mapping shape. Apply call sites SKIP a null (leaving the
+  // token at its stylesheet default), matching the disk emitter
+  // (`build-apply-overrides.ts`) which also skips. The preview caller
+  // (`resolveSemanticPreviewColor`) substitutes a concrete fallback instead.
   if (isIndexMapping(mapping)) return resolveMapping(mapping, palette, bgIndex, fgIndex);
   if (isLiteralMapping(mapping) && isPerModeLiteral(mapping)) {
     // #472 — per-mode literal. Emit `light-dark()` so the browser picks the
@@ -1097,11 +1102,13 @@ function resolveSemanticCssValue(
       const targetCssVar = resolveRefToCssVar(mapping.ref, currentTab, tabs ?? [currentTab]);
       return `var(${targetCssVar})`;
     } catch {
-      // Unresolvable ref (misconfigured manifest) — fall through to the
-      // '#000000' fallback below rather than throwing.
+      // Unresolvable ref (misconfigured manifest / renamed ramp item) — emit
+      // nothing so the token keeps its stylesheet default, exactly as the disk
+      // emitter does. Do NOT paint it black.
+      return null;
     }
   }
-  return '#000000';
+  return null;
 }
 
 /**
@@ -1154,14 +1161,18 @@ export function resolveSemanticPreviewColor(
   currentTab?: TabConfig,
   tabs?: readonly TabConfig[],
 ): string {
-  return resolveSemanticCssValue(
-    mapping,
-    state.palette,
-    state.background,
-    state.foreground,
-    currentTab,
-    tabs,
-    getClusterDefaultMode(cluster),
+  // Preview needs a concrete color; substitute the neutral fallback when the
+  // mapping resolves to nothing (unresolvable ref / unknown shape).
+  return (
+    resolveSemanticCssValue(
+      mapping,
+      state.palette,
+      state.background,
+      state.foreground,
+      currentTab,
+      tabs,
+      getClusterDefaultMode(cluster),
+    ) ?? '#000000'
   );
 }
 
@@ -1225,17 +1236,17 @@ export function applyColorState(
     }
     for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
       const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
-      pairs.push([
-        cssName,
-        resolveSemanticCssValue(
-          mapping,
-          state.palette,
-          state.background,
-          state.foreground,
-          currentTab,
-          tabs,
-        ),
-      ]);
+      const value = resolveSemanticCssValue(
+        mapping,
+        state.palette,
+        state.background,
+        state.foreground,
+        currentTab,
+        tabs,
+      );
+      // Skip an unresolvable ref / unknown shape (null) — leave the token at
+      // its default, matching the disk emitter.
+      if (value !== null) pairs.push([cssName, value]);
     }
     // #472 — when any semantic value emits `light-dark()`, the applied root
     // needs `color-scheme: light dark` for it to resolve. Route it through the
@@ -1268,17 +1279,17 @@ export function applyColorState(
   // Semantic.
   for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
     const mapping = state.semanticMappings[key] ?? cluster.semanticDefaults[key];
-    setCssVar(
-      cssName,
-      resolveSemanticCssValue(
-        mapping,
-        state.palette,
-        state.background,
-        state.foreground,
-        currentTab,
-        tabs,
-      ),
+    const value = resolveSemanticCssValue(
+      mapping,
+      state.palette,
+      state.background,
+      state.foreground,
+      currentTab,
+      tabs,
     );
+    // Skip an unresolvable ref / unknown shape (null) — leave the token at its
+    // default, matching the disk emitter.
+    if (value !== null) setCssVar(cssName, value);
   }
   // #472 — set `color-scheme: light dark` on the applied root so any emitted
   // `light-dark()` semantic value resolves. `setCssVar` writes to

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -621,6 +621,10 @@ export function getActivePrimaryCluster(
  *    slots interpolate. Functional but visually flat; hosts wanting a
  *    designed seed should ship a scheme registry on the cluster and call
  *    `initColorFromScheme(cluster)` instead.
+ *  - A cluster with `paletteSize: 0` (a lone `semantic: true` tier with no
+ *    palette sibling, #458/#466) seeds an EMPTY palette — there is nothing
+ *    to ramp. Forcing a 1-slot grayscale floor here produced a phantom
+ *    `--zudo-stub-p0` swatch/token with no backing tier; see #466.
  *
  * The base-role indices are kept on the state shape for envelope-round-trip
  * compatibility but are inert — `applyColorState` only writes a base role
@@ -630,7 +634,9 @@ export function initSecondaryDefaults(cluster: ColorClusterDataConfig): ColorTwe
   // Deterministic grayscale ramp. Index 0 → black, last → white, middle
   // slots interpolate. Functional but visually flat; hosts wanting a
   // designed seed should ship a scheme registry on the cluster.
-  const size = Math.max(1, cluster.paletteSize);
+  // `paletteSize: 0` seeds an empty palette rather than flooring to 1 slot
+  // (no Math.max(1, ...) floor) — see #466.
+  const size = cluster.paletteSize;
   const palette: string[] = Array.from({ length: size }, (_, i) => {
     if (size === 1) return '#808080';
     const v = Math.round((i / (size - 1)) * 255);

--- a/packages/zdtp/src/styles/panel.css
+++ b/packages/zdtp/src/styles/panel.css
@@ -1105,6 +1105,33 @@ select.tokenpanel-tier-ref-select:focus-visible {
 }
 
 /* ===========================================================================
+ * Per-mode (light/dark) literal editor — S12, #473
+ *
+ * The "Per-mode" checkbox and the light/dark `ColorField` pair it reveals,
+ * shared by `SemanticLiteralRow` (tabs/color-tab.tsx) and the grouped
+ * ref-or-literal editor (controls/tier-ref-selector.tsx).
+ * ========================================================================= */
+
+.tokenpanel-per-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--tokentweak-color-muted);
+  font-family: var(--tokentweak-font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.tokenpanel-per-mode-fields {
+  display: flex;
+  align-items: center;
+  gap: var(--tokentweak-pad-sm);
+  flex-wrap: wrap;
+}
+
+/* ===========================================================================
  * Tab role-button + tier headings (#148)
  *
  * These rules were added as part of the semantic-tag replacement in #148.

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -945,3 +945,184 @@ describe('ColorTab — palette format:"oklch" routing (#436)', () => {
     expect(/^#[0-9a-fA-F]{6,8}$/.test(result!.palette[0])).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// S3 (#464) — literal semantic rows render as editable OKLCH swatches
+//
+// A lone `semantic: true` tier with no palette sibling, whose items all
+// resolve to `{ literal: string }` (an OKLCH color, not a palette-item id —
+// see `deriveSemanticValue` in cluster-config.ts). These must render as
+// editable `ColorField` swatches, NOT `PaletteSelector` dropdowns (there is
+// no palette to pick a slot from).
+// ---------------------------------------------------------------------------
+
+const LITERAL_SEMANTIC_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'lit-fixture',
+    label: 'Lit Fixture',
+    baseRoles: {},
+    baseDefaults: { background: 0, foreground: 0, cursor: 0, selectionBg: 0, selectionFg: 0 },
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      items: [
+        {
+          id: 'danger',
+          cssVar: '--lit-danger',
+          label: 'Danger',
+          default: 'oklch(0.6 0.2 30)',
+          type: { kind: 'color' as const },
+        },
+        {
+          id: 'success',
+          cssVar: '--lit-success',
+          label: 'Success',
+          default: 'oklch(0.7 0.15 140)',
+          type: { kind: 'color' as const },
+        },
+        {
+          id: 'warning',
+          cssVar: '--lit-warning',
+          label: 'Warning',
+          default: 'oklch(0.75 0.18 80)',
+          type: { kind: 'color' as const },
+        },
+      ],
+    },
+  ],
+};
+
+/** Empty-palette color state — the lone semantic tier has no palette sibling. */
+function makeLiteralColorState(): ColorTweakState {
+  return {
+    palette: [],
+    background: 0,
+    foreground: 0,
+    cursor: 0,
+    selectionBg: 0,
+    selectionFg: 0,
+    semanticMappings: {},
+    shikiTheme: 'dracula',
+  };
+}
+
+describe('ColorTab — literal semantic rows render as editable OKLCH swatches (S3, #464)', () => {
+  beforeEach(() => {
+    // Pin the in-picker display mode so the OKLCH (L/C/H) sliders render
+    // deterministically, mirroring the #436 suite above.
+    localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+  });
+  afterEach(() => {
+    localStorage.removeItem('tokenpanel.colorPicker.mode');
+  });
+
+  it('renders one editable ColorField swatch per literal semantic entry (N=3), not a PaletteSelector', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    expect(semanticGrid).not.toBeNull();
+
+    // 3 literal rows → 3 editable swatches. NOT a palette-index dropdown
+    // (there's no palette tier) and NOT an empty section.
+    expect(semanticGrid.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(3);
+    expect(semanticGrid.querySelectorAll('.tokenpanel-palette-selector').length).toBe(0);
+  });
+
+  it('each literal row shows the starting OKLCH color and its cssVar label', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    const row = semanticGrid.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    expect(row).not.toBeNull();
+    const swatch = row.querySelector('[data-testid="color-field-swatch"]') as HTMLElement;
+    expect(swatch.style.backgroundColor).toContain('oklch');
+    expect(row.textContent).toContain('--lit-danger');
+  });
+
+  it('each literal row has the eye/highlight toggle (real cssVar), matching palette-swatch behavior', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    expect(semanticGrid.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(3);
+  });
+
+  it('clicking the eye toggle on a literal row calls toggle with the row cssVar', () => {
+    const toggle = vi.fn();
+    const ctx = makeCtx(makeHighlightState(), toggle);
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    const row = semanticGrid.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const eyeToggle = row.querySelector('.tokenpanel-highlight-toggle') as HTMLElement;
+    act(() => eyeToggle.click());
+
+    expect(toggle).toHaveBeenCalledWith('--lit-danger');
+  });
+
+  it('editing a literal swatch dispatches { literal: <oklch string> } into semanticMappings, not a palette index', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: LITERAL_SEMANTIC_TAB,
+      colorState: makeLiteralColorState(),
+      persistColor,
+    });
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    const row = semanticGrid.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const swatchBtn = row.querySelector('[data-testid="color-field-swatch"]') as HTMLElement;
+    act(() => swatchBtn.click());
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeLiteralColorState());
+    expect(result.semanticMappings.danger).toEqual(
+      expect.objectContaining({ literal: expect.stringMatching(/^oklch\(/) }),
+    );
+  });
+
+  it('does not regress a conventional index-based semantic default (still a PaletteSelector, no ColorField)', () => {
+    // PRIMARY_COLOR_TAB's semantic tier resolves accent/muted to palette
+    // indices (not literals) — must be unaffected by the literal-row change.
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx);
+
+    const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
+    const semanticGrid = baseGrids[1] as HTMLElement;
+    expect(semanticGrid.querySelectorAll('.tokenpanel-palette-selector').length).toBe(2);
+    expect(semanticGrid.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(0);
+  });
+
+  it('renders no banned semantic tags and no <button> elements (hostile-host / panel DOM-hygiene policy)', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,li,table,a,details,summary')).toBeNull();
+  });
+});

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -1000,7 +1000,12 @@ const LITERAL_SEMANTIC_TAB: TabConfig = {
   ],
 };
 
-/** Empty-palette color state — the lone semantic tier has no palette sibling. */
+/**
+ * Empty-palette color state — the lone semantic tier has no palette sibling.
+ * With `palette: []`, Section A (Palette) and Section B (Base) both skip
+ * rendering (#466 follow-up), so `.tokenpanel-color-base-grid` index 0 below
+ * is the Semantic Tokens grid, not the Base grid.
+ */
 function makeLiteralColorState(): ColorTweakState {
   return {
     palette: [],
@@ -1029,7 +1034,7 @@ describe('ColorTab — literal semantic rows render as editable OKLCH swatches (
     renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
 
     const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
-    const semanticGrid = baseGrids[1] as HTMLElement;
+    const semanticGrid = baseGrids[0] as HTMLElement;
     expect(semanticGrid).not.toBeNull();
 
     // 3 literal rows → 3 editable swatches. NOT a palette-index dropdown
@@ -1043,7 +1048,7 @@ describe('ColorTab — literal semantic rows render as editable OKLCH swatches (
     renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
 
     const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
-    const semanticGrid = baseGrids[1] as HTMLElement;
+    const semanticGrid = baseGrids[0] as HTMLElement;
     const row = semanticGrid.querySelector(
       '[data-testid="tokenpanel-semantic-literal-danger"]',
     ) as HTMLElement;
@@ -1058,7 +1063,7 @@ describe('ColorTab — literal semantic rows render as editable OKLCH swatches (
     renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
 
     const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
-    const semanticGrid = baseGrids[1] as HTMLElement;
+    const semanticGrid = baseGrids[0] as HTMLElement;
     expect(semanticGrid.querySelectorAll('.tokenpanel-highlight-toggle').length).toBe(3);
   });
 
@@ -1068,7 +1073,7 @@ describe('ColorTab — literal semantic rows render as editable OKLCH swatches (
     renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
 
     const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
-    const semanticGrid = baseGrids[1] as HTMLElement;
+    const semanticGrid = baseGrids[0] as HTMLElement;
     const row = semanticGrid.querySelector(
       '[data-testid="tokenpanel-semantic-literal-danger"]',
     ) as HTMLElement;
@@ -1088,7 +1093,7 @@ describe('ColorTab — literal semantic rows render as editable OKLCH swatches (
     });
 
     const baseGrids = container.querySelectorAll('.tokenpanel-color-base-grid');
-    const semanticGrid = baseGrids[1] as HTMLElement;
+    const semanticGrid = baseGrids[0] as HTMLElement;
     const row = semanticGrid.querySelector(
       '[data-testid="tokenpanel-semantic-literal-danger"]',
     ) as HTMLElement;

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -1131,3 +1131,227 @@ describe('ColorTab — literal semantic rows render as editable OKLCH swatches (
     expect(container.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,li,table,a,details,summary')).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// S12 (#473) — SemanticLiteralRow per-mode (light/dark) editor toggle
+//
+// A literal semantic row (no `referencesRamps` on its tier) gets a "Per-mode"
+// checkbox. Checking it expands one literal into an independently-editable
+// light/dark `ColorField` pair; unchecking it collapses back to a single
+// value using the cluster's `getClusterDefaultMode()` side.
+// ---------------------------------------------------------------------------
+
+/** `danger` seeded as an already-per-mode literal; `success`/`warning` stay single-mode. */
+function makePerModeColorState(): ColorTweakState {
+  return {
+    ...makeLiteralColorState(),
+    semanticMappings: {
+      danger: { literal: { light: 'oklch(0.9 0.05 30)', dark: 'oklch(0.3 0.1 30)' } },
+    },
+  };
+}
+
+/** Same fixture, but the cluster's configured default mode is "dark". */
+const DARK_DEFAULT_LITERAL_SEMANTIC_TAB: TabConfig = {
+  ...LITERAL_SEMANTIC_TAB,
+  colorExtras: {
+    ...LITERAL_SEMANTIC_TAB.colorExtras!,
+    panelSettings: {
+      colorScheme: '',
+      colorMode: { defaultMode: 'dark' as const, lightScheme: 'L', darkScheme: 'D' },
+    },
+  },
+};
+
+/** Toggle a checkbox and fire its native change event. */
+function fireCheckboxToggle(checkbox: HTMLInputElement, checked: boolean) {
+  act(() => {
+    checkbox.checked = checked;
+    checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
+describe('ColorTab — SemanticLiteralRow per-mode (light/dark) editor toggle (S12, #473)', () => {
+  beforeEach(() => {
+    localStorage.setItem('tokenpanel.colorPicker.mode', 'oklch');
+  });
+  afterEach(() => {
+    localStorage.removeItem('tokenpanel.colorPicker.mode');
+  });
+
+  it('a single-mode literal row shows an unchecked "Per-mode" checkbox and one editable swatch', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makeLiteralColorState() });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox).not.toBeNull();
+    expect(checkbox.checked).toBe(false);
+    expect(row.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(1);
+  });
+
+  it('a per-mode literal row shows a checked "Per-mode" checkbox and two editable swatches', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makePerModeColorState() });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(row.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(2);
+  });
+
+  it('checking "Per-mode" seeds both sides from the current single value and persists { literal: { light, dark } }', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: LITERAL_SEMANTIC_TAB,
+      colorState: makeLiteralColorState(),
+      persistColor,
+    });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireCheckboxToggle(checkbox, true);
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makeLiteralColorState());
+    expect(result.semanticMappings.danger).toEqual({
+      literal: { light: 'oklch(0.6 0.2 30)', dark: 'oklch(0.6 0.2 30)' },
+    });
+  });
+
+  it('unchecking "Per-mode" collapses to the light side (cluster defaultMode is "light" by default)', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: LITERAL_SEMANTIC_TAB,
+      colorState: makePerModeColorState(),
+      persistColor,
+    });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireCheckboxToggle(checkbox, false);
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makePerModeColorState());
+    expect(result.semanticMappings.danger).toEqual({ literal: 'oklch(0.9 0.05 30)' });
+  });
+
+  it('unchecking "Per-mode" collapses to the dark side when the cluster defaultMode is "dark"', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: DARK_DEFAULT_LITERAL_SEMANTIC_TAB,
+      colorState: makePerModeColorState(),
+      persistColor,
+    });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const checkbox = row.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    fireCheckboxToggle(checkbox, false);
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makePerModeColorState());
+    expect(result.semanticMappings.danger).toEqual({ literal: 'oklch(0.3 0.1 30)' });
+  });
+
+  it('editing the Light swatch of a per-mode row updates only the light side', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: LITERAL_SEMANTIC_TAB,
+      colorState: makePerModeColorState(),
+      persistColor,
+    });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const lightSwatch = row.querySelector(
+      '[aria-label="--lit-danger (Light): --lit-danger"]',
+    ) as HTMLElement;
+    expect(lightSwatch).not.toBeNull();
+    act(() => lightSwatch.click());
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makePerModeColorState());
+    expect(result.semanticMappings.danger).toEqual({
+      literal: { light: expect.stringMatching(/^oklch\(/), dark: 'oklch(0.3 0.1 30)' },
+    });
+  });
+
+  it('editing the Dark swatch of a per-mode row updates only the dark side', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    const persistColor = vi.fn();
+    renderColorTab(ctx, {
+      tab: LITERAL_SEMANTIC_TAB,
+      colorState: makePerModeColorState(),
+      persistColor,
+    });
+
+    const row = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-danger"]',
+    ) as HTMLElement;
+    const darkSwatch = row.querySelector(
+      '[aria-label="--lit-danger (Dark): --lit-danger"]',
+    ) as HTMLElement;
+    expect(darkSwatch).not.toBeNull();
+    act(() => darkSwatch.click());
+    fireFirstPickerSliderArrow();
+
+    expect(persistColor).toHaveBeenCalled();
+    const updater = persistColor.mock.calls.at(-1)![0] as (
+      prev: ColorTweakState,
+    ) => ColorTweakState;
+    const result = updater(makePerModeColorState());
+    expect(result.semanticMappings.danger).toEqual({
+      literal: { light: 'oklch(0.9 0.05 30)', dark: expect.stringMatching(/^oklch\(/) },
+    });
+  });
+
+  it('single-mode literal rows for other keys are unaffected (regression check)', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makePerModeColorState() });
+
+    const successRow = container.querySelector(
+      '[data-testid="tokenpanel-semantic-literal-success"]',
+    ) as HTMLElement;
+    expect(successRow.querySelectorAll('[data-testid="color-field-swatch"]').length).toBe(1);
+    const checkbox = successRow.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('renders no banned semantic tags or <button> elements with a per-mode row expanded', () => {
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, { tab: LITERAL_SEMANTIC_TAB, colorState: makePerModeColorState() });
+
+    expect(container.querySelector('button')).toBeNull();
+    expect(
+      container.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,li,table,a,details,summary'),
+    ).toBeNull();
+  });
+});

--- a/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/generic-tab.test.tsx
@@ -163,7 +163,7 @@ afterEach(() => {
 async function renderGenericTab(
   tab: TabConfig,
   overrides: TabOverrides = {},
-  onChange: (tierId: string, itemId: string, next: string) => void = () => undefined,
+  onChange: (tierId: string, itemId: string, next: string | undefined) => void = () => undefined,
   withTooltipProvider = false,
 ): Promise<void> {
   await act(() => {

--- a/packages/zdtp/src/tabs/__tests__/tabs-semantic-replacement.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/tabs-semantic-replacement.test.tsx
@@ -198,7 +198,7 @@ async function renderSizeTab(
 async function renderGenericTab(
   tab: TabConfig = GENERIC_TAB,
   overrides: TabOverrides = {},
-  onChange: (tierId: string, itemId: string, next: string) => void = noop,
+  onChange: (tierId: string, itemId: string, next: string | undefined) => void = noop,
 ): Promise<void> {
   await act(() => {
     render(

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -624,7 +624,10 @@ export default function ColorTab({
 }: ColorTabProps) {
   // Derive the cluster from the tab's colorExtras + tiers. This provides the
   // same shape that the rest of the panel (apply, clear, state) expects.
-  const cluster = useMemo(() => resolveColorClusterFromTab(tab), [tab]);
+  // The full tabs array is threaded in so a semantic tier's cross-tab `{ ref }`
+  // mappings resolve against a ramp tier in another tab (e.g. the Palette tab).
+  const allTabs = getPanelConfig().tabs;
+  const cluster = useMemo(() => resolveColorClusterFromTab(tab, allTabs), [tab, allTabs]);
   // Fallback to an empty stub cluster when the tab has no colorExtras.
   const safeCluster = useMemo(
     () =>
@@ -644,8 +647,8 @@ export default function ColorTab({
   );
   // Secondary cluster derived from the secondary tab (if any).
   const secondaryCluster = useMemo(
-    () => (secondaryTab ? resolveColorClusterFromTab(secondaryTab) ?? null : null),
-    [secondaryTab],
+    () => (secondaryTab ? resolveColorClusterFromTab(secondaryTab, allTabs) ?? null : null),
+    [secondaryTab, allTabs],
   );
   // Host-supplied preset list. Read through the panel
   // config so a host that calls `configurePanel({ ..., colorPresets })`

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -43,8 +43,10 @@ import { Z } from '../styles/z-index-tokens';
 import type { ColorPickerValueFormat } from '../components/color-picker/color-picker';
 import {
   type ColorTweakState,
+  type SemanticValue,
   applyShikiTheme,
   initColorFromSchemeData,
+  isIndexMapping,
   resolvePaletteCssVar,
 } from '../state/tweak-state';
 import { getPanelConfig } from '../config/panel-config';
@@ -65,6 +67,19 @@ import { useTooltip } from '../controls/tooltip';
 // presets. The Color tab reads the active map at render time below —
 // `presetNames` is no longer a module-level constant computed from a
 // baked-in import.
+
+/**
+ * `PaletteSelector` (below) only understands the legacy index shape — it
+ * renders a palette-slot dropdown, not a literal-color or ramp-ref editor.
+ * `semanticMappings` / `semanticDefaults` were widened to `SemanticValue`
+ * (#459 S1); every value flowing through this tab today is still an index
+ * mapping (the `{ literal }` / `{ ref }` editor UI is downstream work), so
+ * this just narrows the type for `PaletteSelector`'s `value` prop, falling
+ * back to `0` for the not-yet-possible non-index case.
+ */
+function toIndexMappingForSelector(v: SemanticValue): number | 'bg' | 'fg' {
+  return isIndexMapping(v) ? v : 0;
+}
 
 // --- Shared popover helpers (Color-tab scoped) ---
 
@@ -824,7 +839,7 @@ export default function ColorTab({
                   key={key}
                   label={semanticCssVar ?? key}
                   idKey={key}
-                  value={state.semanticMappings[key] ?? defaultVal}
+                  value={toIndexMappingForSelector(state.semanticMappings[key] ?? defaultVal)}
                   palette={state.palette}
                   paletteCssVar={clusterPaletteCssVar}
                   onChange={handleSemanticChange}
@@ -884,7 +899,7 @@ export default function ColorTab({
                       key={key}
                       label={secondarySemanticCssVar ?? key}
                       idKey={key}
-                      value={secondaryState.semanticMappings[key] ?? defaultVal}
+                      value={toIndexMappingForSelector(secondaryState.semanticMappings[key] ?? defaultVal)}
                       palette={secondaryState.palette}
                       paletteCssVar={secondaryPaletteCssVar}
                       onChange={handleSecondarySemanticChange}

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -176,15 +176,20 @@ function getFixedPopoverStyle(
 // --- Palette format resolution ---
 
 /**
- * Find the palette tier in a color tab: the first non-reference tier whose
- * items are color-kind. Mirrors the palette-tier detection in
+ * Find the palette tier in a color tab: the first non-reference, non-semantic
+ * tier whose items are color-kind. Mirrors the palette-tier detection in
  * `resolveColorClusterFromTab`, so the format lookup keys off the SAME tier the
  * cluster was flattened from. `resolveColorClusterFromTab` drops the per-item
- * `type.format`, so the swatch grid must recover it from the tier here.
+ * `type.format`, so the swatch grid must recover it from the tier here. A tier
+ * marked `semantic: true` is excluded (#461) even if its items are color-kind.
  */
 function findPaletteTier(tab: TabConfig): TierConfig | undefined {
   return tab.tiers.find(
-    (t) => !t.referencesTier && t.items.length > 0 && t.items[0].type.kind === 'color',
+    (t) =>
+      !t.referencesTier &&
+      !t.semantic &&
+      t.items.length > 0 &&
+      t.items[0].type.kind === 'color',
   );
 }
 

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -49,6 +49,8 @@ import {
   initColorFromSchemeData,
   isIndexMapping,
   isLiteralMapping,
+  isPerModeLiteral,
+  isRefMapping,
   resolvePaletteCssVar,
 } from '../state/tweak-state';
 import { getPanelConfig } from '../config/panel-config';
@@ -58,6 +60,10 @@ import type { PersistColor, PersistSecondary } from '../state/persist';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { TokenLabel } from '../controls/token-label';
 import { useTooltip } from '../controls/tooltip';
+import TierRefSelector, {
+  type TierRefSelectorValue,
+  type TierRefTarget,
+} from '../controls/tier-ref-selector';
 
 // The bundled scheme registry now lives on
 // `panelConfig.colorCluster.colorSchemes`, not on a global import. Read it
@@ -75,14 +81,29 @@ import { useTooltip } from '../controls/tooltip';
  * `PaletteSelector` (below) only understands the legacy index shape — it
  * renders a palette-slot dropdown, not a literal-color or ramp-ref editor.
  * `semanticMappings` / `semanticDefaults` were widened to `SemanticValue`
- * (#459 S1). Single-mode `{ literal: string }` values now render through
- * `SemanticLiteralRow` instead (S3, #464) — see the Semantic Tokens section
- * below — so this helper is only reached for index mappings, `{ ref }`
- * (cross-tab reference — #470) and per-mode `{ literal: { light, dark } }`
- * (#472), both of which fall back to `0` until their dedicated editors land.
+ * (#459 S1). Single-mode `{ literal: string }` values render through
+ * `SemanticLiteralRow` (S3, #464); `{ ref }` and single-mode `{ literal }`
+ * values on a tier that declares `referencesRamps` render through the
+ * grouped ref-or-literal `TierRefSelector` (S9, #470) — see the Semantic
+ * Tokens section below. This helper is only reached for plain index
+ * mappings and per-mode `{ literal: { light, dark } }` (#472), which still
+ * fall back to `0` until its dedicated editor lands.
  */
 function toIndexMappingForSelector(v: SemanticValue): number | 'bg' | 'fg' {
   return isIndexMapping(v) ? v : 0;
+}
+
+/**
+ * Finds the `semantic: true` tier (if any) in `tab` that owns the item with
+ * id `itemId`. Used to look up a semantic key's declared `referencesRamps`
+ * so the render loop below can decide whether to route it through the
+ * grouped ref-or-literal picker. Legacy `referencesTier`-only tiers (the
+ * intra-tab index-mapping style, e.g. a plain "semantic" tier pointing at a
+ * sibling "palette" tier) are NOT matched here — they aren't marked
+ * `semantic: true` and keep rendering through `PaletteSelector` as before.
+ */
+function findSemanticTier(tab: TabConfig, itemId: string): TierConfig | undefined {
+  return tab.tiers.find((t) => t.semantic === true && t.items.some((i) => i.id === itemId));
 }
 
 // --- Shared popover helpers (Color-tab scoped) ---
@@ -561,10 +582,13 @@ const PaletteSelector = memo(function PaletteSelector({
  * `PaletteSelector` / `ColorSwatch` above, so a single handler covers every
  * row and `memo` stays effective.
  *
- * Ref (`{ ref }`, #470) and per-mode (`{ literal: { light, dark } }`, #472)
- * semantic values are NOT handled here — they still fall through to
- * `PaletteSelector` via `toIndexMappingForSelector`'s `0` fallback until
- * their dedicated editors land.
+ * Only reached for a tier with NO `referencesRamps` declared — a tier that
+ * does declare ramp sources renders `SemanticRefOrLiteralRow` instead (S9,
+ * #470), even for its literal-mode rows, so the user can switch back to a
+ * ramp reference. Per-mode (`{ literal: { light, dark } }`, #472) semantic
+ * values are NOT handled here — they still fall through to `PaletteSelector`
+ * via `toIndexMappingForSelector`'s `0` fallback until their dedicated
+ * editor lands.
  */
 const SemanticLiteralRow = memo(function SemanticLiteralRow({
   label,
@@ -594,6 +618,78 @@ const SemanticLiteralRow = memo(function SemanticLiteralRow({
     </div>
   );
 });
+
+/**
+ * Semantic-token row for a tier that declares `referencesRamps` (S9, #470):
+ * wraps `TierRefSelector`'s grouped ref-or-literal control with the same
+ * `.tokenpanel-row` (`TokenLabel` + control + eye toggle) layout every other
+ * semantic row uses. Handles both current-value shapes the selector reads —
+ * `{ ref }` (a cross-tab ramp item) and single-mode `{ literal }` (a
+ * standalone OKLCH color, editable in place) — and can switch between them.
+ *
+ * `onChange` is `(idKey, next: TierRefSelectorValue)` — mirrors the
+ * `SemanticValue` `{ ref } | { literal }` shape one-for-one, so the caller's
+ * handler just needs to spread it straight into `semanticMappings`.
+ */
+const SemanticRefOrLiteralRow = memo(function SemanticRefOrLiteralRow({
+  label,
+  idKey,
+  tab,
+  tabs,
+  tierId,
+  value,
+  onChange,
+  previewValueFor,
+  cssVar,
+}: {
+  label: string;
+  idKey: string;
+  tab: TabConfig;
+  tabs: readonly TabConfig[];
+  tierId: string;
+  value: TierRefSelectorValue;
+  onChange: (idKey: string, next: TierRefSelectorValue) => void;
+  previewValueFor: (ref: TierRefTarget) => string;
+  cssVar?: string;
+}) {
+  return (
+    <div className="tokenpanel-row" data-testid={`tokenpanel-semantic-ref-${idKey}`}>
+      <TokenLabel cssVar={cssVar ?? idKey} label={label} />
+      <TierRefSelector
+        tab={tab}
+        tabs={tabs}
+        tierId={tierId}
+        itemId={idKey}
+        value={value}
+        onChange={onChange}
+        previewValueFor={previewValueFor}
+        label={label}
+        cssVar={cssVar}
+      />
+      {cssVar && <HighlightToggleButton cssVar={cssVar} />}
+    </div>
+  );
+});
+
+/**
+ * Resolve a ramp-option preview string for the grouped picker. Looks the
+ * target item up by its manifest data (`{tab?,tier,item}`) and returns its
+ * `default` — a static preview, not override-aware against the Palette tab's
+ * live tweak state (that state isn't threaded into `ColorTab`). Good enough
+ * to label options distinctly; wiring a live preview is left for a follow-up
+ * (see #471's cross-tab e2e confirmation).
+ */
+function makeRampPreview(
+  currentTab: TabConfig,
+  tabs: readonly TabConfig[],
+): (ref: TierRefTarget) => string {
+  return (ref) => {
+    const targetTab = ref.tab === undefined ? currentTab : tabs.find((t) => t.id === ref.tab);
+    const targetTier = targetTab?.tiers.find((t) => t.id === ref.tier);
+    const item = targetTier?.items.find((i) => i.id === ref.item);
+    return item?.default ?? ref.item;
+  };
+}
 
 // --- Color tab body ---
 
@@ -751,6 +847,25 @@ export default function ColorTab({
     [persistSecondary],
   );
 
+  // Secondary-cluster counterpart to `handleSemanticRefOrLiteralChange` (S9,
+  // #470) — writes whichever variant `TierRefSelector` reports straight into
+  // `semanticMappings`, mirroring the `{ ref } | { literal }` shape 1:1.
+  const handleSecondarySemanticRefOrLiteralChange = useCallback(
+    (key: string, next: TierRefSelectorValue) => {
+      persistSecondary((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          semanticMappings: {
+            ...prev.semanticMappings,
+            [key]: 'ref' in next ? { ref: next.ref } : { literal: next.literal },
+          },
+        };
+      });
+    },
+    [persistSecondary],
+  );
+
   // Accepts `key: string` (broadened from the literal union) so the same
   // handler can be passed directly to memoised <PaletteSelector> rows whose
   // (idKey, val) signature is also string-typed.
@@ -793,6 +908,31 @@ export default function ColorTab({
       }));
     },
     [persistColor],
+  );
+
+  // Writes whichever variant `TierRefSelector`'s grouped ref-or-literal
+  // control reports (S9, #470) — mirrors the `{ ref } | { literal }`
+  // `SemanticValue` shape 1:1, so no further translation is needed.
+  const handleSemanticRefOrLiteralChange = useCallback(
+    (key: string, next: TierRefSelectorValue) => {
+      persistColor((prev) => ({
+        ...prev,
+        semanticMappings: {
+          ...prev.semanticMappings,
+          [key]: 'ref' in next ? { ref: next.ref } : { literal: next.literal },
+        },
+      }));
+    },
+    [persistColor],
+  );
+
+  // Preview-text resolvers for the grouped picker's ramp options — one bound
+  // to the primary cluster's own tab (the default "current tab" for
+  // same-tab ramp sources), one to the secondary cluster's tab.
+  const previewRampValue = useMemo(() => makeRampPreview(tab, allTabs), [tab, allTabs]);
+  const secondaryPreviewRampValue = useMemo(
+    () => (secondaryTab ? makeRampPreview(secondaryTab, allTabs) : undefined),
+    [secondaryTab, allTabs],
   );
 
   const handleLoadPreset = useCallback(
@@ -931,12 +1071,42 @@ export default function ColorTab({
             {Object.entries(safeCluster.semanticDefaults).map(([key, defaultVal]) => {
               const semanticCssVar = safeCluster.semanticCssNames[key];
               const mapping = state.semanticMappings[key] ?? defaultVal;
-              // Single-mode `{ literal: string }` renders an editable OKLCH
-              // swatch (S3, #464) instead of a palette-index dropdown — it
-              // has no palette slot to reference. `{ ref }` and per-mode
-              // `{ literal: { light, dark } }` values still fall through to
-              // `PaletteSelector` (via `toIndexMappingForSelector`'s `0`
-              // fallback) pending #470/#472.
+              // A tier that declares `referencesRamps` routes both its ref
+              // and single-mode-literal values through the grouped
+              // ref-or-literal picker (S9, #470), so the user can switch
+              // between a cross-tab ramp reference and an arbitrary OKLCH
+              // literal. Per-mode `{ literal: { light, dark } }` (#472)
+              // isn't handled by that picker yet, so it still falls through
+              // to `PaletteSelector` below regardless of `referencesRamps`.
+              const semanticTier = findSemanticTier(tab, key);
+              const rampSources = semanticTier?.referencesRamps;
+              if (
+                rampSources &&
+                rampSources.length > 0 &&
+                (isRefMapping(mapping) || (isLiteralMapping(mapping) && !isPerModeLiteral(mapping)))
+              ) {
+                const tierRefValue: TierRefSelectorValue = isRefMapping(mapping)
+                  ? { ref: mapping.ref }
+                  : { literal: mapping.literal as string };
+                return (
+                  <SemanticRefOrLiteralRow
+                    key={key}
+                    label={semanticCssVar ?? key}
+                    idKey={key}
+                    tab={tab}
+                    tabs={allTabs}
+                    tierId={semanticTier!.id}
+                    value={tierRefValue}
+                    onChange={handleSemanticRefOrLiteralChange}
+                    previewValueFor={previewRampValue}
+                    cssVar={semanticCssVar}
+                  />
+                );
+              }
+              // Single-mode `{ literal: string }` (on a tier with NO
+              // `referencesRamps`) renders an editable OKLCH swatch (S3,
+              // #464) instead of a palette-index dropdown — it has no
+              // palette slot to reference.
               if (isLiteralMapping(mapping) && typeof mapping.literal === 'string') {
                 return (
                   <SemanticLiteralRow
@@ -973,7 +1143,7 @@ export default function ColorTab({
          * config. The `data-testid` markers below give Playwright a
          * stable handle for asserting presence / absence.
          */}
-        {secondaryCluster && secondaryState && (
+        {secondaryCluster && secondaryState && secondaryTab && (
           <>
             {/* Section D: SECONDARY — Palette */}
             <div
@@ -1010,7 +1180,33 @@ export default function ColorTab({
                 {Object.entries(secondaryCluster.semanticDefaults).map(([key, defaultVal]) => {
                   const secondarySemanticCssVar = secondaryCluster.semanticCssNames[key];
                   const secondaryMapping = secondaryState.semanticMappings[key] ?? defaultVal;
-                  // Mirrors the primary section's literal-vs-index split above.
+                  // Mirrors the primary section's ramp/literal/index split above.
+                  const secondarySemanticTier = findSemanticTier(secondaryTab, key);
+                  const secondaryRampSources = secondarySemanticTier?.referencesRamps;
+                  if (
+                    secondaryRampSources &&
+                    secondaryRampSources.length > 0 &&
+                    (isRefMapping(secondaryMapping) ||
+                      (isLiteralMapping(secondaryMapping) && !isPerModeLiteral(secondaryMapping)))
+                  ) {
+                    const secondaryTierRefValue: TierRefSelectorValue = isRefMapping(secondaryMapping)
+                      ? { ref: secondaryMapping.ref }
+                      : { literal: secondaryMapping.literal as string };
+                    return (
+                      <SemanticRefOrLiteralRow
+                        key={key}
+                        label={secondarySemanticCssVar ?? key}
+                        idKey={key}
+                        tab={secondaryTab}
+                        tabs={allTabs}
+                        tierId={secondarySemanticTier!.id}
+                        value={secondaryTierRefValue}
+                        onChange={handleSecondarySemanticRefOrLiteralChange}
+                        previewValueFor={secondaryPreviewRampValue!}
+                        cssVar={secondarySemanticCssVar}
+                      />
+                    );
+                  }
                   if (
                     isLiteralMapping(secondaryMapping) &&
                     typeof secondaryMapping.literal === 'string'

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -842,71 +842,82 @@ export default function ColorTab({
         </select>
       </div>
 
-      {/* Section A: Raw Palette */}
-      <div className="tokenpanel-tab-section">
-        <div role="heading" aria-level={3} className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
-          {primaryLabel} — Palette
+      {/*
+       * Section A: Raw Palette — and Section B: Base Theme, which indexes
+       * into that palette. Both are gated on `state.palette.length > 0`: a
+       * lone `semantic: true` tier (no palette sibling, paletteSize 0, #458)
+       * has no palette to render or index into. Rendering either section
+       * unconditionally would show a phantom swatch backed by nothing
+       * (previously a 1-slot grayscale floor in `initSecondaryDefaults`,
+       * #466) or a dead index-picker with zero options.
+       */}
+      {state.palette.length > 0 && (
+        <div className="tokenpanel-tab-section">
+          <div role="heading" aria-level={3} className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+            {primaryLabel} — Palette
+          </div>
+          <div className="tokenpanel-color-palette-grid">
+            {state.palette.map((color, i) => (
+              // ColorSwatch passes `i` back via its (index, value) onChange so we
+              // hand `handlePaletteChange` directly — no inline arrow, memo
+              // stays effective. `valueFormat` routes oklch-format slots through
+              // the lossless OKLCH editor; absent/`'hex'` slots stay hex.
+              <ColorSwatch
+                key={i}
+                color={color}
+                index={i}
+                label={resolvePaletteCssVar(safeCluster, i)}
+                cssVar={resolvePaletteCssVar(safeCluster, i)}
+                valueFormat={resolvePaletteFormat(paletteTier, i)}
+                onChange={handlePaletteChange}
+              />
+            ))}
+          </div>
         </div>
-        <div className="tokenpanel-color-palette-grid">
-          {state.palette.map((color, i) => (
-            // ColorSwatch passes `i` back via its (index, value) onChange so we
-            // hand `handlePaletteChange` directly — no inline arrow, memo
-            // stays effective. `valueFormat` routes oklch-format slots through
-            // the lossless OKLCH editor; absent/`'hex'` slots stay hex.
-            <ColorSwatch
-              key={i}
-              color={color}
-              index={i}
-              label={resolvePaletteCssVar(safeCluster, i)}
-              cssVar={resolvePaletteCssVar(safeCluster, i)}
-              valueFormat={resolvePaletteFormat(paletteTier, i)}
-              onChange={handlePaletteChange}
-            />
-          ))}
-        </div>
-      </div>
+      )}
 
       {/* Base + Semantic wrapper */}
       <div className="tokenpanel-tab-content">
-        {/* Section B: Base Theme */}
-        <div className="tokenpanel-tab-section">
-          <div role="heading" aria-level={3} className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
-            {primaryLabel} — Base
+        {state.palette.length > 0 && (
+          <div className="tokenpanel-tab-section">
+            <div role="heading" aria-level={3} className="tokenpanel-tab-section-heading tokenpanel-tab-section-heading--color">
+              {primaryLabel} — Base
+            </div>
+            {/*
+             * `background (bg)` and `foreground (fg)` are palette-index knobs:
+             * the value picks which palette slot seeds that base role. The
+             * labels read as plain English with the short key in parentheses
+             * rather than the cssVar name. The eye toggle, however, wires to the
+             * cluster's declared base-role cssVar (`cluster.baseRoles.background`
+             * / `.foreground`) — those ARE real tokens written to the DOM by
+             * `applyColorState`, so highlighting them is just as valid as any
+             * semantic token. When a cluster declares no cssVar for a base role,
+             * `cssVar` is undefined and the eye is omitted. The `cursor`,
+             * `sel-bg`, `sel-fg` upstream rows are dropped here because nothing
+             * in this package references them.
+             */}
+            <div className="tokenpanel-color-base-grid">
+              <PaletteSelector
+                label="background (bg)"
+                idKey="background"
+                value={state.background}
+                palette={state.palette}
+                paletteCssVar={clusterPaletteCssVar}
+                onChange={handleBaseIndexChange}
+                cssVar={safeCluster.baseRoles.background}
+              />
+              <PaletteSelector
+                label="foreground (fg)"
+                idKey="foreground"
+                value={state.foreground}
+                palette={state.palette}
+                paletteCssVar={clusterPaletteCssVar}
+                onChange={handleBaseIndexChange}
+                cssVar={safeCluster.baseRoles.foreground}
+              />
+            </div>
           </div>
-          {/*
-           * `background (bg)` and `foreground (fg)` are palette-index knobs:
-           * the value picks which palette slot seeds that base role. The
-           * labels read as plain English with the short key in parentheses
-           * rather than the cssVar name. The eye toggle, however, wires to the
-           * cluster's declared base-role cssVar (`cluster.baseRoles.background`
-           * / `.foreground`) — those ARE real tokens written to the DOM by
-           * `applyColorState`, so highlighting them is just as valid as any
-           * semantic token. When a cluster declares no cssVar for a base role,
-           * `cssVar` is undefined and the eye is omitted. The `cursor`,
-           * `sel-bg`, `sel-fg` upstream rows are dropped here because nothing
-           * in this package references them.
-           */}
-          <div className="tokenpanel-color-base-grid">
-            <PaletteSelector
-              label="background (bg)"
-              idKey="background"
-              value={state.background}
-              palette={state.palette}
-              paletteCssVar={clusterPaletteCssVar}
-              onChange={handleBaseIndexChange}
-              cssVar={safeCluster.baseRoles.background}
-            />
-            <PaletteSelector
-              label="foreground (fg)"
-              idKey="foreground"
-              value={state.foreground}
-              palette={state.palette}
-              paletteCssVar={clusterPaletteCssVar}
-              onChange={handleBaseIndexChange}
-              cssVar={safeCluster.baseRoles.foreground}
-            />
-          </div>
-        </div>
+        )}
 
         {/* Section C: Semantic Token Mappings */}
         <div className="tokenpanel-tab-section">

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -46,12 +46,13 @@ import {
   type ColorTweakState,
   type SemanticValue,
   applyShikiTheme,
+  getClusterDefaultMode,
   initColorFromSchemeData,
   isIndexMapping,
   isLiteralMapping,
-  isPerModeLiteral,
   isRefMapping,
   resolvePaletteCssVar,
+  resolvePerModeLiteral,
 } from '../state/tweak-state';
 import { getPanelConfig } from '../config/panel-config';
 import { resolveColorClusterFromTab } from '../config/cluster-config';
@@ -81,13 +82,13 @@ import TierRefSelector, {
  * `PaletteSelector` (below) only understands the legacy index shape — it
  * renders a palette-slot dropdown, not a literal-color or ramp-ref editor.
  * `semanticMappings` / `semanticDefaults` were widened to `SemanticValue`
- * (#459 S1). Single-mode `{ literal: string }` values render through
- * `SemanticLiteralRow` (S3, #464); `{ ref }` and single-mode `{ literal }`
- * values on a tier that declares `referencesRamps` render through the
- * grouped ref-or-literal `TierRefSelector` (S9, #470) — see the Semantic
- * Tokens section below. This helper is only reached for plain index
- * mappings and per-mode `{ literal: { light, dark } }` (#472), which still
- * fall back to `0` until its dedicated editor lands.
+ * (#459 S1). Every `{ literal }` variant — single-mode `{ literal: string }`
+ * AND per-mode `{ literal: { light, dark } }` (#472) — renders through
+ * `SemanticLiteralRow` (S3 #464 / S12 #473); `{ ref }` and any `{ literal }`
+ * on a tier that declares `referencesRamps` render through the grouped
+ * ref-or-literal `TierRefSelector` (S9 #470 / S12 #473) instead — see the
+ * Semantic Tokens section below. This helper is only reached for plain
+ * index mappings now.
  */
 function toIndexMappingForSelector(v: SemanticValue): number | 'bg' | 'fg' {
   return isIndexMapping(v) ? v : 0;
@@ -570,25 +571,30 @@ const PaletteSelector = memo(function PaletteSelector({
 });
 
 /**
- * Semantic-token row for a single-mode `{ literal: string }` mapping (S3,
- * #464): an editable OKLCH `ColorField` swatch instead of `PaletteSelector`'s
- * palette-index dropdown — the value is a standalone color, not a slot into
+ * Semantic-token row for a `{ literal: string }` OR per-mode
+ * `{ literal: { light, dark } }` mapping (S3 #464 / S12 #473): an editable
+ * OKLCH `ColorField` swatch instead of `PaletteSelector`'s palette-index
+ * dropdown — the value is a standalone color, not a slot into
  * `state.palette`, so there is no palette to pick from. Mirrors the
  * `.tokenpanel-row` layout used by `generic-tab.tsx`'s own `format: 'oklch'`
  * color rows (`TokenLabel` + `ColorField` + eye toggle) for visual
  * consistency across the panel.
+ *
+ * A "Per-mode" checkbox (`<label><input type="checkbox">`, both permitted by
+ * the panel DOM-hygiene policy) switches between a single `ColorField` and a
+ * light/dark pair, each edited independently via its own `ColorField`.
+ * Checking it seeds both sides from the current single value; unchecking it
+ * collapses back to one value — the cluster's `defaultMode` side, via
+ * `resolvePerModeLiteral` (#472's runtime helper for exactly this).
  *
  * `onChange` is `(idKey, value)` — same stable-callback shape as
  * `PaletteSelector` / `ColorSwatch` above, so a single handler covers every
  * row and `memo` stays effective.
  *
  * Only reached for a tier with NO `referencesRamps` declared — a tier that
- * does declare ramp sources renders `SemanticRefOrLiteralRow` instead (S9,
- * #470), even for its literal-mode rows, so the user can switch back to a
- * ramp reference. Per-mode (`{ literal: { light, dark } }`, #472) semantic
- * values are NOT handled here — they still fall through to `PaletteSelector`
- * via `toIndexMappingForSelector`'s `0` fallback until their dedicated
- * editor lands.
+ * does declare ramp sources renders `SemanticRefOrLiteralRow` instead (S9
+ * #470 / S12 #473), even for its literal-mode rows, so the user can switch
+ * back to a ramp reference.
  */
 const SemanticLiteralRow = memo(function SemanticLiteralRow({
   label,
@@ -596,24 +602,92 @@ const SemanticLiteralRow = memo(function SemanticLiteralRow({
   value,
   onChange,
   cssVar,
+  defaultMode = 'light',
 }: {
   label: string;
   idKey: string;
-  value: string;
-  onChange: (idKey: string, val: string) => void;
+  value: { literal: string } | { literal: { light: string; dark: string } };
+  onChange: (
+    idKey: string,
+    val: { literal: string } | { literal: { light: string; dark: string } },
+  ) => void;
   cssVar?: string;
+  /** The cluster's `getClusterDefaultMode()` result (#472) — the side kept
+   *  when the user unchecks "Per-mode". Defaults to `'light'`. */
+  defaultMode?: 'light' | 'dark';
 }) {
-  const handleChange = useCallback((next: string) => onChange(idKey, next), [onChange, idKey]);
+  const isPerMode = typeof value.literal === 'object' && value.literal !== null;
+
+  const handleTogglePerMode = useCallback(() => {
+    const current = value.literal;
+    if (typeof current === 'object' && current !== null) {
+      onChange(idKey, { literal: resolvePerModeLiteral({ literal: current }, defaultMode) });
+    } else {
+      onChange(idKey, { literal: { light: current, dark: current } });
+    }
+  }, [value, defaultMode, onChange, idKey]);
+
+  const handleSingleChange = useCallback(
+    (next: string) => onChange(idKey, { literal: next }),
+    [onChange, idKey],
+  );
+
+  const handleLightChange = useCallback(
+    (next: string) => {
+      const current = value.literal;
+      if (typeof current !== 'object' || current === null) return;
+      onChange(idKey, { literal: { light: next, dark: current.dark } });
+    },
+    [value, onChange, idKey],
+  );
+
+  const handleDarkChange = useCallback(
+    (next: string) => {
+      const current = value.literal;
+      if (typeof current !== 'object' || current === null) return;
+      onChange(idKey, { literal: { light: current.light, dark: next } });
+    },
+    [value, onChange, idKey],
+  );
+
   return (
     <div className="tokenpanel-row" data-testid={`tokenpanel-semantic-literal-${idKey}`}>
       <TokenLabel cssVar={cssVar ?? idKey} label={label} />
-      <ColorField
-        value={value}
-        onChange={handleChange}
-        valueFormat="oklch"
-        label={label}
-        cssVar={cssVar}
-      />
+      <label className="tokenpanel-per-mode-toggle">
+        <input
+          type="checkbox"
+          checked={isPerMode}
+          onChange={handleTogglePerMode}
+          aria-label={`${label} per-mode (light/dark)`}
+        />
+        Per-mode
+      </label>
+      {typeof value.literal === 'object' && value.literal !== null ? (
+        <div className="tokenpanel-per-mode-fields">
+          <ColorField
+            value={value.literal.light}
+            onChange={handleLightChange}
+            valueFormat="oklch"
+            label={`${label} (Light)`}
+            cssVar={cssVar}
+          />
+          <ColorField
+            value={value.literal.dark}
+            onChange={handleDarkChange}
+            valueFormat="oklch"
+            label={`${label} (Dark)`}
+            cssVar={cssVar}
+          />
+        </div>
+      ) : (
+        <ColorField
+          value={value.literal}
+          onChange={handleSingleChange}
+          valueFormat="oklch"
+          label={label}
+          cssVar={cssVar}
+        />
+      )}
       {cssVar && <HighlightToggleButton cssVar={cssVar} />}
     </div>
   );
@@ -641,6 +715,7 @@ const SemanticRefOrLiteralRow = memo(function SemanticRefOrLiteralRow({
   onChange,
   previewValueFor,
   cssVar,
+  defaultMode,
 }: {
   label: string;
   idKey: string;
@@ -651,6 +726,9 @@ const SemanticRefOrLiteralRow = memo(function SemanticRefOrLiteralRow({
   onChange: (idKey: string, next: TierRefSelectorValue) => void;
   previewValueFor: (ref: TierRefTarget) => string;
   cssVar?: string;
+  /** The cluster's `getClusterDefaultMode()` result (#472) — forwarded to
+   *  `TierRefSelector` for its per-mode collapse-to-single-mode fallback. */
+  defaultMode?: 'light' | 'dark';
 }) {
   return (
     <div className="tokenpanel-row" data-testid={`tokenpanel-semantic-ref-${idKey}`}>
@@ -665,6 +743,7 @@ const SemanticRefOrLiteralRow = memo(function SemanticRefOrLiteralRow({
         previewValueFor={previewValueFor}
         label={label}
         cssVar={cssVar}
+        defaultMode={defaultMode}
       />
       {cssVar && <HighlightToggleButton cssVar={cssVar} />}
     </div>
@@ -745,6 +824,15 @@ export default function ColorTab({
   const secondaryCluster = useMemo(
     () => (secondaryTab ? resolveColorClusterFromTab(secondaryTab, allTabs) ?? null : null),
     [secondaryTab, allTabs],
+  );
+  // Each cluster's configured default light/dark mode (#472) — the side a
+  // per-mode literal collapses to when the user unchecks "Per-mode" (S12,
+  // #473). Secondary falls back to 'light' (matching `getClusterDefaultMode`'s
+  // own default) when there's no secondary cluster at all.
+  const primaryDefaultMode = useMemo(() => getClusterDefaultMode(safeCluster), [safeCluster]);
+  const secondaryDefaultMode = useMemo(
+    () => (secondaryCluster ? getClusterDefaultMode(secondaryCluster) : 'light'),
+    [secondaryCluster],
   );
   // Host-supplied preset list. Read through the panel
   // config so a host that calls `configurePanel({ ..., colorPresets })`
@@ -833,14 +921,15 @@ export default function ColorTab({
     [persistSecondary],
   );
 
-  // Secondary-cluster counterpart to `handleSemanticLiteralChange` (S3, #464).
+  // Secondary-cluster counterpart to `handleSemanticLiteralChange` (S3 #464 /
+  // S12 #473) — `val` already carries the full `{ literal: ... }` wrapper.
   const handleSecondarySemanticLiteralChange = useCallback(
-    (key: string, val: string) => {
+    (key: string, val: { literal: string } | { literal: { light: string; dark: string } }) => {
       persistSecondary((prev) => {
         if (!prev) return prev;
         return {
           ...prev,
-          semanticMappings: { ...prev.semanticMappings, [key]: { literal: val } },
+          semanticMappings: { ...prev.semanticMappings, [key]: val },
         };
       });
     },
@@ -854,11 +943,15 @@ export default function ColorTab({
     (key: string, next: TierRefSelectorValue) => {
       persistSecondary((prev) => {
         if (!prev) return prev;
+        // `next` is returned as-is in the literal branch (not rebuilt as
+        // `{ literal: next.literal }`) — reconstructing collapses the
+        // `string | { light, dark }` union into one shape TS can't match
+        // back to `SemanticValue`'s two distinct `{ literal }` members.
         return {
           ...prev,
           semanticMappings: {
             ...prev.semanticMappings,
-            [key]: 'ref' in next ? { ref: next.ref } : { literal: next.literal },
+            [key]: 'ref' in next ? { ref: next.ref } : next,
           },
         };
       });
@@ -898,13 +991,16 @@ export default function ColorTab({
     [persistColor],
   );
 
-  // Writes a `{ literal: <value> }` SemanticValue (S3, #464) — the
-  // `SemanticLiteralRow` counterpart to `handleSemanticChange`'s index write.
+  // Writes a `{ literal }` SemanticValue — single-mode `string` or per-mode
+  // `{ light, dark }` (S3 #464 / S12 #473) — the `SemanticLiteralRow`
+  // counterpart to `handleSemanticChange`'s index write. `val` already
+  // carries the full `{ literal: ... }` wrapper (mirroring
+  // `handleSemanticRefOrLiteralChange` below), so no re-wrapping is needed.
   const handleSemanticLiteralChange = useCallback(
-    (key: string, val: string) => {
+    (key: string, val: { literal: string } | { literal: { light: string; dark: string } }) => {
       persistColor((prev) => ({
         ...prev,
-        semanticMappings: { ...prev.semanticMappings, [key]: { literal: val } },
+        semanticMappings: { ...prev.semanticMappings, [key]: val },
       }));
     },
     [persistColor],
@@ -917,9 +1013,12 @@ export default function ColorTab({
     (key: string, next: TierRefSelectorValue) => {
       persistColor((prev) => ({
         ...prev,
+        // `next` is returned as-is in the literal branch — see the secondary
+        // counterpart above for why reconstructing `{ literal: next.literal }`
+        // does not typecheck.
         semanticMappings: {
           ...prev.semanticMappings,
-          [key]: 'ref' in next ? { ref: next.ref } : { literal: next.literal },
+          [key]: 'ref' in next ? { ref: next.ref } : next,
         },
       }));
     },
@@ -1072,22 +1171,26 @@ export default function ColorTab({
               const semanticCssVar = safeCluster.semanticCssNames[key];
               const mapping = state.semanticMappings[key] ?? defaultVal;
               // A tier that declares `referencesRamps` routes both its ref
-              // and single-mode-literal values through the grouped
-              // ref-or-literal picker (S9, #470), so the user can switch
-              // between a cross-tab ramp reference and an arbitrary OKLCH
-              // literal. Per-mode `{ literal: { light, dark } }` (#472)
-              // isn't handled by that picker yet, so it still falls through
-              // to `PaletteSelector` below regardless of `referencesRamps`.
+              // and literal values — single-mode AND per-mode
+              // `{ literal: { light, dark } }` (#472) alike — through the
+              // grouped ref-or-literal picker (S9 #470 / S12 #473), so the
+              // user can switch between a cross-tab ramp reference and an
+              // arbitrary OKLCH literal (optionally split light/dark).
               const semanticTier = findSemanticTier(tab, key);
               const rampSources = semanticTier?.referencesRamps;
               if (
                 rampSources &&
                 rampSources.length > 0 &&
-                (isRefMapping(mapping) || (isLiteralMapping(mapping) && !isPerModeLiteral(mapping)))
+                (isRefMapping(mapping) || isLiteralMapping(mapping))
               ) {
+                // `mapping` is passed through as-is in the literal branch —
+                // rebuilding `{ literal: mapping.literal }` collapses the
+                // `string | { light, dark }` union into a shape TS can't
+                // match back to `TierRefSelectorValue`'s two `{ literal }`
+                // members.
                 const tierRefValue: TierRefSelectorValue = isRefMapping(mapping)
                   ? { ref: mapping.ref }
-                  : { literal: mapping.literal as string };
+                  : mapping;
                 return (
                   <SemanticRefOrLiteralRow
                     key={key}
@@ -1100,22 +1203,25 @@ export default function ColorTab({
                     onChange={handleSemanticRefOrLiteralChange}
                     previewValueFor={previewRampValue}
                     cssVar={semanticCssVar}
+                    defaultMode={primaryDefaultMode}
                   />
                 );
               }
-              // Single-mode `{ literal: string }` (on a tier with NO
-              // `referencesRamps`) renders an editable OKLCH swatch (S3,
-              // #464) instead of a palette-index dropdown — it has no
-              // palette slot to reference.
-              if (isLiteralMapping(mapping) && typeof mapping.literal === 'string') {
+              // Any `{ literal }` mapping (on a tier with NO
+              // `referencesRamps`) — single-mode string OR per-mode
+              // `{ light, dark }` (S12, #473) — renders an editable OKLCH
+              // swatch (S3, #464) instead of a palette-index dropdown; it has
+              // no palette slot to reference.
+              if (isLiteralMapping(mapping)) {
                 return (
                   <SemanticLiteralRow
                     key={key}
                     label={semanticCssVar ?? key}
                     idKey={key}
-                    value={mapping.literal}
+                    value={mapping}
                     onChange={handleSemanticLiteralChange}
                     cssVar={semanticCssVar}
+                    defaultMode={primaryDefaultMode}
                   />
                 );
               }
@@ -1186,12 +1292,13 @@ export default function ColorTab({
                   if (
                     secondaryRampSources &&
                     secondaryRampSources.length > 0 &&
-                    (isRefMapping(secondaryMapping) ||
-                      (isLiteralMapping(secondaryMapping) && !isPerModeLiteral(secondaryMapping)))
+                    (isRefMapping(secondaryMapping) || isLiteralMapping(secondaryMapping))
                   ) {
+                    // See the primary section's `tierRefValue` above for why
+                    // `secondaryMapping` is passed through as-is here.
                     const secondaryTierRefValue: TierRefSelectorValue = isRefMapping(secondaryMapping)
                       ? { ref: secondaryMapping.ref }
-                      : { literal: secondaryMapping.literal as string };
+                      : secondaryMapping;
                     return (
                       <SemanticRefOrLiteralRow
                         key={key}
@@ -1204,21 +1311,20 @@ export default function ColorTab({
                         onChange={handleSecondarySemanticRefOrLiteralChange}
                         previewValueFor={secondaryPreviewRampValue!}
                         cssVar={secondarySemanticCssVar}
+                        defaultMode={secondaryDefaultMode}
                       />
                     );
                   }
-                  if (
-                    isLiteralMapping(secondaryMapping) &&
-                    typeof secondaryMapping.literal === 'string'
-                  ) {
+                  if (isLiteralMapping(secondaryMapping)) {
                     return (
                       <SemanticLiteralRow
                         key={key}
                         label={secondarySemanticCssVar ?? key}
                         idKey={key}
-                        value={secondaryMapping.literal}
+                        value={secondaryMapping}
                         onChange={handleSecondarySemanticLiteralChange}
                         cssVar={secondarySemanticCssVar}
+                        defaultMode={secondaryDefaultMode}
                       />
                     );
                   }

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -39,6 +39,7 @@ import { memo, useState, useEffect, useCallback, useMemo, useRef, useId } from '
 import type { ColorScheme } from '../config/color-schemes';
 import { pushDismissLayer } from '../controls/dismiss-layer';
 import ColorPicker from '../components/color-picker';
+import ColorField from '../components/color-picker/color-field';
 import { Z } from '../styles/z-index-tokens';
 import type { ColorPickerValueFormat } from '../components/color-picker/color-picker';
 import {
@@ -47,6 +48,7 @@ import {
   applyShikiTheme,
   initColorFromSchemeData,
   isIndexMapping,
+  isLiteralMapping,
   resolvePaletteCssVar,
 } from '../state/tweak-state';
 import { getPanelConfig } from '../config/panel-config';
@@ -54,6 +56,7 @@ import { resolveColorClusterFromTab } from '../config/cluster-config';
 import type { TabConfig, TierConfig } from '../tokens/tier-model';
 import type { PersistColor, PersistSecondary } from '../state/persist';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
+import { TokenLabel } from '../controls/token-label';
 import { useTooltip } from '../controls/tooltip';
 
 // The bundled scheme registry now lives on
@@ -72,10 +75,11 @@ import { useTooltip } from '../controls/tooltip';
  * `PaletteSelector` (below) only understands the legacy index shape — it
  * renders a palette-slot dropdown, not a literal-color or ramp-ref editor.
  * `semanticMappings` / `semanticDefaults` were widened to `SemanticValue`
- * (#459 S1); every value flowing through this tab today is still an index
- * mapping (the `{ literal }` / `{ ref }` editor UI is downstream work), so
- * this just narrows the type for `PaletteSelector`'s `value` prop, falling
- * back to `0` for the not-yet-possible non-index case.
+ * (#459 S1). Single-mode `{ literal: string }` values now render through
+ * `SemanticLiteralRow` instead (S3, #464) — see the Semantic Tokens section
+ * below — so this helper is only reached for index mappings, `{ ref }`
+ * (cross-tab reference — #470) and per-mode `{ literal: { light, dark } }`
+ * (#472), both of which fall back to `0` until their dedicated editors land.
  */
 function toIndexMappingForSelector(v: SemanticValue): number | 'bg' | 'fg' {
   return isIndexMapping(v) ? v : 0;
@@ -544,6 +548,53 @@ const PaletteSelector = memo(function PaletteSelector({
   );
 });
 
+/**
+ * Semantic-token row for a single-mode `{ literal: string }` mapping (S3,
+ * #464): an editable OKLCH `ColorField` swatch instead of `PaletteSelector`'s
+ * palette-index dropdown — the value is a standalone color, not a slot into
+ * `state.palette`, so there is no palette to pick from. Mirrors the
+ * `.tokenpanel-row` layout used by `generic-tab.tsx`'s own `format: 'oklch'`
+ * color rows (`TokenLabel` + `ColorField` + eye toggle) for visual
+ * consistency across the panel.
+ *
+ * `onChange` is `(idKey, value)` — same stable-callback shape as
+ * `PaletteSelector` / `ColorSwatch` above, so a single handler covers every
+ * row and `memo` stays effective.
+ *
+ * Ref (`{ ref }`, #470) and per-mode (`{ literal: { light, dark } }`, #472)
+ * semantic values are NOT handled here — they still fall through to
+ * `PaletteSelector` via `toIndexMappingForSelector`'s `0` fallback until
+ * their dedicated editors land.
+ */
+const SemanticLiteralRow = memo(function SemanticLiteralRow({
+  label,
+  idKey,
+  value,
+  onChange,
+  cssVar,
+}: {
+  label: string;
+  idKey: string;
+  value: string;
+  onChange: (idKey: string, val: string) => void;
+  cssVar?: string;
+}) {
+  const handleChange = useCallback((next: string) => onChange(idKey, next), [onChange, idKey]);
+  return (
+    <div className="tokenpanel-row" data-testid={`tokenpanel-semantic-literal-${idKey}`}>
+      <TokenLabel cssVar={cssVar ?? idKey} label={label} />
+      <ColorField
+        value={value}
+        onChange={handleChange}
+        valueFormat="oklch"
+        label={label}
+        cssVar={cssVar}
+      />
+      {cssVar && <HighlightToggleButton cssVar={cssVar} />}
+    </div>
+  );
+});
+
 // --- Color tab body ---
 
 interface ColorTabProps {
@@ -683,6 +734,20 @@ export default function ColorTab({
     [persistSecondary],
   );
 
+  // Secondary-cluster counterpart to `handleSemanticLiteralChange` (S3, #464).
+  const handleSecondarySemanticLiteralChange = useCallback(
+    (key: string, val: string) => {
+      persistSecondary((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          semanticMappings: { ...prev.semanticMappings, [key]: { literal: val } },
+        };
+      });
+    },
+    [persistSecondary],
+  );
+
   // Accepts `key: string` (broadened from the literal union) so the same
   // handler can be passed directly to memoised <PaletteSelector> rows whose
   // (idKey, val) signature is also string-typed.
@@ -710,6 +775,18 @@ export default function ColorTab({
       persistColor((prev) => ({
         ...prev,
         semanticMappings: { ...prev.semanticMappings, [key]: val },
+      }));
+    },
+    [persistColor],
+  );
+
+  // Writes a `{ literal: <value> }` SemanticValue (S3, #464) — the
+  // `SemanticLiteralRow` counterpart to `handleSemanticChange`'s index write.
+  const handleSemanticLiteralChange = useCallback(
+    (key: string, val: string) => {
+      persistColor((prev) => ({
+        ...prev,
+        semanticMappings: { ...prev.semanticMappings, [key]: { literal: val } },
       }));
     },
     [persistColor],
@@ -839,12 +916,31 @@ export default function ColorTab({
           <div className="tokenpanel-color-base-grid">
             {Object.entries(safeCluster.semanticDefaults).map(([key, defaultVal]) => {
               const semanticCssVar = safeCluster.semanticCssNames[key];
+              const mapping = state.semanticMappings[key] ?? defaultVal;
+              // Single-mode `{ literal: string }` renders an editable OKLCH
+              // swatch (S3, #464) instead of a palette-index dropdown — it
+              // has no palette slot to reference. `{ ref }` and per-mode
+              // `{ literal: { light, dark } }` values still fall through to
+              // `PaletteSelector` (via `toIndexMappingForSelector`'s `0`
+              // fallback) pending #470/#472.
+              if (isLiteralMapping(mapping) && typeof mapping.literal === 'string') {
+                return (
+                  <SemanticLiteralRow
+                    key={key}
+                    label={semanticCssVar ?? key}
+                    idKey={key}
+                    value={mapping.literal}
+                    onChange={handleSemanticLiteralChange}
+                    cssVar={semanticCssVar}
+                  />
+                );
+              }
               return (
                 <PaletteSelector
                   key={key}
                   label={semanticCssVar ?? key}
                   idKey={key}
-                  value={toIndexMappingForSelector(state.semanticMappings[key] ?? defaultVal)}
+                  value={toIndexMappingForSelector(mapping)}
                   palette={state.palette}
                   paletteCssVar={clusterPaletteCssVar}
                   onChange={handleSemanticChange}
@@ -899,12 +995,29 @@ export default function ColorTab({
               <div className="tokenpanel-color-base-grid">
                 {Object.entries(secondaryCluster.semanticDefaults).map(([key, defaultVal]) => {
                   const secondarySemanticCssVar = secondaryCluster.semanticCssNames[key];
+                  const secondaryMapping = secondaryState.semanticMappings[key] ?? defaultVal;
+                  // Mirrors the primary section's literal-vs-index split above.
+                  if (
+                    isLiteralMapping(secondaryMapping) &&
+                    typeof secondaryMapping.literal === 'string'
+                  ) {
+                    return (
+                      <SemanticLiteralRow
+                        key={key}
+                        label={secondarySemanticCssVar ?? key}
+                        idKey={key}
+                        value={secondaryMapping.literal}
+                        onChange={handleSecondarySemanticLiteralChange}
+                        cssVar={secondarySemanticCssVar}
+                      />
+                    );
+                  }
                   return (
                     <PaletteSelector
                       key={key}
                       label={secondarySemanticCssVar ?? key}
                       idKey={key}
-                      value={toIndexMappingForSelector(secondaryState.semanticMappings[key] ?? defaultVal)}
+                      value={toIndexMappingForSelector(secondaryMapping)}
                       palette={secondaryState.palette}
                       paletteCssVar={secondaryPaletteCssVar}
                       onChange={handleSecondarySemanticChange}

--- a/packages/zdtp/src/tabs/font-tab.tsx
+++ b/packages/zdtp/src/tabs/font-tab.tsx
@@ -2,8 +2,7 @@ import { useCallback } from 'preact/compat';
 import type { TabConfig, TierConfig } from '../tokens/tier-model';
 import type { TokenOverrides } from '../state/tweak-state';
 import type { PersistFont } from '../state/persist';
-import TierRefSelector from '../controls/tier-ref-selector';
-import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
+import TierRefSelector, { type TierRefSelectorValue } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { resolveTierItemValue } from '../apply/tier-resolver';
@@ -29,7 +28,18 @@ interface FontTabProps {
 export default function FontTab({ tab, state, persistFont }: FontTabProps) {
   const handleChange = useCallback(
     (id: string, next: string) => {
-      if (next === TIER_REF_LITERAL_SIGNAL) {
+      persistFont((prev) => ({ ...prev, [id]: next }));
+    },
+    [persistFont],
+  );
+
+  // Ref-tier items go through this handler instead: `{ ref }` stores the
+  // target item id (back-compat with the pre-#470 bare-string persisted
+  // shape); `{ literal }` means "flip the item back to literal mode" — drop
+  // the stored override so it reverts to the tier's own default ref.
+  const handleRefChange = useCallback(
+    (id: string, next: TierRefSelectorValue) => {
+      if ('literal' in next) {
         persistFont((prev) => {
           const n = { ...prev };
           delete n[id];
@@ -37,7 +47,7 @@ export default function FontTab({ tab, state, persistFont }: FontTabProps) {
         });
         return;
       }
-      persistFont((prev) => ({ ...prev, [id]: next }));
+      persistFont((prev) => ({ ...prev, [id]: next.ref.item }));
     },
     [persistFont],
   );
@@ -73,6 +83,7 @@ export default function FontTab({ tab, state, persistFont }: FontTabProps) {
           tier={tier}
           state={state}
           onChange={handleChange}
+          onRefChange={handleRefChange}
         />
       ))}
     </div>
@@ -88,9 +99,10 @@ interface TierSectionProps {
   tier: TierConfig;
   state: TokenOverrides;
   onChange: (id: string, next: string) => void;
+  onRefChange: (id: string, next: TierRefSelectorValue) => void;
 }
 
-function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
+function TierSection({ tab, tier, state, onChange, onRefChange }: TierSectionProps) {
   const isRefTier = tier.referencesTier !== undefined;
 
   return (
@@ -106,6 +118,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
         {tier.items.map((item) => {
           const value = state[item.id] ?? item.default;
           if (isRefTier) {
+            const refTierId = tier.referencesTier!;
             return (
               <div
                 key={item.id}
@@ -117,11 +130,10 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   tab={tab}
                   tierId={tier.id}
                   itemId={item.id}
-                  value={value}
-                  onChange={onChange}
-                  previewValueFor={(refItemId) => {
-                    const refTierId = tier.referencesTier!;
-                    const result = resolveTierItemValue(tab, refTierId, refItemId, {
+                  value={{ ref: { tier: refTierId, item: value } }}
+                  onChange={onRefChange}
+                  previewValueFor={(ref) => {
+                    const result = resolveTierItemValue(tab, refTierId, ref.item, {
                       [refTierId]: state,
                     });
                     return result.kind === 'literal' ? result.value : result.targetCssVar;

--- a/packages/zdtp/src/tabs/generic-tab.tsx
+++ b/packages/zdtp/src/tabs/generic-tab.tsx
@@ -19,7 +19,7 @@
 import { useCallback, useState, useEffect } from 'preact/compat';
 import type { TabConfig, TierConfig, TierItem, TierValueKind } from '../tokens/tier-model';
 import { type TabOverrides, resolveTierItemValue } from '../apply/tier-resolver';
-import TierRefSelector from '../controls/tier-ref-selector';
+import TierRefSelector, { type TierRefSelectorValue } from '../controls/tier-ref-selector';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import TokenLabel from '../controls/token-label';
 import ColorField from '../components/color-picker/color-field';
@@ -36,16 +36,26 @@ interface ItemEditorProps {
   overrides: TabOverrides;
   /** Called with (itemId, newValue) when the user commits a change. */
   onChange: (itemId: string, next: string) => void;
+  /**
+   * Called for ref-tier items instead of `onChange`. `undefined` means "drop
+   * the stored override" (revert to the tier's default ref) — the fix for
+   * the pre-#470 bug where the "Literal…" sentinel was written verbatim into
+   * `overrides` because nothing intercepted it at this layer.
+   */
+  onRefChange: (itemId: string, next: string | undefined) => void;
 }
 
 /**
  * Dispatch to TierRefSelector for reference tiers, otherwise render the
  * kind-appropriate editor (slider, select, text, color).
  */
-function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorProps) {
+function ItemEditor({ tab, tier, item, value, overrides, onChange, onRefChange }: ItemEditorProps) {
   // Reference tier: delegate to TierRefSelector.
   if (tier.referencesTier !== undefined) {
     const refTierId = tier.referencesTier;
+    const handleTierRefChange = (itemId: string, next: TierRefSelectorValue) => {
+      onRefChange(itemId, 'literal' in next ? undefined : next.ref.item);
+    };
     return (
       <div className="tokenpanel-row" data-testid={`tier-ref-row-${item.id}`}>
         <TokenLabel cssVar={item.cssVar} label={item.label} />
@@ -53,10 +63,10 @@ function ItemEditor({ tab, tier, item, value, overrides, onChange }: ItemEditorP
           tab={tab}
           tierId={tier.id}
           itemId={item.id}
-          value={value}
-          onChange={onChange}
-          previewValueFor={(refItemId) => {
-            const result = resolveTierItemValue(tab, refTierId, refItemId, overrides);
+          value={{ ref: { tier: refTierId, item: value } }}
+          onChange={handleTierRefChange}
+          previewValueFor={(ref) => {
+            const result = resolveTierItemValue(tab, refTierId, ref.item, overrides);
             return result.kind === 'literal' ? result.value : result.targetCssVar;
           }}
         />
@@ -238,14 +248,31 @@ interface TierSectionProps {
   overrides: Record<string, string>;
   fullOverrides: TabOverrides;
   onItemChange: (tierId: string, itemId: string, next: string) => void;
+  /** Ref-tier counterpart of `onItemChange` — `next: undefined` means "drop
+   *  the override" (see `ItemEditorProps.onRefChange`). */
+  onRefItemChange: (tierId: string, itemId: string, next: string | undefined) => void;
 }
 
-function TierSection({ tab, tier, overrides, fullOverrides, onItemChange }: TierSectionProps) {
+function TierSection({
+  tab,
+  tier,
+  overrides,
+  fullOverrides,
+  onItemChange,
+  onRefItemChange,
+}: TierSectionProps) {
   const handleItemChange = useCallback(
     (itemId: string, next: string) => {
       onItemChange(tier.id, itemId, next);
     },
     [onItemChange, tier.id],
+  );
+
+  const handleRefItemChange = useCallback(
+    (itemId: string, next: string | undefined) => {
+      onRefItemChange(tier.id, itemId, next);
+    },
+    [onRefItemChange, tier.id],
   );
 
   return (
@@ -269,6 +296,7 @@ function TierSection({ tab, tier, overrides, fullOverrides, onItemChange }: Tier
               value={value}
               overrides={fullOverrides}
               onChange={handleItemChange}
+              onRefChange={handleRefItemChange}
             />
           );
         })}
@@ -292,8 +320,10 @@ export interface GenericTabProps {
    * When an item has no override, its `TierItem.default` is used.
    */
   overrides: TabOverrides;
-  /** Called when the user commits a change to any item. */
-  onChange: (tierId: string, itemId: string, next: string) => void;
+  /** Called when the user commits a change to any item. `next: undefined`
+   *  (only reachable for ref-tier items) means "drop the stored override for
+   *  this item" rather than writing a literal value. */
+  onChange: (tierId: string, itemId: string, next: string | undefined) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -316,6 +346,13 @@ export default function GenericTab({ tab, overrides, onChange }: GenericTabProps
     [onChange],
   );
 
+  const handleRefItemChange = useCallback(
+    (tierId: string, itemId: string, next: string | undefined) => {
+      onChange(tierId, itemId, next);
+    },
+    [onChange],
+  );
+
   return (
     <div className="tokenpanel-tab-content" data-testid={`generic-tab-${tab.id}`}>
       {tab.tiers.map((tier) => {
@@ -328,6 +365,7 @@ export default function GenericTab({ tab, overrides, onChange }: GenericTabProps
             overrides={tierOverrides}
             fullOverrides={overrides}
             onItemChange={handleItemChange}
+            onRefItemChange={handleRefItemChange}
           />
         );
       })}

--- a/packages/zdtp/src/tabs/size-tab.tsx
+++ b/packages/zdtp/src/tabs/size-tab.tsx
@@ -2,8 +2,7 @@ import { useCallback } from 'preact/compat';
 import type { TabConfig, TierConfig } from '../tokens/tier-model';
 import type { TokenOverrides } from '../state/tweak-state';
 import type { PersistSize } from '../state/persist';
-import TierRefSelector from '../controls/tier-ref-selector';
-import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
+import TierRefSelector, { type TierRefSelectorValue } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { resolveTierItemValue } from '../apply/tier-resolver';
@@ -27,7 +26,18 @@ interface SizeTabProps {
 export default function SizeTab({ tab, state, persistSize }: SizeTabProps) {
   const handleChange = useCallback(
     (id: string, next: string) => {
-      if (next === TIER_REF_LITERAL_SIGNAL) {
+      persistSize((prev) => ({ ...prev, [id]: next }));
+    },
+    [persistSize],
+  );
+
+  // Ref-tier items go through this handler instead: `{ ref }` stores the
+  // target item id (back-compat with the pre-#470 bare-string persisted
+  // shape); `{ literal }` means "flip the item back to literal mode" — drop
+  // the stored override so it reverts to the tier's own default ref.
+  const handleRefChange = useCallback(
+    (id: string, next: TierRefSelectorValue) => {
+      if ('literal' in next) {
         persistSize((prev) => {
           const n = { ...prev };
           delete n[id];
@@ -35,7 +45,7 @@ export default function SizeTab({ tab, state, persistSize }: SizeTabProps) {
         });
         return;
       }
-      persistSize((prev) => ({ ...prev, [id]: next }));
+      persistSize((prev) => ({ ...prev, [id]: next.ref.item }));
     },
     [persistSize],
   );
@@ -71,6 +81,7 @@ export default function SizeTab({ tab, state, persistSize }: SizeTabProps) {
           tier={tier}
           state={state}
           onChange={handleChange}
+          onRefChange={handleRefChange}
         />
       ))}
     </div>
@@ -86,9 +97,10 @@ interface TierSectionProps {
   tier: TierConfig;
   state: TokenOverrides;
   onChange: (id: string, next: string) => void;
+  onRefChange: (id: string, next: TierRefSelectorValue) => void;
 }
 
-function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
+function TierSection({ tab, tier, state, onChange, onRefChange }: TierSectionProps) {
   const isRefTier = tier.referencesTier !== undefined;
 
   return (
@@ -104,6 +116,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
         {tier.items.map((item) => {
           const value = state[item.id] ?? item.default;
           if (isRefTier) {
+            const refTierId = tier.referencesTier!;
             return (
               <div
                 key={item.id}
@@ -115,11 +128,10 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   tab={tab}
                   tierId={tier.id}
                   itemId={item.id}
-                  value={value}
-                  onChange={onChange}
-                  previewValueFor={(refItemId) => {
-                    const refTierId = tier.referencesTier!;
-                    const result = resolveTierItemValue(tab, refTierId, refItemId, {
+                  value={{ ref: { tier: refTierId, item: value } }}
+                  onChange={onRefChange}
+                  previewValueFor={(ref) => {
+                    const result = resolveTierItemValue(tab, refTierId, ref.item, {
                       [refTierId]: state,
                     });
                     return result.kind === 'literal' ? result.value : result.targetCssVar;

--- a/packages/zdtp/src/tabs/spacing-tab.tsx
+++ b/packages/zdtp/src/tabs/spacing-tab.tsx
@@ -2,8 +2,7 @@ import { useCallback } from 'preact/compat';
 import type { TabConfig, TierConfig } from '../tokens/tier-model';
 import type { TokenOverrides } from '../state/tweak-state';
 import type { PersistSpacing } from '../state/persist';
-import TierRefSelector from '../controls/tier-ref-selector';
-import { TIER_REF_LITERAL_SIGNAL } from '../controls/tier-ref-selector';
+import TierRefSelector, { type TierRefSelectorValue } from '../controls/tier-ref-selector';
 import GenericItemEditor from './_generic-item-editor';
 import { HighlightToggleButton } from '../highlight/highlight-toggle-button';
 import { resolveTierItemValue } from '../apply/tier-resolver';
@@ -30,17 +29,26 @@ interface SpacingTabProps {
 export default function SpacingTab({ tab, state, persistSpacing }: SpacingTabProps) {
   const handleChange = useCallback(
     (id: string, next: string) => {
-      // TIER_REF_LITERAL_SIGNAL means the user wants to flip back to literal
-      // mode — drop the stored ref id so the item reverts to its default.
-      if (next === TIER_REF_LITERAL_SIGNAL) {
+      persistSpacing((prev) => ({ ...prev, [id]: next }));
+    },
+    [persistSpacing],
+  );
+
+  // Ref-tier items go through this handler instead: `{ ref }` stores the
+  // target item id (back-compat with the pre-#470 bare-string persisted
+  // shape); `{ literal }` means the user wants to flip back to literal
+  // mode — drop the stored ref id so the item reverts to its default.
+  const handleRefChange = useCallback(
+    (id: string, next: TierRefSelectorValue) => {
+      if ('literal' in next) {
         persistSpacing((prev) => {
-          const next = { ...prev };
-          delete next[id];
-          return next;
+          const n = { ...prev };
+          delete n[id];
+          return n;
         });
         return;
       }
-      persistSpacing((prev) => ({ ...prev, [id]: next }));
+      persistSpacing((prev) => ({ ...prev, [id]: next.ref.item }));
     },
     [persistSpacing],
   );
@@ -76,6 +84,7 @@ export default function SpacingTab({ tab, state, persistSpacing }: SpacingTabPro
           tier={tier}
           state={state}
           onChange={handleChange}
+          onRefChange={handleRefChange}
         />
       ))}
     </div>
@@ -91,9 +100,10 @@ interface TierSectionProps {
   tier: TierConfig;
   state: TokenOverrides;
   onChange: (id: string, next: string) => void;
+  onRefChange: (id: string, next: TierRefSelectorValue) => void;
 }
 
-function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
+function TierSection({ tab, tier, state, onChange, onRefChange }: TierSectionProps) {
   const isRefTier = tier.referencesTier !== undefined;
 
   return (
@@ -109,6 +119,7 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
         {tier.items.map((item) => {
           const value = state[item.id] ?? item.default;
           if (isRefTier) {
+            const refTierId = tier.referencesTier!;
             return (
               <div
                 key={item.id}
@@ -120,11 +131,10 @@ function TierSection({ tab, tier, state, onChange }: TierSectionProps) {
                   tab={tab}
                   tierId={tier.id}
                   itemId={item.id}
-                  value={value}
-                  onChange={onChange}
-                  previewValueFor={(refItemId) => {
-                    const refTierId = tier.referencesTier!;
-                    const result = resolveTierItemValue(tab, refTierId, refItemId, {
+                  value={{ ref: { tier: refTierId, item: value } }}
+                  onChange={onRefChange}
+                  previewValueFor={(ref) => {
+                    const result = resolveTierItemValue(tab, refTierId, ref.item, {
                       [refTierId]: state,
                     });
                     return result.kind === 'literal' ? result.value : result.targetCssVar;

--- a/packages/zdtp/src/tokens/tier-model.ts
+++ b/packages/zdtp/src/tokens/tier-model.ts
@@ -66,6 +66,31 @@ export interface PillSpec {
 }
 
 // ---------------------------------------------------------------------------
+// Semantic value union (Ramp-native Tier-2 color editor, #459)
+// ---------------------------------------------------------------------------
+
+/**
+ * A semantic token's mapping value.
+ *
+ * Legacy shape stays valid: a palette index (`number`) or the `'bg'` / `'fg'`
+ * sentinel aliases. New variants (added for #459) let a semantic tier point at
+ * an arbitrary literal color (optionally split light/dark) or reference a ramp
+ * item living in another tab/tier — both resolved downstream by #467/#469.
+ *
+ * Defined here (not in `state/tweak-state.ts`) because `config/cluster-config.ts`
+ * needs it for `ColorClusterDataConfig.semanticDefaults`, and cluster-config.ts
+ * already imports types from this module — keeping the definition here avoids
+ * a new type-only import cycle. `state/tweak-state.ts` re-exports it.
+ */
+export type SemanticValue =
+  | number
+  | 'bg'
+  | 'fg'
+  | { literal: string }
+  | { literal: { light: string; dark: string } }
+  | { ref: { tab?: string; tier: string; item: string } };
+
+// ---------------------------------------------------------------------------
 // Tier item
 // ---------------------------------------------------------------------------
 
@@ -91,6 +116,22 @@ export interface TierConfig {
    *  an item in the tier whose id matches referencesTier. The apply pipeline
    *  emits var(--tier1-cssvar). */
   referencesTier?: string;
+  /**
+   * Marks this tier as a SEMANTIC tier (its items hold `SemanticValue`
+   * mappings, not raw palette entries) so the panel never mistakes it for
+   * the palette tier. Optional and additive — omitting it preserves today's
+   * behavior (palette-tier detection stays structural, via
+   * `resolveColorClusterFromTab`'s `kind: 'color'` check).
+   */
+  semantic?: true;
+  /**
+   * Cross-tab ramp-source declaration for a semantic tier: the ramp tier(s)
+   * this tier's `{ ref }` mappings are allowed to point into. Each entry names
+   * a tier id and an optional tab id (omitted `tab` means "this tab").
+   * Reserved here for #467/#469, which wire it into ramp-item resolution and
+   * the Tier-2 editor's item picker; unused until then.
+   */
+  referencesRamps?: readonly { tab?: string; tier: string }[];
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/zdtp/src/utils/__tests__/design-token-serde.test.ts
+++ b/packages/zdtp/src/utils/__tests__/design-token-serde.test.ts
@@ -3,12 +3,14 @@ import {
   DesignTokenSchemaError,
   SCHEMA_V1,
   SCHEMA_V2,
+  SCHEMA_V3,
   deserialize,
   getDesignTokenSchema,
   serialize,
   type DesignTokenJsonV2,
+  type DesignTokenJsonV3,
 } from '../design-token-serde';
-import type { ColorTweakState, TweakState } from '../../state/tweak-state';
+import type { ColorTweakState, SemanticValue, TweakState } from '../../state/tweak-state';
 import { __resetPanelConfigForTests } from '../../config/panel-config';
 import { installFixturePanelConfig, FIXTURE_CLUSTER, FIXTURE_TABS } from '../../__tests__/_test-helpers';
 import type { TabConfig } from '../../tokens/tier-model';
@@ -737,5 +739,182 @@ describe("F29 — serialize() emits 'bg'/'fg' semantic mappings as their resolve
     // Either form that resolves to 0 is acceptable, but the v2 format emits numbers.
     const resolvedAccent = step3State.color.semanticMappings['accent'];
     expect(typeof resolvedAccent === 'number' ? resolvedAccent : -1).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCHEMA_V3 — widened color.semantic leaf for SemanticValue variants (#462)
+// ---------------------------------------------------------------------------
+
+describe('SCHEMA_V3 — serialize/deserialize round-trips for every SemanticValue variant', () => {
+  it('a state whose semantic mappings are all plain indices still emits SCHEMA_V2 (no regression)', () => {
+    const json = serialize(makeState(), { colorDefaults: COLOR_BASELINE });
+    expect(json.$schema).toBe(SCHEMA_V2);
+  });
+
+  it('round-trips an index mapping (number) unchanged and keeps $schema at V2', () => {
+    const color = cloneBaseline();
+    color.semanticMappings.accent = 9; // was 5
+    const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE });
+    expect(json.$schema).toBe(SCHEMA_V2);
+    expect(json.tabs?.['color']?.['semantic']).toEqual({ '--fixture-semantic-accent': 9 });
+
+    const { state, unknownTokens, warnings } = deserialize(JSON.parse(JSON.stringify(json)), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(state.color.semanticMappings.accent).toBe(9);
+  });
+
+  it('round-trips a { literal: string } mapping, upgrading $schema to SCHEMA_V3', () => {
+    const color = cloneBaseline();
+    color.semanticMappings.accent = { literal: '#ff8800' };
+    const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE }) as DesignTokenJsonV3;
+    expect(json.$schema).toBe(SCHEMA_V3);
+    expect(json.tabs?.['color']?.['semantic']).toEqual({
+      '--fixture-semantic-accent': { literal: '#ff8800' },
+    });
+
+    const { state, unknownTokens, warnings } = deserialize(JSON.parse(JSON.stringify(json)), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(state.color.semanticMappings.accent).toEqual({ literal: '#ff8800' });
+  });
+
+  it('round-trips a { literal: { light, dark } } per-mode mapping, upgrading $schema to SCHEMA_V3', () => {
+    const color = cloneBaseline();
+    const perMode: SemanticValue = { literal: { light: '#111111', dark: '#eeeeee' } };
+    color.semanticMappings.muted = perMode;
+    const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE }) as DesignTokenJsonV3;
+    expect(json.$schema).toBe(SCHEMA_V3);
+    expect(json.tabs?.['color']?.['semantic']).toEqual({
+      '--fixture-semantic-muted': { literal: { light: '#111111', dark: '#eeeeee' } },
+    });
+
+    const { state, unknownTokens, warnings } = deserialize(JSON.parse(JSON.stringify(json)), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(state.color.semanticMappings.muted).toEqual(perMode);
+  });
+
+  it('round-trips a { ref } mapping, upgrading $schema to SCHEMA_V3', () => {
+    const color = cloneBaseline();
+    const ref: SemanticValue = { ref: { tab: 'brand', tier: 'ramp', item: 'brand-500' } };
+    color.semanticMappings.active = ref;
+    const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE }) as DesignTokenJsonV3;
+    expect(json.$schema).toBe(SCHEMA_V3);
+    expect(json.tabs?.['color']?.['semantic']).toEqual({
+      '--fixture-semantic-active': { ref: { tab: 'brand', tier: 'ramp', item: 'brand-500' } },
+    });
+
+    const { state, unknownTokens, warnings } = deserialize(JSON.parse(JSON.stringify(json)), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(state.color.semanticMappings.active).toEqual(ref);
+  });
+
+  it('round-trips a { ref } mapping without an optional tab field', () => {
+    const color = cloneBaseline();
+    const ref: SemanticValue = { ref: { tier: 'ramp', item: 'brand-500' } };
+    color.semanticMappings.active = ref;
+    const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE });
+    expect(json.$schema).toBe(SCHEMA_V3);
+
+    const { state } = deserialize(JSON.parse(JSON.stringify(json)), { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.active).toEqual(ref);
+  });
+
+  it('upgrades to SCHEMA_V3 when only ONE of several semantic mappings is an object variant', () => {
+    const color = cloneBaseline();
+    color.semanticMappings.accent = 7; // still an index mapping
+    color.semanticMappings.muted = { literal: '#ff8800' };
+    const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE });
+    expect(json.$schema).toBe(SCHEMA_V3);
+    expect(json.tabs?.['color']?.['semantic']).toEqual({
+      '--fixture-semantic-accent': 7,
+      '--fixture-semantic-muted': { literal: '#ff8800' },
+    });
+  });
+
+  it('warns and keeps baseline for a malformed { literal } value (missing string/light+dark)', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        color: {
+          semantic: { '--fixture-semantic-accent': { literal: 42 } },
+        },
+      },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.accent).toBe(COLOR_BASELINE.semanticMappings.accent);
+    expect(warnings.some((w) => w.includes('accent'))).toBe(true);
+  });
+
+  it('warns and keeps baseline for a malformed { ref } value (missing tier/item)', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        color: {
+          semantic: { '--fixture-semantic-active': { ref: { tab: 'brand' } } },
+        },
+      },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.active).toBe(COLOR_BASELINE.semanticMappings.active);
+    expect(warnings.some((w) => w.includes('active'))).toBe(true);
+  });
+
+  it('SCHEMA_V3 still deserializes spacing/font/size/generic tabs identically to SCHEMA_V2', () => {
+    const original = makeState({
+      spacing: { 'hsp-md': '50px' },
+      typography: { 'text-base': '1.3rem' },
+      size: { 'radius-lg': '12px' },
+    });
+    original.color.semanticMappings.accent = { literal: '#ff8800' }; // forces V3 upgrade
+
+    const json = serialize(original, { colorDefaults: COLOR_BASELINE });
+    expect(json.$schema).toBe(SCHEMA_V3);
+    const { state, unknownTokens } = deserialize(JSON.parse(JSON.stringify(json)), {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(state.spacing).toEqual(original.spacing);
+    expect(state.typography).toEqual(original.typography);
+    expect(state.size).toEqual(original.size);
+  });
+
+  it('a legacy SCHEMA_V2 document (index-only color.semantic) still hydrates losslessly under the widened deserializer', () => {
+    // A pre-#462 export tagged $schema v2 — every semantic value is a plain
+    // palette-index integer. Must parse identically whether routed through
+    // deserializeV2 (this doc's own tag) — this is the "keep SCHEMA_V2
+    // deserialize lossless" guarantee from #462.
+    const legacyV2Doc: DesignTokenJsonV2 = {
+      $schema: SCHEMA_V2,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        color: {
+          semantic: { '--fixture-semantic-accent': 3, '--fixture-semantic-muted': 9 },
+        },
+        spacing: { raw: { '--zd-spacing-hgap-md': '60px' } },
+      },
+    };
+    const { state, unknownTokens, warnings } = deserialize(legacyV2Doc, {
+      colorDefaults: COLOR_BASELINE,
+    });
+    expect(unknownTokens).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(state.color.semanticMappings.accent).toBe(3);
+    expect(state.color.semanticMappings.muted).toBe(9);
+    expect(state.color.semanticMappings.active).toBe(COLOR_BASELINE.semanticMappings.active);
+    expect(state.spacing['hsp-md']).toBe('60px');
   });
 });

--- a/packages/zdtp/src/utils/design-token-serde.ts
+++ b/packages/zdtp/src/utils/design-token-serde.ts
@@ -11,12 +11,19 @@
  * | `$schema` value            | Status   | Structure                                |
  * |----------------------------|----------|------------------------------------------|
  * | `zudo-design-tokens/v1`    | Legacy   | Flat top-level `color`/`spacing`/`typography`/`size` keys |
- * | `zudo-design-tokens/v2`    | Current  | `tabs` wrapper keyed by tab id; cssVar-keyed leaves |
+ * | `zudo-design-tokens/v2`    | Current  | `tabs` wrapper keyed by tab id; cssVar-keyed leaves; `color.semantic` leaves are palette-index integers only |
+ * | `zudo-design-tokens/v3`    | Current  | Same shape as v2, but `color.semantic` leaves may ALSO be `{ literal }` / `{ literal: { light, dark } }` / `{ ref }` objects (#462) |
  *
- * `serialize()` always emits v2. `deserialize()` accepts both v1 and v2 and
- * normalises to an internal `TweakState` regardless of which schema was in the
- * payload. Hosts that export v1 docs (custom `schemaId`) get a `schema-mismatch`
- * error on import unless they have opted into the dual-accept path (see below).
+ * `serialize()` emits v2 when every semantic mapping in the state resolves to
+ * a plain palette-index integer (byte-identical to the pre-#462 output), and
+ * opportunistically upgrades to v3 only when at least one semantic mapping is
+ * one of the new `SemanticValue` object variants — v3 is a strict superset of
+ * v2's shape, so this upgrade never loses information and never happens for a
+ * doc that v2 could already represent losslessly. `deserialize()` accepts v1,
+ * v2, and v3, and normalises to an internal `TweakState` regardless of which
+ * schema was in the payload. Hosts that export v1 docs (custom `schemaId`) get
+ * a `schema-mismatch` error on import unless they have opted into the
+ * dual-accept path (see below).
  *
  * ## v2 format
  *
@@ -79,7 +86,14 @@ import type {
   TokenOverrides,
   TweakState,
 } from '../state/tweak-state';
-import { getActivePrimaryCluster, normalizeSchemePaletteEntry } from '../state/tweak-state';
+import {
+  getActivePrimaryCluster,
+  isIndexMapping,
+  isLiteralMapping,
+  isPerModeLiteral,
+  isRefMapping,
+  normalizeSchemePaletteEntry,
+} from '../state/tweak-state';
 import { getPanelConfig, type PanelConfig } from '../config/panel-config';
 import { resolvePaletteCssVar } from '../config/cluster-config';
 import type { TierItem } from '../tokens/tier-model';
@@ -166,11 +180,23 @@ function buildTabVarLookup(
   return map;
 }
 
-/** The canonical v2 schema identifier emitted by serialize(). */
+/** The canonical v2 schema identifier emitted by serialize() when every
+ *  semantic mapping is a plain palette-index integer. */
 export const SCHEMA_V2 = 'zudo-design-tokens/v2';
 
 /** The legacy v1 schema identifier accepted by deserialize() for back-compat. */
 export const SCHEMA_V1 = 'zudo-design-tokens/v1';
+
+/**
+ * The v3 schema identifier — emitted by serialize() instead of `SCHEMA_V2`
+ * only when the state carries at least one `SemanticValue` object variant
+ * (`{ literal }` / `{ literal: { light, dark } }` / `{ ref }`) that v2's
+ * number-only `color.semantic` leaf cannot represent (#462). Structurally a
+ * strict superset of v2 — a v3 deserializer accepts every v2 document too,
+ * but `deserialize()` still dispatches v2 docs through the unmodified v2 path
+ * so legacy exports keep parsing byte-for-byte as before.
+ */
+export const SCHEMA_V3 = 'zudo-design-tokens/v3';
 
 /** Local alias for an empty override map — inlined (rather than imported from
  *  `../state/tweak-state`) to avoid pulling the tweak-state runtime module into
@@ -268,6 +294,42 @@ export interface DesignTokenJsonV2 {
 }
 
 // ---------------------------------------------------------------------------
+// v3 external JSON types (widened `color.semantic` leaf, #462)
+// ---------------------------------------------------------------------------
+
+/** A single-color (non-per-mode) literal semantic mapping, external shape. */
+export type SemanticLiteralExternal = { literal: string } | { literal: { light: string; dark: string } };
+
+/** A cross-tab/tier ramp-item reference semantic mapping, external shape. */
+export type SemanticRefExternal = { ref: { tab?: string; tier: string; item: string } };
+
+/**
+ * The widened leaf type for `tabs.color.semantic` entries under `SCHEMA_V3`.
+ * A plain `number` is still the palette-index shape v2 has always emitted;
+ * the object variants are the new `SemanticValue` shapes serialize() emits
+ * verbatim (no index resolution) when the state holds one (#462).
+ */
+export type SemanticExternalValue = number | SemanticLiteralExternal | SemanticRefExternal;
+
+/** `tabs.color.semantic` leaf map under `SCHEMA_V3` — same cssVar keys as
+ *  v2's `V2TierMap`, but values may be the wider `SemanticExternalValue`. */
+export type V3SemanticTierMap = Record<string, SemanticExternalValue>;
+
+/**
+ * Per-tab overrides accepted/emitted at `SCHEMA_V3`. Identical to `V2TabEntry`
+ * for every tier EXCEPT `color.semantic`, whose leaf may be the widened
+ * `SemanticExternalValue` union instead of just `string | number`.
+ */
+export type V3TabEntry = Record<string, V2TierMap | V3SemanticTierMap>;
+
+/** v3 external JSON document shape — see `SCHEMA_V3` for when serialize() emits this. */
+export interface DesignTokenJsonV3 {
+  $schema: string;
+  exportedAt: string;
+  tabs?: Record<string, V3TabEntry>;
+}
+
+// ---------------------------------------------------------------------------
 // Shared types (SerializeOptions, DeserializeResult, errors)
 // ---------------------------------------------------------------------------
 
@@ -328,16 +390,23 @@ export class DesignTokenSchemaError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// Serialize (v2 output)
+// Serialize (v2 output, opportunistically upgraded to v3)
 // ---------------------------------------------------------------------------
 
 /**
- * Produce the external JSON document (v2 format) for a given tweak state.
+ * Produce the external JSON document for a given tweak state.
  *
  * By default this is diff-only against `opts.colorDefaults` + manifest
  * defaults; set `opts.includeDefaults = true` to dump everything.
  *
- * The output `$schema` is always `SCHEMA_V2` ("zudo-design-tokens/v2").
+ * The output `$schema` is `SCHEMA_V2` ("zudo-design-tokens/v2") UNLESS the
+ * state holds at least one semantic mapping that is a `SemanticValue` object
+ * variant (`{ literal }` / `{ literal: { light, dark } }` / `{ ref }`) — those
+ * can't be represented by v2's number-only `color.semantic` leaf, so the
+ * output is upgraded to `SCHEMA_V3` instead (#462). A state whose semantic
+ * mappings are all plain palette-index integers (the only shape that existed
+ * before #459) always emits byte-identical `SCHEMA_V2` output, unchanged from
+ * pre-#462 behavior.
  *
  * `cfg` defaults to the active (most-recently-configured) instance so the
  * single-default path stays byte-identical. The Export / Apply modals thread
@@ -349,18 +418,18 @@ export function serialize(
   state: TweakState,
   opts: SerializeOptions = {},
   cfg: PanelConfig = getPanelConfig(),
-): DesignTokenJsonV2 {
+): DesignTokenJsonV3 {
   const now = opts.now ? opts.now() : new Date();
-  const out: DesignTokenJsonV2 = {
-    $schema: SCHEMA_V2,
-    exportedAt: now.toISOString(),
-  };
 
-  const tabs: Record<string, V2TabEntry> = {};
+  const tabs: Record<string, V3TabEntry> = {};
+  let needsV3 = false;
 
   // Color tab — keyed under "color".
-  const colorTab = serializeColorV2(state.color, opts, cfg);
-  if (colorTab) tabs['color'] = colorTab;
+  const colorResult = serializeColorTab(state.color, opts, cfg);
+  if (colorResult) {
+    tabs['color'] = colorResult.tab;
+    if (colorResult.usesObjectSemanticLeaf) needsV3 = true;
+  }
 
   // Read items from tabs[] so a host-supplied config drives the diff pass.
   // The internal state slice is named `typography`; the external tab id is
@@ -388,6 +457,11 @@ export function serialize(
     if (genericTab) tabs[tab.id] = genericTab;
   }
 
+  const out: DesignTokenJsonV3 = {
+    $schema: needsV3 ? SCHEMA_V3 : SCHEMA_V2,
+    exportedAt: now.toISOString(),
+  };
+
   if (Object.keys(tabs).length > 0) {
     out.tabs = tabs;
   }
@@ -396,30 +470,35 @@ export function serialize(
 }
 
 /**
- * Serialize a `ColorTweakState` into the v2 `color` tab entry.
+ * Serialize a `ColorTweakState` into the `color` tab entry.
  *
  * `palette` tier: cssVar-keyed map from `resolvePaletteCssVar(cluster, i)` to
  * the hex color string at that index. Only changed slots are emitted in
  * diff-only mode.
  *
  * `semantic` tier: cssVar-keyed map from `semanticCssNames[key]` to the
- * palette-index integer. Only changed entries in diff-only mode.
+ * mapping's external value. Only changed entries in diff-only mode. Index
+ * mappings (`number` / `'bg'` / `'fg'`) resolve to a palette-index integer
+ * exactly as v2 always has; the newer `{ literal }` / `{ ref }` variants are
+ * emitted verbatim as objects (#462) — `usesObjectSemanticLeaf` tells the
+ * caller whether that happened, so `serialize()` knows to upgrade `$schema`
+ * to `SCHEMA_V3`.
  *
- * The legacy `base` / `shikiTheme` fields are NOT emitted in v2; they were
+ * The legacy `base` / `shikiTheme` fields are NOT emitted; they were
  * panel-internal and not needed by AI consumers. They survive through the
  * internal `TweakState` persist envelope and are round-tripped through storage,
  * but are dropped from the external export to keep the format minimal.
  */
-function serializeColorV2(
+function serializeColorTab(
   color: ColorTweakState,
   opts: SerializeOptions,
   cfg: PanelConfig,
-): V2TabEntry | undefined {
+): { tab: V3TabEntry; usesObjectSemanticLeaf: boolean } | undefined {
   const baseline = opts.colorDefaults;
   const full = opts.includeDefaults === true;
   const cluster = getActivePrimaryCluster(cfg);
 
-  const out: V2TabEntry = {};
+  const out: V3TabEntry = {};
   let wrote = false;
 
   // Palette tier — cssVar-keyed.
@@ -437,38 +516,95 @@ function serializeColorV2(
     wrote = true;
   }
 
-  // Semantic tier — cssVar-keyed palette-index integers.
-  // 'bg' and 'fg' are legacy alias values admitted by v1 deserialize; resolve
-  // them to their concrete palette index (mirroring resolveMappingIndex in
-  // build-apply-overrides.ts) so they survive round-trips through the v2 format,
-  // which only admits numbers on deserialize (F29 fix).
-  const semantic: Record<string, number> = {};
+  // Semantic tier — cssVar-keyed. Index mappings ('bg'/'fg' legacy aliases
+  // admitted by v1 deserialize, and plain palette-index numbers) resolve to
+  // their concrete palette index (mirroring resolveMappingIndex in
+  // build-apply-overrides.ts) so they survive round-trips exactly as v2
+  // always has (F29 fix). The newer `{ literal }` / `{ ref }` variants
+  // (#459/#462) can't be resolved to an index — they're written verbatim as
+  // objects, which flips `usesObjectSemanticLeaf` so the caller upgrades
+  // `$schema` to `SCHEMA_V3`.
+  const semantic: Record<string, SemanticExternalValue> = {};
   let semanticWrote = false;
+  let usesObjectSemanticLeaf = false;
   for (const [key, cssName] of Object.entries(cluster.semanticCssNames)) {
     const cur = color.semanticMappings[key];
     if (cur === undefined) continue;
-    const resolvedCur: number =
-      typeof cur === 'number' ? cur : cur === 'bg' ? color.background : color.foreground;
     const baselineVal = baseline?.semanticMappings[key];
-    const resolvedBaseline: number | undefined =
-      baselineVal === undefined
-        ? undefined
-        : typeof baselineVal === 'number'
-          ? baselineVal
-          : baselineVal === 'bg'
-            ? (baseline?.background ?? 0)
-            : (baseline?.foreground ?? 1);
-    if (full || resolvedBaseline === undefined || resolvedCur !== resolvedBaseline) {
-      semantic[cssName] = resolvedCur;
-      semanticWrote = true;
-    }
+    const unchanged =
+      !full &&
+      baselineVal !== undefined &&
+      semanticMappingsEqual(cur, baselineVal, color.background, color.foreground, baseline);
+    if (unchanged) continue;
+    const external = toSemanticExternalValue(cur, color.background, color.foreground);
+    semantic[cssName] = external;
+    semanticWrote = true;
+    if (typeof external !== 'number') usesObjectSemanticLeaf = true;
   }
   if (semanticWrote) {
     out['semantic'] = semantic;
     wrote = true;
   }
 
-  return wrote ? out : undefined;
+  return wrote ? { tab: out, usesObjectSemanticLeaf } : undefined;
+}
+
+/**
+ * Resolve an index-style mapping (`number` / `'bg'` / `'fg'`) to a concrete
+ * palette index, given the state's own background/foreground indices.
+ */
+function resolveIndexMapping(v: number | 'bg' | 'fg', bg: number, fg: number): number {
+  return typeof v === 'number' ? v : v === 'bg' ? bg : fg;
+}
+
+/**
+ * True when `cur` (the current state's mapping) is unchanged from
+ * `baselineVal` for diff-only serialize purposes. Index mappings are compared
+ * by their RESOLVED palette index (so e.g. `'bg'` and a baseline numeric
+ * mapping that happens to equal the current background index are treated as
+ * equal, matching pre-#462 behavior). The `{ literal }` / `{ ref }` variants
+ * have no index to resolve to, so they're compared structurally; a mapping
+ * that changed KIND (index → object or vice versa) is always "changed".
+ */
+function semanticMappingsEqual(
+  cur: SemanticValue,
+  baselineVal: SemanticValue,
+  curBg: number,
+  curFg: number,
+  baseline: ColorTweakState | undefined,
+): boolean {
+  if (isIndexMapping(cur) && isIndexMapping(baselineVal)) {
+    const resolvedBaseline = resolveIndexMapping(
+      baselineVal,
+      baseline?.background ?? 0,
+      baseline?.foreground ?? 1,
+    );
+    return resolveIndexMapping(cur, curBg, curFg) === resolvedBaseline;
+  }
+  if (isIndexMapping(cur) !== isIndexMapping(baselineVal)) return false;
+  // Both are object variants (literal / ref) — compare structurally.
+  return JSON.stringify(cur) === JSON.stringify(baselineVal);
+}
+
+/**
+ * Resolve a `SemanticValue` to its external (JSON-serializable) form. Index
+ * mappings resolve to a concrete palette-index integer (unchanged v2
+ * behavior); the `{ literal }` / `{ ref }` variants pass through verbatim —
+ * they're already plain-JSON-serializable shapes.
+ */
+function toSemanticExternalValue(
+  v: SemanticValue,
+  bg: number,
+  fg: number,
+): SemanticExternalValue {
+  if (isIndexMapping(v)) return resolveIndexMapping(v, bg, fg);
+  if (isPerModeLiteral(v)) return { literal: { light: v.literal.light, dark: v.literal.dark } };
+  if (isLiteralMapping(v)) return { literal: v.literal as string };
+  if (isRefMapping(v)) return { ref: v.ref };
+  // Exhaustive over `SemanticValue`; kept as a safe fallback rather than a
+  // thrown error so a future non-exhaustive addition to the union degrades to
+  // a background-color fallback instead of crashing serialize().
+  return bg;
 }
 
 /**
@@ -510,14 +646,18 @@ function serializeOverridesV2(
 }
 
 // ---------------------------------------------------------------------------
-// Deserialize (accepts v1 and v2)
+// Deserialize (accepts v1, v2, and v3)
 // ---------------------------------------------------------------------------
 
 /**
  * Parse a design-token JSON document and lift it back into a tweak state.
  *
  * Accepted schema values:
- *  - `SCHEMA_V2` ("zudo-design-tokens/v2") — parsed directly.
+ *  - `SCHEMA_V3` ("zudo-design-tokens/v3") — parsed directly; `color.semantic`
+ *    leaves may be a palette-index integer OR a `SemanticValue` object
+ *    variant (#462).
+ *  - `SCHEMA_V2` ("zudo-design-tokens/v2") — parsed directly; `color.semantic`
+ *    leaves are palette-index integers only (unchanged since before #462).
  *  - `SCHEMA_V1` ("zudo-design-tokens/v1") — lifted to equivalent internal
  *    state (one-way migration; v1 is no longer a valid OUTPUT format).
  *  - Any other value (including custom host schema ids) — throws
@@ -551,8 +691,12 @@ export function deserialize(
   if (schema === undefined) {
     throw new DesignTokenSchemaError(
       'schema-missing',
-      `Missing "$schema" key. Expected "${SCHEMA_V2}" or "${SCHEMA_V1}".`,
+      `Missing "$schema" key. Expected "${SCHEMA_V3}", "${SCHEMA_V2}", or "${SCHEMA_V1}".`,
     );
+  }
+
+  if (schema === SCHEMA_V3) {
+    return deserializeV3(obj, opts, cfg);
   }
 
   if (schema === SCHEMA_V2) {
@@ -565,33 +709,35 @@ export function deserialize(
 
   throw new DesignTokenSchemaError(
     'schema-mismatch',
-    `Unsupported "$schema" value: ${JSON.stringify(schema)}. Expected "${SCHEMA_V2}" or "${SCHEMA_V1}".`,
+    `Unsupported "$schema" value: ${JSON.stringify(schema)}. Expected "${SCHEMA_V3}", "${SCHEMA_V2}", or "${SCHEMA_V1}".`,
     schema,
   );
 }
 
-// ---------------------------------------------------------------------------
-// v2 deserialization
-// ---------------------------------------------------------------------------
-
-function deserializeV2(
-  obj: Record<string, unknown>,
-  opts: DeserializeOptions,
-  cfg: PanelConfig,
-): DeserializeResult {
-  const warnings: string[] = [];
-  const unknownTokens: string[] = [];
-  const baseline = opts.colorDefaults ?? neutralColorDefaults(cfg);
-  const cluster = getActivePrimaryCluster(cfg);
-
-  const tabsRaw = obj.tabs && typeof obj.tabs === 'object' && !Array.isArray(obj.tabs)
-    ? (obj.tabs as Record<string, unknown>)
+/** Narrow `obj.tabs` into a plain object, defaulting to `{}` for any other shape. */
+function normalizeTabsRaw(tabs: unknown): Record<string, unknown> {
+  return tabs && typeof tabs === 'object' && !Array.isArray(tabs)
+    ? (tabs as Record<string, unknown>)
     : {};
+}
 
-  // Color tab.
-  const colorTabRaw = tabsRaw['color'];
-  const color = deserializeColorV2(colorTabRaw, baseline, cluster, warnings);
-
+/**
+ * Shared deserialization for every tab EXCEPT `color` — spacing / font / size
+ * and host-coined generic tabs. Identical between v2 and v3 (the widened
+ * `SemanticValue` leaf only affects `color.semantic`), so both
+ * `deserializeV2` and `deserializeV3` call this instead of duplicating it.
+ */
+function deserializeNonColorSlices(
+  tabsRaw: Record<string, unknown>,
+  cfg: PanelConfig,
+  unknownTokens: string[],
+  warnings: string[],
+): {
+  spacing: TokenOverrides;
+  typography: TokenOverrides;
+  size: TokenOverrides;
+  tabsState: Record<string, TabOverrides> | undefined;
+} {
   // Spacing tab (id "spacing").
   const spacingTab = tabsRaw['spacing'];
   const spacingRaw = spacingTab && typeof spacingTab === 'object'
@@ -599,7 +745,7 @@ function deserializeV2(
     : undefined;
   const spacing = deserializeOverridesV2(spacingRaw, getTabItems('spacing', cfg), 'spacing', unknownTokens, warnings);
 
-  // Font tab (id "font" in v2 external, maps to internal "typography").
+  // Font tab (id "font" in external schema, maps to internal "typography").
   const fontTab = tabsRaw['font'];
   const fontRaw = fontTab && typeof fontTab === 'object'
     ? (fontTab as Record<string, unknown>)['raw']
@@ -652,10 +798,201 @@ function deserializeV2(
     }
   }
 
+  return { spacing, typography, size, tabsState };
+}
+
+// ---------------------------------------------------------------------------
+// v2 deserialization
+// ---------------------------------------------------------------------------
+
+function deserializeV2(
+  obj: Record<string, unknown>,
+  opts: DeserializeOptions,
+  cfg: PanelConfig,
+): DeserializeResult {
+  const warnings: string[] = [];
+  const unknownTokens: string[] = [];
+  const baseline = opts.colorDefaults ?? neutralColorDefaults(cfg);
+  const cluster = getActivePrimaryCluster(cfg);
+
+  const tabsRaw = normalizeTabsRaw(obj.tabs);
+
+  // Color tab.
+  const color = deserializeColorV2(tabsRaw['color'], baseline, cluster, warnings);
+
+  const { spacing, typography, size, tabsState } = deserializeNonColorSlices(
+    tabsRaw,
+    cfg,
+    unknownTokens,
+    warnings,
+  );
+
   return {
     state: { color, spacing, typography, size, ...(tabsState ? { tabs: tabsState } : {}) },
     unknownTokens,
     warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// v3 deserialization — same shape as v2, but `color.semantic` leaves may also
+// be a `SemanticValue` object variant (#462).
+// ---------------------------------------------------------------------------
+
+function deserializeV3(
+  obj: Record<string, unknown>,
+  opts: DeserializeOptions,
+  cfg: PanelConfig,
+): DeserializeResult {
+  const warnings: string[] = [];
+  const unknownTokens: string[] = [];
+  const baseline = opts.colorDefaults ?? neutralColorDefaults(cfg);
+  const cluster = getActivePrimaryCluster(cfg);
+
+  const tabsRaw = normalizeTabsRaw(obj.tabs);
+
+  // Color tab — the only slice that differs from v2.
+  const color = deserializeColorV3(tabsRaw['color'], baseline, cluster, warnings);
+
+  const { spacing, typography, size, tabsState } = deserializeNonColorSlices(
+    tabsRaw,
+    cfg,
+    unknownTokens,
+    warnings,
+  );
+
+  return {
+    state: { color, spacing, typography, size, ...(tabsState ? { tabs: tabsState } : {}) },
+    unknownTokens,
+    warnings,
+  };
+}
+
+/**
+ * Parse a single external `color.semantic` leaf value into a `SemanticValue`.
+ * Accepts a plain palette-index `number` (the v2/pre-#462 shape) plus the
+ * `{ literal }` / `{ literal: { light, dark } }` / `{ ref }` object variants
+ * (#462, SCHEMA_V3+). Returns `undefined` for any other shape so the caller
+ * can warn-and-keep-baseline exactly like the other malformed-value paths in
+ * this module.
+ */
+function parseSemanticExternalValue(val: unknown): SemanticValue | undefined {
+  if (typeof val === 'number') return val;
+  if (!val || typeof val !== 'object' || Array.isArray(val)) return undefined;
+
+  const o = val as Record<string, unknown>;
+
+  if ('literal' in o) {
+    const lit = o.literal;
+    if (typeof lit === 'string') return { literal: lit };
+    if (lit && typeof lit === 'object' && !Array.isArray(lit)) {
+      const lo = lit as Record<string, unknown>;
+      if (typeof lo.light === 'string' && typeof lo.dark === 'string') {
+        return { literal: { light: lo.light, dark: lo.dark } };
+      }
+    }
+    return undefined;
+  }
+
+  if ('ref' in o) {
+    const ref = o.ref;
+    if (ref && typeof ref === 'object' && !Array.isArray(ref)) {
+      const ro = ref as Record<string, unknown>;
+      if (typeof ro.tier === 'string' && typeof ro.item === 'string') {
+        return {
+          ref: {
+            tier: ro.tier,
+            item: ro.item,
+            ...(typeof ro.tab === 'string' ? { tab: ro.tab } : {}),
+          },
+        };
+      }
+    }
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Deserialize the `palette` tier shared by v2 and v3 `color` tabs — a
+ * cssVar-keyed map of hex/oklch color strings. Extracted so
+ * `deserializeColorV2` and `deserializeColorV3` don't duplicate it.
+ */
+function deserializePaletteTier(
+  raw: Record<string, unknown>,
+  baseline: ColorTweakState,
+  cluster: ReturnType<typeof getActivePrimaryCluster>,
+): string[] {
+  if (!raw['palette'] || typeof raw['palette'] !== 'object' || Array.isArray(raw['palette'])) {
+    return [...baseline.palette];
+  }
+  const paletteMap = raw['palette'] as Record<string, unknown>;
+  const newPalette = [...baseline.palette];
+  for (let i = 0; i < cluster.paletteSize; i++) {
+    const cssVar = resolvePaletteCssVar(cluster, i);
+    const val = paletteMap[cssVar];
+    if (typeof val === 'string') {
+      // Apply the same seed-time sanitiser (commit 8d54e07): preserve
+      // valid oklch() verbatim and route everything else through
+      // cssColorToHex() so a garbage entry like "18" becomes '#000000'
+      // instead of leaking verbatim into a CSS custom property.
+      newPalette[i] = normalizeSchemePaletteEntry(val);
+    }
+  }
+  return newPalette;
+}
+
+function deserializeColorV3(
+  raw: unknown,
+  baseline: ColorTweakState,
+  cluster: ReturnType<typeof getActivePrimaryCluster>,
+  warnings: string[],
+): ColorTweakState {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    // No color tab — fall back entirely to baseline.
+    return { ...baseline, palette: [...baseline.palette], semanticMappings: { ...baseline.semanticMappings } };
+  }
+
+  const c = raw as Record<string, unknown>;
+  const palette = deserializePaletteTier(c, baseline, cluster);
+
+  // Semantic tier: cssVar-keyed. Accepts a palette-index integer (same as v2)
+  // OR one of the `SemanticValue` object variants (#462) via
+  // `parseSemanticExternalValue`.
+  const semanticMappings: Record<string, SemanticValue> = { ...baseline.semanticMappings };
+  if (c['semantic'] && typeof c['semantic'] === 'object' && !Array.isArray(c['semantic'])) {
+    const semMap = c['semantic'] as Record<string, unknown>;
+    // Build reverse map: cssName → key from cluster.semanticCssNames.
+    const cssNameToKey = new Map<string, string>(
+      Object.entries(cluster.semanticCssNames).map(([k, v]) => [v, k]),
+    );
+    for (const [cssName, val] of Object.entries(semMap)) {
+      const key = cssNameToKey.get(cssName);
+      if (!key) {
+        warnings.push(`color.semantic: unknown cssVar "${cssName}"; skipped.`);
+        continue;
+      }
+      const parsed = parseSemanticExternalValue(val);
+      if (parsed !== undefined) {
+        semanticMappings[key] = parsed;
+      } else {
+        warnings.push(
+          `color.semantic.${cssName} has unsupported value ${JSON.stringify(val)}; kept baseline.`,
+        );
+      }
+    }
+  }
+
+  return {
+    palette,
+    background: baseline.background,
+    foreground: baseline.foreground,
+    cursor: baseline.cursor,
+    selectionBg: baseline.selectionBg,
+    selectionFg: baseline.selectionFg,
+    semanticMappings,
+    shikiTheme: baseline.shikiTheme,
   };
 }
 

--- a/packages/zdtp/src/utils/design-token-serde.ts
+++ b/packages/zdtp/src/utils/design-token-serde.ts
@@ -72,7 +72,13 @@
  * Read-only manifest tokens are skipped in both directions.
  */
 
-import type { ColorTweakState, TabOverrides, TokenOverrides, TweakState } from '../state/tweak-state';
+import type {
+  ColorTweakState,
+  SemanticValue,
+  TabOverrides,
+  TokenOverrides,
+  TweakState,
+} from '../state/tweak-state';
 import { getActivePrimaryCluster, normalizeSchemePaletteEntry } from '../state/tweak-state';
 import { getPanelConfig, type PanelConfig } from '../config/panel-config';
 import { resolvePaletteCssVar } from '../config/cluster-config';
@@ -685,8 +691,12 @@ function deserializeColorV2(
     palette = newPalette;
   }
 
-  // Semantic tier: cssVar-keyed palette-index integers.
-  const semanticMappings: Record<string, number | 'bg' | 'fg'> = { ...baseline.semanticMappings };
+  // Semantic tier: cssVar-keyed palette-index integers. Only ever populated
+  // with legacy `number` values below (v2 deserialize doesn't admit
+  // `'bg'`/`'fg'` or the newer `SemanticValue` object variants) — typed as
+  // `SemanticValue` because that's `ColorTweakState.semanticMappings`'s type
+  // (#459), and `baseline.semanticMappings` may already carry the wider shape.
+  const semanticMappings: Record<string, SemanticValue> = { ...baseline.semanticMappings };
   if (c['semantic'] && typeof c['semantic'] === 'object' && !Array.isArray(c['semantic'])) {
     const semMap = c['semantic'] as Record<string, unknown>;
     // Build reverse map: cssName → key from cluster.semanticCssNames.
@@ -823,8 +833,11 @@ function deserializeColorV1(
   const selectionFg = numOr(base['sel-fg'], baseline.selectionFg);
 
   // Semantic mappings — merge over baseline so diff-only exports still
-  // produce a complete map.
-  const semanticMappings: Record<string, number | 'bg' | 'fg'> = {
+  // produce a complete map. Typed as `SemanticValue` (not the legacy
+  // `number | 'bg' | 'fg'`) because that's `ColorTweakState.semanticMappings`'s
+  // type (#459); v1 deserialize below still only ever writes `number` or
+  // `'bg'`/`'fg'` into it.
+  const semanticMappings: Record<string, SemanticValue> = {
     ...baseline.semanticMappings,
   };
   if (c.semantic && typeof c.semantic === 'object') {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/459 (epic)

---

Closes #458. Implements epic #459 in full — the misclassification **bug** plus all three **enhancements** — as one additive, backward-compatible feature.

## Summary

The reserved Color tab can now model a ramp-native three-tier color model.

- **Bug fix** — a lone `semantic:true` color tier (no palette sibling) is no longer misclassified as the palette: no grayscale swatches, no empty "Semantic Tokens", no F4 throw, no dead Scheme dropdown. It renders editable literal OKLCH swatches.
- **ENH-1 — cross-tab refs** — a semantic row can reference the Palette tab's `base`/`accent`/`state` ramps (`TierConfig.referencesRamps` + per-row `{ ref }`) and emits `var(--palette-base-3)`, so Palette edits cascade live.
- **ENH-2 — literal rows** — a semantic row can carry an editable literal OKLCH, emitted verbatim.
- **ENH-3 — per-mode** — a literal can be per-mode (`{ literal: { light, dark } }`), emitted as `--zd-danger: light-dark(<light>, <dark>)` with `color-scheme: light dark` on the applied root; `colorMode.defaultMode` is now live.

New public API (all additive): `TierConfig.semantic`, `TierConfig.referencesRamps`, and the widened `SemanticValue` union. Serde `SCHEMA_V3` round-trips all shapes; legacy v2 exports still hydrate.

## Waves (16 sub-issues, dependency-ordered)

- **W1** #460 foundation types
- **W2 (bug unblock)** #461 disambiguation → #463 lone-tier cluster derivation → {#464 render, #465 apply} + #462 serde → #466 confirm
- **W3 (cross-tab refs)** #467 resolution → {#468 emission, #469 validation, #470 grouped picker} → #471 confirm
- **W4 (per-mode)** #472 light-dark() state+emission → #473 editor UI → #474 confirm
- **W5** #475 docs + example manifest + cascade Invariant H

## Verification

- `pnpm typecheck` (panel + doc) clean; `pnpm build` (panel + doc, 61 pages) clean.
- Full node test suite: **1805 tests passing** across 102 files (emitter-parity, serde round-trip, cross-tab cascade, per-mode, and three issue-scoped e2e confirms).
- Opus code review over the full diff: no blockers; the one should-fix (disk/DOM divergence on an unresolvable `{ref}`) is fixed in this branch (both now skip).

## ⚠️ Mac / browser verification deferred

Implemented on Claude Code web (no browser). jsdom cannot resolve `light-dark()` or render the grouped picker / per-mode editor visually. **A human should verify on a real browser:** (1) per-mode `light-dark()` resolves to the correct side per `color-scheme`/`data-theme`, (2) the grouped ref-or-literal picker + per-mode toggle render and behave correctly, (3) the cross-tab `var()` cascade updates a semantic token when a Palette ramp stop is edited. See the follow-up `mac` issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPpSwKTy67pd8U9gY7bYXU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPpSwKTy67pd8U9gY7bYXU)_