### PR TITLE
Ramp Tier2 Followups: post-#459 audit fixes (D1/D2/D3) + #479 nits + #478 JP docs

### DIFF
--- a/doc/src/content/docs-ja/reference/color-cluster.mdx
+++ b/doc/src/content/docs-ja/reference/color-cluster.mdx
@@ -4,4 +4,513 @@ sidebar_position: 4
 description: カラータブが colorExtras を持つ TabConfig から ColorClusterDataConfig を派生させる方法、パレット + セマンティックティアモデル、ColorScheme、スキームプリセット。
 ---
 
-> このページは現在英語のみです。後ほど翻訳予定です。英語版を参照してください: [Color cluster](/docs/reference/color-cluster)
+カラータブ（パレット + ベースロール + セマンティックテーブル + スキームリスト）は、予約済み id `'color'` を持つ `TabConfig` によって駆動されます。タブの `tiers` はパレットとセマンティックのデータを `TierItem` の配列として保持し、同じ `TabConfig` の `colorExtras` フィールドがティア以外のメタデータ（ベースロール、カラースキーム、パネル設定）を保持します。パネルは内部でこれを `resolveColorClusterFromTab` を介して `ColorClusterDataConfig` へブリッジします。
+
+このページでは、カラータブの `TabConfig` 構造、`ColorClusterExtras` の形状、`ColorScheme` 型、マルチクラスターのサポート、そしてホスト提供のスキームプリセットについて説明します。
+
+## カラータブの `TabConfig` 構造
+
+カラータブ用の `TabConfig` は、他のタブと同じ形状に従いますが、2 つの制約があります。
+
+1. `id` は `'color'`（プライマリ）または `'color-secondary'`（セカンダリ）でなければなりません。
+2. `colorExtras` が存在しなければなりません。カラーの apply パイプラインが必要とするティア以外のメタデータを保持します。
+
+### パレットティア
+
+**パレットティア**は、アイテムがすべて `type.kind === 'color'` を持ち、`referencesTier` を持たない最初のティアです。各アイテムは 1 つのパレットスロットを表し、その `cssVar` は apply 時に書き込まれる CSS カスタムプロパティです（例: `--myapp-palette-0`）。
+
+内部ブリッジは、最初のアイテムの `cssVar` の末尾の数字列を `{n}` に置き換えることで `paletteCssVarTemplate` を派生させます。
+
+```
+--myapp-palette-0  →  --myapp-palette-{n}
+```
+
+### セマンティックティア
+
+**セマンティックティア**は、`referencesTier` がパレットティアの id を指す最初のティアです。各セマンティックアイテムの `default` はパレットアイテムの id を保持し、その id を引くことでデフォルトのパレットインデックスが得られます。
+
+ユーザーがセマンティックトークンをオーバーライドすると、apply パイプラインは参照先のパレットアイテムの `cssVar` を読み取り、そのセマンティックスロットに対して `var(--that-cssVar)` を出力します。
+
+### 最小構成の例
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+export const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: [
+        { id: 'p0', cssVar: '--myapp-palette-0', label: 'P0', default: '#1a1a2e', type: { kind: 'color' } },
+        { id: 'p1', cssVar: '--myapp-palette-1', label: 'P1', default: '#16213e', type: { kind: 'color' } },
+        { id: 'p2', cssVar: '--myapp-palette-2', label: 'P2', default: '#0f3460', type: { kind: 'color' } },
+        { id: 'p3', cssVar: '--myapp-palette-3', label: 'P3', default: '#e94560', type: { kind: 'color' } },
+      ],
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        { id: 'bg',      cssVar: '--myapp-color-bg',      label: 'Background', default: 'p0', type: { kind: 'color' } },
+        { id: 'surface', cssVar: '--myapp-color-surface',  label: 'Surface',    default: 'p1', type: { kind: 'color' } },
+        { id: 'accent',  cssVar: '--myapp-color-accent',   label: 'Accent',     default: 'p3', type: { kind: 'color' } },
+      ],
+    },
+  ],
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: { background: '--myapp-palette-0', foreground: '--myapp-palette-3' },
+    baseDefaults: { background: 0, foreground: 3 },
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {
+      'Default Dark': {
+        background: 0, foreground: 3, cursor: 3, selectionBg: 2, selectionFg: 3,
+        palette: ['#1a1a2e', '#16213e', '#0f3460', '#e94560'],
+        shikiTheme: 'github-dark',
+      },
+    },
+    panelSettings: {
+      colorScheme: 'Default Dark',
+      colorMode: false,
+    },
+  },
+};
+```
+
+## セマンティック専用ティア（`semantic: true`）
+
+上記のパレットティアは**構造的に**検出されます。すなわち、`referencesTier` を持たず、アイテムが `kind: 'color'` である最初のティアです。このヒューリスティックは、番号付きのパレットスロットを一切持たず、名前付きセマンティックトークン（`--zd-danger`、`--zd-warning`、`--zd-info` など）だけを提供するデザインシステムでは破綻します。セマンティックティア自身の `kind: 'color'` アイテムが、不正なパレットと誤認されてしまうためです（issue #458）。
+
+`TierConfig.semantic: true` を設定すると、そのティアはあらゆる場所でパレットティア検出の対象外になります。バリデーション、`resolveColorClusterFromTab`、内部の `findPaletteTier` ヘルパーは、アイテムが color 種別であってもそれをパレットとして扱いません。唯一のティアが `semantic: true` である Color `TabConfig` は、**孤立したセマンティックティア（lone semantic tier）**です。
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+export const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true, // no palette tier anywhere in this TabConfig
+      items: [
+        { id: 'danger',  cssVar: '--zd-danger',  label: 'Danger',  default: 'oklch(0.55 0.22 25)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'warning', cssVar: '--zd-warning', label: 'Warning', default: 'oklch(0.75 0.18 80)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'info',    cssVar: '--zd-info',    label: 'Info',    default: 'oklch(0.6 0.1 230)',  type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+```
+
+孤立したセマンティックティアの帰結として、`resolveColorClusterFromTab` は `paletteSize: 0` を報告し、Color タブはそれに応じてレンダリングします。
+
+| #459 より前（バグ、issue #458） | #459 以降 |
+| --- | --- |
+| `configurePanel` が例外を投げていました。F4 のパレット cssVar 連続性チェックが、セマンティックティアの非連続な名前付き cssVar を不正なパレットと誤認していたためです。 | `configurePanel` はこれを受け入れます。F4 は `semantic: true` ティアに対しては発火しません。 |
+| 「Semantic Tokens」セクションは、合成された 1 スロットのパレットを指すグレースケールの `PaletteSelector` ドロップダウンをレンダリングしていました。 | 各行は編集可能な OKLCH の `ColorField` スウォッチを直接レンダリングします。選択元となるパレットが存在しないため、選択するものは何もありません。 |
+| 「Scheme…」プリセットドロップダウンは機能しないコントロールとしてレンダリングされていました。 | `colorSchemes` が空の場合、スキームドロップダウンは一切レンダリングされません。 |
+
+孤立したセマンティックティアは、`referencesRamps` を併用して、その行の一部（またはすべて）を別のタブにあるパレットから供給することもできます。詳しくは次のセクションを参照してください。
+
+## タブをまたぐランプ参照（`referencesRamps`）
+
+`semantic: true` ティアは、スタンドアロンのリテラルに限定されません。`TierConfig.referencesRamps` は 1 つ以上の*ランプソース*、すなわちセマンティックティアの行が参照できるアイテムを持つティア（任意で別タブ上のもの）を宣言します。
+
+```ts
+referencesRamps?: readonly { tab?: string; tier: string }[];
+```
+
+各エントリはティアの `id` と、任意で `tab` の id を指定します（`tab` を省略すると「このタブ」を意味します）。`assertValidPanelConfig` は宣言されたすべてのソースを事前に検証します。未知のタブやティアは、いずれかの行がレンダリングされる前に、明確な configure 時エラーを投げます。
+
+### 実例: Palette タブがカラータブのセマンティックティアに値を供給する
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+// The ramp source — a standalone Palette tab (no colorExtras: see
+// [Grouped palette tab](../recipes/grouped-palette-tab.mdx) for the full
+// rationale). Two ramps, "base" and "accent".
+export const paletteTab: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.7 0 0)',  type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-2', cssVar: '--palette-base-2', label: 'Base 2', default: 'oklch(0.2 0 0)',  type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-0', cssVar: '--palette-accent-0', label: 'Accent 0', default: 'oklch(0.65 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'accent-1', cssVar: '--palette-accent-1', label: 'Accent 1', default: 'oklch(0.45 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+// The Color tab: a lone semantic tier that references BOTH of the Palette
+// tab's ramps.
+export const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [
+        { tab: 'palette', tier: 'base' },   // ramp source #1 (the default)
+        { tab: 'palette', tier: 'accent' }, // ramp source #2
+      ],
+      items: [
+        {
+          id: 'surface',
+          cssVar: '--zd-surface',
+          label: 'Surface',
+          // A bare ramp-item id resolves against the FIRST declared ramp
+          // source (referencesRamps[0] — here, "base").
+          default: 'base-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+        {
+          id: 'brand',
+          cssVar: '--zd-brand',
+          label: 'Brand',
+          // "tierId:itemId" picks a NON-first ramp source by name.
+          default: 'accent:accent-1',
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+```
+
+`resolveColorClusterFromTab` は、各行のマニフェストのデフォルトを `{ ref }` の `SemanticValue` へ派生させます。
+
+```ts
+cluster.semanticDefaults['surface'] === { ref: { tab: 'palette', tier: 'base',   item: 'base-1' } }
+cluster.semanticDefaults['brand']   === { ref: { tab: 'palette', tier: 'accent', item: 'accent-1' } }
+```
+
+apply パイプラインはそれぞれについて**ライブ**な `var(...)` 参照を出力します。解決済みのスナップショットではありません。そのため、Palette タブで `--palette-accent-1` を調整すると、再 apply することなく `--zd-brand` が即座に再着色されます。
+
+```
+surface -> --zd-surface: var(--palette-base-1)
+brand   -> --zd-brand:   var(--palette-accent-1)
+```
+
+パネル UI では、`referencesRamps` ティア上の行はグループ化された `<select>` としてレンダリングされます。宣言された各ランプソース（`Base`、`Accent`）ごとに 1 つの `<optgroup>` があり、加えてその行をスタンドアロンのリテラルカラーへ切り替える `"Literal…"` オプションがあります（次のセクションを参照）。別のランプオプションを選ぶと新しい `{ ref }` マッピングが永続化され、`"Literal…"` を選ぶと、その行の現在解決されているカラーを初期値とする `{ literal }` マッピングが永続化されます。
+
+## `SemanticValue` のマッピング形状
+
+セマンティックティア（`referencesTier` 方式または `semantic: true`）のすべてのアイテムは、1 つの `SemanticValue` へ解決されます。
+
+```ts
+export type SemanticValue =
+  | number
+  | 'bg'
+  | 'fg'
+  | { literal: string }
+  | { literal: { light: string; dark: string } }
+  | { ref: { tab?: string; tier: string; item: string } };
+```
+
+| 形状 | 意味 | マニフェストのデフォルト | Apply 時の出力 |
+| --- | --- | --- | --- |
+| `number` | パレットインデックスのマッピング（このページ冒頭で説明した従来の `referencesTier` 形状）。 | パレットアイテムの id。そのインデックスへ解決されます。 | `var(--palette-item-cssVar)` |
+| `'bg'` / `'fg'` | レガシーエイリアス。スキームの現在の背景/前景パレットインデックスへ解決されます。 | マニフェストのデフォルトとして使われることはまれで、多くは v1 インポートの名残です。 | `'bg'`/`'fg'` が現在解決するインデックスに対応する `var(--palette-item-cssVar)`。 |
+| `{ literal: string }` | パレットに依存しない独立したカラー。 | リテラルの CSS カラー文字列（例: `'oklch(0.6 0.1 230)'`）。 | リテラル文字列をそのまま出力。 |
+| `{ literal: { light, dark } }` | **モード別リテラル**（#472/#473）。カラースキームのモードごとに 1 つずつ、独立して編集される 2 つのカラー。 | なし。`TierItem.default` は常にプレーンな文字列であるため、この形状は実行時にのみ発生します（パネルの「Per-mode」エディターのチェックボックス、または手作業で組み立てた `ColorTweakState` / インポートされた `SCHEMA_V3` JSON）。 | `light-dark(<light>, <dark>)`。さらに DOM の apply パスは、ブラウザーが片方を選べるように、適用先のルートに `color-scheme: light dark` を設定します（Reset 時に再度クリアされます）。ディスクエミッターはこのベア（`--` 接頭辞なし）プロパティを書き出せません（下記参照）。 |
+| `{ ref: { tab?, tier, item } }` | タブ/ティアをまたぐ**ランプ参照**（#467/#468）。対象ティアを指定する `referencesRamps` を宣言したティアでのみ有効です。 | `"itemId"`（そのまま指定した場合は最初に宣言したソース）または `"tierId:itemId"`（名前付きソース）という短縮記法。上記の実例を参照してください。 | `var(--target-item-cssVar)`。ライブ参照であり、ランプソースが変わるたびにブラウザーが再解決します。焼き込まれたスナップショットではありません。 |
+
+### モード別リテラルと `colorMode.defaultMode`
+
+`ClusterPanelSettings.colorMode.defaultMode`（下記で説明）は、モード別リテラルが関わると 2 つ目の役割を担います。すなわち、パネル自身のスウォッチプレビューに使う側（`'light'` または `'dark'`）を選択し、また実ブラウザーで `light-dark()` を解決できない場所（エクスポートプレビュー、SSR シード）でのフラットなフォールバックとしても使われます。これは出力される内容を**変えません**。`applyColorState` / `buildApplyOverrides` は常に完全な `light-dark(<light>, <dark>)` 関数を出力します。`defaultMode` はパネル自身が表示する、あるいはフォールバックする値にのみ影響します。
+
+ただし、これに付随する `color-scheme: light dark` 宣言は DOM 限定です。`applyColorState` は適用先のルートにこれを設定しますが、`buildApplyOverrides`（ディスクエミッター）はできません。`routeTokensToFiles` は `--` 接頭辞を持つプロパティ名しか書き換えず、ベアな `color-scheme` プロパティにはそれがないためです。したがって、ディスクへ出力されたトークンに依存するホストは、自身のトークン CSS で `color-scheme` を自ら宣言する必要があります（`generateLightDarkCssProperties` を参照）。
+
+```ts
+panelSettings: {
+  colorScheme: 'default',
+  colorMode: { defaultMode: 'dark', lightScheme: 'Light', darkScheme: 'Dark' },
+},
+```
+
+### リグレッション: #459 以前の形状は影響を受けない
+
+従来の 2 ティア構成のパレット + セマンティッククラスター（このページで先に説明した `referencesTier` 駆動の形状）は、変わらずそのまま動作します。`number` のインデックスマッピングは引き続き `PaletteSelector` ドロップダウンとしてレンダリングされ、引き続き `var(--palette-item-cssVar)` を出力します。`semantic: true` と `referencesRamps` は純粋に追加的なものです。これらを設定しないタブは、#459 以前とまったく同じ挙動になります。
+
+## 最小のエンドツーエンド例
+
+以下のスニペットは、グループ化された Palette タブ（`base` / `accent` のランプ）と、唯一のティアが `semantic: true` である Color タブを備えた `configurePanel({...})` の呼び出しを構成します。この Color タブは、#459 以降の 3 つの `SemanticValue` 形状をすべて並べて実演します。すなわち、タブをまたぐ `{ ref }`、スタンドアロンの `{ literal }`、そして（`TierItem.default` では表現できないため実行時の状態の手動編集による）モード別の `{ literal: { light, dark } }` です。
+
+```ts
+import { configurePanel } from '@takazudo/zdtp';
+import type { TabConfig, PanelConfig } from '@takazudo/zdtp';
+
+const paletteTab: TabConfig = {
+  id: 'palette',
+  label: 'Palette',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base',
+      items: [
+        { id: 'base-0', cssVar: '--palette-base-0', label: 'Base 0', default: 'oklch(0.98 0 0)', type: { kind: 'color', format: 'oklch' } },
+        { id: 'base-1', cssVar: '--palette-base-1', label: 'Base 1', default: 'oklch(0.7 0 0)',  type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+    {
+      id: 'accent',
+      label: 'Accent',
+      items: [
+        { id: 'accent-0', cssVar: '--palette-accent-0', label: 'Accent 0', default: 'oklch(0.65 0.2 250)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+const colorTab: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'myapp',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'github-dark',
+    colorSchemes: {},
+    panelSettings: { colorScheme: 'default', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [{ tab: 'palette', tier: 'base' }, { tab: 'palette', tier: 'accent' }],
+      items: [
+        // { ref } — bare id resolves against the first ramp source ("base").
+        { id: 'brand', cssVar: '--zd-brand', label: 'Brand', default: 'base-1', type: { kind: 'color', format: 'oklch' } },
+        // { literal } — a standalone color, unrelated to any ramp.
+        { id: 'info', cssVar: '--zd-info', label: 'Info', default: 'oklch(0.6 0.1 230)', type: { kind: 'color', format: 'oklch' } },
+        // Manifest default is a single-mode literal; the per-mode pair below
+        // is layered on top of the seeded state at runtime.
+        { id: 'danger', cssVar: '--zd-danger', label: 'Danger', default: 'oklch(0.55 0.22 25)', type: { kind: 'color', format: 'oklch' } },
+      ],
+    },
+  ],
+};
+
+const config: PanelConfig = {
+  storagePrefix: 'myapp-design-token-panel',
+  consoleNamespace: 'myapp',
+  modalClassPrefix: 'myapp-design-token-panel-modal',
+  schemaId: 'myapp-design-tokens/v1',
+  exportFilenameBase: 'myapp-design-tokens',
+  tabs: [paletteTab, colorTab],
+};
+
+configurePanel(config);
+
+// Optional: seed "danger" with a per-mode literal, exactly as the panel's own
+// "Per-mode" editor checkbox would produce it. (Sketch — the real call site
+// reads the current state via the panel's persisted-state helpers rather than
+// constructing ColorTweakState by hand.)
+// state.color.semanticMappings.danger = {
+//   literal: { light: 'oklch(0.55 0.22 25)', dark: 'oklch(0.7 0.19 25)' },
+// };
+```
+
+<Tip title="パッケージ自身のテストスイートにある実行可能なフィクスチャ">
+この形状そのもの（Palette タブ + `{ ref }`・`{ literal }`・さらに実行時の `{ literal: { light, dark } }` オーバーライドを持つ、唯一のティアが `semantic: true` の Color タブ）は、パッケージ自身のリポジトリにある実在の `configurePanel` 検証済みフィクスチャです（`packages/zdtp/src/__tests__/_example-ramp-native-tier2.ts`）。`manifest-cascade-verification.test.ts` の Invariant H で実行されています。
+</Tip>
+
+## `ColorClusterExtras`
+
+カラー `TabConfig` の `colorExtras` フィールドは、ティアモデルに収まらないすべてのメタデータを保持します。
+
+```ts
+export interface ColorClusterExtras {
+  /** Stable id forwarded to internal cluster helpers. */
+  id: string;
+  /** Optional label for Color-tab section headings. Falls back to `id.toUpperCase()`. */
+  label?: string;
+  /** CSS custom-property names for terminal base roles. */
+  baseRoles: Partial<Record<BaseRoleKey, string>>;
+  /** Fallback palette indices when a scheme omits a base role. */
+  baseDefaults: Partial<Record<BaseRoleKey, number>>;
+  /** Fallback shikiTheme name when a scheme lacks one. Inert when no shiki integration. */
+  defaultShikiTheme: string;
+  /** Bundled color-scheme registry keyed by display name. Pass `{}` when unused. */
+  colorSchemes: Record<string, ColorScheme>;
+  /** Panel-level scheme settings. */
+  panelSettings: ClusterPanelSettings;
+}
+
+export type BaseRoleKey = 'background' | 'foreground' | 'cursor' | 'selectionBg' | 'selectionFg';
+```
+
+`baseRoles` は部分マップです。クラスターは、そのデザインシステムが公開するターミナルロールのみを宣言します。空のマップも有効で、宣言されたロールのみが apply 時に CSS の書き込みを発生させます。
+
+## `ColorScheme`
+
+```ts
+export type ColorRef = number | string;
+
+export interface ColorScheme {
+  background: ColorRef;
+  foreground: ColorRef;
+  cursor: ColorRef;
+  selectionBg: ColorRef;
+  selectionFg: ColorRef;
+  palette: readonly string[]; // length must equal the palette tier's item count
+  shikiTheme: string;
+  semantic?: Record<string, ColorRef>; // keys must be a subset of the semantic tier's item ids
+}
+```
+
+`ColorScheme` は完全に解決されたスナップショットです。パレットの hex 値に加え、ベースロールとセマンティックロールがどのパレットインデックスを指すかを固定するロール割り当てを持ちます。
+
+### `ColorRef`
+
+- **number** は `palette` へのインデックスを参照します（例: `2` → `palette[2]`）。
+- **string** はリテラルのカラー値です（`#33ff33` のような hex、`rgb(...)` など）。短縮記法の `"bg"` はスキームの背景に、`"fg"` は前景に解決されます。
+
+### パレット長の不変条件
+
+`ColorScheme.palette.length` は、パレットティアのアイテム数と一致しなければなりません。パレット長が一致しないスキームは初期化時に拒否されます。
+
+### セマンティックキーの不変条件
+
+`ColorScheme.semantic` のキーは、セマンティックティアのアイテム id のサブセットでなければなりません。スキームは新しいセマンティックトークンを導入できません。ティアモデルが正典となる語彙です。
+
+## `ClusterPanelSettings`
+
+`ColorClusterExtras.panelSettings` の中で保持されます。
+
+```ts
+export interface ClusterPanelSettings {
+  /** Scheme name to seed state from when `colorMode` is `false`. */
+  colorScheme: string;
+  /**
+   * `false` to disable light/dark UI; an object to honour `data-theme` on
+   * `<html>` and switch schemes on init.
+   */
+  colorMode: false | { defaultMode: 'light' | 'dark'; lightScheme: string; darkScheme: string };
+}
+```
+
+## 内部ブリッジ: `resolveColorClusterFromTab`
+
+`resolveColorClusterFromTab(tab, tabs = [tab])` は、`colorExtras` を持つ任意の `TabConfig` から `ColorClusterDataConfig` を派生させます。パネルが `'color'` および `'color-secondary'` タブを処理する際に自動的に呼び出されます。第 2 引数はパネルの完全な `tabs` 配列です。これを渡すことで、セマンティックティアのタブをまたぐ `referencesRamps`（上記参照）が、別タブにあるランプティアに対して解決されます。引数が 1 つだけの呼び出しは `[tab]` にフォールバックするため、渡したタブ上のタブをまたぐ `{ ref }` はベストエフォートでしか解決されず、エミッターはそれをスキップします。
+
+ホストがこれを直接呼び出すことはありません。テストや高度なホストツール向けに `cluster-config` から公開されています。
+
+```ts
+import { resolveColorClusterFromTab } from '@takazudo/zdtp';
+
+const cluster = resolveColorClusterFromTab(colorTab, config.tabs);
+// cluster.paletteSize, cluster.paletteCssVarTemplate, cluster.semanticDefaults, ...
+```
+
+タブに `colorExtras` がない場合は `undefined` を返します。
+
+## マルチクラスターのサポート
+
+`id: 'color-secondary'` を持つ 2 つ目の `TabConfig` を与えると、セカンダリのカラーセクションが有効になります。
+
+```ts
+configurePanel({
+  // ...
+  tabs: [
+    colorTab,         // id: 'color'
+    colorSecondaryTab, // id: 'color-secondary'
+    // ... other tabs
+  ],
+});
+```
+
+| セカンダリタブの状態 | 意味 |
+| --- | --- |
+| `tabs` に存在しない | セカンダリセクションは非表示。apply / clear はセカンダリのコードパスをスキップします。 |
+| `colorExtras` を持って存在する | セカンダリセクションが独立してレンダリング・適用されます。 |
+
+解決は、`panel-config` からエクスポートされる `resolveSecondaryColorClusterFromTabs(tabs)` を介して行われます。
+
+## ホスト提供のスキームプリセット
+
+`PanelConfig.colorPresets` は任意の、ホストが提供するプリセットマップで、Color タブの「Scheme...」ドロップダウンに表示されます。デフォルトは `{}` で、パッケージはプリセットを一切同梱しません。
+
+| `colorPresets` の値 | 効果 |
+| --- | --- |
+| `undefined` または `{}` | ドロップダウンには `colorExtras.colorSchemes` のみが入ります。 |
+| `Record<string, ColorScheme>` | 各キーがクラスターにバンドルされたスキームの下に、アルファベット順で表示されます。 |
+
+### ドロップダウンでのマージ順
+
+```
+<option disabled>Scheme...</option>
+... colorExtras.colorSchemes (insertion order) ...
+<hr />
+... colorPresets (alphabetical) ...
+```
+
+キーが衝突した場合、ロード時のルックアップではクラスターにバンドルされたスキームが優先されます。ドロップダウンは両方のエントリをレンダリングします。視覚的な重複排除は対象外です。
+
+### `setPanelColorPresets()` による遅延アタッチ
+
+大きなプリセットライブラリは、インラインの SSR 設定ブロブが肥大化するのを避けるために遅延させることができます。
+
+```ts
+import { setPanelColorPresets } from '@takazudo/zdtp';
+
+void import('./large-preset-library').then(({ presets }) => {
+  setPanelColorPresets(presets);
+});
+```
+
+完全な契約については [`setPanelColorPresets`](/ja/docs/reference/configure-panel#setpanelcolorpresetspresets) を参照してください。
+
+## Apply の挙動
+
+ユーザーが Color タブで Apply をクリックすると、パイプラインは次を行います。
+
+1. パレットアイテムを反復します（パレットティアが存在する場合。孤立した `semantic: true` タブにはありません）。各スロットについて `paletteTier.items[i].cssVar` ← `palette[i]` を書き込みます。
+2. `baseRoles` を反復します。`cssName` ← `palette[state[roleKey]]` を書き込みます。存在しないロールは書き込みを行いません。
+3. セマンティックアイテムを反復します。各アイテムの `SemanticValue` マッピングを解決し、上記の [`SemanticValue` のマッピング形状](#semanticvalue-のマッピング形状) の表に従って出力します。インデックスまたは `{ ref }` マッピングには `var(...)`、`{ literal }` にはリテラル文字列をそのまま、モード別の `{ literal: { light, dark } }` には `light-dark(<light>, <dark>)`（加えて適用先のルートに `color-scheme: light dark`。DOM apply のみ。上記のモード別リテラルの注意点を参照）を出力します。
+
+`clearAppliedStyles` は、クラスターが設定し得たすべての CSS プロパティを削除します（パレット + ベースロール + セマンティック + モード別リテラルが残した `color-scheme`）。
+
+## 関連ページ
+
+- [`PanelConfig.tabs`](/ja/docs/reference/configure-panel#panelconfig-interface) — Color `TabConfig` を指定する場所。
+- [トークン階層](/ja/docs/reference/token-manifest) — `TabConfig` / `TierConfig` / `TierItem` の完全な型リファレンス。
+- [Apply パイプライン](/ja/docs/reference/apply-pipeline) — ティアリゾルバー + ティアをまたぐ参照が CSS 変数の出力をどう駆動するか。

--- a/doc/src/content/docs-ja/reference/token-manifest.mdx
+++ b/doc/src/content/docs-ja/reference/token-manifest.mdx
@@ -4,4 +4,271 @@ sidebar_position: 3
 description: TabConfig・TierConfig・TierItem・TierValueKind・PillSpec・ColorClusterExtras — パネルの編集可能タブを定義するすべての型。
 ---
 
-> このページは現在英語のみです。後ほど翻訳予定です。英語版を参照してください: [Token tiers (tab manifest)](/docs/reference/token-manifest)
+<Info title="コンセプト概要">
+このページは、ティアモデルを型ごとに正確に定義するリファレンスです。まず設計上の意図と、リテラルティアと参照ティアの関係を理解したい場合は、[抽象トークンティアモデル](/ja/docs/reference/architecture#the-abstract-token-tier-model)を先にお読みください。
+</Info>
+
+パネルは、`PanelConfig.tabs` として渡される `TabConfig` オブジェクトのフラットな配列からタブストリップをレンダリングします。各タブは、編集可能な行からなる 1 つ以上の*ティア*を保持します。ティアはリテラル値を保持することも、別のティアのアイテムへの参照を保持することもできます。このページでは、ティアモデルのすべての公開型を正確に定義します。
+
+## `TierValueKind`
+
+行にどのエディターウィジェットが表示されるかを制御する、判別可能なユニオン型（discriminated union）です。
+
+```ts
+export type TierValueKind =
+  | { kind: 'length'; step: number; unit: string }
+  | { kind: 'number'; step: number }
+  | { kind: 'select'; options: readonly string[] }
+  | { kind: 'text' }
+  | { kind: 'color' }
+  | { kind: 'cursor' }
+  | { kind: 'content' }
+  | { kind: 'mask-image' };
+```
+
+| `kind` | 説明 | エディター | 追加で必須のフィールド |
+| --- | --- | --- | --- |
+| `'length'` | 単位付きの寸法値 | 単位サフィックス付きのテキスト入力（例: `rem`・`px`） | `step`・`unit` |
+| `'number'` | 単位なしの数値 | 制約のないテキスト入力 | `step` |
+| `'select'` | 定義済みの選択肢セット | ドロップダウン | `options`（空でない文字列配列） |
+| `'text'` | 自由形式の CSS 式（イージングカーブ、フォントファミリー、生の文字列） | 自由形式のテキスト入力 | — |
+| `'color'` | カラー値 — カラータブのパレットティアで使用 | カラーピッカー | — |
+| `'cursor'` | cursor プロパティの値（`pointer`・`crosshair` などのキーワード、または `url(...) <fallback>`） | 自由形式のテキスト入力 | — |
+| `'content'` | 疑似要素向けの content プロパティの値（引用符付き文字列、`none`、`normal`、`url(...)`、生成コンテンツ関数） | 自由形式のテキスト入力 | — |
+| `'mask-image'` | mask-image プロパティの値（`none`、`url(...)`、グラデーション関数） | 自由形式のテキスト入力 | — |
+
+特定の `TierConfig.items` 配列内のすべてのアイテムは、同じ `kind` を共有しなければなりません（MUST）。1 つのティア内で `kind` を混在させると、バリデーション時に拒否されます。
+
+## `PillSpec`
+
+単一の `TierItem` のメイン入力を補完する、オプションのピルトグルです。
+
+```ts
+export interface PillSpec {
+  /** Sentinel value emitted when the pill is ON (e.g. `"9999px"` for border-radius-full). */
+  value: string;
+  /** Default CSS value used when the pill is OFF and no override is active. */
+  customDefault: string;
+}
+```
+
+`TierItem` が `pill` を持つ場合、ティアリゾルバーはオーバーライドマップを次のように解釈します。
+
+- オーバーライドが `pill.value` と等しい → ピルのセンチネル値をそのまま出力します。
+- オーバーライドなし → `item.default` ではなく `pill.customDefault` をベースラインとして使用します。
+- `item.default` が使われるのは、オーバーライドも `customDefault` もどちらも適用されない場合のみです。
+
+## `TierItem`
+
+ティア内の 1 つの編集可能な行です。
+
+```ts
+export interface TierItem {
+  /** Stable id used as the key in persisted state. Rename = state loss. */
+  id: string;
+  /** CSS custom property written to `:root` (must start with `--`). */
+  cssVar: string;
+  /** Human-visible label rendered in the panel row. */
+  label: string;
+  /** Default CSS string value — used when no override is active. */
+  default: string;
+  /** Discriminated union controlling the edit widget. */
+  type: TierValueKind;
+  /** Opt-in sentinel-value toggle. */
+  pill?: PillSpec;
+  /** Display-only flag — the row is rendered but not editable. */
+  readonly?: true;
+}
+```
+
+<Note title="`group` フィールドなし">
+`TierItem.group`（ティア内のサブ見出しキー）は #148 で削除されました。パネルの[1 ティア 1 見出しポリシー](/ja/docs/reference/architecture)により、各ティアはちょうど 1 つのセクション見出しをレンダリングする必要があります。概念的にサブグループ分けが必要なティアは、代わりに複数の `TierConfig` エントリに分割します。サンプルマニフェストで `group` を参照してはいけません。
+</Note>
+
+### フィールドリファレンス
+
+| フィールド | 必須 | 備考 |
+| --- | --- | --- |
+| `id` | Yes | 永続化されたオーバーライドマップにおける安定したキー。名前を変更すると、`legacyIdRenameMap` を設定していない限り既存のユーザー状態が壊れます。 |
+| `cssVar` | Yes | `:root` に書き込まれる CSS カスタムプロパティ。`--` で始まり、プレフィックスの後が空でない必要があります。`assertValidPanelConfig` によって検証されます。 |
+| `label` | Yes | パネル行内の表示ラベル。 |
+| `default` | Yes | オーバーライドが有効でないときに出力されるフォールバックの CSS 文字列。 |
+| `type` | Yes | この行にどのエディターがレンダリングされるかを制御します。 |
+| `pill` | No | メインエディターと並べて、オプトインのセンチネルトグルを追加します。 |
+| `readonly` | No | `true` の場合、行は表示されますが編集不可となり、apply パイプラインからスキップされます。 |
+
+## `TierConfig`
+
+タブ内の `TierItem` エントリの名前付きグループです。
+
+```ts
+export interface TierConfig {
+  /** Stable id — must be unique within the parent `TabConfig`. */
+  id: string;
+  /** Human-visible label (e.g. "Raw values", "Semantic"). */
+  label: string;
+  /** The editable rows this tier owns. All items must share the same `kind`. */
+  items: readonly TierItem[];
+  /**
+   * When set, this tier holds cross-tier references.
+   * Each item's override value is interpreted as the id of an item in the
+   * tier named by this field. The apply pipeline emits
+   * `var(--that-tier-item-cssVar)` rather than the raw value string.
+   */
+  referencesTier?: string;
+  /**
+   * Marks this tier as a SEMANTIC tier on the Color tab — its items hold
+   * `SemanticValue` mappings (index, literal, per-mode literal, or a
+   * cross-tab ramp reference) rather than raw palette entries, so the
+   * panel never mistakes it for the palette tier even when its items are
+   * `kind: 'color'`. A tier with `semantic: true` and no sibling palette
+   * tier is a **lone semantic tier** — the Color tab renders it with no
+   * palette grid at all. Additive: omitting `semantic` preserves the
+   * pre-#459 structural palette-detection behavior.
+   */
+  semantic?: true;
+  /**
+   * Cross-tab ramp-source declaration for a `semantic: true` tier: the ramp
+   * tier(s) this tier's `{ ref }` mappings are allowed to point into. Each
+   * entry names a tier `id` and an optional `tab` id (omitted `tab` means
+   * "this tab"). Validated up front by `assertValidPanelConfig` — an
+   * unknown tab or tier throws at configure time, before any row renders.
+   */
+  referencesRamps?: readonly { tab?: string; tier: string }[];
+}
+```
+
+`referencesTier` を持つティアは**参照ティア**と呼ばれます。そのアイテムは直接の CSS 値を保持せず、別の（リテラル）ティア内の*ソース*アイテムの id を保持します。`referencesTier` の値は、同じ `TabConfig` 内に存在するティアの `id` でなければなりません。ティアの `kind` は一致している必要があります（例: 両方とも `'color'`、または両方とも `'length'`）。
+
+<Info title="semantic と referencesRamps はカラータブの概念">
+`semantic` と `referencesRamps` が意味を持つのは、`'color'` / `'color-secondary'` の `TabConfig` 内のティア（カラータブの `resolveColorClusterFromTab` ブリッジが読み取るティア）に対してのみです。完全な動作契約 — `SemanticValue` ユニオン、単独セマンティックティアのレンダリング方法、タブ間の実例 — については、[カラークラスター § セマンティック専用ティア](/ja/docs/reference/color-cluster#semantic-only-tier-semantic-true)を参照してください。
+</Info>
+
+## `TabConfig`
+
+最上位の単位 — パネルのストリップにおける 1 つのタブです。
+
+```ts
+export interface TabConfig {
+  /** Stable id. Reserved ids dispatch to built-in tab components. */
+  id: string;
+  /** Human-visible tab label. */
+  label: string;
+  /** Ordered tiers rendered inside the tab. */
+  tiers: readonly TierConfig[];
+  /**
+   * Color-tab metadata. Required for the reserved `'color'` and
+   * `'color-secondary'` ids — ignored (and unnecessary) for all other ids.
+   */
+  colorExtras?: ColorClusterExtras;
+}
+```
+
+<Note title="`advancedTiers` フィールドなし">
+`TabConfig.advancedTiers`（タブごとの「Advanced」`<details>` 開閉）は #148 で削除されました。パネルの[プログレッシブディスクロージャー禁止ポリシー](/ja/docs/reference/architecture)により、すべてのティアは折りたたみセクションなしでフラットにレンダリングされる必要があります。タブに多数のトークンがある場合は、代わりにティアセクション順にフラットにレンダリングします。サンプルマニフェストで `advancedTiers` を参照してはいけません。
+</Note>
+
+### 予約済みタブ id
+
+| `id` | ディスパッチ先 |
+| --- | --- |
+| `'color'` | プライマリカラータブ — パレット + ベースロール + セマンティックテーブル。`colorExtras` が必須。 |
+| `'color-secondary'` | セカンダリカラータブ。`colorExtras` が必須。 |
+| `'font'` | タイポグラフィタブ。 |
+| `'spacing'` | スペーシングタブ。 |
+| `'size'` | サイズタブ。 |
+| その他の任意の文字列 | `GenericTab` — kind に応じたエディターを使ってタブの `tiers` をレンダリングします。 |
+
+## `ColorClusterExtras`
+
+カラータブが必要とする、ティア以外のメタデータです。予約済みカラー id を持つタブの `TabConfig.colorExtras` に配置します。
+
+```ts
+export interface ColorClusterExtras {
+  /** Stable id forwarded to the internal ColorClusterDataConfig bridge. */
+  id: string;
+  /** Optional label for Color-tab section headings. Falls back to `id.toUpperCase()`. */
+  label?: string;
+  /** CSS custom-property names for base terminal roles. */
+  baseRoles: Partial<Record<BaseRoleKey, string>>;
+  /** Fallback palette indices when a scheme omits a base role. */
+  baseDefaults: Partial<Record<BaseRoleKey, number>>;
+  /** Fallback shikiTheme name when a scheme lacks one. */
+  defaultShikiTheme: string;
+  /** Bundled color-scheme registry keyed by display name. */
+  colorSchemes: Record<string, ColorScheme>;
+  /** Panel-level scheme settings (seed scheme, optional light/dark mode). */
+  panelSettings: ClusterPanelSettings;
+}
+
+export type BaseRoleKey = 'background' | 'foreground' | 'cursor' | 'selectionBg' | 'selectionFg';
+```
+
+## 例: 単一ティアの spacing タブ
+
+1 つのリテラルティアを持つシンプルなタブです。すべてのアイテムが length トークンです。
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+export const spacingTab: TabConfig = {
+  id: 'spacing',
+  label: 'Spacing',
+  tiers: [
+    {
+      id: 'base',
+      label: 'Base spacing',
+      items: [
+        { id: 'sp-xs', cssVar: '--myapp-spacing-xs', label: 'XS', default: '0.25rem', type: { kind: 'length', step: 0.125, unit: 'rem' } },
+        { id: 'sp-sm', cssVar: '--myapp-spacing-sm', label: 'SM', default: '0.5rem',  type: { kind: 'length', step: 0.125, unit: 'rem' } },
+        { id: 'sp-md', cssVar: '--myapp-spacing-md', label: 'MD', default: '1rem',    type: { kind: 'length', step: 0.25,  unit: 'rem' } },
+      ],
+    },
+  ],
+};
+```
+
+## 例: 2 ティアの easing タブ（リテラル + 参照）
+
+*セマンティック*ティアが *raw* ティアを参照するジェネリックタブです。パネルはセマンティックアイテムに対して、生の cubic-bezier 文字列ではなく `var(--myapp-easing-ease-in)` を出力します。
+
+```ts
+import type { TabConfig } from '@takazudo/zdtp';
+
+export const easingTab: TabConfig = {
+  id: 'easing',
+  label: 'Easing',
+  tiers: [
+    {
+      id: 'raw',
+      label: 'Raw values',
+      items: [
+        { id: 'ease-in',    cssVar: '--myapp-easing-ease-in',    label: 'Ease in',    default: 'cubic-bezier(0.42, 0, 1, 1)', type: { kind: 'text' } },
+        { id: 'ease-out',   cssVar: '--myapp-easing-ease-out',   label: 'Ease out',   default: 'cubic-bezier(0, 0, 0.58, 1)', type: { kind: 'text' } },
+        { id: 'ease-inout', cssVar: '--myapp-easing-ease-inout', label: 'Ease in-out',default: 'cubic-bezier(0.42, 0, 0.58, 1)', type: { kind: 'text' } },
+      ],
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic aliases',
+      // referencesTier causes the apply pipeline to emit var(--myapp-easing-*)
+      // rather than the raw cubic-bezier string.
+      referencesTier: 'raw',
+      items: [
+        { id: 'tab-open',  cssVar: '--myapp-transition-tab-open',  label: 'Tab open',  default: 'ease-in',    type: { kind: 'text' } },
+        { id: 'tab-close', cssVar: '--myapp-transition-tab-close', label: 'Tab close', default: 'ease-out',   type: { kind: 'text' } },
+        { id: 'modal',     cssVar: '--myapp-transition-modal',     label: 'Modal',     default: 'ease-inout', type: { kind: 'text' } },
+      ],
+    },
+  ],
+};
+```
+
+この構成では、`tab-open` を `'ease-out'` にオーバーライドすると、apply パイプラインはリテラルのイージング文字列ではなく `--myapp-transition-tab-open: var(--myapp-easing-ease-out)` を出力します。
+
+## 関連ページ
+
+- [`PanelConfig.tabs`](/ja/docs/reference/configure-panel#panelconfig-interface) — `TabConfig[]` が組み込まれる場所。
+- [カラークラスター](/ja/docs/reference/color-cluster) — カラータブが `colorExtras` を持つ `TabConfig` から `ColorClusterDataConfig` を派生させる仕組み。
+- [アプライパイプライン](/ja/docs/reference/apply-pipeline) — ティアリゾルバーがオーバーライドとティア間参照を CSS 変数の書き込みに変換する仕組み。
+- [グループ化パレットタブ](../recipes/grouped-palette-tab.mdx) — `colorExtras` なしで複数の `kind: 'color'` ティアを使うスタンドアロン Palette タブの実例。

--- a/doc/src/content/docs/reference/color-cluster.mdx
+++ b/doc/src/content/docs/reference/color-cluster.mdx
@@ -249,12 +249,14 @@ export type SemanticValue =
 | `number` | Palette-index mapping (the conventional `referencesTier` shape at the top of this page). | The id of a palette item, looked up to its index. | `var(--palette-item-cssVar)` |
 | `'bg'` / `'fg'` | Legacy aliases — resolve to the scheme's current background/foreground palette index. | Rare as a manifest default; mostly a v1-import artifact. | `var(--palette-item-cssVar)` for whichever index `'bg'`/`'fg'` currently resolves to. |
 | `{ literal: string }` | A standalone color, independent of any palette. | A literal CSS color string (e.g. `'oklch(0.6 0.1 230)'`). | The literal string verbatim. |
-| `{ literal: { light, dark } }` | The **per-mode literal** (#472/#473) — two independently-edited colors, one per color-scheme mode. | Never — `TierItem.default` is always a plain string, so this shape can only arise at RUNTIME (the panel's "Per-mode" editor checkbox, or a hand-built `ColorTweakState` / imported `SCHEMA_V3` JSON). | `light-dark(<light>, <dark>)`, and the apply pipeline additionally sets `color-scheme: light dark` on the applied root (cleared again on Reset) so the browser can pick a side. |
+| `{ literal: { light, dark } }` | The **per-mode literal** (#472/#473) — two independently-edited colors, one per color-scheme mode. | Never — `TierItem.default` is always a plain string, so this shape can only arise at RUNTIME (the panel's "Per-mode" editor checkbox, or a hand-built `ColorTweakState` / imported `SCHEMA_V3` JSON). | `light-dark(<light>, <dark>)`, and the DOM apply path additionally sets `color-scheme: light dark` on the applied root (cleared again on Reset) so the browser can pick a side — the disk emitter cannot write this bare property (see below). |
 | `{ ref: { tab?, tier, item } }` | A cross-tab/tier **ramp reference** (#467/#468) — only legal on a tier that declares `referencesRamps` naming the target tier. | The `"itemId"` (bare, first declared source) or `"tierId:itemId"` (named source) shorthand — see the worked example above. | `var(--target-item-cssVar)` — a live reference, re-resolved by the browser on every change to the ramp source, never a baked snapshot. |
 
 ### Per-mode literal and `colorMode.defaultMode`
 
 `ClusterPanelSettings.colorMode.defaultMode` (documented below) gains a second job once a per-mode literal is in play: it selects which side (`'light'` or `'dark'`) is used for the panel's own swatch preview and as the flat fallback anywhere `light-dark()` cannot be resolved by a real browser (an export preview, an SSR seed). It does **not** change what gets emitted — `applyColorState` / `buildApplyOverrides` always emit the full `light-dark(<light>, <dark>)` function; `defaultMode` only affects which value the panel itself displays or falls back to.
+
+The accompanying `color-scheme: light dark` declaration, though, is DOM-only: `applyColorState` sets it on the applied root, but `buildApplyOverrides` (the disk emitter) cannot — `routeTokensToFiles` only rewrites `--`-prefixed property names, and a bare `color-scheme` property has none — so a host relying on disk-emitted tokens must declare `color-scheme` itself in its own tokens CSS (see `generateLightDarkCssProperties`).
 
 ```ts
 panelSettings: {
@@ -428,14 +430,14 @@ export interface ClusterPanelSettings {
 
 ## Internal bridge: `resolveColorClusterFromTab`
 
-`resolveColorClusterFromTab(tab)` derives a `ColorClusterDataConfig` from any `TabConfig` that has `colorExtras`. It is called automatically by the panel when it processes the `'color'` and `'color-secondary'` tabs.
+`resolveColorClusterFromTab(tab, tabs = [tab])` derives a `ColorClusterDataConfig` from any `TabConfig` that has `colorExtras`. It is called automatically by the panel when it processes the `'color'` and `'color-secondary'` tabs. The second argument is the panel's full `tabs` array — pass it so a semantic tier's cross-tab `referencesRamps` (see above) resolves against a ramp tier living on another tab; a single-argument call falls back to `[tab]`, so a cross-tab `{ ref }` on the tab you passed resolves only best-effort and the emitters skip it.
 
 Hosts do not call this directly — it is exposed from `cluster-config` for testing and advanced host tooling.
 
 ```ts
 import { resolveColorClusterFromTab } from '@takazudo/zdtp';
 
-const cluster = resolveColorClusterFromTab(colorTab);
+const cluster = resolveColorClusterFromTab(colorTab, config.tabs);
 // cluster.paletteSize, cluster.paletteCssVarTemplate, cluster.semanticDefaults, ...
 ```
 
@@ -503,7 +505,7 @@ When the user clicks Apply for the Color tab, the pipeline:
 
 1. Iterates palette items (palette tier, when one exists — a lone `semantic: true` tab has none): writes `paletteTier.items[i].cssVar` ← `palette[i]` for each slot.
 2. Iterates `baseRoles`: writes `cssName` ← `palette[state[roleKey]]`. Absent roles emit no writes.
-3. Iterates semantic items: resolves each item's `SemanticValue` mapping and emits per the table in [`SemanticValue` mapping shapes](#semanticvalue-mapping-shapes) above — `var(...)` for an index or `{ ref }` mapping, the literal string verbatim for `{ literal }`, or `light-dark(<light>, <dark>)` (plus `color-scheme: light dark` on the applied root) for a per-mode `{ literal: { light, dark } }`.
+3. Iterates semantic items: resolves each item's `SemanticValue` mapping and emits per the table in [`SemanticValue` mapping shapes](#semanticvalue-mapping-shapes) above — `var(...)` for an index or `{ ref }` mapping, the literal string verbatim for `{ literal }`, or `light-dark(<light>, <dark>)` (plus `color-scheme: light dark` on the applied root — DOM apply only, see the per-mode literal caveat above) for a per-mode `{ literal: { light, dark } }`.
 
 `clearAppliedStyles` removes every CSS property that the cluster could have set (palette + base roles + semantic + any `color-scheme` a per-mode literal left behind).
 

--- a/packages/zdtp/src/__tests__/issue-458-lone-semantic-tier-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-458-lone-semantic-tier-e2e.test.tsx
@@ -55,6 +55,7 @@ import {
   getActivePrimaryCluster,
   getStorageKeyV3,
   initColorFromScheme,
+  initColorFromSchemeData,
   loadPersistedState,
   savePersistedState,
   type ColorTweakState,
@@ -63,6 +64,7 @@ import {
 } from '../state/tweak-state';
 import { buildApplyOverrides } from '../apply/build-apply-overrides';
 import { serialize, deserialize, SCHEMA_V3 } from '../utils/design-token-serde';
+import type { ColorScheme } from '../config/color-schemes';
 import {
   HighlightContext,
   type HighlightContextValue,
@@ -644,5 +646,98 @@ describe('6. regression: a conventional palette+semantic 2-tier color tab is una
     expect(semanticGrid.querySelectorAll('[data-testid^="tokenpanel-semantic-literal-"]').length).toBe(
       0,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. #488 — a host colorPresets entry is a no-op against a palette-less cluster
+// ---------------------------------------------------------------------------
+
+/**
+ * A full 16-slot preset — the shape a host's `configurePanel({ colorPresets })`
+ * entry ships, and the exact shape that historically resurrected a phantom
+ * palette + collapsed literal/ref semantic rows to index 0 when loaded
+ * against a lone `semantic: true` tier cluster (#488).
+ */
+const HOST_PRESET: ColorScheme = {
+  background: 9,
+  foreground: 11,
+  cursor: 6,
+  selectionBg: 11,
+  selectionFg: 10,
+  palette: [
+    '#303030',
+    '#dd3131',
+    '#266538',
+    '#a83838',
+    '#3277c8',
+    '#a35e0f',
+    '#90a1b9',
+    '#7a5218',
+    '#6b6b6b',
+    '#e2ddda',
+    '#ece9e9',
+    '#303030',
+    '#5b99dc',
+    '#b89ee7',
+    '#8590a0',
+    '#b91c1c',
+  ],
+  shikiTheme: 'catppuccin-latte',
+  // Keys match SEMANTIC_IDS 1:1 — this is exactly the scenario that used to
+  // flatten `{ literal }` rows to these plain palette indices.
+  semantic: { danger: 1, warning: 3, info: 4 },
+};
+
+const LONE_SEMANTIC_PANEL_CONFIG_WITH_PRESETS: PanelConfig = {
+  ...LONE_SEMANTIC_PANEL_CONFIG,
+  colorPresets: { 'Host Preset': HOST_PRESET },
+};
+
+describe('7. #488 — a host colorPresets entry is a no-op against a palette-less cluster', () => {
+  beforeEach(() => {
+    __resetPanelConfigForTests();
+    configurePanel(LONE_SEMANTIC_PANEL_CONFIG_WITH_PRESETS);
+  });
+
+  it('the Scheme… dropdown is absent entirely, even though colorPresets is non-empty', () => {
+    renderColorTab(LONE_SEMANTIC_TAB, makeLoneSemanticState());
+    expect(container.querySelector('.tokenpanel-color-preset-select')).toBeNull();
+  });
+
+  it('loading the preset directly does not resurrect a palette or collapse literal rows', () => {
+    const cluster = getActivePrimaryCluster();
+    const seeded = initColorFromSchemeData(HOST_PRESET, cluster);
+
+    expect(seeded.palette).toEqual([]);
+    expect(seeded.semanticMappings).toEqual(cluster.semanticDefaults);
+    for (const id of SEMANTIC_IDS) {
+      expect(seeded.semanticMappings[id]).toEqual({ literal: SEMANTIC_LITERALS[id] });
+    }
+  });
+
+  it('neither emitter writes a --zudo-stub-p* key after a preset "load"', () => {
+    const cluster = getActivePrimaryCluster();
+    const colorState = initColorFromSchemeData(HOST_PRESET, cluster);
+    const fullState: TweakState = {
+      color: colorState,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    const diskMap = buildApplyOverrides(fullState, undefined, cluster, getPanelConfig().tabs);
+    expect(Object.keys(diskMap).some((k) => k.startsWith('--zudo-stub-p'))).toBe(false);
+
+    applyColorState(colorState, cluster);
+    const inlineStyle = document.documentElement.getAttribute('style') ?? '';
+    expect(inlineStyle).not.toMatch(/--zudo-stub-p\d/);
+  });
+
+  it('rendering after the "load" still shows zero palette swatches (Section A stays gated off)', () => {
+    const cluster = getActivePrimaryCluster();
+    const seeded = initColorFromSchemeData(HOST_PRESET, cluster);
+    renderColorTab(LONE_SEMANTIC_TAB, seeded);
+    expect(container.querySelector('.tokenpanel-color-palette-grid')).toBeNull();
   });
 });

--- a/packages/zdtp/src/__tests__/issue-459-per-mode-literal-e2e.test.tsx
+++ b/packages/zdtp/src/__tests__/issue-459-per-mode-literal-e2e.test.tsx
@@ -58,6 +58,7 @@ import { render } from 'preact';
 import { act } from 'preact/test-utils';
 
 import ColorTab from '../tabs/color-tab';
+import DesignTokenTweakPanel from '../panel';
 import {
   __resetPanelConfigForTests,
   assertValidPanelConfig,
@@ -74,6 +75,7 @@ import {
   clearAppliedStyles,
   getActivePrimaryCluster,
   getClusterDefaultMode,
+  getOpenKey,
   initColorFromScheme,
   isLiteralMapping,
   isPerModeLiteral,
@@ -101,7 +103,7 @@ import { DEFAULT_HIGHLIGHT_SLOTS, type HighlightState } from '../highlight/highl
 import { TooltipProvider } from '../controls/tooltip';
 import type { TabConfig } from '../tokens/tier-model';
 import type { PersistColor, PersistSecondary } from '../state/persist';
-import { FIXTURE_TABS, FIXTURE_PANEL_CONFIG } from './_test-helpers';
+import { FIXTURE_TABS, FIXTURE_PANEL_CONFIG, flushEffects } from './_test-helpers';
 
 // ---------------------------------------------------------------------------
 // FIXTURE — a grouped Palette tab (ramp source) + a Color tab whose lone
@@ -732,5 +734,423 @@ describe('8. Reset removes a lingering color-scheme left by a per-mode literal a
 
     __resetPanelConfigForTests();
     configurePanel(PER_MODE_PANEL_CONFIG);
+  });
+
+  // -------------------------------------------------------------------------
+  // D2 (#482) — `clearAppliedStyles`' own sink branch (used by the panel's
+  // Reset button and the post-Apply cleanup) built its clear set from
+  // `clusterVarNames()` + `nonColorTabVarNames()` only, never including
+  // "color-scheme" — unlike `clearAppliedColorStylesImpl`'s sink branch
+  // exercised just above. A sink target kept `color-scheme: light dark`
+  // inline indefinitely after Reset.
+  // -------------------------------------------------------------------------
+
+  it('D2: clearAppliedStyles (sink instance, full panel Reset) ALSO includes "color-scheme" in its clear set', () => {
+    const sink = makeSinkSpy();
+    const sinkCfg: PanelConfig = { ...PER_MODE_PANEL_CONFIG, applySink: sink };
+    __resetPanelConfigForTests();
+    configurePanel(sinkCfg);
+
+    const colorState = makePerModeState();
+    applyFullState({ color: colorState, spacing: {}, typography: {}, size: {} }, sinkCfg);
+    clearAppliedStyles(undefined, sinkCfg);
+
+    const cleared = flatClearNames(sink.clearCalls);
+    expect(cleared).toContain('color-scheme');
+
+    __resetPanelConfigForTests();
+    configurePanel(PER_MODE_PANEL_CONFIG);
+  });
+
+  // -------------------------------------------------------------------------
+  // D3 (#482) — `applyColorState` only ever SETS `color-scheme: light dark`
+  // when its own cluster has a per-mode literal; nothing removed it, so
+  // demoting the last per-mode row (back to a single-mode literal, or to a
+  // `{ ref }`) left the DOM's inline `color-scheme` stale on the next apply.
+  // -------------------------------------------------------------------------
+
+  it('D3: demoting the last per-mode row to a single-mode literal removes the stale color-scheme on the next apply', () => {
+    const perModeState = makePerModeState();
+    applyFullState({ color: perModeState, spacing: {}, typography: {}, size: {} });
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+
+    const demoted: ColorTweakState = {
+      ...perModeState,
+      semanticMappings: { ...perModeState.semanticMappings, danger: { literal: LIGHT_DANGER } },
+    };
+    applyFullState({ color: demoted, spacing: {}, typography: {}, size: {} });
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('D3: switching the last per-mode row to a { ref } also removes the stale color-scheme', () => {
+    const perModeState = makePerModeState();
+    applyFullState({ color: perModeState, spacing: {}, typography: {}, size: {} });
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+
+    const refState: ColorTweakState = {
+      ...perModeState,
+      semanticMappings: {
+        ...perModeState.semanticMappings,
+        danger: { ref: { tab: 'palette', tier: 'base', item: 'base-1' } },
+      },
+    };
+    applyFullState({ color: refState, spacing: {}, typography: {}, size: {} });
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('D3: on a sink instance, demoting the last per-mode row clears "color-scheme" through the sink too', () => {
+    const sink = makeSinkSpy();
+    const sinkCfg: PanelConfig = { ...PER_MODE_PANEL_CONFIG, applySink: sink };
+    __resetPanelConfigForTests();
+    configurePanel(sinkCfg);
+
+    const perModeState = makePerModeState();
+    applyFullState({ color: perModeState, spacing: {}, typography: {}, size: {} }, sinkCfg);
+    expect(
+      flatApplyPairs(sink.applyCalls).find(([name]) => name === 'color-scheme'),
+    ).toEqual(['color-scheme', 'light dark']);
+
+    const demoted: ColorTweakState = {
+      ...perModeState,
+      semanticMappings: { ...perModeState.semanticMappings, danger: { literal: LIGHT_DANGER } },
+    };
+    applyFullState({ color: demoted, spacing: {}, typography: {}, size: {} }, sinkCfg);
+
+    expect(flatClearNames(sink.clearCalls)).toContain('color-scheme');
+
+    __resetPanelConfigForTests();
+    configurePanel(PER_MODE_PANEL_CONFIG);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Multi-cluster color-scheme aggregate (#482 D3) — `applyFullState` must
+// manage "color-scheme" as an AGGREGATE across the primary + secondary
+// clusters: a per-mode-free cluster must never clear what the other cluster
+// just required, in either direction.
+// ---------------------------------------------------------------------------
+
+const AGG_PRIMARY_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'agg-primary',
+    label: 'Aggregate Primary',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      items: [
+        {
+          id: 'danger',
+          cssVar: '--agg-primary-danger',
+          label: 'Danger',
+          default: LIGHT_DANGER,
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+const AGG_SECONDARY_COLOR_TAB: TabConfig = {
+  id: 'color-secondary',
+  label: 'Secondary Color',
+  colorExtras: {
+    id: 'agg-secondary',
+    label: 'Aggregate Secondary',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      items: [
+        {
+          id: 'danger',
+          cssVar: '--agg-secondary-danger',
+          label: 'Danger',
+          default: LIGHT_DANGER,
+          type: { kind: 'color', format: 'oklch' },
+        },
+      ],
+    },
+  ],
+};
+
+/** Panel config with a lone-semantic-tier primary + secondary cluster, no palette tier on either. */
+const AGG_PANEL_CONFIG: PanelConfig = {
+  storagePrefix: 'issue-482-color-scheme-aggregate',
+  consoleNamespace: 'issue-482-agg',
+  modalClassPrefix: 'issue-482-agg-modal',
+  schemaId: 'zudo-design-tokens/v1',
+  exportFilenameBase: 'issue-482-agg-tokens',
+  tabs: [AGG_PRIMARY_COLOR_TAB, AGG_SECONDARY_COLOR_TAB],
+  colorPresets: {},
+};
+
+/** A lone-semantic-tier, no-palette ColorTweakState (paletteSize: 0 cluster shape, mirrors COLOR_TAB above). */
+function makeAggColorState(danger: ColorTweakState['semanticMappings']['danger']): ColorTweakState {
+  return {
+    palette: [],
+    background: 0,
+    foreground: 0,
+    cursor: 0,
+    selectionBg: 0,
+    selectionFg: 0,
+    semanticMappings: { danger },
+    shikiTheme: 'dracula',
+  };
+}
+
+const PER_MODE_DANGER = { literal: { light: LIGHT_DANGER, dark: DARK_DANGER } };
+const SINGLE_MODE_DANGER = { literal: LIGHT_DANGER };
+
+describe('9. applyFullState manages "color-scheme" as an aggregate across primary + secondary', () => {
+  it('primary has a per-mode literal, secondary does not — color-scheme REMAINS after the full apply', () => {
+    const fullState: TweakState = {
+      color: makeAggColorState(PER_MODE_DANGER),
+      secondary: makeAggColorState(SINGLE_MODE_DANGER),
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    applyFullState(fullState, AGG_PANEL_CONFIG);
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+  });
+
+  it('secondary has a per-mode literal, primary does not — color-scheme REMAINS after the full apply', () => {
+    const fullState: TweakState = {
+      color: makeAggColorState(SINGLE_MODE_DANGER),
+      secondary: makeAggColorState(PER_MODE_DANGER),
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    applyFullState(fullState, AGG_PANEL_CONFIG);
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+  });
+
+  it('neither cluster has a per-mode literal — color-scheme is cleared (and stays cleared)', () => {
+    const fullState: TweakState = {
+      color: makeAggColorState(SINGLE_MODE_DANGER),
+      secondary: makeAggColorState(SINGLE_MODE_DANGER),
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+    applyFullState(fullState, AGG_PANEL_CONFIG);
+
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('regression: a prior per-mode apply on BOTH clusters, then demoting BOTH, clears the stale color-scheme', () => {
+    applyFullState(
+      {
+        color: makeAggColorState(PER_MODE_DANGER),
+        secondary: makeAggColorState(PER_MODE_DANGER),
+        spacing: {},
+        typography: {},
+        size: {},
+      },
+      AGG_PANEL_CONFIG,
+    );
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('light dark');
+
+    applyFullState(
+      {
+        color: makeAggColorState(SINGLE_MODE_DANGER),
+        secondary: makeAggColorState(SINGLE_MODE_DANGER),
+        spacing: {},
+        typography: {},
+        size: {},
+      },
+      AGG_PANEL_CONFIG,
+    );
+    expect(document.documentElement.style.getPropertyValue('color-scheme')).toBe('');
+  });
+
+  it('a sink instance: only the secondary needs color-scheme — it is set once via the sink, never cleared by the primary\'s own apply', () => {
+    const sink = makeSinkSpy();
+    const sinkCfg: PanelConfig = { ...AGG_PANEL_CONFIG, applySink: sink };
+
+    applyFullState(
+      {
+        color: makeAggColorState(SINGLE_MODE_DANGER),
+        secondary: makeAggColorState(PER_MODE_DANGER),
+        spacing: {},
+        typography: {},
+        size: {},
+      },
+      sinkCfg,
+    );
+
+    const colorSchemePairs = flatApplyPairs(sink.applyCalls).filter(
+      ([name]) => name === 'color-scheme',
+    );
+    expect(colorSchemePairs).toEqual([['color-scheme', 'light dark']]);
+    expect(flatClearNames(sink.clearCalls)).not.toContain('color-scheme');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Import clear-before-apply (#482 import nit) — a dangling `{ ref }` in
+// an imported state must not inherit the PREVIOUS session's painted value.
+// `handleLoadFromJson` (panel.tsx) now clears color cluster vars before
+// calling `applyFullState`, mirroring the scheme-change clear at panel.tsx.
+// This test drives the same two-call sequence directly at the state layer.
+// ---------------------------------------------------------------------------
+
+describe('10. handleLoadFromJson-style import clears color cluster vars before applying', () => {
+  it('a dangling ref in the imported state does not leave the previous resolvable ref painted', () => {
+    const baseState = makeBaseState();
+
+    // 1. Apply a state whose "brand" resolves to a real ramp item.
+    const resolvableState: ColorTweakState = {
+      ...baseState,
+      semanticMappings: {
+        ...baseState.semanticMappings,
+        brand: { ref: { tab: 'palette', tier: 'base', item: 'base-1' } },
+      },
+    };
+    applyFullState({ color: resolvableState, spacing: {}, typography: {}, size: {} });
+    expect(document.documentElement.style.getPropertyValue('--zd-brand')).toBe(
+      'var(--palette-base-1)',
+    );
+
+    // 2. "Import" a state whose "brand" ref names a ramp item that does not
+    // exist — the resolver skips it (emits nothing), exactly like a
+    // misconfigured/edited manifest.
+    const danglingState: ColorTweakState = {
+      ...resolvableState,
+      semanticMappings: {
+        ...resolvableState.semanticMappings,
+        brand: { ref: { tab: 'palette', tier: 'base', item: 'does-not-exist' } },
+      },
+    };
+
+    // Mirrors handleLoadFromJson: clear color cluster vars BEFORE applying
+    // the loaded state.
+    clearAppliedColorStyles();
+    applyFullState({ color: danglingState, spacing: {}, typography: {}, size: {} });
+
+    // The stale var(--palette-base-1) from step 1 must be gone — the token
+    // falls back to its stylesheet default, matching a fresh reload of the
+    // imported (dangling-ref) state.
+    expect(document.documentElement.style.getPropertyValue('--zd-brand')).toBe('');
+  });
+
+  it('the real panel.tsx handleLoadFromJson wiring clears the previous paint before applying the imported (dangling-ref) state', async () => {
+    // jsdom does not implement <dialog>.showModal()/close() (see
+    // modal-backdrop-drag.test.tsx) — polyfill both for this test only.
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.setAttribute('open', '');
+    };
+    HTMLDialogElement.prototype.close = function close() {
+      this.removeAttribute('open');
+      this.dispatchEvent(new Event('close'));
+    };
+
+    try {
+      // 1. The host page currently has a resolvable ref applied from a prior
+      // session — write it directly to the DOM, exactly like a real mount
+      // would have left it.
+      const baseState = makeBaseState();
+      const resolvableState: ColorTweakState = {
+        ...baseState,
+        semanticMappings: {
+          ...baseState.semanticMappings,
+          brand: { ref: { tab: 'palette', tier: 'base', item: 'base-1' } },
+        },
+      };
+      applyFullState({ color: resolvableState, spacing: {}, typography: {}, size: {} });
+      expect(document.documentElement.style.getPropertyValue('--zd-brand')).toBe(
+        'var(--palette-base-1)',
+      );
+
+      // 2. Build the "imported" JSON — same shape, but "brand" now names a
+      // ramp item that no longer exists (a dangling ref).
+      const fullState: TweakState = {
+        color: resolvableState,
+        spacing: {},
+        typography: {},
+        size: {},
+      };
+      const json = serialize(fullState, { colorDefaults: baseState }) as unknown as {
+        $schema: string;
+        tabs?: Record<string, Record<string, Record<string, unknown>>>;
+      };
+      json.tabs ??= {};
+      json.tabs.color ??= {};
+      json.tabs.color.semantic ??= {};
+      json.tabs.color.semantic['--zd-brand'] = {
+        ref: { tab: 'palette', tier: 'base', item: 'does-not-exist' },
+      };
+      // The "brand" override happens to equal the cluster's own default ref,
+      // so the diff-only serializer never emitted it and left $schema at V2
+      // (see serialize()'s usesObjectSemanticLeaf gate). Now that an
+      // object-shaped { ref } leaf has been added by hand, bump to V3 so
+      // deserializeV3 (not the legacy numeric-only V2 path) reads it back.
+      json.$schema = SCHEMA_V3;
+      const jsonText = JSON.stringify(json);
+
+      // 3. Mount the REAL panel, pre-opened via localStorage (mirrors a
+      // returning user who left the panel open) with no persisted state, so
+      // the init effect does NOT re-apply/touch the DOM (see panel.tsx's
+      // "no saved state" branch) — the step-1 paint stays exactly as applied.
+      localStorage.setItem(getOpenKey(PER_MODE_PANEL_CONFIG), '1');
+      act(() => {
+        render(<DesignTokenTweakPanel instanceConfig={PER_MODE_PANEL_CONFIG} />, container);
+      });
+      await flushEffects();
+
+      const loadTrigger = Array.from(container.querySelectorAll('[role="button"]')).find((el) =>
+        el.textContent?.includes('Load from JSON'),
+      ) as HTMLElement | undefined;
+      expect(loadTrigger).toBeTruthy();
+      act(() => loadTrigger!.click());
+
+      const dialog = container.querySelector('dialog');
+      expect(dialog).not.toBeNull();
+      const textarea = dialog!.querySelector('textarea') as HTMLTextAreaElement;
+      act(() => {
+        textarea.value = jsonText;
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+
+      const loadBtn = Array.from(dialog!.querySelectorAll('[role="button"]')).find(
+        (el) => el.textContent?.trim() === 'Load',
+      ) as HTMLElement | undefined;
+      expect(loadBtn).toBeTruthy();
+      act(() => loadBtn!.click());
+
+      // handleLoadFromJson (panel.tsx) clears color cluster vars BEFORE
+      // applying the loaded (dangling-ref) state — the stale
+      // var(--palette-base-1) from the pre-existing session must be gone.
+      expect(document.documentElement.style.getPropertyValue('--zd-brand')).toBe('');
+    } finally {
+      act(() => {
+        render(null, container);
+      });
+      delete (HTMLDialogElement.prototype as { showModal?: unknown }).showModal;
+      delete (HTMLDialogElement.prototype as { close?: unknown }).close;
+      localStorage.removeItem(getOpenKey(PER_MODE_PANEL_CONFIG));
+    }
   });
 });

--- a/packages/zdtp/src/__tests__/panel-config.test.ts
+++ b/packages/zdtp/src/__tests__/panel-config.test.ts
@@ -832,6 +832,140 @@ describe('panel-config — assertValidPanelConfig host-tabs validation', () => {
     expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [tab] }))).not.toThrow();
   });
 
+  it('F4: still finds the real palette tier when a `semantic: true` tier is ordered BEFORE it', () => {
+    // Regression guard mirroring the mixed-order test in cluster-config.test.ts:
+    // this exercises the F4 finder's own `t.semantic === true` exclusion.
+    // Ordering the semantic tier FIRST means Array.prototype.find would pick
+    // it up (and throw on its non-numbered, multi-item cssVars) if that
+    // exclusion were ever deleted.
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: {
+        id: 'test',
+        defaultShikiTheme: 'dracula',
+        baseRoles: {},
+        baseDefaults: {},
+        colorSchemes: {},
+        panelSettings: { colorScheme: 'default', colorMode: false },
+      },
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: '#ff0000',
+              type: { kind: 'color' as const, format: 'oklch' as const },
+            },
+            {
+              id: 'warning',
+              cssVar: '--zd-warning',
+              label: 'Warning',
+              default: '#ffaa00',
+              type: { kind: 'color' as const, format: 'oklch' as const },
+            },
+          ],
+        },
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p1',
+              cssVar: '--pal-1',
+              label: 'Palette 1',
+              default: '#ffffff',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [tab] }))).not.toThrow();
+  });
+
+  // Rule: `semantic` must be exactly `true` when present -----------------------
+  //
+  // A truthy-but-not-`true` marker (e.g. `1`, `'true'`) is reachable from a
+  // plain-JS host config (TS's structural typing offers no defense at that
+  // boundary) and would otherwise get divergent treatment across the five
+  // separate `semantic` predicate sites in this file, cluster-config.ts, and
+  // color-tab.tsx — some compare with truthiness, some with `=== true`.
+  // Rejecting it here at config-validation time makes that ambiguity
+  // unreachable instead of leaving it to silently misbehave downstream.
+
+  it('rejects a tier with `semantic: 1` (truthy, not exactly `true`)', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          semantic: 1 as any,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: '#ff0000',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [tab] }))).toThrow(
+      /tiers\["semantic"\]\.semantic must be exactly `true`/,
+    );
+  });
+
+  it('rejects a tier with `semantic: \'true\'` (string, not the boolean `true`)', () => {
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          semantic: 'true' as any,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: '#ff0000',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+    expect(() => assertValidPanelConfig(makeBaseConfig({ tabs: [tab] }))).toThrow(
+      /tiers\["semantic"\]\.semantic must be exactly `true`/,
+    );
+  });
+
+  it('accepts a tier with `semantic: true` (unchanged) and a tier with `semantic` absent (unchanged)', () => {
+    expect(() =>
+      assertValidPanelConfig(makeBaseConfig({ tabs: [VALID_TEXT_TAB, VALID_TWO_TIER_TAB] })),
+    ).not.toThrow();
+  });
+
   // F8: colorExtras deep validation (issue #440) ----------------------------
 
   function makeColorExtrasTab(overrides: Record<string, unknown> = {}): TabConfig {

--- a/packages/zdtp/src/__tests__/tweak-state.test.ts
+++ b/packages/zdtp/src/__tests__/tweak-state.test.ts
@@ -6,6 +6,7 @@ import {
   getStorageKeyV2,
   getStorageKeyV3,
   initColorFromSchemeData,
+  initSecondaryDefaults,
   type ColorTweakState,
   type StorageLike,
   type TweakState,
@@ -625,6 +626,76 @@ describe('#342 — ColorScheme.shikiTheme is optional', () => {
       cluster,
     );
     expect(state.shikiTheme).toBe('vitesse-dark');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #488 (S7) — initColorFromSchemeData is a no-op for a palette-less cluster
+// ---------------------------------------------------------------------------
+
+describe('#488 — initColorFromSchemeData no-ops for a palette-less (paletteSize: 0) cluster', () => {
+  // A lone `semantic: true` tier cluster (#458/#466) — no palette sibling.
+  // `semanticDefaults` mixes every SemanticValue shape a scheme cannot
+  // express, so a regression back to the pre-#488 flattening (every
+  // non-numeric default collapsed to palette index 0) is caught here.
+  const loneSemanticCluster: ColorClusterDataConfig = {
+    id: 'lone-semantic-fixture',
+    label: 'Lone Semantic',
+    paletteSize: 0,
+    baseRoles: {},
+    paletteCssVarTemplate: '--zudo-stub-p{n}',
+    semanticDefaults: {
+      danger: { literal: 'oklch(0.55 0.22 25)' },
+      accent: { ref: { tier: 'ramp', item: 'p5' } },
+      legacyIndex: 3,
+    },
+    semanticCssNames: { danger: '--zd-danger', accent: '--zd-accent', legacyIndex: '--zd-legacy' },
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  };
+
+  // A fully-populated 16-slot scheme — exactly the shape a bundled preset or
+  // a host `colorPresets` entry ships. Loading it against the palette-less
+  // cluster above must not resurrect any of this into state.
+  const fullScheme: ColorScheme = {
+    background: 9,
+    foreground: 11,
+    cursor: 6,
+    selectionBg: 11,
+    selectionFg: 10,
+    palette: palette16 as ColorScheme['palette'],
+    shikiTheme: 'catppuccin-latte',
+    semantic: { danger: 1, accent: 5 },
+  };
+
+  it('returns an empty palette instead of seeding scheme.palette', () => {
+    const state = initColorFromSchemeData(fullScheme, loneSemanticCluster);
+    expect(state.palette).toEqual([]);
+  });
+
+  it('leaves semanticMappings byte-identical to cluster.semanticDefaults (literal/ref rows intact)', () => {
+    const state = initColorFromSchemeData(fullScheme, loneSemanticCluster);
+    expect(state.semanticMappings).toEqual(loneSemanticCluster.semanticDefaults);
+  });
+
+  it('does not collapse the { literal } / { ref } rows to a palette index', () => {
+    const state = initColorFromSchemeData(fullScheme, loneSemanticCluster);
+    expect(state.semanticMappings.danger).toEqual({ literal: 'oklch(0.55 0.22 25)' });
+    expect(state.semanticMappings.accent).toEqual({ ref: { tier: 'ramp', item: 'p5' } });
+  });
+
+  it('warns once via console.warn instead of throwing', () => {
+    expect(() => initColorFromSchemeData(fullScheme, loneSemanticCluster)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain('lone-semantic-fixture');
+  });
+
+  it('matches initSecondaryDefaults(cluster) exactly — a scheme load is indistinguishable from no scheme', () => {
+    const state = initColorFromSchemeData(fullScheme, loneSemanticCluster);
+    const noSchemeState = initSecondaryDefaults(loneSemanticCluster);
+    expect(state).toEqual(noSchemeState);
   });
 });
 

--- a/packages/zdtp/src/apply-modal.tsx
+++ b/packages/zdtp/src/apply-modal.tsx
@@ -312,18 +312,25 @@ export function ApplyModal(props: ApplyModalProps) {
     //   2. Host kept the default but the persist envelope has no secondary
     //      slice yet — `state.secondary` undefined → skip.
     //   3. Otherwise — diff against `undefined` (no scheme baseline yet)
-    //      and merge into the flat overrides. The shallow
-    //      `{ ...state, color: state.secondary }` swap lets
-    //      `buildApplyOverrides` reuse its existing logic without
-    //      signature changes.
+    //      and merge into the flat overrides. Spacing/typography/size/tabs
+    //      are zeroed out on the secondary call — the primary call above
+    //      already emitted them from the same `state`, so re-walking them
+    //      here would just redundantly re-emit identical values.
+    //
+    // `currentTab` is threaded as the `'color-secondary'` tab — mirroring
+    // `applyFullState`'s DOM-emitter threading (`state/tweak-state.ts`) — so a
+    // cross-tab/tier `{ ref }` semantic mapping on the secondary cluster
+    // resolves against the SECONDARY tab, not the primary `'color'` tab.
     const secondaryCluster = resolveSecondaryColorCluster(cfg);
+    const secondaryColorTab = cfg.tabs.find((t) => t.id === 'color-secondary');
     const secondaryOverrides =
       secondaryCluster && state.secondary
         ? buildApplyOverrides(
-            { ...state, color: state.secondary },
+            { color: state.secondary, spacing: {}, typography: {}, size: {} },
             undefined,
             secondaryCluster,
             cfg.tabs,
+            secondaryColorTab,
           )
         : {};
     return { ...zdOverrides, ...secondaryOverrides };

--- a/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
+++ b/packages/zdtp/src/apply/__tests__/build-apply-overrides.test.ts
@@ -913,3 +913,161 @@ describe('buildApplyOverrides — per-mode literal semantic value (S11, #472)', 
     expect(result['--zd-danger']).toBe('oklch(0.55 0.2 25)');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Tests — secondary-cluster { ref } resolution against the OWNING tab, not
+// the primary 'color' tab (audit defect D1, issue #481)
+// ---------------------------------------------------------------------------
+
+describe('buildApplyOverrides — secondary-cluster { ref } resolves against currentTab (D1, #481)', () => {
+  // Primary color tab. Its 'ramp' tier shares an id with the secondary tab's
+  // 'ramp' tier below, but the items (and cssVars) differ — this is the
+  // fixture that proves resolution picks the OWNING tab's item, not just
+  // "any tab with a same-id tier".
+  const PRIMARY_COLOR_TAB: TabConfig = {
+    id: 'color',
+    label: 'Color',
+    tiers: [
+      {
+        id: 'ramp',
+        label: 'Ramp',
+        items: [
+          {
+            id: 'ramp-1',
+            cssVar: '--zd-color-ramp-1',
+            label: 'ramp-1',
+            default: '#111111',
+            type: { kind: 'color' },
+          },
+        ],
+      },
+    ],
+  };
+
+  // Secondary color tab — the 'color-secondary' tab per resolveSecondaryColorCluster's
+  // convention. Same tier id ('ramp') as the primary tab, different cssVar.
+  const SECONDARY_COLOR_TAB: TabConfig = {
+    id: 'color-secondary',
+    label: 'Color (secondary)',
+    tiers: [
+      {
+        id: 'ramp',
+        label: 'Ramp',
+        items: [
+          {
+            id: 'ramp-1',
+            cssVar: '--zd-color-secondary-ramp-1',
+            label: 'ramp-1',
+            default: '#222222',
+            type: { kind: 'color' },
+          },
+        ],
+      },
+    ],
+  };
+
+  const SECONDARY_CLUSTER = {
+    id: 'secondary-fixture',
+    label: 'Secondary Fixture',
+    paletteSize: 4,
+    baseRoles: {},
+    paletteCssVarTemplate: '--secondary-p{n}',
+    semanticDefaults: { 'surface-secondary': 1 },
+    semanticCssNames: { 'surface-secondary': '--zd-surface-secondary' },
+    baseDefaults: { background: 0, foreground: 3, cursor: 1, selectionBg: 0, selectionFg: 3 },
+    defaultShikiTheme: 'dracula' as const,
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false as const },
+  };
+
+  // Intra-tab ref (no `tab` key) — must resolve against whichever tab is
+  // passed as `currentTab`, not a hardcoded 'color'.
+  const SECONDARY_COLOR_STATE: ColorTweakState = {
+    palette: ['#000000', '#111111', '#222222', '#ffffff'],
+    background: 0,
+    foreground: 3,
+    cursor: 1,
+    selectionBg: 0,
+    selectionFg: 3,
+    semanticMappings: { 'surface-secondary': { ref: { tier: 'ramp', item: 'ramp-1' } } },
+    shikiTheme: 'dracula',
+  };
+
+  it('an intra-tab ref on the secondary cluster resolves against color-secondary, not the primary color tab', () => {
+    const tabs: readonly TabConfig[] = [PRIMARY_COLOR_TAB, SECONDARY_COLOR_TAB];
+    const state: TweakState = {
+      color: SECONDARY_COLOR_STATE,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    // Correct usage (mirrors apply-modal.tsx's secondary call site): thread
+    // the owning 'color-secondary' tab as currentTab.
+    const result = buildApplyOverrides(
+      state,
+      undefined,
+      SECONDARY_CLUSTER,
+      tabs,
+      SECONDARY_COLOR_TAB,
+    );
+    expect(result['--zd-surface-secondary']).toBe('var(--zd-color-secondary-ramp-1)');
+
+    // Contrast: omitting currentTab falls back to the default 'color' tab
+    // lookup — the pre-fix behavior — and resolves against the WRONG tab's
+    // same-id tier, proving the defect this test guards against.
+    const buggyResult = buildApplyOverrides(state, undefined, SECONDARY_CLUSTER, tabs);
+    expect(buggyResult['--zd-surface-secondary']).toBe('var(--zd-color-ramp-1)');
+  });
+
+  it('a config with a color-secondary tab but no "color" tab still emits the ref (no silent drop)', () => {
+    // No primary 'color' tab at all — the pre-fix `tabs.find(t => t.id ===
+    // 'color')` guard would find nothing and silently drop the ref entirely.
+    const tabs: readonly TabConfig[] = [SECONDARY_COLOR_TAB];
+    const state: TweakState = {
+      color: SECONDARY_COLOR_STATE,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    const result = buildApplyOverrides(
+      state,
+      undefined,
+      SECONDARY_CLUSTER,
+      tabs,
+      SECONDARY_COLOR_TAB,
+    );
+    expect(result['--zd-surface-secondary']).toBe('var(--zd-color-secondary-ramp-1)');
+  });
+
+  it('disk output equals the DOM-applied (sink) value for the secondary-cluster ref (parity)', () => {
+    const tabs: readonly TabConfig[] = [PRIMARY_COLOR_TAB, SECONDARY_COLOR_TAB];
+    const state: TweakState = {
+      color: SECONDARY_COLOR_STATE,
+      spacing: {},
+      typography: {},
+      size: {},
+    };
+
+    const diskResult = buildApplyOverrides(
+      state,
+      undefined,
+      SECONDARY_CLUSTER,
+      tabs,
+      SECONDARY_COLOR_TAB,
+    );
+
+    const applied: Record<string, string> = {};
+    const sink: ApplySink = {
+      apply(pairs) {
+        for (const [name, value] of pairs) applied[name] = value;
+      },
+      clear() {},
+    };
+    applyColorState(SECONDARY_COLOR_STATE, SECONDARY_CLUSTER, sink, SECONDARY_COLOR_TAB, tabs);
+
+    expect(diskResult['--zd-surface-secondary']).toBe('var(--zd-color-secondary-ramp-1)');
+    expect(applied['--zd-surface-secondary']).toBe(diskResult['--zd-surface-secondary']);
+  });
+});

--- a/packages/zdtp/src/apply/build-apply-overrides.ts
+++ b/packages/zdtp/src/apply/build-apply-overrides.ts
@@ -94,12 +94,21 @@ import { structuralEqual } from '../utils/structural-equal';
  *
  * `tabs` defaults to the active panel config's tab list. Injected by tests so
  * non-color token resolution works without a live panel config singleton.
+ *
+ * `currentTab` is the color TabConfig `state.color`'s semantic mappings live
+ * on — needed so a cross-tab/tier `{ ref }` mapping (#468) with an omitted
+ * `ref.tab` resolves against the RIGHT tab. Defaults to the `'color'` tab
+ * (primary-cluster behavior, unchanged). Secondary-cluster callers MUST pass
+ * the `'color-secondary'` tab explicitly — mirroring the DOM emitter's
+ * `applyFullState`/`applyColorState` `currentTab` threading
+ * (`state/tweak-state.ts`).
  */
 export function buildApplyOverrides(
   state: TweakState,
   colorDefaults: ColorTweakState | undefined,
   cluster: ColorClusterConfig = getActivePrimaryCluster(),
   tabs: readonly TabConfig[] = getPanelConfig().tabs,
+  currentTab: TabConfig | undefined = tabs.find((t) => t.id === 'color'),
 ): Record<string, string> {
   const out: Record<string, string> = {};
   const color = state.color;
@@ -154,16 +163,17 @@ export function buildApplyOverrides(
     }
 
     // `{ ref: { tab?, tier, item } }` — cross-tab/tier ramp reference (#468).
-    // Resolve against the Color tab (the tier the semantic mapping lives on)
-    // using the panel's full `tabs` array so a ref pointing into another tab
-    // (e.g. the grouped Palette tab) resolves. A ref that fails to resolve
-    // (misconfigured manifest) is silently skipped rather than crashing the
-    // apply pipeline — up-front source validation is #469's job.
+    // Resolve against `currentTab` (the tab the semantic mapping lives on —
+    // `'color'` for the primary cluster, `'color-secondary'` when the caller
+    // passed that tab explicitly) using the panel's full `tabs` array so a
+    // ref pointing into another tab (e.g. the grouped Palette tab) resolves.
+    // A ref that fails to resolve (misconfigured manifest) is silently
+    // skipped rather than crashing the apply pipeline — up-front source
+    // validation is #469's job.
     if (isRefMapping(currentMapping)) {
-      const colorTab = tabs.find((t) => t.id === 'color');
-      if (colorTab) {
+      if (currentTab) {
         try {
-          const targetCssVar = resolveRefToCssVar(currentMapping.ref, colorTab, tabs);
+          const targetCssVar = resolveRefToCssVar(currentMapping.ref, currentTab, tabs);
           out[cssVar] = `var(${targetCssVar})`;
         } catch {
           // Unresolvable ref — skip rather than emit a broken var() reference.

--- a/packages/zdtp/src/config/__tests__/cluster-config.test.ts
+++ b/packages/zdtp/src/config/__tests__/cluster-config.test.ts
@@ -152,6 +152,70 @@ describe('resolveColorClusterFromTab — palette vs. semantic disambiguation (#4
     expect(cluster?.paletteSize).toBe(1);
     expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
   });
+
+  it('does not pick a `semantic: true` tier as the palette when it is ordered BEFORE the real palette tier', () => {
+    // Regression guard: the test above places the real palette tier FIRST, so
+    // it still passes even if the `!t.semantic` exclusion in the paletteTier
+    // finder were deleted (Array.prototype.find would just return the same
+    // first match either way). Order the semantic tier first instead — with a
+    // differing `type.format` from the real palette tier — so this test
+    // actually exercises the guard.
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: 'oklch(0.6 0.2 25)',
+              type: { kind: 'color' as const, format: 'oklch' as const },
+            },
+            {
+              id: 'warning',
+              cssVar: '--zd-warning',
+              label: 'Warning',
+              default: 'oklch(0.8 0.15 80)',
+              type: { kind: 'color' as const, format: 'oklch' as const },
+            },
+          ],
+        },
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p1',
+              cssVar: '--pal-1',
+              label: 'Palette 1',
+              default: '#ffffff',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster).toBeDefined();
+    // The `palette` tier (not the `semantic: true` tier ordered before it)
+    // must be the one reported as the 2-slot palette.
+    expect(cluster?.paletteSize).toBe(2);
+    expect(cluster?.paletteCssVarTemplate).toBe('--pal-{n}');
+  });
 });
 
 /**

--- a/packages/zdtp/src/config/__tests__/cluster-config.test.ts
+++ b/packages/zdtp/src/config/__tests__/cluster-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { resolveColorClusterFromTab } from '../cluster-config';
 import { resolveRefToCssVar } from '../../apply/tier-resolver';
 import type { TabConfig } from '../../tokens/tier-model';
@@ -371,6 +371,208 @@ describe('resolveColorClusterFromTab — cross-tab ramp ref derivation (#467)', 
     const cluster = resolveColorClusterFromTab(COLOR_TAB);
     expect(cluster?.semanticDefaults).toEqual({
       surface: { ref: { tab: 'palette', tier: 'base', item: 'base-3' } },
+    });
+  });
+});
+
+/**
+ * Legacy index-0 fallback (#479 n1, S3a). A LEGACY `referencesTier` semantic
+ * tier's `default` is contractually always a palette id (or `bg`/`fg`) — a
+ * bogus default (e.g. a renamed/removed palette item) must fall back to
+ * palette index 0 with a warning, restoring pre-#459 behavior, instead of
+ * falling through to `{ literal: <bogus-id> }` (an invalid CSS custom
+ * property value once emitted). A `semantic: true` tier hitting the same
+ * bogus-default case keeps the `{ literal }` fallthrough — that IS the new
+ * model's contract.
+ */
+describe('resolveColorClusterFromTab — legacy palette-index fallback (#479 n1)', () => {
+  it('falls back to palette index 0 with a console.warn when a legacy tier default names no palette item', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'palette',
+          label: 'Palette',
+          items: [
+            {
+              id: 'p0',
+              cssVar: '--pal-0',
+              label: 'Palette 0',
+              default: '#000000',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'p1',
+              cssVar: '--pal-1',
+              label: 'Palette 1',
+              default: '#ffffff',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          referencesTier: 'palette',
+          items: [
+            {
+              id: 'accent',
+              cssVar: '--semantic-accent',
+              label: 'Accent',
+              default: 'p-nonexistent',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster?.semanticDefaults).toEqual({ accent: 0 });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('accent');
+    expect(warnSpy.mock.calls[0][0]).toContain('p-nonexistent');
+
+    warnSpy.mockRestore();
+  });
+
+  it('keeps the { literal } fallthrough (no warning) for a `semantic: true` tier with the same bogus default', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const tab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          items: [
+            {
+              id: 'accent',
+              cssVar: '--semantic-accent',
+              label: 'Accent',
+              default: 'p-nonexistent',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(tab);
+    expect(cluster?.semanticDefaults).toEqual({ accent: { literal: 'p-nonexistent' } });
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});
+
+/**
+ * Named-color literal detection (#479 n2, S3a). `looksLikeColorLiteral` must
+ * recognise bare CSS named-color keywords and value sentinels (`red`,
+ * `transparent`, `currentColor`, …) as literals — not just `#`/`(`-prefixed
+ * values — so a `semantic: true` tier with `referencesRamps` routes them to
+ * `{ literal }` instead of a broken best-effort `{ ref }`. Matching is
+ * case-insensitive; the stored literal preserves the default's original
+ * casing.
+ */
+describe('resolveColorClusterFromTab — named-color literal detection (#479 n2)', () => {
+  const PALETTE_TAB: TabConfig = {
+    id: 'palette',
+    label: 'Palette',
+    tiers: [
+      {
+        id: 'base',
+        label: 'Base',
+        items: [
+          {
+            id: 'base-1',
+            cssVar: '--palette-base-1',
+            label: 'Base 1',
+            default: 'oklch(0.98 0 0)',
+            type: { kind: 'color' as const, format: 'oklch' as const },
+          },
+        ],
+      },
+    ],
+  };
+
+  it.each([
+    ['red', 'red'],
+    ['transparent', 'transparent'],
+    ['currentColor', 'currentColor'],
+    ['currentcolor', 'currentcolor'],
+    ['rebeccapurple', 'rebeccapurple'],
+  ])('treats default %s as a literal, preserving its casing', (defaultValue, expectedLiteral) => {
+    const colorTab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          referencesRamps: [{ tab: 'palette', tier: 'base' }],
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: defaultValue,
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const cluster = resolveColorClusterFromTab(colorTab, [colorTab, PALETTE_TAB]);
+    expect(cluster?.semanticDefaults).toEqual({ danger: { literal: expectedLiteral } });
+  });
+
+  it('still derives a real ramp ref alongside a named-color-literal sibling on the same tier', () => {
+    const colorTab: TabConfig = {
+      id: 'color',
+      label: 'Color',
+      colorExtras: COLOR_EXTRAS,
+      tiers: [
+        {
+          id: 'semantic',
+          label: 'Semantic',
+          semantic: true,
+          referencesRamps: [{ tab: 'palette', tier: 'base' }],
+          items: [
+            {
+              id: 'danger',
+              cssVar: '--zd-danger',
+              label: 'Danger',
+              default: 'red',
+              type: { kind: 'color' as const },
+            },
+            {
+              id: 'surface',
+              cssVar: '--zd-surface',
+              label: 'Surface',
+              default: 'base-1',
+              type: { kind: 'color' as const },
+            },
+          ],
+        },
+      ],
+    };
+
+    const tabs = [colorTab, PALETTE_TAB];
+    const cluster = resolveColorClusterFromTab(colorTab, tabs);
+    expect(cluster?.semanticDefaults).toEqual({
+      danger: { literal: 'red' },
+      surface: { ref: { tab: 'palette', tier: 'base', item: 'base-1' } },
     });
   });
 });

--- a/packages/zdtp/src/config/cluster-config.ts
+++ b/packages/zdtp/src/config/cluster-config.ts
@@ -132,14 +132,52 @@ import type { TabConfig, TierItem } from '../tokens/tier-model';
 import { resolveRefToCssVar } from '../apply/tier-resolver';
 
 /**
+ * CSS Color Module Level 4 named-color keywords, plus the non-named `<color>`
+ * sentinels (`transparent`, `currentcolor`) and CSS-wide keywords a literal
+ * default may legitimately hold. Lowercase — `looksLikeColorLiteral` compares
+ * against `value.toLowerCase()` since CSS named colors are case-insensitive;
+ * the matched value itself is stored with its original casing intact. A
+ * static Set (not `CSS.supports`) keeps this SSR-safe.
+ */
+const CSS_NAMED_COLOR_KEYWORDS = new Set([
+  'aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black',
+  'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse',
+  'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan',
+  'darkgoldenrod', 'darkgray', 'darkgreen', 'darkgrey', 'darkkhaki', 'darkmagenta',
+  'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen',
+  'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise', 'darkviolet', 'deeppink',
+  'deepskyblue', 'dimgray', 'dimgrey', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen',
+  'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow',
+  'grey', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender',
+  'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan',
+  'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightgrey', 'lightpink', 'lightsalmon',
+  'lightseagreen', 'lightskyblue', 'lightslategray', 'lightslategrey', 'lightsteelblue',
+  'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine',
+  'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue',
+  'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream',
+  'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange',
+  'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred',
+  'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple',
+  'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell',
+  'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow', 'springgreen',
+  'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white',
+  'whitesmoke', 'yellow', 'yellowgreen',
+  'transparent', 'currentcolor', 'inherit', 'initial', 'unset', 'revert', 'revert-layer',
+]);
+
+/**
  * True when `value` reads as a literal CSS color (e.g. `#fff`, `oklch(...)`,
- * `rgb(...)`) rather than an id referencing another tier's item. Bare ids
- * (palette-item ids, ramp-item ids) never start with `#` or contain `(`, so
- * this is a cheap, reliable-enough discriminator for #463's best-effort
- * literal-vs-ref split.
+ * `red`, `transparent`) rather than an id referencing another tier's item.
+ * Bare ids (palette-item ids, ramp-item ids) never start with `#`, contain
+ * `(`, or spell a CSS named-color keyword, so this is a cheap, reliable-enough
+ * discriminator for #463's best-effort literal-vs-ref split.
  */
 function looksLikeColorLiteral(value: string): boolean {
-  return value.startsWith('#') || value.includes('(');
+  return (
+    value.startsWith('#') ||
+    value.includes('(') ||
+    CSS_NAMED_COLOR_KEYWORDS.has(value.toLowerCase())
+  );
 }
 
 /**
@@ -204,7 +242,14 @@ function deriveRampRef(
  * 3. Cross-tab ramp reference — the tier declares `referencesRamps` and
  *    `default` doesn't read as a literal color, so it's treated as naming a
  *    ramp item (best-effort shape; see `deriveRampRef`).
- * 4. Literal color default (e.g. an `oklch(...)`/hex string) — the common
+ * 4. Legacy tier (`referencesTier`, not `semantic: true`) whose `default`
+ *    names neither a palette item nor `bg`/`fg` — a bogus/renamed palette id.
+ *    Pre-#459 behavior fell back to palette index 0; restored here (with a
+ *    `console.warn`) so the emitters don't write the bogus id straight into
+ *    a CSS custom property. A `semantic: true` tier hitting this same case
+ *    instead falls through to branch 5 — `{ literal }` is the new model's
+ *    actual contract, not a bug to warn about.
+ * 5. Literal color default (e.g. an `oklch(...)`/hex string) — the common
  *    case for a lone `semantic: true` tier with no palette sibling.
  */
 function deriveSemanticValue(
@@ -213,6 +258,7 @@ function deriveSemanticValue(
   referencesRamps: readonly { tab?: string; tier: string }[] | undefined,
   currentTab: TabConfig,
   tabs: readonly TabConfig[],
+  isLegacyTier: boolean,
 ): SemanticValue {
   const paletteIdx = paletteIdToIndex.get(item.default);
   if (paletteIdx !== undefined) return paletteIdx;
@@ -221,6 +267,13 @@ function deriveSemanticValue(
 
   if (referencesRamps && referencesRamps.length > 0 && !looksLikeColorLiteral(item.default)) {
     return deriveRampRef(item.default, referencesRamps, currentTab, tabs);
+  }
+
+  if (isLegacyTier) {
+    console.warn(
+      `[design-token-panel] semantic item "${item.id}" default "${item.default}" names no palette item; falling back to palette index 0`,
+    );
+    return 0;
   }
 
   return { literal: item.default };
@@ -323,6 +376,7 @@ export function resolveColorClusterFromTab(
   const semanticCssNames: Record<string, string> = {};
 
   if (semanticTier) {
+    const isLegacyTier = !semanticTier.semantic;
     for (const item of semanticTier.items) {
       semanticCssNames[item.id] = item.cssVar;
       semanticDefaults[item.id] = deriveSemanticValue(
@@ -331,6 +385,7 @@ export function resolveColorClusterFromTab(
         semanticTier.referencesRamps,
         tab,
         tabs,
+        isLegacyTier,
       );
     }
   }

--- a/packages/zdtp/src/config/panel-config.ts
+++ b/packages/zdtp/src/config/panel-config.ts
@@ -989,6 +989,21 @@ function assertValidTab(tabId: string, tab: Record<string, unknown>, allTabs: un
     }
     tierIds.add(ti.id);
 
+    // Rule: `semantic` is a boolean marker (`TierConfig.semantic?: true`) read
+    // by five separate predicate sites across this file, cluster-config.ts,
+    // and color-tab.tsx — some compare with truthiness, some with `=== true`.
+    // A present-but-not-`true` value (e.g. `1`, `'true'`) is reachable from a
+    // plain-JS host config, where TS's structural typing offers no defense,
+    // and would get divergent treatment across those sites (e.g. excluded
+    // from palette-pick here but still able to be picked elsewhere). Reject
+    // it up front so the ambiguity is never reachable at runtime.
+    if (ti.semantic !== undefined && ti.semantic !== true) {
+      throw new Error(
+        `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${ti.id}"].semantic must be` +
+          ` exactly \`true\` when present (got ${JSON.stringify(ti.semantic)})`,
+      );
+    }
+
     if (!Array.isArray(ti.items)) {
       throw new Error(
         `[design-token-panel] PanelConfig.tabs["${tabId}"].tiers["${ti.id}"].items must be an array`,

--- a/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
+++ b/packages/zdtp/src/controls/__tests__/tier-ref-selector.test.tsx
@@ -274,10 +274,22 @@ describe('TierRefSelector — flat/intra-tab mode', () => {
     expect(selected?.textContent).toContain('--easing-ease-out');
   });
 
-  it('falls back to the first item when the ref is unrecognised', () => {
-    renderFlatSelector({ ref: { tier: 'raw', item: 'unknown-id' } }, vi.fn());
+  it('renders a disabled, selected placeholder when the ref is unrecognised (issue #479 nit n3)', () => {
+    const onChange = vi.fn();
+    renderFlatSelector({ ref: { tier: 'raw', item: 'unknown-id' } }, onChange);
     const selected = getOptions().find((o) => o.selected);
-    expect(selected?.textContent).toContain('--easing-ease-in');
+    expect(selected?.textContent).toContain('unresolved: raw/unknown-id');
+    expect(selected?.disabled).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('picking a real option out of the unresolved placeholder emits a valid { ref }', () => {
+    const onChange = vi.fn();
+    renderFlatSelector({ ref: { tier: 'raw', item: 'unknown-id' } }, onChange);
+
+    fireSelectChange(getSelect(), findOptionByText('--easing-linear').value);
+
+    expect(onChange).toHaveBeenCalledWith('tab-open', { ref: { tier: 'raw', item: 'linear' } });
   });
 
   it('each raw item option label includes cssVar and preview value', () => {
@@ -378,6 +390,28 @@ describe('TierRefSelector — grouped ref-or-literal mode', () => {
   it('does NOT render a literal editor while a ramp ref is selected', () => {
     renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'base-3' } }, vi.fn());
     expect(container.querySelector('[data-testid="color-field-swatch"]')).toBeNull();
+  });
+
+  it('renders a disabled, selected placeholder when a cross-tab ref no longer resolves (issue #479 nit n3)', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'gone' } }, onChange);
+    const selected = getOptions().find((o) => o.selected);
+    expect(selected?.textContent).toContain('unresolved: base/gone');
+    expect(selected?.disabled).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+    // Stays out of the literal editor too — it's neither a resolved ref nor a literal.
+    expect(container.querySelector('[data-testid="color-field-swatch"]')).toBeNull();
+  });
+
+  it('picking a real ramp option out of the unresolved placeholder emits a valid { ref }', () => {
+    const onChange = vi.fn();
+    renderGroupedSelector({ ref: { tab: 'palette', tier: 'base', item: 'gone' } }, onChange);
+
+    fireSelectChange(getSelect(), findOptionByText('--palette-accent-2').value);
+
+    expect(onChange).toHaveBeenCalledWith('surface', {
+      ref: { tab: 'palette', tier: 'accent', item: 'accent-2' },
+    });
   });
 
   it('selecting a ramp option emits { ref: { tab, tier, item } }', () => {

--- a/packages/zdtp/src/controls/tier-ref-selector.tsx
+++ b/packages/zdtp/src/controls/tier-ref-selector.tsx
@@ -16,6 +16,14 @@ import { resolvePerModeLiteral } from '../state/tweak-state';
 const LITERAL_OPTION_VALUE = '__literal__';
 
 /**
+ * `<select>` option value for the synthesized "unresolved ref" placeholder —
+ * shown, disabled and selected, when `value.ref` no longer resolves to a
+ * built option (issue #479 nit n3). Like `LITERAL_OPTION_VALUE`, it's purely
+ * an internal DOM detail and never appears on the `onChange` payload.
+ */
+const UNRESOLVED_OPTION_VALUE = '__unresolved__';
+
+/**
  * Maximum length of a value preview string shown in option labels.
  * Long values like cubic-bezier strings are truncated so the UI stays compact.
  */
@@ -72,6 +80,18 @@ function findTier(tab: TabConfig, tierId: string): TierConfig | undefined {
 
 function refsEqual(a: TierRefTarget, b: TierRefTarget): boolean {
   return (a.tab ?? '') === (b.tab ?? '') && a.tier === b.tier && a.item === b.item;
+}
+
+const warnedUnresolvedRefs = new Set<string>();
+
+/** Logs a dangling `{ ref }` once per distinct target, so a re-render loop doesn't spam the console. */
+function warnUnresolvedRefOnce(ref: TierRefTarget): void {
+  const key = `${ref.tab ?? ''}/${ref.tier}/${ref.item}`;
+  if (warnedUnresolvedRefs.has(key)) return;
+  warnedUnresolvedRefs.add(key);
+  console.warn(
+    `TierRefSelector: ref "${key}" does not resolve to a built option — showing a disabled placeholder instead of silently falling back to another selection.`,
+  );
 }
 
 /** One flattened, selectable ramp/ref option. */
@@ -223,15 +243,25 @@ function TierRefSelector({
 
   const allOptions = groups.flatMap((g) => g.options);
 
-  // Determine the currently selected option — fall back to the first option
-  // when the value is a ref that doesn't (or no longer) resolve.
+  // Determine the currently selected option. When the value is a ref that
+  // doesn't (or no longer) resolve to a built option, leave it undefined —
+  // rendering a disabled "(unresolved: …)" placeholder below instead of
+  // silently falling back to some other option, which would misrepresent a
+  // broken reference as a valid selection.
   const selectedOption = isLiteralValue(value)
     ? undefined
-    : (allOptions.find((o) => refsEqual(o.ref, value.ref)) ?? allOptions[0]);
+    : allOptions.find((o) => refsEqual(o.ref, value.ref));
+
+  const unresolvedRef: TierRefTarget | undefined =
+    !isLiteralValue(value) && !selectedOption ? value.ref : undefined;
+
+  if (unresolvedRef) {
+    warnUnresolvedRefOnce(unresolvedRef);
+  }
 
   const selectedKey = isLiteralValue(value)
     ? LITERAL_OPTION_VALUE
-    : (selectedOption?.key ?? LITERAL_OPTION_VALUE);
+    : (selectedOption?.key ?? UNRESOLVED_OPTION_VALUE);
 
   const rowLabel = label ?? itemId;
 
@@ -241,6 +271,9 @@ function TierRefSelector({
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const key = e.currentTarget.value;
+    // The placeholder is disabled, so the browser never fires a real change
+    // to it — this guard is defense-in-depth, not a path users can hit.
+    if (key === UNRESOLVED_OPTION_VALUE) return;
     if (key === LITERAL_OPTION_VALUE) {
       // Seed the literal editor from whatever was visible a moment ago, so
       // the user starts from a real color rather than a blank field. Always
@@ -311,6 +344,11 @@ function TierRefSelector({
         onChange={handleSelectChange}
         aria-label={`${rowLabel} tier reference`}
       >
+        {unresolvedRef && (
+          <option value={UNRESOLVED_OPTION_VALUE} disabled>
+            (unresolved: {unresolvedRef.tier}/{unresolvedRef.item})
+          </option>
+        )}
         {isGrouped
           ? groups.map((group) => (
               <optgroup key={group.label} label={group.label}>

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -513,6 +513,12 @@ export default function DesignTokenTweakPanel({
 
   const handleLoadFromJson = useCallback(
     (loaded: TweakState) => {
+      // Clear color cluster vars first — mirrors the scheme-change clear
+      // above. Without this, a dangling `{ ref }` in the imported state
+      // (skipped by the resolver, #482 import nit) would leave the PREVIOUS
+      // session's inline value painted instead of falling back to the
+      // stylesheet default.
+      clearAppliedColorStyles(undefined, undefined, instanceConfig);
       // Replace the panel state with the loaded tweak, apply CSS vars, persist
       // to localStorage (v3). Unknown tokens have already been filtered out by
       // deserialize(). Apply + persist are scoped to THIS instance (#357).

--- a/packages/zdtp/src/panel.tsx
+++ b/packages/zdtp/src/panel.tsx
@@ -786,6 +786,7 @@ export default function DesignTokenTweakPanel({
                     secondaryTab={tabConfigById['color-secondary'] ?? null}
                     secondaryState={state.secondary ?? initSecondaryFromConfig(instanceConfig) ?? null}
                     persistSecondary={persistSecondary}
+                    instanceConfig={instanceConfig}
                   />
                 )}
                 {tab.id === 'spacing' && state && tabConfigById['spacing'] && (

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -1059,8 +1059,10 @@ export function safeIndex(index: number, len: number): number {
  * `currentTab` / `tabs` are optional so existing callers that have no tab
  * context (or only ever produce index/literal mappings) keep compiling. A
  * `{ ref }` mapping with no `currentTab` supplied, or one that fails to
- * resolve (misconfigured manifest), falls back to `'#000000'` rather than
- * throwing — up-front source validation is #469's job, not this function's.
+ * resolve (misconfigured manifest), returns `null` — "emit nothing", matching
+ * the disk emitter's skip behavior (see the inline comment below) — rather
+ * than throwing or painting a fallback color. Up-front source validation is
+ * #469's job, not this function's.
  *
  * The per-mode `{ literal: { light, dark } }` variant (#472) emits a CSS
  * `light-dark(<light>, <dark>)` function so the browser resolves the correct
@@ -1211,8 +1213,10 @@ function hasPerModeLiteralSemantic(
  * `'color-secondary'`), and `tabs` the panel's full tabs array so a ref
  * pointing into another tab (e.g. the grouped Palette tab) resolves. Callers
  * that never hold `{ ref }` mappings (or have no tab context, e.g. most
- * existing tests) can omit both — `resolveSemanticCssValue` falls back to
- * `'#000000'` for an unresolvable ref rather than throwing.
+ * existing tests) can omit both — `resolveSemanticCssValue` returns `null`
+ * for an unresolvable ref rather than throwing, and this function skips a
+ * `null` (leaving the token at its stylesheet default) rather than painting
+ * a fallback color.
  */
 export function applyColorState(
   state: ColorTweakState,
@@ -1364,6 +1368,15 @@ export function applyTokenOverrides(
  * When `cfg` is supplied its `applySink` (if any) is used to route all
  * CSS-var writes for this instance. Omitting `cfg` uses the default active
  * config (single-panel path, unchanged behavior).
+ *
+ * `color-scheme` is managed as an AGGREGATE across the primary + secondary
+ * clusters, not per-cluster (#482 D3): `applyColorState` only ever SETS
+ * `color-scheme: light dark` when its OWN cluster needs it, it never clears
+ * it, so demoting the last per-mode-literal row (in either cluster) would
+ * otherwise leave the previous apply's value stale. A naive per-cluster
+ * clear inside `applyColorState` would let a per-mode-free secondary undo
+ * what the primary just required (or vice versa), so the clear-when-neither-
+ * needs-it decision is made here, once, after both clusters have applied.
  */
 export function applyFullState(state: TweakState, cfg?: PanelConfig) {
   const config = cfg ?? getPanelConfig();
@@ -1373,7 +1386,8 @@ export function applyFullState(state: TweakState, cfg?: PanelConfig) {
   // mapping (#468) resolves against a ramp tier living in another tab (e.g.
   // the grouped Palette tab).
   const colorTab = config.tabs.find((t) => t.id === 'color');
-  applyColorState(state.color, getActivePrimaryCluster(config), sink, colorTab, config.tabs);
+  const primaryCluster = getActivePrimaryCluster(config);
+  applyColorState(state.color, primaryCluster, sink, colorTab, config.tabs);
   // Apply spacing / typography / size from tabs[] (required field post-Wave-5).
   applyTabOverridesFlat(config.tabs, 'spacing', state.spacing, sink);
   applyTabOverridesFlat(config.tabs, 'font', state.typography, sink);
@@ -1381,9 +1395,26 @@ export function applyFullState(state: TweakState, cfg?: PanelConfig) {
   // The secondary cluster is host-driven via the 'color-secondary' tab.
   // When no such tab is configured, skip the secondary apply pass entirely.
   const secondaryCluster = resolveSecondaryColorCluster(config);
+  let secondaryHasPerMode = false;
   if (secondaryCluster && state.secondary) {
     const secondaryColorTab = config.tabs.find((t) => t.id === 'color-secondary');
     applyColorState(state.secondary, secondaryCluster, sink, secondaryColorTab, config.tabs);
+    secondaryHasPerMode = hasPerModeLiteralSemantic(state.secondary, secondaryCluster);
+  }
+  // #482 D3 — clear the aggregate `color-scheme` exactly when NEITHER
+  // cluster needs it. When either does, that cluster's own `applyColorState`
+  // call already set it above (see the docstring above for why this can't
+  // be a per-cluster decision).
+  if (!hasPerModeLiteralSemantic(state.color, primaryCluster) && !secondaryHasPerMode) {
+    if (sink) {
+      try {
+        sink.clear([COLOR_SCHEME_PROP]);
+      } catch (err) {
+        console.warn('[design-token-panel] applySink.clear threw; falling back silently.', err);
+      }
+    } else {
+      document.documentElement.style.removeProperty(COLOR_SCHEME_PROP);
+    }
   }
   // Apply generic tab overrides (v3 envelope tabs field).
   // The `tabs` field stores `TabOverrides` (tierId → { itemId → value }).
@@ -1659,6 +1690,12 @@ export function clearAppliedStyles(
     for (const cluster of resolvedClusters) {
       names.push(...clusterVarNames(cluster));
     }
+    // #482 D2 — same rationale as `clearAppliedColorStylesImpl`'s sink
+    // branch: the apply path may have set `color-scheme: light dark` on this
+    // sink's target root (#472/#474); clear it here too so a Reset (or the
+    // post-Apply cleanup) doesn't leave it lingering. Harmless when it was
+    // never set — clearing an absent property is a no-op.
+    if (resolvedClusters.length > 0) names.push(COLOR_SCHEME_PROP);
     names.push(...nonColorTabVarNames(config));
     if (names.length > 0) {
       try {

--- a/packages/zdtp/src/state/tweak-state.ts
+++ b/packages/zdtp/src/state/tweak-state.ts
@@ -961,6 +961,23 @@ export function initColorFromSchemeData(
   scheme: ColorScheme,
   cluster: ColorClusterDataConfig = getActivePrimaryCluster(),
 ): ColorTweakState {
+  // A palette-less cluster (paletteSize: 0, a lone `semantic: true` tier with
+  // no palette sibling, #458/#466) has nothing for a scheme/preset to seed:
+  // schemes only carry a 16-slot palette + index/string refs, never the
+  // `{ literal }` / `{ ref }` / per-mode SemanticValue shapes such a tier's
+  // rows hold. Loading one anyway previously reseeded `scheme.palette` wholesale
+  // (phantom `--zudo-stub-p*` swatches, since paletteCssVarTemplate falls back
+  // to the stub template with no palette tier to name slots after) and
+  // collapsed every non-numeric semanticDefault to palette index 0 (below),
+  // destroying literal/ref rows. Treat the load as a no-op instead — identical
+  // to the cluster's own no-scheme cold seed (#488).
+  if (cluster.paletteSize === 0) {
+    console.warn(
+      `[tweak] Scheme/preset load ignored for palette-less cluster "${cluster.id}" ` +
+        '(paletteSize: 0) — schemes cannot seed a tier with no palette.',
+    );
+    return initSecondaryDefaults(cluster);
+  }
   // Preserve raw `oklch(...)` losslessly (wide-gamut chroma survives; never
   // collapses to '#000000' under jsdom). Every other entry is sanitised through
   // cssColorToHex() exactly as before this OKLCH work — canonicalises valid

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -40,8 +40,9 @@ import type { PersistColor, PersistSecondary } from '../../state/persist';
 import {
   installFixturePanelConfig,
   FIXTURE_CLUSTER,
+  FIXTURE_PANEL_CONFIG,
 } from '../../__tests__/_test-helpers';
-import { __resetPanelConfigForTests } from '../../config/panel-config';
+import { __resetPanelConfigForTests, type PanelConfig } from '../../config/panel-config';
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -163,6 +164,7 @@ function renderColorTab(
     secondaryState?: ColorTweakState | null;
     persistColor?: PersistColor;
     persistSecondary?: PersistSecondary;
+    instanceConfig?: PanelConfig;
   } = {},
 ): void {
   const {
@@ -172,6 +174,7 @@ function renderColorTab(
     secondaryState = null,
     persistColor = noop,
     persistSecondary = noop,
+    instanceConfig,
   } = opts;
   act(() => {
     render(
@@ -184,6 +187,7 @@ function renderColorTab(
             secondaryTab={secondaryTab}
             secondaryState={secondaryState}
             persistSecondary={persistSecondary}
+            instanceConfig={instanceConfig}
           />
         </HighlightContext.Provider>
       </TooltipProvider>,
@@ -1353,5 +1357,163 @@ describe('ColorTab — SemanticLiteralRow per-mode (light/dark) editor toggle (S
     expect(
       container.querySelector('h1,h2,h3,h4,h5,h6,ul,ol,li,table,a,details,summary'),
     ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S9 — cross-tab semantic refs resolve against the passed `instanceConfig`,
+// not the active default instance (#357/#491 audit finding)
+// ---------------------------------------------------------------------------
+
+/**
+ * Two distinct multi-instance manifests sharing the SAME color-tab shape (a
+ * lone `semantic: true` tier whose one row references a Palette tab's "base"
+ * ramp) but each instance's own Palette tab holds a DIFFERENT, non-overlapping
+ * ramp item — `a-only` vs `b-only`. Before #491, `ColorTab` always read
+ * `getPanelConfig().tabs` (the active DEFAULT instance) for cluster
+ * derivation, the grouped ref-or-literal picker's ramp groups, and preview
+ * resolution — so a non-default instance's `{ ref }` mappings resolved
+ * against whichever instance happened to be the last-configured default, not
+ * against its OWN Palette tab. `instanceConfig` (mirroring the
+ * `usePersist`/`applyFullState` apply-path seam) fixes that.
+ */
+function makeRampSourceTab(itemId: string): TabConfig {
+  return {
+    id: 'palette',
+    label: 'Palette',
+    tiers: [
+      {
+        id: 'base',
+        label: 'Base',
+        items: [
+          {
+            id: itemId,
+            cssVar: `--instance-${itemId}`,
+            label: itemId,
+            default: 'oklch(0.5 0 0)',
+            type: { kind: 'color' as const, format: 'oklch' as const },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const INSTANCE_SEMANTIC_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'instance-cluster',
+    label: 'Instance',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      semantic: true,
+      referencesRamps: [{ tab: 'palette', tier: 'base' }],
+      items: [
+        {
+          id: 'surface',
+          cssVar: '--zd-surface',
+          label: 'Surface',
+          default: 'a-only',
+          type: { kind: 'color' as const, format: 'oklch' as const },
+        },
+      ],
+    },
+  ],
+};
+
+const INSTANCE_A_CONFIG: PanelConfig = {
+  ...FIXTURE_PANEL_CONFIG,
+  storagePrefix: 'instance-a',
+  tabs: [makeRampSourceTab('a-only'), INSTANCE_SEMANTIC_COLOR_TAB],
+};
+
+const INSTANCE_B_CONFIG: PanelConfig = {
+  ...FIXTURE_PANEL_CONFIG,
+  storagePrefix: 'instance-b',
+  tabs: [makeRampSourceTab('b-only'), INSTANCE_SEMANTIC_COLOR_TAB],
+};
+
+/**
+ * A `{ ref }`-only color state pointing `surface` at `refItem` in the Palette
+ * tab's "base" tier. No palette of its own (paletteSize 0 — the lone
+ * `semantic: true` tier shape, #458).
+ */
+function makeInstanceRefState(refItem: string): ColorTweakState {
+  return {
+    palette: [],
+    background: 0,
+    foreground: 0,
+    cursor: 0,
+    selectionBg: 0,
+    selectionFg: 0,
+    semanticMappings: { surface: { ref: { tab: 'palette', tier: 'base', item: refItem } } },
+    shikiTheme: 'dracula',
+  };
+}
+
+function getSurfaceRefSelect(): HTMLSelectElement {
+  const row = container.querySelector('[data-testid="tokenpanel-semantic-ref-surface"]');
+  expect(row).not.toBeNull();
+  const select = row!.querySelector('select.tokenpanel-tier-ref-select') as HTMLSelectElement;
+  expect(select).not.toBeNull();
+  return select;
+}
+
+describe('S9 — ColorTab resolves cross-tab refs against `instanceConfig`, not the default instance (#491)', () => {
+  it("instance B's ref resolves against B's OWN tabs even though the active default instance is A", () => {
+    // Active default instance is A — B's ramp item ('b-only') does not exist
+    // anywhere in A's Palette tab.
+    installFixturePanelConfig(INSTANCE_A_CONFIG);
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      tab: INSTANCE_SEMANTIC_COLOR_TAB,
+      colorState: makeInstanceRefState('b-only'),
+      instanceConfig: INSTANCE_B_CONFIG,
+    });
+
+    const selected = Array.from(getSurfaceRefSelect().querySelectorAll('option')).find(
+      (o) => o.selected,
+    );
+    expect(selected?.textContent).toContain('--instance-b-only');
+    expect(selected?.disabled).not.toBe(true);
+  });
+
+  it('sanity: the SAME ref renders UNRESOLVED when instanceConfig is omitted and the default instance is A (proves A and B are genuinely distinct fixtures)', () => {
+    installFixturePanelConfig(INSTANCE_A_CONFIG);
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      tab: INSTANCE_SEMANTIC_COLOR_TAB,
+      colorState: makeInstanceRefState('b-only'),
+      // No instanceConfig — falls back to getPanelConfig() (instance A).
+    });
+
+    const selected = Array.from(getSurfaceRefSelect().querySelectorAll('option')).find(
+      (o) => o.selected,
+    );
+    expect(selected?.textContent).toContain('unresolved: base/b-only');
+  });
+
+  it('single-instance default path unchanged: omitting instanceConfig resolves against getPanelConfig() when it already matches', () => {
+    // Active default instance IS B this time — the pre-#491 single-panel path.
+    installFixturePanelConfig(INSTANCE_B_CONFIG);
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      tab: INSTANCE_SEMANTIC_COLOR_TAB,
+      colorState: makeInstanceRefState('b-only'),
+    });
+
+    const selected = Array.from(getSurfaceRefSelect().querySelectorAll('option')).find(
+      (o) => o.selected,
+    );
+    expect(selected?.textContent).toContain('--instance-b-only');
   });
 });

--- a/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
+++ b/packages/zdtp/src/tabs/__tests__/color-tab.test.tsx
@@ -43,6 +43,7 @@ import {
   FIXTURE_PANEL_CONFIG,
 } from '../../__tests__/_test-helpers';
 import { __resetPanelConfigForTests, type PanelConfig } from '../../config/panel-config';
+import type { ColorScheme } from '../../config/color-schemes';
 
 // ---------------------------------------------------------------------------
 // Setup / teardown
@@ -1515,5 +1516,180 @@ describe('S9 — ColorTab resolves cross-tab refs against `instanceConfig`, not 
       (o) => o.selected,
     );
     expect(selected?.textContent).toContain('--instance-b-only');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S9 follow-up (audit / codex-review) — loading a Scheme preset must seed
+// against the passed `instanceConfig`'s cluster, not the global active primary
+// cluster. Regression guard for the #491 seam: ColorTab threaded
+// `instanceConfig` into cluster derivation + the preset LIST, but the preset
+// LOAD handler still called `initColorFromSchemeData(scheme)` with no cluster,
+// defaulting to `getActivePrimaryCluster()` — so a non-default instance's
+// preset built state for the wrong cluster.
+// ---------------------------------------------------------------------------
+
+function make16(color: string): ColorScheme['palette'] {
+  return Array.from({ length: 16 }, () => color) as unknown as ColorScheme['palette'];
+}
+
+const PRESET_X: ColorScheme = {
+  background: 0,
+  foreground: 1,
+  cursor: 0,
+  selectionBg: 0,
+  selectionFg: 1,
+  palette: make16('#123456'),
+};
+
+// Global (active default) instance — its primary cluster carries the semantic
+// key `accent-global`, which instance B's cluster does NOT have.
+const GLOBAL_DEFAULT_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'global-cluster',
+    label: 'Global',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: {},
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: Array.from({ length: 3 }, (_, i) => ({
+        id: `g-p${i}`,
+        cssVar: `--g-p${i}`,
+        label: `G${i}`,
+        default: '#000000',
+        type: { kind: 'color' as const },
+      })),
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        {
+          id: 'accent-global',
+          cssVar: '--g-accent',
+          label: 'Accent',
+          default: 'g-p1',
+          type: { kind: 'color' as const },
+        },
+      ],
+    },
+  ],
+};
+
+const GLOBAL_DEFAULT_CONFIG: PanelConfig = {
+  ...FIXTURE_PANEL_CONFIG,
+  storagePrefix: 'global-default-inst',
+  tabs: [GLOBAL_DEFAULT_COLOR_TAB],
+};
+
+// Instance B — a DIFFERENT primary cluster (semantic key `surface-b`, and its
+// own bundled `PresetX` scheme so the Scheme… dropdown offers a load target).
+const INSTANCE_B_PRESET_COLOR_TAB: TabConfig = {
+  id: 'color',
+  label: 'Color',
+  colorExtras: {
+    id: 'b-cluster',
+    label: 'B',
+    baseRoles: {},
+    baseDefaults: {},
+    defaultShikiTheme: 'dracula',
+    colorSchemes: { PresetX: PRESET_X },
+    panelSettings: { colorScheme: '', colorMode: false },
+  },
+  tiers: [
+    {
+      id: 'palette',
+      label: 'Palette',
+      items: Array.from({ length: 2 }, (_, i) => ({
+        id: `b-p${i}`,
+        cssVar: `--b-p${i}`,
+        label: `B${i}`,
+        default: '#000000',
+        type: { kind: 'color' as const },
+      })),
+    },
+    {
+      id: 'semantic',
+      label: 'Semantic',
+      referencesTier: 'palette',
+      items: [
+        {
+          id: 'surface-b',
+          cssVar: '--b-surface',
+          label: 'Surface',
+          default: 'b-p0',
+          type: { kind: 'color' as const },
+        },
+      ],
+    },
+  ],
+};
+
+const INSTANCE_B_PRESET_CONFIG: PanelConfig = {
+  ...FIXTURE_PANEL_CONFIG,
+  storagePrefix: 'instance-b-preset',
+  tabs: [INSTANCE_B_PRESET_COLOR_TAB],
+};
+
+describe('S9 follow-up — Scheme preset load seeds against `instanceConfig`, not the global default cluster (#491 audit)', () => {
+  it("loading a preset builds state for the instance's cluster (its semantic keys), not the active default instance's", () => {
+    // Active default instance is the GLOBAL config (cluster key `accent-global`).
+    installFixturePanelConfig(GLOBAL_DEFAULT_CONFIG);
+    const persistColor = vi.fn();
+    const ctx = makeCtx(makeHighlightState(), vi.fn());
+    renderColorTab(ctx, {
+      tab: INSTANCE_B_PRESET_COLOR_TAB,
+      colorState: {
+        palette: ['#111111', '#222222'],
+        background: 0,
+        foreground: 1,
+        cursor: 0,
+        selectionBg: 0,
+        selectionFg: 1,
+        semanticMappings: { 'surface-b': 0 },
+        shikiTheme: 'dracula',
+      },
+      instanceConfig: INSTANCE_B_PRESET_CONFIG,
+      persistColor,
+    });
+
+    const select = container.querySelector('.tokenpanel-color-preset-select') as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    // PresetX is bundled on instance B's cluster, so it must be offered.
+    expect(Array.from(select.querySelectorAll('option')).some((o) => o.value === 'PresetX')).toBe(
+      true,
+    );
+
+    act(() => {
+      select.value = 'PresetX';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    expect(persistColor).toHaveBeenCalledTimes(1);
+    const updater = persistColor.mock.calls.at(-1)![0] as (prev: ColorTweakState) => ColorTweakState;
+    const newState = updater({
+      palette: [],
+      background: 0,
+      foreground: 0,
+      cursor: 0,
+      selectionBg: 0,
+      selectionFg: 0,
+      semanticMappings: {},
+      shikiTheme: 'dracula',
+    });
+
+    // Seeded from instance B's cluster.semanticDefaults ...
+    expect(Object.keys(newState.semanticMappings)).toContain('surface-b');
+    // ... NOT the global active default cluster's.
+    expect(Object.keys(newState.semanticMappings)).not.toContain('accent-global');
   });
 });

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -54,7 +54,7 @@ import {
   resolvePaletteCssVar,
   resolvePerModeLiteral,
 } from '../state/tweak-state';
-import { getPanelConfig } from '../config/panel-config';
+import { getPanelConfig, type PanelConfig } from '../config/panel-config';
 import { resolveColorClusterFromTab } from '../config/cluster-config';
 import type { TabConfig, TierConfig } from '../tokens/tier-model';
 import type { PersistColor, PersistSecondary } from '../state/persist';
@@ -787,6 +787,17 @@ interface ColorTabProps {
   secondaryTab: TabConfig | null;
   secondaryState: ColorTweakState | null;
   persistSecondary: PersistSecondary;
+  /**
+   * The mounted panel instance's config (multi-instance, #353/#357). When
+   * supplied, cross-tab cluster/ref resolution (cluster derivation, the
+   * grouped ref-or-literal picker's ramp groups, preview resolution, and the
+   * host preset list) reads THIS instance's `tabs` / `colorPresets` rather
+   * than the active default instance — matching the apply path, which
+   * already resolves against `cfg.tabs` via `usePersist` (`applyFullState`,
+   * `state/persist.ts`). Omitted (e.g. a direct test render) →
+   * `getPanelConfig()`, preserving the single-instance path.
+   */
+  instanceConfig?: PanelConfig;
 }
 
 export default function ColorTab({
@@ -796,12 +807,14 @@ export default function ColorTab({
   secondaryTab,
   secondaryState,
   persistSecondary,
+  instanceConfig,
 }: ColorTabProps) {
   // Derive the cluster from the tab's colorExtras + tiers. This provides the
   // same shape that the rest of the panel (apply, clear, state) expects.
   // The full tabs array is threaded in so a semantic tier's cross-tab `{ ref }`
   // mappings resolve against a ramp tier in another tab (e.g. the Palette tab).
-  const allTabs = getPanelConfig().tabs;
+  const cfg = instanceConfig ?? getPanelConfig();
+  const allTabs = cfg.tabs;
   const cluster = useMemo(() => resolveColorClusterFromTab(tab, allTabs), [tab, allTabs]);
   // Fallback to an empty stub cluster when the tab has no colorExtras.
   const safeCluster = useMemo(
@@ -840,7 +853,7 @@ export default function ColorTab({
   // ships zero presets — `colorPresets` defaults to `{}` on
   // `DEFAULT_PANEL_CONFIG` so a host that omits the field sees only
   // `cluster.colorSchemes` (the bundled, cluster-local scheme registry).
-  const hostPresets = getPanelConfig().colorPresets ?? {};
+  const hostPresets = cfg.colorPresets ?? {};
   // Cluster-bundled schemes win on key collision: they are the cluster
   // owner's documented defaults (e.g. "Default Light" / "Default Dark"),
   // and the host preset list is the broader experimentation pool.

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -1051,11 +1051,16 @@ export default function ColorTab({
     (name: string) => {
       const scheme = allPresets[name];
       if (!scheme) return;
-      const newState = initColorFromSchemeData(scheme);
+      // Seed against THIS instance's derived cluster (`safeCluster`), not the
+      // global active primary cluster. In a multi-instance / direct-render host
+      // the instance's palette size or semantic tokens can differ from the
+      // default config; without the explicit cluster the preset load builds
+      // state for the wrong cluster (#491 follow-up, audit).
+      const newState = initColorFromSchemeData(scheme, safeCluster);
       persistColor(() => newState);
       applyShikiTheme(newState.shikiTheme);
     },
-    [persistColor],
+    [persistColor, safeCluster, allPresets],
   );
 
   return (

--- a/packages/zdtp/src/tabs/color-tab.tsx
+++ b/packages/zdtp/src/tabs/color-tab.tsx
@@ -1047,42 +1047,53 @@ export default function ColorTab({
 
   return (
     <div className="tokenpanel-tab-content">
-      {/* Preset loader — tab-scoped so the outer header row stays general */}
-      <div className="tokenpanel-tab-actions">
-        <select
-          onChange={(e) => {
-            const target = e.target as HTMLSelectElement;
-            const name = target.value;
-            if (name) {
-              handleLoadPreset(name);
-              target.value = '';
-            }
-          }}
-          className="tokenpanel-color-preset-select"
-          aria-label="Load color scheme preset"
-          defaultValue=""
-        >
-          <option value="" disabled>
-            Scheme...
-          </option>
-          <optgroup label="Built-in">
-            {bundledNames.map((name) => (
-              <option key={name} value={name}>
-                {name}
-              </option>
-            ))}
-          </optgroup>
-          {presetNames.length > 0 && (
-            <optgroup label="Presets">
-              {presetNames.map((name) => (
-                <option key={name} value={name}>
-                  {name}
-                </option>
-              ))}
-            </optgroup>
-          )}
-        </select>
-      </div>
+      {/*
+       * Preset loader — tab-scoped so the outer header row stays general.
+       * Gated on `safeCluster.paletteSize > 0`: a palette-less cluster (a
+       * lone `semantic: true` tier, #458) has no palette for a scheme/preset
+       * to seed — `initColorFromSchemeData` treats a load against it as a
+       * no-op (#488), so offering the control here would be dead UI even
+       * when the host configured `colorPresets`.
+       */}
+      {safeCluster.paletteSize > 0 && (
+        <div className="tokenpanel-tab-actions">
+          <select
+            onChange={(e) => {
+              const target = e.target as HTMLSelectElement;
+              const name = target.value;
+              if (name) {
+                handleLoadPreset(name);
+                target.value = '';
+              }
+            }}
+            className="tokenpanel-color-preset-select"
+            aria-label="Load color scheme preset"
+            defaultValue=""
+          >
+            <option value="" disabled>
+              Scheme...
+            </option>
+            {bundledNames.length > 0 && (
+              <optgroup label="Built-in">
+                {bundledNames.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+            {presetNames.length > 0 && (
+              <optgroup label="Presets">
+                {presetNames.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+        </div>
+      )}
 
       {/*
        * Section A: Raw Palette — and Section B: Base Theme, which indexes

--- a/packages/zdtp/src/tokens/tier-model.ts
+++ b/packages/zdtp/src/tokens/tier-model.ts
@@ -128,8 +128,12 @@ export interface TierConfig {
    * Cross-tab ramp-source declaration for a semantic tier: the ramp tier(s)
    * this tier's `{ ref }` mappings are allowed to point into. Each entry names
    * a tier id and an optional tab id (omitted `tab` means "this tab").
-   * Reserved here for #467/#469, which wire it into ramp-item resolution and
-   * the Tier-2 editor's item picker; unused until then.
+   * `assertValidPanelConfig` validates every declared source up front (the
+   * tab/tier must exist and share this tier's kind); `resolveColorClusterFromTab`
+   * (`config/cluster-config.ts`) uses the allow-list to derive each row's
+   * `SemanticValue`; the grouped `TierRefSelector` picker
+   * (`controls/tier-ref-selector.tsx`) renders one `<optgroup>` per declared
+   * source.
    */
   referencesRamps?: readonly { tab?: string; tier: string }[];
 }

--- a/packages/zdtp/src/utils/__tests__/design-token-serde.test.ts
+++ b/packages/zdtp/src/utils/__tests__/design-token-serde.test.ts
@@ -10,6 +10,7 @@ import {
   type DesignTokenJsonV2,
   type DesignTokenJsonV3,
 } from '../design-token-serde';
+import { applyFullState } from '../../state/tweak-state';
 import type { ColorTweakState, SemanticValue, TweakState } from '../../state/tweak-state';
 import { __resetPanelConfigForTests } from '../../config/panel-config';
 import { installFixturePanelConfig, FIXTURE_CLUSTER, FIXTURE_TABS } from '../../__tests__/_test-helpers';
@@ -803,13 +804,16 @@ describe('SCHEMA_V3 — serialize/deserialize round-trips for every SemanticValu
   });
 
   it('round-trips a { ref } mapping, upgrading $schema to SCHEMA_V3', () => {
+    // 'color'/'palette'/'fixture-p3' is a real target in FIXTURE_TABS, so this
+    // ref resolves cleanly (no stale-ref warning) — see the S5 describe block
+    // below for the warn-on-missing-target behavior.
     const color = cloneBaseline();
-    const ref: SemanticValue = { ref: { tab: 'brand', tier: 'ramp', item: 'brand-500' } };
+    const ref: SemanticValue = { ref: { tab: 'color', tier: 'palette', item: 'fixture-p3' } };
     color.semanticMappings.active = ref;
     const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE }) as DesignTokenJsonV3;
     expect(json.$schema).toBe(SCHEMA_V3);
     expect(json.tabs?.['color']?.['semantic']).toEqual({
-      '--fixture-semantic-active': { ref: { tab: 'brand', tier: 'ramp', item: 'brand-500' } },
+      '--fixture-semantic-active': { ref: { tab: 'color', tier: 'palette', item: 'fixture-p3' } },
     });
 
     const { state, unknownTokens, warnings } = deserialize(JSON.parse(JSON.stringify(json)), {
@@ -821,8 +825,10 @@ describe('SCHEMA_V3 — serialize/deserialize round-trips for every SemanticValu
   });
 
   it('round-trips a { ref } mapping without an optional tab field', () => {
+    // Intra-tab ref (no `tab`) resolving within the 'color' tab's own
+    // 'palette' tier — a real target, so no stale-ref warning.
     const color = cloneBaseline();
-    const ref: SemanticValue = { ref: { tier: 'ramp', item: 'brand-500' } };
+    const ref: SemanticValue = { ref: { tier: 'palette', item: 'fixture-p3' } };
     color.semanticMappings.active = ref;
     const json = serialize(makeState({ color }), { colorDefaults: COLOR_BASELINE });
     expect(json.$schema).toBe(SCHEMA_V3);
@@ -916,5 +922,160 @@ describe('SCHEMA_V3 — serialize/deserialize round-trips for every SemanticValu
     expect(state.color.semanticMappings.muted).toBe(9);
     expect(state.color.semanticMappings.active).toBe(COLOR_BASELINE.semanticMappings.active);
     expect(state.spacing['hsp-md']).toBe('60px');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S5 — serde robustness (#459 audit): order-independent diff compare,
+// stale-ref import warning, integer-only V3 index leaves.
+// ---------------------------------------------------------------------------
+
+describe('S5 — order-independent semantic diff compare (JSON.stringify key-order bug)', () => {
+  it('does not emit a { ref } mapping as changed when only its property insertion order differs from baseline', () => {
+    const baseline = cloneBaseline();
+    baseline.semanticMappings.active = { ref: { tier: 'palette', item: 'fixture-p3' } };
+
+    const color = cloneBaseline();
+    // Structurally identical to the baseline ref above, just built with a
+    // different key insertion order (mirrors baseline built by
+    // parseSemanticExternalValue's `{tier, item, tab}` vs a UI-produced
+    // `{tab, tier, item}}`).
+    color.semanticMappings.active = { ref: { item: 'fixture-p3', tier: 'palette' } };
+
+    const json = serialize(makeState({ color }), { colorDefaults: baseline });
+    const semMap = json.tabs?.['color']?.['semantic'] as Record<string, unknown> | undefined;
+    expect(semMap?.['--fixture-semantic-active']).toBeUndefined();
+  });
+
+  it('still emits a { ref } mapping that is genuinely changed from baseline', () => {
+    const baseline = cloneBaseline();
+    baseline.semanticMappings.active = { ref: { tier: 'palette', item: 'fixture-p3' } };
+
+    const color = cloneBaseline();
+    color.semanticMappings.active = { ref: { tier: 'palette', item: 'fixture-p9' } };
+
+    const json = serialize(makeState({ color }), { colorDefaults: baseline });
+    expect(json.tabs?.['color']?.['semantic']).toEqual({
+      '--fixture-semantic-active': { ref: { tier: 'palette', item: 'fixture-p9' } },
+    });
+  });
+});
+
+describe('S5 — stale { ref } target produces a warning on import (#459 audit)', () => {
+  it('warns when a { ref } targets a tab/tier/item absent from the current config, but keeps the parsed ref', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        color: {
+          semantic: {
+            // No 'ramp' tier exists on any configured tab — a stale reference
+            // (e.g. a renamed ramp item, or a host that dropped a tab).
+            '--fixture-semantic-active': { ref: { tier: 'ramp', item: 'brand-500' } },
+          },
+        },
+      },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    // The value is preserved verbatim rather than falling back to baseline —
+    // the apply path already skips an unresolvable ref gracefully.
+    expect(state.color.semanticMappings.active).toEqual({ ref: { tier: 'ramp', item: 'brand-500' } });
+    expect(
+      warnings.some((w) => w.includes('active') && w.includes('ramp') && w.includes('brand-500')),
+    ).toBe(true);
+  });
+
+  it('does not warn for a { ref } targeting a real tab/tier/item', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        color: {
+          semantic: {
+            '--fixture-semantic-active': { ref: { tier: 'palette', item: 'fixture-p3' } },
+          },
+        },
+      },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.active).toEqual({ ref: { tier: 'palette', item: 'fixture-p3' } });
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('S5 — V3 index leaves require an in-range integer (#459 audit)', () => {
+  it('warns and keeps baseline for a non-integer index leaf (2.5)', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: { color: { semantic: { '--fixture-semantic-accent': 2.5 } } },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.accent).toBe(COLOR_BASELINE.semanticMappings.accent);
+    expect(warnings.some((w) => w.includes('accent'))).toBe(true);
+  });
+
+  it('warns and keeps baseline for an out-of-range integer index leaf', () => {
+    // FIXTURE_CLUSTER.paletteSize is 16, so 99 is out of range.
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: { color: { semantic: { '--fixture-semantic-accent': 99 } } },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.accent).toBe(COLOR_BASELINE.semanticMappings.accent);
+    expect(warnings.some((w) => w.includes('accent'))).toBe(true);
+  });
+
+  it('still accepts a valid in-range integer index leaf (no regression)', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: { color: { semantic: { '--fixture-semantic-accent': 7 } } },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(state.color.semanticMappings.accent).toBe(7);
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('S5 — composed: stale-ref V3 import + applyFullState keeps the stylesheet default', () => {
+  it('a stale { ref } import surfaces a warning AND is skipped at apply time (token keeps its stylesheet default)', () => {
+    const payload = {
+      $schema: SCHEMA_V3,
+      exportedAt: new Date().toISOString(),
+      tabs: {
+        color: {
+          semantic: {
+            '--fixture-semantic-active': { ref: { tier: 'ramp', item: 'brand-500' } },
+          },
+        },
+      },
+    };
+    const { state, warnings } = deserialize(payload, { colorDefaults: COLOR_BASELINE });
+    expect(warnings.some((w) => w.includes('active'))).toBe(true);
+
+    // An applySink spy avoids any dependency on a real DOM/jsdom environment
+    // (design-token-serde.test.ts runs under the plain "node" vitest project).
+    const applyCalls: Array<ReadonlyArray<readonly [string, string]>> = [];
+    installFixturePanelConfig({
+      applySink: {
+        apply(pairs) {
+          applyCalls.push(pairs);
+        },
+        clear() {
+          // no-op — this test only asserts on what was applied.
+        },
+      },
+    });
+
+    applyFullState(state);
+
+    const appliedNames = applyCalls.flat().map(([name]) => name);
+    // resolveSemanticCssValue's { ref } branch throws inside
+    // resolveRefToCssVar (no 'ramp' tier exists), returns null, and the apply
+    // path skips a null — so the token is never written and keeps whatever
+    // its stylesheet declares.
+    expect(appliedNames).not.toContain('--fixture-semantic-active');
   });
 });

--- a/packages/zdtp/src/utils/design-token-serde.ts
+++ b/packages/zdtp/src/utils/design-token-serde.ts
@@ -96,6 +96,8 @@ import {
 } from '../state/tweak-state';
 import { getPanelConfig, type PanelConfig } from '../config/panel-config';
 import { resolvePaletteCssVar } from '../config/cluster-config';
+import { resolveRefToCssVar } from '../apply/tier-resolver';
+import { structuralEqual } from './structural-equal';
 import type { TierItem } from '../tokens/tier-model';
 
 /** Minimal token-like interface extracted from TierItem for serde lookups. */
@@ -563,8 +565,11 @@ function resolveIndexMapping(v: number | 'bg' | 'fg', bg: number, fg: number): n
  * by their RESOLVED palette index (so e.g. `'bg'` and a baseline numeric
  * mapping that happens to equal the current background index are treated as
  * equal, matching pre-#462 behavior). The `{ literal }` / `{ ref }` variants
- * have no index to resolve to, so they're compared structurally; a mapping
- * that changed KIND (index → object or vice versa) is always "changed".
+ * have no index to resolve to, so they're compared structurally (order-
+ * independent — see `structuralEqual`, so a `{ ref }` reconstructed by
+ * `parseSemanticExternalValue` compares equal to a UI-produced ref with
+ * different key insertion order); a mapping that changed KIND (index → object
+ * or vice versa) is always "changed".
  */
 function semanticMappingsEqual(
   cur: SemanticValue,
@@ -583,7 +588,12 @@ function semanticMappingsEqual(
   }
   if (isIndexMapping(cur) !== isIndexMapping(baselineVal)) return false;
   // Both are object variants (literal / ref) — compare structurally.
-  return JSON.stringify(cur) === JSON.stringify(baselineVal);
+  // JSON.stringify is key-order sensitive, so a structurally identical ref
+  // built with a different property insertion order (e.g. baseline via
+  // parseSemanticExternalValue's `{tier, item, tab}` vs. a UI-produced
+  // `{tab, tier, item}`) would spuriously compare "changed" and get emitted
+  // as diff-noise (import-modal.tsx's `structuralEqual` avoids the same trap).
+  return structuralEqual(cur, baselineVal);
 }
 
 /**
@@ -852,7 +862,7 @@ function deserializeV3(
   const tabsRaw = normalizeTabsRaw(obj.tabs);
 
   // Color tab — the only slice that differs from v2.
-  const color = deserializeColorV3(tabsRaw['color'], baseline, cluster, warnings);
+  const color = deserializeColorV3(tabsRaw['color'], baseline, cluster, warnings, cfg);
 
   const { spacing, typography, size, tabsState } = deserializeNonColorSlices(
     tabsRaw,
@@ -875,9 +885,18 @@ function deserializeV3(
  * (#462, SCHEMA_V3+). Returns `undefined` for any other shape so the caller
  * can warn-and-keep-baseline exactly like the other malformed-value paths in
  * this module.
+ *
+ * `paletteSize` gates the `number` branch to an in-range INTEGER index: a
+ * non-integer like `2.5` passes `safeIndex`'s bounds check downstream
+ * (`safeIndex` only checks `index < len`, not `Number.isInteger`) and indexes
+ * `palette[2.5] === undefined`, painting the token black instead of being
+ * caught here at parse time. V1/V2 index parsing is untouched — only the
+ * V3-only path (this function) gates on integer + range.
  */
-function parseSemanticExternalValue(val: unknown): SemanticValue | undefined {
-  if (typeof val === 'number') return val;
+function parseSemanticExternalValue(val: unknown, paletteSize: number): SemanticValue | undefined {
+  if (typeof val === 'number') {
+    return Number.isInteger(val) && val >= 0 && val < paletteSize ? val : undefined;
+  }
   if (!val || typeof val !== 'object' || Array.isArray(val)) return undefined;
 
   const o = val as Record<string, unknown>;
@@ -948,6 +967,7 @@ function deserializeColorV3(
   baseline: ColorTweakState,
   cluster: ReturnType<typeof getActivePrimaryCluster>,
   warnings: string[],
+  cfg: PanelConfig,
 ): ColorTweakState {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
     // No color tab — fall back entirely to baseline.
@@ -973,14 +993,34 @@ function deserializeColorV3(
         warnings.push(`color.semantic: unknown cssVar "${cssName}"; skipped.`);
         continue;
       }
-      const parsed = parseSemanticExternalValue(val);
-      if (parsed !== undefined) {
-        semanticMappings[key] = parsed;
-      } else {
+      const parsed = parseSemanticExternalValue(val, cluster.paletteSize);
+      if (parsed === undefined) {
         warnings.push(
           `color.semantic.${cssName} has unsupported value ${JSON.stringify(val)}; kept baseline.`,
         );
+        continue;
       }
+      // A `{ ref }` mapping's target tab/tier/item may no longer exist
+      // (renamed ramp item, host dropped a tab) — `resolveRefToCssVar` throws
+      // in that case. Warn so the Import modal can surface it, but still keep
+      // the parsed ref (not degraded to baseline): the apply path
+      // (`resolveSemanticCssValue`) already skips an unresolvable ref and
+      // leaves the token at its stylesheet default, so this stays a graceful
+      // degradation rather than a silent no-op.
+      if (isRefMapping(parsed)) {
+        const colorTab = cfg.tabs.find((t) => t.id === 'color');
+        try {
+          if (!colorTab) throw new Error('no color tab configured');
+          resolveRefToCssVar(parsed.ref, colorTab, cfg.tabs);
+        } catch {
+          warnings.push(
+            `color.semantic.${cssName} ref points to a missing target ` +
+              `(tab "${parsed.ref.tab ?? colorTab?.id ?? '?'}", tier "${parsed.ref.tier}", ` +
+              `item "${parsed.ref.item}"); kept as an unresolved reference.`,
+          );
+        }
+      }
+      semanticMappings[key] = parsed;
     }
   }
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/480

---

## Summary

Epic #480 — post-#459 audit fixes + #479 robustness nits + #478 JP docs translation, implemented as 11 topics across 4 dependency waves via `/x-wt-teams`. All topic branches merged into `base/ramp-tier2-followups`; this PR aggregates them into `main`.

Closes #478 (JP docs), #479 (robustness nits). Fixes audit defects D1/D2/D3 from the post-#459 6-auditor audit.

## Audit defects fixed

- **D1** (#481) — Disk emitter now threads the owning color tab into `buildApplyOverrides`' `{ ref }` resolution, so a secondary-cluster semantic ref resolves against the `color-secondary` tab (byte-identical to the DOM emitter), instead of the hardcoded primary `'color'` tab. Adds disk/DOM parity + same-id-tier-on-both-tabs coverage.
- **D2 + D3** (#482) — `color-scheme` lifecycle: (D2) `clearAppliedStyles`' sink branch now clears `color-scheme` on Reset; (D3) demoting the last per-mode row removes the stale inline `color-scheme`. Managed as an **aggregate** in `applyFullState` (set iff *any* cluster has a per-mode literal; `applyColorState` still only ever SETs → single-cluster/direct callers unchanged). Plus import clear-before-apply and two stale `#000000` docstrings.

## #479 robustness nits (closes #479)

- **n1 + n2** (#483) — legacy `referencesTier` bogus default → palette index 0 + one warn; `looksLikeColorLiteral` recognizes CSS named-color keywords (`red`/`transparent`/`currentColor`, case-insensitive) so they store as `{ literal }` instead of broken refs.
- **n3** (#484) — `TierRefSelector` surfaces a dangling `{ ref }` as a disabled `(unresolved: …)` placeholder instead of silently faking the first option (no `onChange` on render).

## Other robustness / correctness

- **#485** — serde: order-independent ref diff compare, stale-ref import warnings, integer-only V3 index leaves.
- **#487** — config-time validation rejects a malformed `semantic` marker (present but not exactly `true`); mixed-order palette-pick regression tests.
- **#488** — scheme/preset load is a no-op on a palette-less cluster (no phantom `--zudo-stub-p*`); scheme dropdown hidden + empty `Built-in` optgroup gated.
- **#491** — `ColorTab` threads `instanceConfig` so multi-instance UI resolution matches the apply layer. **Deep-review follow-up (a1b0dd8):** preset **load** now also seeds against the instance cluster, not the global default (mutation-verified regression test).

## Docs (closes #478)

- **#486** — EN doc-drift fixes (`referencesRamps` JSDoc, `resolveColorClusterFromTab` bridge signature, disk `color-scheme` caveat).
- **#489 / #490** — full Japanese translations of `reference/color-cluster.mdx` and `reference/token-manifest.mdx`.

## Confirm (#492)

Full workspace validation on the merged base: `typecheck` 0, `pnpm test` (node + browser) **2053 passed / 108 files**, `pnpm build` (zdtp + doc, 61 pages), both JA pages render in the built site, manifest-cascade invariants D/F/H green. CI green.

## Notes

- Raised #494 — a pre-existing flaky jsdom `canvas.getContext` unhandled-rejection (out of scope for this epic).