### PR TITLE
test(zdtp): eliminate intermittent vitest unhandled-error flake (closes #494)

### DIFF
--- a/packages/zdtp/src/controls/tooltip.tsx
+++ b/packages/zdtp/src/controls/tooltip.tsx
@@ -135,6 +135,11 @@ export function TooltipProvider({ children }: TooltipProviderProps) {
 
   // Escape key hides tooltip.
   useEffect(() => {
+    // Guard document: preact flushes effects via a scheduled timer, which can
+    // fire after a test's jsdom environment tears down (leaking into a later
+    // node-environment test file). Matches the `typeof document` guard on the
+    // portal render below.
+    if (typeof document === 'undefined') return;
     function onKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') hideAll();
     }
@@ -145,6 +150,7 @@ export function TooltipProvider({ children }: TooltipProviderProps) {
   // Scroll (capture) repositions the tooltip by hiding it.
   // The trigger will re-show it on next mouseenter if still hovered.
   useEffect(() => {
+    if (typeof window === 'undefined') return;
     function onScroll() {
       if (currentTriggerRef.current) hideAll();
     }

--- a/packages/zdtp/vitest-setup-node.ts
+++ b/packages/zdtp/vitest-setup-node.ts
@@ -1,0 +1,18 @@
+// Vitest node-project setup (per-file, runs in each file's environment).
+//
+// Under jsdom, `HTMLCanvasElement.prototype.getContext('2d')` is unimplemented:
+// jsdom emits a "Not implemented" jsdomError to its virtual console, which
+// vitest intermittently counts as an unhandled error and fails the run even
+// though every test passes. `_canvasCtxSupported` (state/tweak-state.ts) only
+// needs a falsy return to correctly skip the canvas colour path under jsdom, so
+// stub getContext to return null — the probe stays `false` WITHOUT tripping
+// jsdom's not-implemented path.
+//
+// Guarded on `typeof HTMLCanvasElement` so it no-ops in the pure-node env (node
+// test files, where the class is undefined). Test files that manage getContext
+// themselves (css-color-to-hex.test.ts save/spy/restore around this baseline)
+// keep working: this only replaces the throwing default.
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = (() =>
+    null) as unknown as HTMLCanvasElement['getContext'];
+}

--- a/packages/zdtp/vitest.config.ts
+++ b/packages/zdtp/vitest.config.ts
@@ -40,6 +40,10 @@ export default mergeConfig(
             // behavior of the original single-project config.
             include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
             exclude: ['src/**/*.browser.test.ts', 'src/**/*.browser.test.tsx'],
+            // Stubs jsdom's unimplemented canvas getContext so the intermittent
+            // "Not implemented" jsdomError can't fail the run. Node-project only
+            // — the browser project keeps real Chromium canvas.
+            setupFiles: ['./vitest-setup-node.ts'],
           },
         },
         {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-design-token-panel/issues/494

---

## Summary

Follow-up from the epic #480 session: post-merge `main` CI went red on an intermittent vitest "Errors 1 error" (all tests passing). Two async sources escaped test boundaries; both are now deterministically fixed.

### Source 1 — leaked tooltip effect timer (the failure that reddened main)
`TooltipProvider`'s `document`/`window` listener effects are flushed by preact's scheduled effect timer, which can fire **after** a jsdom test tears down — landing in a later node-env test file (`host-adapter-autoload.test.ts`) where `document` is undefined → `ReferenceError: document is not defined` at `tooltip.tsx`. Guarded both effects with `typeof document/window` (matching the file's existing portal-render guard).

### Source 2 — jsdom unimplemented canvas getContext (#494)
`HTMLCanvasElement.getContext('2d')` is unimplemented under jsdom; the "Not implemented" jsdomError is intermittently counted by vitest. A node-project `setupFiles` stub returns `null` so `_canvasCtxSupported` stays `false` (correct — unchanged behavior) without tripping jsdom's not-implemented path. **Node project only** — the browser project keeps real Chromium canvas.

## Verification
- `test:unit` run **4× consecutively → all exit 0, zero "Errors"** (previously ~50% exit 1).
- Full node + browser suite **2053 passed**; build + lint + typecheck green.
- Existing `css-color-to-hex.test.ts` getContext save/spy/restore tests unaffected.

Closes #494.